### PR TITLE
Enable cross-mode navigation between trash and boss fights

### DIFF
--- a/src/features/report_details/FightDetailsView.tsx
+++ b/src/features/report_details/FightDetailsView.tsx
@@ -297,7 +297,9 @@ export const FightDetailsView: React.FC<FightDetailsViewProps> = ({
             >
               {navigationData.currentIndex >= 0 && navigationData.totalCount > 0
                 ? `${navigationData.currentIndex + 1}/${navigationData.totalCount}`
-                : '0/0'}
+                : navigationData.previousFight || navigationData.nextFight
+                  ? `—/${navigationData.totalCount}`
+                  : '0/0'}
             </Typography>
           </Box>
 

--- a/src/features/report_details/ReportFightHeader.tsx
+++ b/src/features/report_details/ReportFightHeader.tsx
@@ -84,7 +84,35 @@ export const useFightNavigation = (): {
       currentFight?.difficulty != null ? 'boss' : 'trash';
 
     if (currentIndex === -1) {
-      // Current fight not found in active list
+      // Current fight not found in active list - handle cross-mode navigation
+      if (navigationMode === 'bosses' && currentFightType === 'trash') {
+        // We're on a trash fight but in boss mode - find nearest boss fights
+        const currentFightStartTime = currentFight?.startTime;
+        if (currentFightStartTime != null) {
+          // Find the previous boss fight (last boss before current fight)
+          const previousBoss =
+            bossFights
+              .filter((boss) => boss.startTime < currentFightStartTime)
+              .sort((a, b) => b.startTime - a.startTime)[0] || null;
+
+          // Find the next boss fight (first boss after current fight)
+          const nextBoss =
+            bossFights
+              .filter((boss) => boss.startTime > currentFightStartTime)
+              .sort((a, b) => a.startTime - b.startTime)[0] || null;
+
+          return {
+            currentIndex: -1, // Not in boss list
+            previousFight: previousBoss,
+            nextFight: nextBoss,
+            totalCount: activeList.length,
+            modeLabel: 'Boss', // We're in bosses mode when doing cross-navigation
+            currentFightType,
+          };
+        }
+      }
+
+      // Default case - current fight not found in active list
       return {
         currentIndex: -1,
         previousFight: null,


### PR DESCRIPTION
Fixes issue where switching to boss mode on a trash fight would show 0/0 navigation. Now provides seamless navigation to nearest boss fights using chronological ordering.

Changes:
- Find previous/next boss fights based on start times when on trash fight in boss mode
- Display '--/X' counter to indicate cross-navigation capability
- Maintain proper navigation state across mode switches
- Preserve existing navigation behavior for same-mode scenarios