### PR TITLE
fix: migrate merge queue to GitHub App authentication

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -54,10 +54,17 @@ jobs:
       github.event_name == 'status'
     
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_QUEUE_APP_ID }}
+          private-key: ${{ secrets.MERGE_QUEUE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -66,7 +73,7 @@ jobs:
       - name: Process Merge Queue
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { execSync } = require('child_process');
             const fs = require('fs');


### PR DESCRIPTION
Fixes the merge queue permission issues by migrating from personal access token to GitHub App authentication.

## Changes
- Replace PAT with GitHub App token generation using \ctions/create-github-app-token@v1\
- Use app token for checkout and github-script authentication
- Provides reliable access to check runs across all PRs

## GitHub App Details
- App ID: 2853993
- Permissions: Actions (Read), Checks (Read), Contents (R/W), Pull Requests (R/W), Workflows (R/W)

## Testing
Once merged, manually trigger the merge queue to verify it can read check runs:
\\\
gh workflow run merge-queue.yml
\\\

Resolves permission errors preventing automatic PR merging.