### PR TITLE
Remove max-width constraint on landing page URL input at md breakpoint

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -309,7 +309,6 @@ export const LogInputContainer = styled(Box)(({ theme }) => ({
       theme.palette.mode === 'dark' ? 'rgba(56, 189, 248, 0.4)' : 'rgba(30, 41, 59, 0.25)',
   },
   [theme.breakpoints.down('md')]: {
-    maxWidth: '500px',
     borderRadius: '12px',
   },
   [theme.breakpoints.down('sm')]: {


### PR DESCRIPTION
The URL input container had a 500px max-width rule at 899.95px breakpoint that was preventing the input from being full width on medium screens. Removed this constraint while preserving responsive border radius styling.