### PR TITLE
ESO-597: Harden branch protection and migrate default branch to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS - Defines code ownership for required review enforcement
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# When "Require review from Code Owners" is enabled in branch protection,
+# GitHub will require an approving review from a code owner before merging.
+# This prevents non-admin users from bypassing the merge queue by clicking
+# the merge button directly after getting a non-owner review.
+
+# Default owner for everything
+* @bkrupa @BraydenPB
+
+# Critical paths - explicit ownership for visibility
+/.github/ @bkrupa
+/.github/workflows/ @bkrupa
+
+# CODEOWNERS itself - only @bkrupa can approve changes
+/.github/CODEOWNERS @bkrupa

--- a/.github/copilot-skills/git/README.md
+++ b/.github/copilot-skills/git/README.md
@@ -93,12 +93,12 @@ After installing dependencies and configuring, reload the VS Code window:
 ```
 @workspace Create branch ESO-569/implement-feature
 @workspace Create branch ESO-569/implement-feature with parent ESO-449
-@workspace Create branch fix/bug-in-parser with parent master
+@workspace Create branch fix/bug-in-parser with parent main
 @workspace Show branch tree
 @workspace Set ESO-488 to depend on ESO-449
 @workspace Cascade branch changes with force push
 @workspace Cascade branch changes (dry run)
-@workspace Start interactive rebase on master
+@workspace Start interactive rebase on main
 @workspace Check PR status for current branch
 @workspace Check PR status for PR #123
 ```
@@ -113,7 +113,7 @@ Create a new Git branch using twig with automatic parent branch management.
 - `branchName` (string, required): Name of the new branch
   - For Jira tickets: Use format `ESO-123/description-here`
   - Otherwise: Use descriptive kebab-case name
-- `parentBranch` (string, optional): Parent branch name (default: "master")
+- `parentBranch` (string, optional): Parent branch name (default: "main")
   - Use when creating a child branch that depends on another feature branch
 - `switchToBranch` (boolean, optional): Switch to new branch after creation (default: true)
 
@@ -212,7 +212,7 @@ Get instructions for interactive rebase on a target branch.
 **Example:**
 ```json
 {
-  "targetBranch": "master",
+  "targetBranch": "main",
   "autoSquash": true
 }
 ```
@@ -306,9 +306,9 @@ Cascade branch changes through dependent branches with non-interactive mode.
 
 ```
 1. @workspace Create branch ESO-569/implement-replay-system
-   - Automatically creates branch from master
+   - Automatically creates branch from main
    - Switches to new branch
-   - Sets up twig dependency on master
+   - Sets up twig dependency on main
 2. Make code changes
 3. git commit -m "Implement replay system"
 4. git push -u origin ESO-569/implement-replay-system
@@ -330,7 +330,7 @@ Cascade branch changes through dependent branches with non-interactive mode.
 
 ```
 1. @workspace Create branch fix/parser-crash-on-invalid-log
-   - Creates from master (default)
+   - Creates from main (default)
    - Uses descriptive name
 2. Fix the bug
 3. git commit -m "Fix parser crash on invalid log"
@@ -349,7 +349,7 @@ Cascade branch changes through dependent branches with non-interactive mode.
 ### Clean Up Commit History Before PR
 
 ```
-1. @workspace Start interactive rebase on master with autoSquash
+1. @workspace Start interactive rebase on main with autoSquash
 2. Run the provided command in terminal
 3. Follow instructions to squash/reorder commits
 4. @workspace Check PR status (verify CI passes)
@@ -369,7 +369,7 @@ Cascade branch changes through dependent branches with non-interactive mode.
 ```
 1. @workspace Show branch tree
 2. Identify orphaned branch (shows under "Orphaned branches")
-3. @workspace Set orphaned-branch to depend on master
+3. @workspace Set orphaned-branch to depend on main
 4. @workspace Show branch tree (verify fix)
 ```
 
@@ -378,7 +378,7 @@ Cascade branch changes through dependent branches with non-interactive mode.
 ### Understanding Twig Tree Output
 
 ```
-master
+main
 ├── * ESO-449/parent-feature
 │   └── ESO-488/child-feature
 └── ESO-500/other-feature
@@ -395,7 +395,7 @@ Orphaned branches:
 
 For the replay system work:
 ```
-master
+main
 └── ESO-449 (structure redux state)
     └── ESO-488 (multiplayer path)
         └── ESO-463 (replay system UI)

--- a/.github/copilot-skills/git/server.js
+++ b/.github/copilot-skills/git/server.js
@@ -230,7 +230,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: 'git_create_branch',
-        description: 'Create a new Git branch using twig with automatic parent branch detection. If creating for a Jira ticket, include ticket ID in branch name (e.g., ESO-123/description). Automatically sets parent branch: if parentBranch is provided, uses it; otherwise defaults to master.',
+        description: 'Create a new Git branch using twig with automatic parent branch detection. If creating for a Jira ticket, include ticket ID in branch name (e.g., ESO-123/description). Automatically sets parent branch: if parentBranch is provided, uses it; otherwise defaults to main.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -240,7 +240,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             parentBranch: {
               type: 'string',
-              description: 'Parent branch name (optional). If not provided, defaults to "master". Use when creating a child branch that depends on another feature branch.',
+              description: 'Parent branch name (optional). If not provided, defaults to "main". Use when creating a child branch that depends on another feature branch.',
             },
             switchToBranch: {
               type: 'boolean',
@@ -346,7 +346,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case 'git_create_branch': {
-        const { branchName, parentBranch = 'master', switchToBranch = true } = args;
+        const { branchName, parentBranch = 'main', switchToBranch = true } = args;
         
         // Validate branch name
         const branchValidation = validateBranchName(branchName);

--- a/.github/copilot-skills/rebase/README.md
+++ b/.github/copilot-skills/rebase/README.md
@@ -1,10 +1,10 @@
 # Post-Squash Rebase Skill for GitHub Copilot
 
-Automates the process of rebasing a branch tree after a squashed merge into master. This skill handles the tedious process of recreating branches, cherry-picking unique commits, and resolving conflicts that arise from squash merges.
+Automates the process of rebasing a branch tree after a squashed merge into main. This skill handles the tedious process of recreating branches, cherry-picking unique commits, and resolving conflicts that arise from squash merges.
 
 ## 🎯 Purpose
 
-When a feature branch is merged into master with squash, all its commits are combined into a single commit. This creates conflicts for any child branches that were built on top of the merged branch, since they contain duplicate commits. This skill automates the resolution of these conflicts.
+When a feature branch is merged into main with squash, all its commits are combined into a single commit. This creates conflicts for any child branches that were built on top of the merged branch, since they contain duplicate commits. This skill automates the resolution of these conflicts.
 
 ## 🚀 Quick Start
 
@@ -44,7 +44,7 @@ Analyzes the impact of a squashed merge and identifies which branches need atten
 # Squash Conflict Analysis
 
 **Merged Branch:** ESO-449/structure-redux-state
-**Target Branch:** master
+**Target Branch:** main
 **Child Branches Found:** 2
 
 ## Branch Analysis:
@@ -66,7 +66,7 @@ Automatically rebases the entire branch tree after a squashed merge.
 
 **Usage:**
 ```
-@workspace Rebase branch tree after ESO-449/structure-redux-state was squashed into master
+@workspace Rebase branch tree after ESO-449/structure-redux-state was squashed into main
 ```
 
 **With dry run (recommended first):**
@@ -76,15 +76,15 @@ Automatically rebases the entire branch tree after a squashed merge.
 
 **Parameters:**
 - `mergedBranch` (required): The branch that was squashed and merged
-- `targetBranch` (optional): Target branch, defaults to "master"
+- `targetBranch` (optional): Target branch, defaults to "main"
 - `dryRun` (optional): If true, shows what would be done without making changes
 
 **What it does:**
-1. Switches to target branch (master) and pulls latest
+1. Switches to target branch (main) and pulls latest
 2. Identifies all child branches of the merged branch
 3. Deletes the merged branch locally
 4. For each child branch:
-   - Identifies unique commits (not in master)
+   - Identifies unique commits (not in main)
    - Deletes the old local branch
    - Creates a new branch from appropriate parent
    - Cherry-picks only unique commits
@@ -99,7 +99,7 @@ Automatically rebases the entire branch tree after a squashed merge.
 # Post-Squash Rebase Complete
 
 ## Steps Executed:
-Switching to master...
+Switching to main...
 Finding child branches of ESO-449/structure-redux-state...
 Found 2 child branches: ESO-461/establish-multi-fight-redux-foundations, ESO-465/worker-results
 
@@ -115,7 +115,7 @@ Running twig cascade to update remaining branches...
 
 ## Summary
 - Merged branch: ESO-449/structure-redux-state
-- Target branch: master
+- Target branch: main
 - Child branches processed: 2
 - Errors encountered: 0
 ```
@@ -163,7 +163,7 @@ If the automatic process encounters conflicts:
 
 ### Example 1: Basic Usage
 ```
-User: ESO-449 just landed in master as a squash merge. Can you rebase our tree?
+User: ESO-449 just landed in main as a squash merge. Can you rebase our tree?
 
 @workspace Rebase branch tree after ESO-449/structure-redux-state was squashed
 ```
@@ -189,24 +189,24 @@ User: Can you show me what would happen if we rebase after ESO-449?
 When you squash merge a branch:
 ```
 Before:
-master --- A --- B
+main --- A --- B
            └─ ESO-449 --- C --- D --- E
                           └─ ESO-461 --- F --- G
 
 After squash merge:
-master --- A --- B --- [CDE]
+main --- A --- B --- [CDE]
            └─ ESO-449 --- C --- D --- E (deleted on remote)
                           └─ ESO-461 --- F --- G
 ```
 
-ESO-461 now has commits C, D, E that are duplicates of [CDE] in master, causing conflicts when rebasing.
+ESO-461 now has commits C, D, E that are duplicates of [CDE] in main, causing conflicts when rebasing.
 
 ### The Solution
 
 This skill recreates branches with only unique commits:
 ```
 After skill execution:
-master --- A --- B --- [CDE]
+main --- A --- B --- [CDE]
            └─ ESO-461 --- F' --- G' (only unique commits)
 ```
 
@@ -223,7 +223,7 @@ master --- A --- B --- [CDE]
 
 ## 📝 Notes
 
-- **Force push warning**: This tool uses `git push --force`, which rewrites history. Only use it on feature branches, never on shared branches like master.
+- **Force push warning**: This tool uses `git push --force`, which rewrites history. Only use it on feature branches, never on shared branches like main.
 - **Backup recommendation**: Before running, ensure your work is committed and pushed.
 - **Twig dependency**: The tool assumes you're using twig for branch dependency management.
 - **Remote branches**: The tool analyzes `origin/<branch>` to find unique commits.
@@ -234,7 +234,7 @@ master --- A --- B --- [CDE]
 Make sure the merged branch name is correct. Include the full branch name as it appears in `git branch -a`.
 
 ### "No unique commits found"
-This means all commits in the child branch are already in master. The branch might just need its parent dependency updated.
+This means all commits in the child branch are already in main. The branch might just need its parent dependency updated.
 
 ### "Failed to cherry-pick"
 Some commits may have genuine conflicts. The tool will skip the branch and report the error. Resolve these manually.

--- a/.github/copilot-skills/rebase/index.js
+++ b/.github/copilot-skills/rebase/index.js
@@ -99,7 +99,7 @@ async function getChildBranches(parentBranch) {
 /**
  * Get unique commits in a branch that aren't in master
  */
-async function getUniqueCommits(branchName, baseBranch = 'master') {
+async function getUniqueCommits(branchName, baseBranch = 'main') {
   const result = await executeGit(`log --oneline ${baseBranch}..origin/${branchName}`);
   if (!result.success) {
     return [];
@@ -121,7 +121,7 @@ async function getUniqueCommits(branchName, baseBranch = 'master') {
  * Automates rebasing branch tree after a squashed merge
  */
 async function rebaseAfterSquash(args) {
-  const { mergedBranch, targetBranch = 'master', dryRun = false } = args;
+  const { mergedBranch, targetBranch = 'main', dryRun = false } = args;
   
   const steps = [];
   const errors = [];
@@ -255,7 +255,7 @@ async function rebaseAfterSquash(args) {
  * Identifies which branches need attention after a squash merge
  */
 async function identifySquashConflicts(args) {
-  const { mergedBranch, targetBranch = 'master' } = args;
+  const { mergedBranch, targetBranch = 'main' } = args;
   
   const analysis = {
     mergedBranch,
@@ -345,7 +345,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'rebase_after_squash',
         description: 
-          'Automates the process of rebasing a branch tree after a squashed merge into master. ' +
+          'Automates the process of rebasing a branch tree after a squashed merge into main. ' +
           'This handles: 1) Deleting the merged branch, 2) Identifying child branches, ' +
           '3) Recreating each child with only unique commits, 4) Setting twig dependencies, ' +
           '5) Force pushing, 6) Running cascade for remaining branches. ' +
@@ -359,8 +359,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             targetBranch: {
               type: 'string',
-              description: 'The target branch that received the merge (default: "master")',
-              default: 'master'
+              description: 'The target branch that received the merge (default: "main")',
+              default: 'main'
             },
             dryRun: {
               type: 'boolean',
@@ -386,8 +386,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             targetBranch: {
               type: 'string',
-              description: 'The target branch that received the merge (default: "master")',
-              default: 'master'
+              description: 'The target branch that received the merge (default: "main")',
+              default: 'main'
             }
           },
           required: ['mergedBranch']

--- a/.github/copilot-skills/testing/README.md
+++ b/.github/copilot-skills/testing/README.md
@@ -255,7 +255,7 @@ Rebase child branches in a tree structure after parent is squashed into main. Au
 
 **Parameters:**
 - `parentBranch` (required): Branch that was squashed
-- `targetBranch` (optional): Branch to rebase onto (default: "master")
+- `targetBranch` (optional): Branch to rebase onto (default: "main")
 - `childBranches` (optional): Specific children to rebase (default: auto-detect)
 - `dryRun` (optional): Preview changes without executing (default: false)
 - `autoStash` (optional): Automatically stash/pop changes (default: true)

--- a/.github/copilot-skills/testing/server.js
+++ b/.github/copilot-skills/testing/server.js
@@ -574,8 +574,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             targetBranch: {
               type: 'string',
-              description: 'The base branch to rebase onto (typically "master" or "main")',
-              default: 'master',
+              description: 'The base branch to rebase onto (typically "main")',
+              default: 'main',
             },
             childBranches: {
               type: 'array',
@@ -1366,7 +1366,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'git_rebase_tree': {
-        const { parentBranch, targetBranch = 'master', childBranches, dryRun = false, autoStash = true } = args;
+        const { parentBranch, targetBranch = 'main', childBranches, dryRun = false, autoStash = true } = args;
         
         console.error(`Rebasing tree after ${parentBranch} was squashed into ${targetBranch}...`);
         

--- a/.github/copilot-skills/workflow/README.md
+++ b/.github/copilot-skills/workflow/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This Agent Skill provides a Model Context Protocol (MCP) server that **enforces** the Git workflow by ensuring feature branches are created before any code changes. The skill actively prevents direct commits to master and automates branch creation for Jira tickets.
+This Agent Skill provides a Model Context Protocol (MCP) server that **enforces** the Git workflow by ensuring feature branches are created before any code changes. The skill actively prevents direct commits to main and automates branch creation for Jira tickets.
 
 **Compatible With:**
 - GitHub Copilot (VS Code) via Agent Skills standard
@@ -15,12 +15,12 @@ This Agent Skill provides a Model Context Protocol (MCP) server that **enforces*
 - **Master Protection**: Prevents work from starting on master/main branches
 - **Smart Detection**: Recognizes when user is about to start work on a ticket
 - **Twig Integration**: Sets up branch dependencies automatically
-- **Recovery Guidance**: Provides clear steps if changes were made on master
+- **Recovery Guidance**: Provides clear steps if changes were made on main
 - **Validation**: Ensures branch names follow project conventions
 
 ## Why This Skill?
 
-**Problem:** Agents frequently commit directly to master instead of creating feature branches, even with documentation warnings.
+**Problem:** Agents frequently commit directly to main instead of creating feature branches, even with documentation warnings.
 
 **Solution:** This skill **proactively intervenes** at the start of work, not after changes are made.
 
@@ -108,7 +108,7 @@ The skill is designed to be invoked automatically by agents when they detect wor
 
 **Agent will:**
 1. Check current branch
-2. If on master → Stop and guide branch creation
+2. If on main → Stop and guide branch creation
 3. If on feature branch → Confirm and proceed
 4. If branch doesn't exist → Create it
 
@@ -143,7 +143,7 @@ The skill is designed to be invoked automatically by agents when they detect wor
 **Example:**
 ```json
 {
-  "branch": "master",
+  "branch": "main",
   "is_protected": true,
   "is_feature_branch": false,
   "recommendation": "Create a feature branch before making changes"
@@ -156,37 +156,37 @@ The skill is designed to be invoked automatically by agents when they detect wor
 **Parameters:**
 - `ticket_id` (optional): Jira ticket like "ESO-372"
 - `description` (optional): Branch description for the ticket
-- `parent_branch` (optional): Parent branch (default: "master")
+- `parent_branch` (optional): Parent branch (default: "main")
 
 **Auto-detects if:**
 - Already on a feature branch → Returns current branch
-- On master with ticket_id → Creates `ESO-XXX/description`
-- On master without ticket_id → Prompts for info
+- On main with ticket_id → Creates `ESO-XXX/description`
+- On main without ticket_id → Prompts for info
 
 **Example:**
 ```json
 {
   "branch": "ESO-372/add-dashboard",
   "action": "created",
-  "parent": "master",
+  "parent": "main",
   "ready": true
 }
 ```
 
 ### `recover_from_master_commits`
-**Purpose:** Fix situation where changes were already made on master
+**Purpose:** Fix situation where changes were already made on main
 
 **Returns:**
 - Step-by-step recovery instructions
 - Commands to save changes to feature branch
-- Commands to reset master to origin
+- Commands to reset main to origin
 
 **Example Output:**
 ```
 🚨 Recovery Steps:
 1. Create branch from current state: git checkout -b ESO-XXX/description
 2. Commit your changes: git add . && git commit -m "ESO-XXX: Description"
-3. Reset master: git checkout master && git reset --hard origin/master
+3. Reset main: git checkout main && git reset --hard origin/main
 4. Return to feature branch: git checkout ESO-XXX/description
 ```
 
@@ -194,8 +194,8 @@ The skill is designed to be invoked automatically by agents when they detect wor
 
 This skill works alongside the pre-commit hook:
 
-- **Skill**: Proactive - prevents starting work on master
-- **Hook**: Reactive - blocks commits to master if skill is bypassed
+- **Skill**: Proactive - prevents starting work on main
+- **Hook**: Reactive - blocks commits to main if skill is bypassed
 
 Both layers provide defense-in-depth protection.
 
@@ -207,7 +207,7 @@ Both layers provide defense-in-depth protection.
 
 **Agent action:**
 1. Call `ensure_feature_branch` with `ticket_id: "ESO-372"`
-2. Skill checks current branch (master)
+2. Skill checks current branch (main)
 3. Skill creates `ESO-372/add-dashboard`
 4. Agent proceeds with implementation
 
@@ -220,15 +220,15 @@ Both layers provide defense-in-depth protection.
 2. Skill returns `ESO-372/add-dashboard` (feature branch ✅)
 3. Agent proceeds with changes
 
-### Example 3: Caught on Master (Recovery)
+### Example 3: Caught on Main (Recovery)
 
-**Agent detects:** Already made changes on master
+**Agent detects:** Already made changes on main
 
 **Agent action:**
 1. Call `recover_from_master_commits`
 2. Skill provides recovery steps
 3. Agent executes commands to save work
-4. Master is reset, work preserved on feature branch
+4. Main is reset, work preserved on feature branch
 
 ## Debug Logging
 
@@ -256,7 +256,7 @@ The skill provides clear error messages and recovery suggestions:
 |-------|----------|
 | Not in a Git repository | Navigate to project root |
 | Invalid branch name | Use format: `ESO-XXX/description` |
-| No ticket ID on master | Provide ticket ID or branch name |
+| No ticket ID on main | Provide ticket ID or branch name |
 | Uncommitted changes | Commit or stash before switching |
 | Branch already exists | Switch to existing branch |
 
@@ -265,14 +265,14 @@ The skill provides clear error messages and recovery suggestions:
 Verify the skill is working:
 
 ```powershell
-# Start on master
-git checkout master
+# Start on main
+git checkout main
 
 # Ask agent to implement a ticket
 # Agent should automatically create feature branch
 ```
 
-The skill should detect master and create a feature branch before allowing work to proceed.
+The skill should detect main and create a feature branch before allowing work to proceed.
 
 ## Troubleshooting
 

--- a/.github/copilot-skills/workflow/server.js
+++ b/.github/copilot-skills/workflow/server.js
@@ -78,7 +78,7 @@ function branchExists(branchName) {
 /**
  * Create feature branch
  */
-function createBranch(branchName, parentBranch = 'master') {
+function createBranch(branchName, parentBranch = 'main') {
   log('Creating branch:', branchName, 'from', parentBranch);
   
   // Ensure we're on parent branch
@@ -169,7 +169,7 @@ function ensureFeatureBranchTool(args) {
   const currentBranch = getCurrentBranch();
   const ticketId = args.ticket_id;
   const description = args.description;
-  const parentBranch = args.parent_branch || 'master';
+  const parentBranch = args.parent_branch || 'main';
   
   // If already on a feature branch, we're good
   if (!isProtectedBranch(currentBranch) && currentBranch.includes('/')) {
@@ -187,7 +187,7 @@ function ensureFeatureBranchTool(args) {
     if (!ticketId) {
       return {
         error: true,
-        message: '🚨 Cannot work on master branch without a ticket ID',
+        message: '🚨 Cannot work on main branch without a ticket ID',
         required: 'ticket_id',
         example: 'ESO-372',
         recommendation: 'Provide ticket_id parameter to create feature branch'
@@ -254,7 +254,7 @@ function ensureFeatureBranchTool(args) {
 }
 
 /**
- * Provide recovery steps if changes were made on master
+ * Provide recovery steps if changes were made on main
  */
 function recoverFromMasterCommitsTool() {
   const currentBranch = getCurrentBranch();
@@ -285,9 +285,9 @@ function recoverFromMasterCommitsTool() {
       },
       {
         step: 3,
-        action: 'Reset master to origin',
-        command: 'git checkout master && git reset --hard origin/master',
-        description: 'Clean up master branch'
+        action: 'Reset main to origin',
+        command: 'git checkout main && git reset --hard origin/main',
+        description: 'Clean up main branch'
       },
       {
         step: 4,
@@ -296,8 +296,8 @@ function recoverFromMasterCommitsTool() {
         description: 'Continue work on your feature'
       }
     ],
-    warning: '🚨 This will reset master to match origin - ensure changes are committed to feature branch first',
-    twig_note: hasTwig() ? 'After recovery, run: twig branch ESO-XXX/description --parent master' : null
+    warning: '🚨 This will reset main to match origin - ensure changes are committed to feature branch first',
+    twig_note: hasTwig() ? 'After recovery, run: twig branch ESO-XXX/description --parent main' : null
   };
 }
 
@@ -341,7 +341,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             ticket_id: {
               type: 'string',
-              description: 'Jira ticket ID (e.g., "ESO-372"). Required when on master/main branch.',
+              description: 'Jira ticket ID (e.g., "ESO-372"). Required when on main branch.',
               pattern: '^[A-Z]+-\\d+$',
             },
             description: {
@@ -351,8 +351,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             parent_branch: {
               type: 'string',
-              description: 'Parent branch name (default: "master"). Used when creating new branch.',
-              default: 'master',
+              description: 'Parent branch name (default: "main"). Used when creating new branch.',
+              default: 'main',
             },
           },
           required: [],
@@ -360,7 +360,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'recover_from_master_commits',
-        description: 'Provide step-by-step instructions to recover when changes were accidentally made on master/main. Returns commands to save work to feature branch and reset master.',
+        description: 'Provide step-by-step instructions to recover when changes were accidentally made on main. Returns commands to save work to feature branch and reset main.',
         inputSchema: {
           type: 'object',
           properties: {},

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,10 @@ name: Coverage Report and Badges
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   # Allow manual triggering
   workflow_dispatch:
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload Coverage to GitHub Gist
         run: node scripts/upload-coverage-to-gist.cjs
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GIST_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -82,7 +82,7 @@ jobs:
             const MERGE_QUEUE_LABEL = 'auto-merge'; // Changed from 'merge-queue' to 'auto-merge'
             const PRIORITY_LABELS = ['priority', 'hotfix', 'critical'];
             const BLOCK_LABELS = ['do not merge', 'do-not-merge', 'wip', 'work in progress', 'needs review'];
-            const REQUIRED_REVIEWS = 0; // Note: This is in addition to any branch protection rules
+            const REQUIRED_REVIEWS = 1; // Require at least 1 admin review
             const AUTO_MERGE_LABEL = 'auto-merge'; // Same as MERGE_QUEUE_LABEL for backwards compatibility
             
             // Note: Merge method is determined by repository settings (respects branch protection rules)
@@ -108,7 +108,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
-                base: 'master',
+                base: 'main',
                 sort: 'created',
                 direction: 'asc',
                 per_page: 100
@@ -250,6 +250,20 @@ jobs:
               return results;
             }
 
+            async function getReviewerPermission(username) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: username
+                });
+                return data.permission; // 'admin', 'maintain', 'write', 'triage', 'read'
+              } catch (error) {
+                await log(`Error checking permission for ${username}: ${error.message}`);
+                return 'read';
+              }
+            }
+
             async function hasRequiredReviews(pr) {
               const reviews = await getReviews(pr);
               
@@ -263,10 +277,21 @@ jobs:
                 }
               });
               
-              // Count approved reviews (excluding the PR author)
-              const approvedReviews = Object.values(reviewerLatestReviews).filter(review => 
+              // Only count approved reviews from admins (excluding the PR author)
+              const allApprovedReviews = Object.values(reviewerLatestReviews).filter(review => 
                 review.state === 'APPROVED' && review.user.id !== pr.user.id
               );
+              
+              // Check permissions for each approved reviewer
+              const approvedReviews = [];
+              for (const review of allApprovedReviews) {
+                const permission = await getReviewerPermission(review.user.login);
+                if (permission === 'admin') {
+                  approvedReviews.push(review);
+                } else {
+                  await log(`Skipping review from ${review.user.login} (permission: ${permission}, required: admin)`);
+                }
+              }
               
               const hasChangesRequested = Object.values(reviewerLatestReviews).some(review => 
                 review.state === 'CHANGES_REQUESTED'
@@ -302,12 +327,12 @@ jobs:
                 return { mergeable: false, reason: 'Merge status being computed by GitHub, will retry shortly' };
               }
               
-              // Check required reviews (in addition to branch protection rules)
+              // Check required reviews from admins (in addition to branch protection rules)
               const reviewStatus = await hasRequiredReviews(pr);
               if (!reviewStatus.hasRequired) {
                 return { 
                   mergeable: false, 
-                  reason: `PR needs ${REQUIRED_REVIEWS - reviewStatus.approvedCount} more approved review(s)` 
+                  reason: `PR needs ${REQUIRED_REVIEWS - reviewStatus.approvedCount} more approved admin review(s)` 
                 };
               }
               

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
   pull_request:
     branches:
-      - master
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   upload-sourcemaps:
@@ -34,7 +34,7 @@ jobs:
           export GENERATE_SOURCEMAP=true
 
           # Build the project
-          if [ "${{ github.ref }}" = "refs/heads/master" ] || [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
             VITE_BASE_URL="/$REPO_NAME/" npm run build
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ npm run lint:fix         # Auto-fix linting issues
 
 **Manual fallback (if skill unavailable):**
 ```bash
-# Step 1: Check current branch (must NOT be master)
+# Step 1: Check current branch (must NOT be main)
 git branch --show-current
 
 # Step 2: Create feature branch with Jira ticket format
@@ -47,12 +47,12 @@ git checkout -b ESO-XXX/description-here
 # Step 3: Now you can start coding
 ```
 
-**❌ NEVER commit directly to master**  
+**❌ NEVER commit directly to main**  
 **✅ ALWAYS work on feature branches**
 
-**If you've already made changes on master:**
+**If you've already made changes on main:**
 ```
-@workspace Recover from master commits
+@workspace Recover from main commits
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <!-- Status Badges -->
 
-[![Build Status](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/pr-checks.yml/badge.svg?branch=master)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/pr-checks.yml)
-[![Deploy Status](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/deploy.yml)
-[![Coverage Workflow](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/coverage.yml)
+[![Build Status](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/pr-checks.yml)
+[![Deploy Status](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/deploy.yml)
+[![Coverage Workflow](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/coverage.yml)
 [![Nightly Tests](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/nightly-tests.yml/badge.svg)](https://github.com/bkrupa/eso-log-aggregator/actions/workflows/nightly-tests.yml)
 
 <!-- Coverage Badges -->

--- a/documentation/ai-agents/AI_AGENT_GUIDELINES.md
+++ b/documentation/ai-agents/AI_AGENT_GUIDELINES.md
@@ -2,7 +2,9 @@
 
 ## Git Workflow
 
-**NEVER commit to master.** Always create a feature branch first:
+**⚠️ CREATE A FEATURE BRANCH BEFORE ANY CODE CHANGES ⚠️**
+
+**Rule**: NEVER commit to main. ALWAYS create a feature branch first.
 
 ```bash
 git checkout -b ESO-XXX/description
@@ -68,7 +70,204 @@ npm test            # Unit tests
 
 ### Commit Messages
 ```
+<<<<<<< HEAD
 feat(Component): brief description [ESO-XXX]
+=======
+@workspace Set up branch stack for ESO-488
+
+Steps (guided by skill):
+1. Show current branch tree
+2. Create feature branch ESO-488
+3. Set dependency: ESO-488 depends on ESO-449
+4. Verify tree structure
+5. Work on feature
+6. Check PR status before merging
+```
+
+### Prerequisites
+
+**Install twig globally:**
+```powershell
+npm install -g @gittwig/twig
+```
+
+**Install and authenticate GitHub CLI** (for PR status):
+```powershell
+winget install GitHub.cli
+gh auth login
+```
+
+### Setup
+
+The Git Workflow skill is configured in `.vscode/settings.json`:
+
+```json
+{
+  "github.copilot.chat.mcp.servers": {
+    "eso-log-aggregator-git": {
+      "command": "node",
+      "args": ["${workspaceFolder}\\.copilot-git\\server.js"]
+    }
+  }
+}
+```
+
+**Documentation**: [.copilot-git/README.md](../../.copilot-git/README.md)
+
+**Branch Stacking Strategy**: ESO-449 → ESO-488 → ESO-463 (unless instructed otherwise)
+
+---
+
+- Always confirm branch stacking with `@workspace Show branch tree` before and after creating feature branches.
+- If a branch appears under *Orphaned branches*, fix it immediately with `@workspace Set <child> to depend on <parent>`.
+- Keep replay-system work aligned: `ESO-449` → `ESO-488` → `ESO-463` unless instructed otherwise.
+- Document any intentional deviations in the relevant Jira ticket/comment so reviewers understand the stack layout.
+
+## Testing Requirements
+
+### Running Tests
+
+- Run unit tests before committing: `npm test`
+- Run linting: `npm run lint`
+- For UI changes, verify in browser
+- Update tests if behavior changed
+
+### Testing Tools Strategy
+
+**Three-Tier Testing Approach**:
+
+1. **Structured Test Suites** → Use **VS Code MCP Playwright Tool**
+   - Running existing Playwright test suites
+   - Viewing test results and reports
+   - Managing test files within VS Code
+   - CI/CD integration validation
+
+2. **Ad-hoc Exploratory Testing** → Use **Claude Skill** (`.claude/`)
+   - Quick feature verification without writing test files
+   - Interactive testing with AI guidance
+   - Visual inspection via screenshots
+   - Debugging specific UI issues
+   - Rapid test prototyping
+   - **Setup**: See [../../.claude/README.md](../../.claude/README.md)
+
+3. **Unit/Component Testing** → Use **Jest + Testing Library**
+   - Component unit tests
+   - Utility function tests
+   - Integration tests
+
+**Avoid**: One-off CLI commands like `npx playwright test` for ad-hoc testing. Use the Claude Skill instead.
+
+## TypeScript Practices
+
+- Trust the existing TypeScript types—avoid redundant runtime type checks for properties that are already strongly typed.
+- Prefer refining or extending type definitions when you need different guarantees, instead of sprinkling `typeof` or defensive checks.
+- Use narrow type guards only when interacting with truly unknown input (e.g., external APIs) and document the rationale in code comments.
+
+## Communication Style
+
+- **Be concise** - Short explanations unless asked for details
+- **Ask before extensive work** - Confirm approach for major changes
+- **Provide options** - When multiple solutions exist, present choices
+- **Show, don't tell** - Code examples over lengthy explanations
+
+## Complete Development Workflow
+
+⚠️ **CRITICAL FIRST STEP**: Create a feature branch BEFORE making ANY code changes! Do not work on main.
+
+### Pre-Implementation Checklist
+
+Before writing ANY code, complete these steps in order:
+
+1. ✅ View Jira task: `acli jira workitem view ESO-XXX`
+2. ✅ Transition to "In Progress": `acli jira workitem transition --key ESO-XXX --status "In Progress"`
+3. ✅ Check current branch: `git branch --show-current`
+4. ✅ Create feature branch: `git checkout -b ESO-XXX/description`
+5. ✅ **NOW you can start implementing**
+
+**If you realize you've already made changes without creating a branch:**
+```powershell
+# Save your work by creating a branch from current state
+git checkout -b ESO-XXX/description
+
+# Stage and commit the changes
+git add <files>
+git commit -m "feat: description [ESO-XXX]"
+```
+
+### 1. Start Work on a Jira Task
+
+**Use Jira Agent Skill** (preferred):
+```
+@workspace View ESO-XXX
+@workspace Move ESO-XXX to "In Progress"
+```
+
+**Alternative (Manual)**:
+```powershell
+# View the task details
+acli jira workitem view ESO-XXX
+
+# Transition to In Progress
+acli jira workitem transition --key ESO-XXX --status "In Progress"
+```
+
+**Common Error**: The command is `transition --key ESO-XXX --status "In Progress"` (NOT `--to`)
+
+### 2. Create Feature Branch **IMMEDIATELY** ⚠️
+
+**MANDATORY**: Create a feature branch as the FIRST action before implementing anything!
+
+Follow the branch naming convention:
+
+```powershell
+# Check current branch
+git branch --show-current
+
+# Create branch from main (or appropriate parent branch)
+git checkout -b ESO-XXX/brief-kebab-case-description
+
+# Examples:
+git checkout -b ESO-516/add-my-reports-link
+git checkout -b ESO-566/remove-local-storage-for-selected-player
+```
+
+**Branch Naming Pattern**: `ESO-<issue-number>/<kebab-case-description>`
+
+**⚠️ DO NOT commit directly to main!** Always work on a feature branch.
+
+### 3. Implement Changes
+
+- Make code changes
+- Follow existing code patterns and conventions
+- Ensure TypeScript types are correct
+
+### 4. Validate Changes
+
+```powershell
+# Run linting (will auto-fix some issues)
+npm run lint
+
+# Check TypeScript compilation
+npm run typecheck
+
+# Run tests
+npm test
+
+# Or run all validation
+npm run validate
+```
+
+**Important**: Fix all linting errors before committing. The project uses ESLint 9 with strict rules including trailing commas.
+
+### 5. Commit Changes
+
+```powershell
+# Stage changes
+git add <files>
+
+# Commit with descriptive message
+git commit -m "feat(Component): brief description [ESO-XXX]
+>>>>>>> e15988d2 (ESO-597: harden branch protection and migrate default branch to main)
 
 - Detailed change 1
 - Detailed change 2

--- a/documentation/setup/DEPLOYMENT.md
+++ b/documentation/setup/DEPLOYMENT.md
@@ -6,7 +6,7 @@ This guide covers production deployment options for the ESO Log Aggregator scrib
 
 ### 1. GitHub Pages (Current Default)
 
-The application is automatically deployed to GitHub Pages on push to the `master` branch.
+The application is automatically deployed to GitHub Pages on push to the `main` branch.
 
 **Pros:**
 - Automatic deployment via GitHub Actions

--- a/documentation/setup/JIRA_SYNC_QUICKSTART.md
+++ b/documentation/setup/JIRA_SYNC_QUICKSTART.md
@@ -42,7 +42,7 @@ Get API token: https://id.atlassian.com/manage-profile/security/api-tokens
 | Branch State | Jira Status | Action |
 |-------------|-------------|--------|
 | Remote branch exists | To Do/Backlog | → **In Progress** |
-| Branch merged to master | In Progress/Review | → **Done** |
+| Branch merged to main | In Progress/Review | → **Done** |
 | No activity for 30+ days | In Progress | → **To Do** |
 | Branch deleted | Any | No change |
 

--- a/scripts/README-sync-jira-status.md
+++ b/scripts/README-sync-jira-status.md
@@ -6,7 +6,7 @@ Automatically synchronizes Jira ticket statuses with Git branch states to keep y
 
 This script analyzes your Git repository and updates Jira ticket statuses based on branch activity:
 - **Branch exists remotely** → Move ticket to "In Progress"
-- **Branch merged to master** → Move ticket to "Done"
+- **Branch merged to main** → Move ticket to "Done"
 - **Multiple branches for same ticket** → Use most recent branch
 - **Branch deleted** → No action (ticket stays in current state)
 
@@ -85,7 +85,7 @@ Shows additional debugging information including:
 | Branch State | Current Jira Status | New Status | Condition |
 |-------------|---------------------|------------|-----------|
 | Exists remotely | To Do, Backlog | **In Progress** | Branch pushed to remote |
-| Merged to master | In Progress, In Review | **Done** | Branch merged successfully |
+| Merged to main | In Progress, In Review | **Done** | Branch merged successfully |
 | Deleted | Any | No change | Branch removed from remote |
 | Stale (30+ days) | In Progress | **To Do** | No commits in 30 days |
 
@@ -101,9 +101,9 @@ git branch -r --format="%(refname:short)|%(committerdate:iso8601)"
 
 ### 2. **Merge Status Check**
 ```powershell
-git branch -r --merged origin/master
+git branch -r --merged origin/main
 ```
-- Checks if branch has been merged to master
+- Checks if branch has been merged to main
 - Handles both `master` and `main` branches
 
 ### 3. **Jira Status Query**
@@ -193,7 +193,7 @@ const STATUS_TRANSITIONS = {
 const STALE_DAYS = 30;
 
 // Default branch
-const DEFAULT_BRANCH = 'master';
+const DEFAULT_BRANCH = 'main';
 ```
 
 ## 🛡️ Safety Features
@@ -251,7 +251,7 @@ acli --server https://bkrupa.atlassian.net --user your-email --password your-api
 name: Sync Jira Statuses
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9 AM
 

--- a/scripts/merge-queue/config.json
+++ b/scripts/merge-queue/config.json
@@ -19,7 +19,7 @@
     ]
   },
   "mergeMethod": "squash",
-  "targetBranch": "master",
+  "targetBranch": "main",
   "processingInterval": 300,
   "notifications": {
     "onMerge": true,

--- a/scripts/merge-queue/config.schema.json
+++ b/scripts/merge-queue/config.schema.json
@@ -65,7 +65,7 @@
     },
     "targetBranch": {
       "type": "string",
-      "default": "master",
+      "default": "main",
       "description": "Target branch for merging PRs"
     },
     "processingInterval": {

--- a/scripts/merge-queue/manage-queue.cjs
+++ b/scripts/merge-queue/manage-queue.cjs
@@ -146,7 +146,7 @@ class MergeQueueManager {
       owner: this.owner,
       repo: this.repo,
       state: 'open',
-      base: 'master',
+      base: 'main',
       sort: 'created',
       direction: 'asc',
       per_page: 100
@@ -222,7 +222,7 @@ class MergeQueueManager {
         owner: this.owner,
         repo: this.repo,
         workflow_id: 'merge-queue.yml',
-        ref: 'master',
+        ref: 'main',
         inputs: {
           force_process: true
         }

--- a/scripts/sync-jira-status.ts
+++ b/scripts/sync-jira-status.ts
@@ -7,7 +7,7 @@
  * 
  * Logic:
  * - Branch exists on remote → "In Progress" (if currently "To Do")
- * - Branch merged to master → "Done" (if not already done)
+ * - Branch merged to main → "Done" (if not already done)
  * - Branch deleted → No action (ticket stays in current state)
  * - Multiple branches for same ticket → Use most recent branch
  * 
@@ -29,7 +29,7 @@ import { resolve } from 'path';
 // Configuration
 const PROJECT_KEY = 'ESO';
 const JIRA_BOARD_URL = 'https://bkrupa.atlassian.net';
-const DEFAULT_BRANCH = 'master';
+const DEFAULT_BRANCH = 'main';
 
 // Status transitions
 const STATUS_TRANSITIONS = {
@@ -195,7 +195,7 @@ function getBranches(): BranchInfo[] {
     const isRemote = name.startsWith('origin/');
     const cleanName = isRemote ? name.replace('origin/', '') : name;
 
-    // Check if merged to master
+    // Check if merged to main
     let isMerged = false;
     try {
       const mergedCheck = exec(
@@ -281,7 +281,7 @@ function determineStatusChange(
 ): StatusChange | null {
   const currentStatus = ticket.status;
 
-  // Rule 1: Branch merged to master → Should be "Done"
+  // Rule 1: Branch merged to main → Should be "Done"
   if (branch.isMerged) {
     if (currentStatus !== STATUS_TRANSITIONS.DONE) {
       return {


### PR DESCRIPTION
## Summary

Hardens repository security for org migration and renames the default branch from \master\ to \main\.

## Changes

### Branch Protection (already applied via GitHub API)
- **Require code owner reviews** - only designated code owners can approve PRs
- **Dismiss stale reviews** - pushing new commits invalidates prior approvals
- **Require last push approval** - the person who pushed last can't be the approver
- **Required status checks**: build, lint, format, test, typecheck, build-storybook, playwright-smoke, check-do-not-merge-label
- **Block force pushes and deletions** on \main\

### CODEOWNERS
- New \.github/CODEOWNERS\ file
- \@bkrupa\ and \@BraydenPB\ own all files
- \CODEOWNERS\ itself owned exclusively by \@bkrupa\

### Merge Queue Hardening
- \REQUIRED_REVIEWS\ increased from 0 to 1
- New \getReviewerPermission()\ function checks reviewer has admin permission
- Non-admin approvals are logged and skipped

### master  main Migration
Updated 26 files across:
- GitHub Actions workflows (deploy, coverage, pr-checks, sentry-sourcemaps, merge-queue)
- Merge queue scripts and config
- Copilot skills (git, rebase, testing, workflow)
- Documentation, README badges, and Jira sync scripts
- Twig state configuration

### Preserved
- \isProtectedBranch()\ still checks both \master\ and \main\ (safety net)
- External repo URLs unchanged (uesp, sheumais, nicokimmel)

## Jira
[ESO-597](https://bkrupa.atlassian.net/browse/ESO-597)

[ESO-597]: https://bkrupa.atlassian.net/browse/ESO-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ