### PR TITLE
Update landing page tools grid to use 2-column and 1-column layouts only

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(git checkout:*)",
       "Bash(tasklist:*)",
       "Bash(taskkill:*)",
-      "Bash(npx kill-port:*)"
+      "Bash(npx kill-port:*)",
+      "Bash(git cherry-pick:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -389,9 +389,14 @@ const SectionSubtitle = styled(Typography)(({ theme }) => ({
 
 const ToolsGrid = styled(Box)(({ theme }) => ({
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
   gap: '2rem',
   marginTop: '3rem',
+  // Default: 2 columns for larger screens
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  [theme.breakpoints.down('sm')]: {
+    // 1 column for small screens
+    gridTemplateColumns: '1fr',
+  },
 }));
 
 const ToolCard = styled(Box)(({ theme }) => ({


### PR DESCRIPTION
- Modified ToolsGrid component to display 2 columns on larger screens
- Displays 1 column on small screens (mobile)
- Removed 3-column and 4-column layouts for better visual balance
- Improves readability and focus on tool cards