### PR TITLE
Fix mobile tabs overflow issue by constraining container width

### DIFF
--- a/src/features/report_details/FightDetailsView.tsx
+++ b/src/features/report_details/FightDetailsView.tsx
@@ -139,7 +139,8 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
           mb: 1,
           width: '100%',
           minWidth: 0,
-          overflow: 'visible',
+          overflow: 'hidden',
+          maxWidth: '100vw',
         }}
       >
         <Tabs
@@ -148,10 +149,11 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
             onTabChange(v as TabId);
           }}
           sx={{
-            minWidth: 'auto',
+            minWidth: 0,
             flexGrow: 1,
             minHeight: 'auto',
-            overflow: 'visible !important',
+            overflow: 'hidden',
+            maxWidth: 'calc(100vw - 80px)', // Leave space for experimental toggle
             '& .MuiTabs-indicator': {
               display: 'none',
             },
@@ -176,6 +178,7 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
               minWidth: 32,
               padding: 0,
               margin: 0,
+              flexShrink: 0,
               '&.Mui-disabled': {
                 opacity: 0.3,
               },
@@ -187,6 +190,7 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
               margin: 0,
               opacity: 1,
               borderRadius: 100,
+              flexShrink: 0,
             },
           }}
           variant="scrollable"


### PR DESCRIPTION
- Add maxWidth constraint to prevent tabs from breaking out of viewport
- Improve flex properties with flexShrink: 0 for scroll buttons and tabs
- Change container overflow from visible to hidden for proper containment
- Maintain scrollable functionality with allowScrollButtonsMobile