### PR TITLE
Fix mobile touch event handling for gear set tooltips in PlayerCard

### DIFF
--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -644,6 +644,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                   title={<GearSetTooltip {...tooltipProps} />}
                                   placement="top"
                                   enterDelay={300}
+                                  enterTouchDelay={0}
+                                  leaveTouchDelay={3000}
                                   arrow
                                   disableInteractive={false}
                                 >


### PR DESCRIPTION
- Add enterTouchDelay and leaveTouchDelay props to gear set tooltip
- Ensure tooltips appear immediately on mobile tap and stay visible for 3 seconds
- Consistent with other tooltip behavior in the player card component
- Resolves issue where gear set tooltips were not appearing on mobile devices