### PR TITLE
feat(HeaderBar): Add My Reports link to reports menu [ESO-516]

### DIFF
--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -641,23 +641,39 @@ export const HeaderBar: React.FC = () => {
     },
   ];
 
-  const reportsItems = [
-    {
-      text: 'Sample Report',
-      icon: '🎲',
-      action: handleSampleReport,
-    },
-    {
-      text: 'Latest Report',
-      icon: '📊',
-      path: '/latest-reports',
-    },
-    {
-      text: 'Leaderboards',
-      icon: '🏆',
-      path: '/leaderboards',
-    },
-  ];
+  const reportsItems = React.useMemo(() => {
+    const items = [];
+
+    // Add "My Reports" if user is logged in
+    if (isLoggedIn) {
+      items.push({
+        text: 'My Reports',
+        icon: '📁',
+        path: '/my-reports',
+      });
+    }
+
+    // Always show these items
+    items.push(
+      {
+        text: 'Sample Report',
+        icon: '🎲',
+        action: handleSampleReport,
+      },
+      {
+        text: 'Latest Report',
+        icon: '📊',
+        path: '/latest-reports',
+      },
+      {
+        text: 'Leaderboards',
+        icon: '🏆',
+        path: '/leaderboards',
+      },
+    );
+
+    return items;
+  }, [isLoggedIn, handleSampleReport]);
 
   const accountItems = React.useMemo(() => {
     const items: Array<{


### PR DESCRIPTION
## Summary
Adds a "My Reports" link to the reports submenu that appears when users are logged in.

## Changes
- Converted `reportsItems` from static array to `React.useMemo` for dynamic rendering
- Added conditional "My Reports" menu item (📁 icon) that appears first in the reports menu
- Menu item navigates to `/my-reports` route
- Uses `isLoggedIn` dependency to update menu when authentication state changes

## Menu Structure (when logged in)
- My Reports 📁 **(NEW)**
- Sample Report 🎲
- Latest Report 📊
- Leaderboards 🏆

## Testing
- ✅ TypeScript compilation passed
- ✅ ESLint linting passed
- ✅ Code follows project conventions

## Related
Jira: ESO-516