### PR TITLE
fix: change Artaeum Takeaway Broth abbreviation from ARTAEU to ATB

### DIFF
--- a/src/utils/foodDetectionUtils.test.ts
+++ b/src/utils/foodDetectionUtils.test.ts
@@ -332,7 +332,7 @@ describe('foodDetectionUtils', () => {
 
         expect(detected.name).toBe('Artaeum Takeaway Broth');
         expect(detected.id).toBe(1001);
-        expect(abbreviated).toBe('ARTAEU'); // Truncated unknown name
+        expect(abbreviated).toBe('ATB'); // Artaeum Takeaway Broth abbreviation
         expect(color).toBe('#4CAF50'); // Tri-stat color
       }
     });

--- a/src/utils/foodDetectionUtils.ts
+++ b/src/utils/foodDetectionUtils.ts
@@ -114,7 +114,7 @@ export function abbreviateFood(name: string): string {
   if (name === 'custom food') return 'CUSTOM';
   if (name === 'weird-name') return 'WEIRD-';
   if (name === 'Unknown') return 'UNKNOW';
-  if (name === 'Artaeum Takeaway Broth') return 'ARTAEU';
+  if (name === 'Artaeum Takeaway Broth') return 'ATB';
 
   // For short names, return as-is
   if (name.length <= 2) return name.toUpperCase();


### PR DESCRIPTION
- Update foodDetectionUtils.ts to return 'ATB' instead of 'ARTAEU' for better abbreviation
- Update corresponding test to expect 'ATB' abbreviation
- Improves consistency with other food abbreviations (CCF, BSS, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)