### PR TITLE
Replace loading spinners with consistent table skeletons in damage an…

### DIFF
--- a/src/features/report_details/damage/DamageDonePanel.tsx
+++ b/src/features/report_details/damage/DamageDonePanel.tsx
@@ -1,7 +1,8 @@
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { GenericTabSkeleton } from '../../../components/GenericTabSkeleton';
 import {
   useDamageEventsLookup,
   useReportMasterData,
@@ -202,21 +203,16 @@ export const DamageDonePanel: React.FC = () => {
     activePercentages,
   ]);
 
-  // Show loading spinner while data is being fetched
+  // Show table skeleton while data is being fetched
   if (isLoading) {
     return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: 200,
-        }}
-      >
-        <CircularProgress sx={{ mb: 2 }} />
-        <Typography variant="h6">Loading damage data...</Typography>
-      </Box>
+      <GenericTabSkeleton
+        title="Damage Done"
+        showChart={true}
+        chartHeight={400}
+        showTable={true}
+        tableRows={10}
+      />
     );
   }
 

--- a/src/features/report_details/healing/HealingDonePanel.tsx
+++ b/src/features/report_details/healing/HealingDonePanel.tsx
@@ -1,6 +1,7 @@
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
 
+import { GenericTabSkeleton } from '../../../components/GenericTabSkeleton';
 import { FightFragment } from '../../../graphql/generated';
 import {
   useCastEvents,
@@ -144,21 +145,16 @@ export const HealingDonePanel: React.FC<HealingDonePanelProps> = ({ fight }) => 
     getPlayerRole,
   ]);
 
-  // Show loading spinner while data is being fetched
+  // Show table skeleton while data is being fetched
   if (isLoading) {
     return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: 200,
-        }}
-      >
-        <CircularProgress sx={{ mb: 2 }} />
-        <Typography variant="h6">Loading healing data...</Typography>
-      </Box>
+      <GenericTabSkeleton
+        title="Healing Done"
+        showChart={true}
+        chartHeight={400}
+        showTable={true}
+        tableRows={8}
+      />
     );
   }
 


### PR DESCRIPTION
…d healing panels

- Remove CircularProgress spinners from HealingDonePanel and DamageDonePanel loading states
- Replace with GenericTabSkeleton components that match the Suspense fallback skeletons
- Ensure consistent skeleton appearance throughout the entire loading sequence
- HealingDonePanel: Uses GenericTabSkeleton with title "Healing Done", chart + 8 table rows
- DamageDonePanel: Uses GenericTabSkeleton with title "Damage Done", chart + 10 table rows

This eliminates the jarring transition from table skeleton → spinner → table skeleton, providing a smooth and consistent loading experience for users.