### PR TITLE
Refactor battle-tested chip positioning and extract reusable component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -149,7 +149,7 @@ export const Footer: React.FC = React.memo(() => {
               }}
             >
               Essential tools built by the ESO community for enhanced gameplay, optimization, and
-              guild management. Battle-tested by veterans across Tamriel.
+              guild management.
             </Typography>
           </Box>
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -600,38 +600,6 @@ const ComingSoonBadge = styled(Box)({
   },
 });
 
-const MarketingBadge = styled(Box)({
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: '0.5rem',
-  background: 'linear-gradient(135deg, rgba(56, 189, 248, 0.1), rgba(0, 225, 255, 0.05))',
-  border: '1px solid rgba(56, 189, 248, 0.2)',
-  borderRadius: '50px',
-  padding: '0.5rem 1.2rem',
-  marginBottom: '1rem',
-  fontSize: '0.9rem',
-  fontWeight: 600,
-  color: '#38bdf8',
-  backdropFilter: 'blur(10px)',
-  boxShadow: '0 4px 20px rgba(56, 189, 248, 0.1)',
-  animation: 'float 3s ease-in-out infinite',
-  '@keyframes float': {
-    '0%, 100%': { transform: 'translateY(0px)' },
-    '50%': { transform: 'translateY(-4px)' },
-  },
-});
-
-const BadgeContainer = styled(Box)(({ theme }) => ({
-  display: 'flex',
-  justifyContent: 'center',
-  marginBottom: '3rem',
-  marginTop: '2rem',
-  [theme.breakpoints.down('sm')]: {
-    marginBottom: '2rem',
-    marginTop: '2rem',
-  },
-}));
-
 const ParticleContainer = styled(Box)(({ theme }) => ({
   position: 'absolute',
   top: 0,
@@ -817,9 +785,6 @@ export const LandingPage: React.FC = () => {
       </HeroSection>
 
       <ToolsSection id="tools">
-        <BadgeContainer>
-          <MarketingBadge>⚔️ Battle-Tested by ESO Veterans</MarketingBadge>
-        </BadgeContainer>
         <SectionTitle variant="h2">Our Tools</SectionTitle>
         <SectionSubtitle>Everything you need to excel in Tamriel</SectionSubtitle>
 

--- a/src/components/MarketingBadge.tsx
+++ b/src/components/MarketingBadge.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const StyledMarketingBadge = styled(Box)({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  background: 'linear-gradient(135deg, rgba(56, 189, 248, 0.1), rgba(0, 225, 255, 0.05))',
+  border: '1px solid rgba(56, 189, 248, 0.2)',
+  borderRadius: '50px',
+  padding: '0.5rem 1.2rem',
+  fontSize: '0.9rem',
+  fontWeight: 600,
+  color: '#38bdf8',
+  backdropFilter: 'blur(10px)',
+  boxShadow: '0 4px 20px rgba(56, 189, 248, 0.1)',
+  animation: 'float 3s ease-in-out infinite',
+  '@keyframes float': {
+    '0%, 100%': { transform: 'translateY(0px)' },
+    '50%': { transform: 'translateY(-4px)' },
+  },
+});
+
+export const MarketingBadge: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <StyledMarketingBadge>{children}</StyledMarketingBadge>;
+};


### PR DESCRIPTION
- Remove battle-tested marketing badge from landing page hero section
- Clean up unused styled components and imports in Footer and LandingPage
- Extract MarketingBadge into standalone reusable component
- Remove redundant text from footer description to avoid duplication

The badge is now available as a component for future placement when the optimal position is determined.