### PR TITLE
feat(ESO-546): Add Sentry error tracking for unknown gear sets

### DIFF
--- a/src/utils/setNameUtils.test.ts
+++ b/src/utils/setNameUtils.test.ts
@@ -84,7 +84,7 @@ describe('setNameUtils', () => {
       getSetDisplayName(33333 as KnownSetIDs);
 
       expect(sentryUtils.reportError).toHaveBeenCalledTimes(3);
-      
+
       const calls = (sentryUtils.reportError as jest.Mock).mock.calls;
       expect(calls[0][1].setId).toBe(11111);
       expect(calls[1][1].setId).toBe(22222);

--- a/src/utils/setNameUtils.ts
+++ b/src/utils/setNameUtils.ts
@@ -305,9 +305,9 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
  */
 export function getSetDisplayName(setId: KnownSetIDs | undefined | null): string {
   if (setId === undefined || setId === null) return '';
-  
+
   const displayName = SET_DISPLAY_NAMES[setId];
-  
+
   // If set is not found, report to Sentry
   if (!displayName) {
     reportError(new Error(`Unknown set ID detected: ${setId}`), {
@@ -319,7 +319,7 @@ export function getSetDisplayName(setId: KnownSetIDs | undefined | null): string
     });
     return `Unknown Set (${setId})`;
   }
-  
+
   return displayName;
 }
 


### PR DESCRIPTION
- Enhanced getSetDisplayName() to report unknown set IDs to Sentry
- Added comprehensive context data (setId, type, available set count)
- Created complete test suite with 15 tests (all passing)
- Sentry reporting only occurs in production environment
- Helps identify new gear sets that need to be added to KnownSetIDs