### PR TITLE
fix: scrub exposed OAuth credentials from documentation

### DIFF
--- a/documentation/ai-agents/mcp-tools/AI_MCP_PLAYWRIGHT_AUTH_SETUP.md
+++ b/documentation/ai-agents/mcp-tools/AI_MCP_PLAYWRIGHT_AUTH_SETUP.md
@@ -38,8 +38,8 @@ Generate a fresh token using the client credentials from `.env`:
 **Step 1: Read OAuth credentials from .env**
 ```typescript
 // .env contains:
-// OAUTH_CLIENT_ID=9ffe9fe3-b873-459a-9d78-acc9f168d79f
-// OAUTH_CLIENT_SECRET=R8B71E3qbUmdFlVnUdQiZkUKkbW6wZ1dXjuVTUE4
+// OAUTH_CLIENT_ID=your_client_id_here
+// OAUTH_CLIENT_SECRET=your_client_secret_here
 
 const clientId = process.env.OAUTH_CLIENT_ID;
 const clientSecret = process.env.OAUTH_CLIENT_SECRET;
@@ -293,8 +293,8 @@ await page.evaluate(() => {
 cat .env
 
 # Verify credentials are present
-# OAUTH_CLIENT_ID=9ffe9fe3-b873-459a-9d78-acc9f168d79f
-# OAUTH_CLIENT_SECRET=R8B71E3qbUmdFlVnUdQiZkUKkbW6wZ1dXjuVTUE4
+# OAUTH_CLIENT_ID=your_client_id_here
+# OAUTH_CLIENT_SECRET=your_client_secret_here
 
 # Load .env in your script
 import * as dotenv from 'dotenv';

--- a/documentation/ai-agents/mcp-tools/AI_MCP_QUICK_REFERENCE.md
+++ b/documentation/ai-agents/mcp-tools/AI_MCP_QUICK_REFERENCE.md
@@ -67,8 +67,8 @@ await page.reload();
 
 ### Required .env Variables
 ```properties
-OAUTH_CLIENT_ID=9ffe9fe3-b873-459a-9d78-acc9f168d79f
-OAUTH_CLIENT_SECRET=R8B71E3qbUmdFlVnUdQiZkUKkbW6wZ1dXjuVTUE4
+OAUTH_CLIENT_ID=your_client_id_here
+OAUTH_CLIENT_SECRET=your_client_secret_here
 ```
 
 ### Load .env in Scripts


### PR DESCRIPTION
## Summary

Replaces hardcoded OAuth client ID and client secret with placeholder values in AI agent documentation files.

## What changed
- **AI_MCP_PLAYWRIGHT_AUTH_SETUP.md**  replaced 2 occurrences of real credentials with \your_client_id_here\ / \your_client_secret_here\
- **AI_MCP_QUICK_REFERENCE.md**  replaced 1 occurrence of real credentials with placeholders

## Why
The OAuth client secret and client ID were inadvertently committed to tracked documentation files. The credentials have been **rotated** so the exposed values are no longer valid.

## Notes
- The \.env\ file (which also contains these values) is properly gitignored and was never committed
- \.env.example\ already used placeholder values  these docs now follow the same pattern