### PR TITLE
Upgrade death event panel skeleton loading state

### DIFF
--- a/src/features/report_details/deaths/DeathEventPanelView.tsx
+++ b/src/features/report_details/deaths/DeathEventPanelView.tsx
@@ -123,9 +123,58 @@ export const DeathEventPanelView: React.FC<DeathEventPanelViewProps> = ({
   if (isLoading) {
     return (
       <Box mt={2}>
-        <Typography variant="h6" sx={{ mb: 2 }}>
-          💀 Death Events
-        </Typography>
+        {/* Header with summary skeleton */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+          <Typography variant="h6">💀 Death Events</Typography>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Skeleton variant="rounded" width={120} height={24} sx={{ borderRadius: '12px' }} />
+            <Skeleton variant="rounded" width={100} height={24} sx={{ borderRadius: '12px' }} />
+          </Box>
+        </Box>
+
+        {/* Death summary skeleton */}
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            variant="subtitle2"
+            sx={{ mb: 1, color: theme.palette.text.primary, fontWeight: 600 }}
+          >
+            Death Summary
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                variant="rounded"
+                width={80 + i * 10}
+                height={24}
+                sx={{ borderRadius: '12px' }}
+              />
+            ))}
+          </Box>
+        </Box>
+
+        {/* Skills summary skeleton */}
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            variant="subtitle2"
+            sx={{ mb: 1, color: theme.palette.text.primary, fontWeight: 600 }}
+          >
+            ⚔️ Deadly Skills Summary
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                variant="rounded"
+                width={90 + i * 15}
+                height={24}
+                sx={{ borderRadius: '12px' }}
+              />
+            ))}
+          </Box>
+        </Box>
+
+        {/* Death events grid skeleton */}
         <Box
           sx={{
             display: 'grid',
@@ -145,20 +194,67 @@ export const DeathEventPanelView: React.FC<DeathEventPanelViewProps> = ({
                 borderRadius: '16px',
                 background:
                   theme.palette.mode === 'dark'
-                    ? 'linear-gradient(135deg, rgb(110 214 240 / 25%) 0%, rgb(131 208 227 / 15%) 50%, rgb(35 122 144 / 8%) 100%)'
-                    : 'linear-gradient(135deg, rgb(236 246 255 / 90%) 0%, rgba(248, 250, 252, 0.95) 50%, rgba(241, 245, 249, 0.98) 100%)',
+                    ? 'linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%)'
+                    : 'linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%)',
                 border:
                   theme.palette.mode === 'dark'
                     ? '1px solid rgba(255, 255, 255, 0.15)'
-                    : '1px solid rgba(15, 23, 42, 0.12)',
+                    : '1px solid rgba(59, 130, 246, 0.3)',
                 backdropFilter: 'blur(10px)',
                 WebkitBackdropFilter: 'blur(10px)',
+                boxShadow:
+                  '0 8px 32px 0 rgba(0, 0, 0, 0.37), inset 0 1px 0 rgba(255, 255, 255, 0.2)',
               }}
             >
               <CardContent sx={{ p: 2 }}>
-                <Skeleton variant="text" width="60%" height={24} sx={{ mb: 1 }} />
-                <Skeleton variant="text" width="40%" height={20} sx={{ mb: 2 }} />
-                <Skeleton variant="rectangular" width="100%" height={60} sx={{ borderRadius: 1 }} />
+                {/* Player header skeleton */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                  <Skeleton variant="circular" width={40} height={40} />
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Skeleton variant="text" width="70%" height={20} sx={{ mb: 0.5 }} />
+                    <Skeleton variant="text" width="50%" height={16} />
+                  </Box>
+                </Box>
+
+                {/* Status sections skeleton */}
+                <Box sx={{ mb: 2 }}>
+                  <Skeleton variant="text" width="40%" height={16} sx={{ mb: 0.5 }} />
+                  <Skeleton
+                    variant="rounded"
+                    width="80%"
+                    height={32}
+                    sx={{ borderRadius: '16px', mb: 1 }}
+                  />
+                  <Skeleton variant="text" width="50%" height={16} sx={{ mb: 0.5 }} />
+                  <Skeleton
+                    variant="rounded"
+                    width="60%"
+                    height={32}
+                    sx={{ borderRadius: '16px' }}
+                  />
+                </Box>
+
+                {/* Killing blow skeleton */}
+                <Box sx={{ mb: 2 }}>
+                  <Skeleton variant="text" width="40%" height={16} sx={{ mb: 0.5 }} />
+                  <Skeleton
+                    variant="rounded"
+                    width="90%"
+                    height={48}
+                    sx={{ borderRadius: '16px' }}
+                  />
+                </Box>
+
+                {/* Recent attacks skeleton */}
+                <Box>
+                  <Skeleton variant="text" width="45%" height={16} sx={{ mb: 0.5 }} />
+                  {Array.from({ length: 3 }).map((_, j) => (
+                    <Box key={j} sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                      <Skeleton variant="text" width="70%" height={14} />
+                      <Skeleton variant="text" width="20%" height={14} />
+                    </Box>
+                  ))}
+                </Box>
               </CardContent>
             </Card>
           ))}

--- a/src/utils/getSkeletonForTab.tsx
+++ b/src/utils/getSkeletonForTab.tsx
@@ -164,7 +164,245 @@ export const getSkeletonForTab = (
           />
         );
       case TabId.DEATHS:
-        return <GenericTabSkeleton title="Death Events" showTable={true} tableRows={5} />;
+        return (
+          <Box mt={2}>
+            {/* Header with summary skeleton */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+              <Box
+                sx={{
+                  width: 140,
+                  height: 28,
+                  backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                  borderRadius: 1,
+                }}
+              />
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 120,
+                    height: 24,
+                    backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                    borderRadius: '12px',
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 100,
+                    height: 24,
+                    backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                    borderRadius: '12px',
+                  }}
+                />
+              </Box>
+            </Box>
+
+            {/* Death summary skeleton */}
+            <Box sx={{ mb: 3 }}>
+              <Box
+                sx={{
+                  width: 120,
+                  height: 20,
+                  backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                  borderRadius: 1,
+                  mb: 1,
+                }}
+              />
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      width: 80 + i * 10,
+                      height: 24,
+                      backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                      borderRadius: '12px',
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+
+            {/* Skills summary skeleton */}
+            <Box sx={{ mb: 3 }}>
+              <Box
+                sx={{
+                  width: 180,
+                  height: 20,
+                  backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                  borderRadius: 1,
+                  mb: 1,
+                }}
+              />
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      width: 90 + i * 15,
+                      height: 24,
+                      backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                      borderRadius: '12px',
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+
+            {/* Death events grid skeleton */}
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(1, 1fr)',
+                  md: 'repeat(2, 1fr)',
+                  lg: 'repeat(3, 1fr)',
+                },
+                gap: 2,
+              }}
+            >
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Box
+                  key={i}
+                  sx={{
+                    borderRadius: '16px',
+                    background: 'rgba(0, 0, 0, 0.04)',
+                    border: '1px solid rgba(0, 0, 0, 0.08)',
+                    p: 2,
+                    minHeight: 200,
+                  }}
+                >
+                  {/* Player header skeleton */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                    <Box
+                      sx={{
+                        width: 40,
+                        height: 40,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: '50%',
+                      }}
+                    />
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Box
+                        sx={{
+                          width: '70%',
+                          height: 20,
+                          backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                          borderRadius: 1,
+                          mb: 0.5,
+                        }}
+                      />
+                      <Box
+                        sx={{
+                          width: '50%',
+                          height: 16,
+                          backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                          borderRadius: 1,
+                        }}
+                      />
+                    </Box>
+                  </Box>
+
+                  {/* Status sections skeleton */}
+                  <Box sx={{ mb: 2 }}>
+                    <Box
+                      sx={{
+                        width: '40%',
+                        height: 16,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: 1,
+                        mb: 0.5,
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        width: '80%',
+                        height: 32,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: '16px',
+                        mb: 1,
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        width: '50%',
+                        height: 16,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: 1,
+                        mb: 0.5,
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        width: '60%',
+                        height: 32,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: '16px',
+                      }}
+                    />
+                  </Box>
+
+                  {/* Killing blow skeleton */}
+                  <Box sx={{ mb: 2 }}>
+                    <Box
+                      sx={{
+                        width: '40%',
+                        height: 16,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: 1,
+                        mb: 0.5,
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        width: '90%',
+                        height: 48,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: '16px',
+                      }}
+                    />
+                  </Box>
+
+                  {/* Recent attacks skeleton */}
+                  <Box>
+                    <Box
+                      sx={{
+                        width: '45%',
+                        height: 16,
+                        backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                        borderRadius: 1,
+                        mb: 0.5,
+                      }}
+                    />
+                    {Array.from({ length: 3 }).map((_, j) => (
+                      <Box
+                        key={j}
+                        sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}
+                      >
+                        <Box
+                          sx={{
+                            width: '70%',
+                            height: 14,
+                            backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                            borderRadius: 1,
+                          }}
+                        />
+                        <Box
+                          sx={{
+                            width: '20%',
+                            height: 14,
+                            backgroundColor: 'rgba(0, 0, 0, 0.11)',
+                            borderRadius: 1,
+                          }}
+                        />
+                      </Box>
+                    ))}
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        );
       case TabId.CRITICAL_DAMAGE:
         return <CriticalDamageSkeleton />;
       case TabId.PENETRATION:


### PR DESCRIPTION
- Replace generic table skeleton with detailed card-based skeleton layout
- Add comprehensive header skeletons for summary chips and sections
- Update card skeletons with modern purple/blue gradients matching real content
- Include detailed internal card structure: player headers, status sections, killing blow, and recent attacks
- Synchronize global tab skeleton with component-level skeleton for consistent loading experience
- Remove initial unrelated table skeleton that appeared before proper skeleton

The skeleton now provides accurate preview of final content structure with proper spacing, gradients, and section organization.