### PR TITLE
Fix reflective gradient clipping issues in table headers and cards

### DIFF
--- a/src/features/report_details/damage/DamageDonePanelView.tsx
+++ b/src/features/report_details/damage/DamageDonePanelView.tsx
@@ -239,10 +239,9 @@ export const DamageDonePanelView: React.FC<DamageDonePanelViewProps> = ({
               top: 0,
               left: '-100%',
               width: '100%',
-              height: '50%',
+              height: '100%',
               background:
                 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)',
-              transform: 'skewX(-25deg)',
               transition: 'left 0.5s ease',
             },
             '&::after': {
@@ -304,11 +303,10 @@ export const DamageDonePanelView: React.FC<DamageDonePanelViewProps> = ({
                 top: 0,
                 left: '-100%',
                 width: '100%',
-                height: '50%',
+                height: '100%',
                 background: roleColors.isDarkMode
                   ? 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)'
                   : 'linear-gradient(90deg, transparent, rgba(15,23,42,0.08), transparent)',
-                transform: 'skewX(-25deg)',
                 transition: 'left 0.5s ease',
               },
               '&::after': {

--- a/src/features/report_details/deaths/DeathEventPanelView.tsx
+++ b/src/features/report_details/deaths/DeathEventPanelView.tsx
@@ -381,12 +381,13 @@ export const DeathEventPanelView: React.FC<DeathEventPanelViewProps> = ({
                   top: 0,
                   left: '-100%',
                   width: '100%',
-                  height: '50%',
+                  height: '100%',
                   background:
                     theme.palette.mode === 'dark'
                       ? 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)'
                       : 'linear-gradient(90deg, transparent, rgba(15,23,42,0.08), transparent)',
-                  transform: 'skewX(-25deg)',
+                  transform: 'skewX(-15deg)',
+                  transformOrigin: 'center center',
                   transition: 'left 0.5s ease',
                 },
                 '&:hover': {

--- a/src/features/report_details/healing/HealingDonePanelView.tsx
+++ b/src/features/report_details/healing/HealingDonePanelView.tsx
@@ -239,10 +239,9 @@ export const HealingDonePanelView: React.FC<HealingDonePanelViewProps> = ({ heal
               top: 0,
               left: '-100%',
               width: '100%',
-              height: '50%',
+              height: '100%',
               background:
                 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)',
-              transform: 'skewX(-25deg)',
               transition: 'left 0.5s ease',
             },
             '&::after': {
@@ -304,11 +303,10 @@ export const HealingDonePanelView: React.FC<HealingDonePanelViewProps> = ({ heal
                 top: 0,
                 left: '-100%',
                 width: '100%',
-                height: '50%',
+                height: '100%',
                 background: roleColors.isDarkMode
                   ? 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)'
                   : 'linear-gradient(90deg, transparent, rgba(15,23,42,0.08), transparent)',
-                transform: 'skewX(-25deg)',
                 transition: 'left 0.5s ease',
               },
               '&::after': {

--- a/src/utils/playerCardStyleUtils.ts
+++ b/src/utils/playerCardStyleUtils.ts
@@ -54,9 +54,10 @@ const getGlossyBaseSx = (theme: Theme): SxProps<Theme> => ({
     top: 0,
     left: '-100%',
     width: '100%',
-    height: '50%',
+    height: '100%',
     background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)',
-    transform: 'skewX(-25deg)',
+    transform: 'skewX(-15deg)',
+    transformOrigin: 'center center',
     transition: 'left 0.5s ease',
   },
   '&::after': {


### PR DESCRIPTION
- Remove skew transform from large table headers to eliminate bottom clipping
- Adjust skew angles for smaller card elements to reduce clipping
- Restore full height (100%) for gradient effects across all components
- Fix both parent container and child element gradient implementations

Affected components:
- DamageDonePanelView: table header gradient container
- HealingDonePanelView: table header gradient container
- DeathEventPanelView: card hover effects with reduced skew
- playerCardStyleUtils: chip hover effects with reduced skew