### PR TITLE
chore: migrate screen-size-testing workflow to GitHub App authentication

### DIFF
--- a/.github/workflows/screen-size-testing.yml
+++ b/.github/workflows/screen-size-testing.yml
@@ -475,11 +475,21 @@ jobs:
           path: screen-size-reports/
           retention-days: 90
 
+      - name: Generate GitHub App Token
+        if: always()
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_QUEUE_APP_ID }}
+          private-key: ${{ secrets.MERGE_QUEUE_APP_PRIVATE_KEY }}
+          owner: bkrupa
+          repositories: eso-log-aggregator-reports
+
       - name: Deploy Reports to GitHub Pages
         if: always()
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+          personal_token: ${{ steps.generate-token.outputs.token }}
           external_repository: bkrupa/eso-log-aggregator-reports
           publish_dir: screen-size-reports
           destination_dir: screen-size-tests/${{ github.ref_name }}/${{ github.run_number }}


### PR DESCRIPTION
## Summary

Migrates screen-size-testing workflow from Personal Access Token to GitHub App authentication.

## Changes

- Added GitHub App token generation step using \ctions/create-github-app-token@v1\
- Replaced \MERGE_QUEUE_TOKEN\ secret with dynamically generated app token
- Token scoped to \krupa/eso-log-aggregator-reports\ repository

## Benefits

- **Security**: GitHub App tokens expire after 1 hour (vs permanent PAT)
- **Audit trail**: Better tracking of cross-repo deployments
- **Consistency**: All workflows now use GitHub App authentication

## Prerequisites

-  GitHub App installed on \krupa/eso-log-aggregator-reports\ repository

## Post-Merge

After this merges, the \MERGE_QUEUE_TOKEN\ secret can be safely deleted as no workflows will reference it.

## Related

- PR #655 - Migrated merge-queue.yml to GitHub App