### PR TITLE
Remove underline indicator from tab navigation

### DIFF
--- a/src/features/report_details/FightDetailsView.tsx
+++ b/src/features/report_details/FightDetailsView.tsx
@@ -150,6 +150,9 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
             flexGrow: 1,
             minHeight: 'auto',
             overflow: 'visible !important',
+            '& .MuiTabs-indicator': {
+              display: 'none',
+            },
             '& .MuiTabs-flexContainer': {
               gap: '8px',
               justifyContent: 'flex-start',


### PR DESCRIPTION
Hide the Material-UI tabs underline indicator by adding display: none to .MuiTabs-indicator class. This affects all 8 main tabs (Insights, Players, Damage Done, Healing Done, Deaths, Critical Damage, Penetration, Damage Reduction) and all experimental tabs when enabled.