### PR TITLE
fix: add GitHub Pages base path configuration

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
-    base: process.env.VITE_BASE_URL || '/',
+    base: '/eso-log-aggregator/',
     plugins: [
       svgr({
         svgrOptions: {


### PR DESCRIPTION
- Update vite.config.mjs to use '/eso-log-aggregator/' base path
- This ensures background images load correctly on GitHub Pages
- Fixes 404 errors for images in subdirectory deployment

