### PR TITLE
chore: add open source licensing and community files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Checklist
+
+- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
+- [ ] If prompted by the CLA check, I commented exactly:
+  `I have read the CLA Document and I hereby sign the CLA`

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,35 @@
+name: CLA Check
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event_name == 'issue_comment' && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/${{ github.repository }}/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: dependabot[bot],github-actions[bot],renovate[bot]
+          custom-notsigned-prcomment: >
+            Thank you for your contribution. Please review and sign our CLA at
+            https://github.com/${{ github.repository }}/blob/main/CLA.md by commenting exactly:
+            I have read the CLA Document and I hereby sign the CLA
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thank you.
+          lock-pullrequest-aftermerge: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,66 @@ on:
       - unlabeled
 
 jobs:
+  check-cla-status:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
+    steps:
+      - name: Wait for and verify CLA check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const maxAttempts = 12; // 2 minutes total (12 × 10s)
+            const delayMs = 10000;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              // Check runs API (used by newer versions of contributor-assistant)
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+                check_name: 'CLA Assistant'
+              });
+
+              if (checkRuns.total_count > 0) {
+                const run = checkRuns.check_runs[0];
+                if (run.status === 'completed') {
+                  if (run.conclusion === 'success') {
+                    console.log('✅ CLA check passed');
+                    return;
+                  }
+                  core.setFailed(`❌ CLA check failed (${run.conclusion}). All contributors must sign the CLA by commenting exactly:\n\n    I have read the CLA Document and I hereby sign the CLA`);
+                  return;
+                }
+              }
+
+              // Commit statuses API (used by older versions)
+              const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha
+              });
+
+              const cla = statuses.find(s => s.context === 'CLA Assistant');
+              if (cla) {
+                if (cla.state === 'success') {
+                  console.log('✅ CLA status passed');
+                  return;
+                }
+                if (cla.state === 'failure' || cla.state === 'error') {
+                  core.setFailed(`❌ CLA not signed (${cla.state}). All contributors must sign the CLA by commenting exactly:\n\n    I have read the CLA Document and I hereby sign the CLA`);
+                  return;
+                }
+              }
+
+              if (attempt < maxAttempts) {
+                console.log(`⏳ CLA check not yet complete — waiting 10s (attempt ${attempt}/${maxAttempts})`);
+                await new Promise(r => setTimeout(r, delayMs));
+              }
+            }
+
+            core.setFailed('❌ CLA check did not complete within 2 minutes. Please verify the CLA workflow is configured correctly.');
+
   check-do-not-merge-label:
     runs-on: ubuntu-latest
     steps:

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,45 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to ESO Log Aggregator.
+
+To protect both contributors and project maintainers, all contributors agree to the terms below by submitting a pull request.
+
+## 1. Grant of Copyright License
+
+You grant to Alcova AI and to recipients of software distributed by Alcova AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contributions and such derivative works.
+
+## 2. Grant of Patent License
+
+You grant to Alcova AI and to recipients of software distributed by Alcova AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contributions.
+
+If you institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that a contribution submitted by you, or the Licensed Work to which you contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that contribution shall terminate as of the date such litigation is filed.
+
+## 3. Authority and Ownership
+
+You represent that:
+
+- You are legally entitled to grant the above licenses.
+- Each contribution is your original work, or you have sufficient rights to submit it under these terms.
+- You understand and agree that contributions are provided without any expectation of compensation.
+
+## 4. Project License Compatibility
+
+You acknowledge that this repository is distributed under the Business Source License 1.1 (`BUSL-1.1`) with a delayed conversion to Apache License 2.0, as described in the root LICENSE file.
+
+You agree that your contributions may be distributed under the same terms and under any future open source or commercial licenses applied by Alcova AI to this project.
+
+## 5. Submission Process
+
+By opening a pull request, you affirm that you have read and agreed to this CLA.
+
+For contributions made on behalf of an employer, you represent that your employer has authorized the contribution under these terms.
+
+## 6. How to Sign in GitHub
+
+This repository enforces CLA via a GitHub status check.
+
+If the CLA check reports that you have not signed yet, add this exact comment on your pull request:
+
+I have read the CLA Document and I hereby sign the CLA
+
+After posting that comment, the check should pass automatically. If needed, comment `recheck` to re-run the CLA check.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of ESO Log Aggregator pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — GitHub issues, pull requests, discussions, and any other communication channels used for this project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by opening a [GitHub issue](https://github.com/bkrupa/eso-log-aggregator/issues/new) or contacting a maintainer directly via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+Maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to ESO Log Aggregator
+
+Thank you for your interest in contributing! This is a community tool built for ESO players, and contributions are welcome.
+
+## Before You Start
+
+- Read the [CLA](CLA.md) — you'll need to sign it when you open your first pull request.
+- Check [open issues](https://github.com/bkrupa/eso-log-aggregator/issues) before starting new work to avoid duplicating effort.
+- For significant changes, open an issue first to discuss the approach.
+
+## Development Setup
+
+```powershell
+# Install Node.js 20+ first, then:
+npm ci
+npm run codegen     # generate GraphQL types
+npm run dev         # start dev server
+```
+
+See [README.md](README.md) for full setup and testing instructions.
+
+## Making Changes
+
+1. Fork the repo and create a feature branch from `main`.
+2. Keep commits focused — one logical change per commit.
+3. Run the full validation suite before pushing:
+   ```powershell
+   npm run validate  # typecheck + lint + format
+   npm test          # unit tests
+   ```
+4. Open a pull request against `main`. The PR template will walk you through the checklist.
+
+## Pull Request Guidelines
+
+- Provide a clear summary of what changed and why.
+- Include or update tests for any logic changes.
+- Keep PRs small and reviewable — large PRs take longer to merge.
+- The CLA check must pass before merge. If prompted, comment exactly:
+  ```
+  I have read the CLA Document and I hereby sign the CLA
+  ```
+
+## Code Style
+
+- TypeScript — always use types; avoid `any`.
+- Follow existing patterns in the codebase.
+- `npm run lint:fix` and `npm run format` handle most style issues automatically.
+
+## Reporting Bugs
+
+Open a [GitHub issue](https://github.com/bkrupa/eso-log-aggregator/issues/new) with:
+- Steps to reproduce
+- Expected vs. actual behaviour
+- Browser/OS and any relevant console errors
+
+## Security Issues
+
+Please do **not** open a public issue for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
+
+## License
+
+By contributing you agree that your contributions will be licensed under the same terms as this project. See [LICENSE](LICENSE) and [CLA.md](CLA.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,69 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor: Alcova AI
+
+Licensed Work: ESO Log Aggregator (all source code and associated files in this repository)
+
+Additional Use Grant: You may use, copy, modify, create derivative works, and distribute the Licensed Work for non-production and non-commercial purposes.
+
+Change Date: Four years after each portion of the Licensed Work is first made publicly available.
+
+Change License: Apache License, Version 2.0
+
+Terms
+
+Business Source License 1.1
+
+License text copyright (C) 2017 MariaDB Corporation Ab, All Rights Reserved.
+
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+This Business Source License (this "License") is a License Agreement between Licensor and You (as defined below) governing the use of the Licensed Work. By using the Licensed Work, You agree to comply with all of the terms and conditions below.
+
+1. Definitions
+
+"Change Date" means the date specified in the Parameters.
+
+"Change License" means the license specified in the Parameters.
+
+"Licensed Work" means the work of authorship specified in the Parameters, including all modifications and additions made to that work from time to time by Licensor.
+
+"Licensor" means the individual or entity specified in the Parameters.
+
+"You" (or "Your") means an individual or a legal entity exercising permissions granted by this License.
+
+"Your Company" means the company you worked for when you accepted this License.
+
+"Use" means use, copy, modify, create derivative works, redistribute, make available, and run the Licensed Work.
+
+2. Grant of Rights
+
+Subject to the terms and conditions of this License, Licensor hereby grants You a non-exclusive, worldwide, royalty-free, non-transferable, non-sublicensable license to Use the Licensed Work in accordance with the terms of this License and the Additional Use Grant.
+
+3. Limitations
+
+The license granted in Section 2 is limited by the Additional Use Grant and by this Section 3.
+
+Any use of the Licensed Work not permitted by this License, including use beyond the Additional Use Grant, will automatically terminate Your rights under this License.
+
+4. Change Date and Change License
+
+On the Change Date, this License will automatically convert to the Change License for the applicable portion of the Licensed Work. The Change Date applies on a rolling basis as specified in the Parameters.
+
+5. Disclaimer
+
+THE LICENSED WORK IS PROVIDED "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+6. Limitation of Liability
+
+IN NO EVENT WILL LICENSOR BE LIABLE TO YOU FOR ANY DAMAGES, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR RELATING TO THIS LICENSE OR THE USE OF THE LICENSED WORK.
+
+7. Termination
+
+This License terminates automatically if You fail to comply with any term of this License.
+
+8. Miscellaneous
+
+If any provision of this License is held unenforceable, that provision shall be interpreted to accomplish its objectives to the greatest extent possible, and the remaining provisions shall remain in full force and effect.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+We apply security fixes to the latest version of the application. Older versions are not actively patched.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub's private vulnerability reporting](https://github.com/bkrupa/eso-log-aggregator/security/advisories/new) to submit a security advisory directly on the repository.
+
+### What to include
+
+- A description of the vulnerability
+- Steps to reproduce or a proof-of-concept
+- The potential impact
+- Any suggested mitigations (optional)
+
+### What to expect
+
+- **Acknowledgement** within 48 hours.
+- **Status update** within 7 days with an assessment and expected timeline.
+- **Credit** in the release notes if you'd like (optional).
+
+We ask that you give us reasonable time to address the issue before any public disclosure.
+
+## Scope
+
+This project is a client-side web application. Areas of particular interest include:
+
+- Authentication / OAuth handling
+- Cross-site scripting (XSS) via log data parsing
+- Dependency vulnerabilities (though these should be reported to the upstream package maintainers first)
+
+## Out of Scope
+
+- Issues in ESO Logs' own API (report those to ESO Logs directly)
+- Bugs that are not security-relevant (open a regular issue instead)

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     ]
   },
   "name": "eso-log-aggregator",
+  "license": "BUSL-1.1",
   "private": true,
   "scripts": {
     "analyze": "npm run build && npx vite-bundle-analyzer build/assets/*.js",

--- a/src/assets/LICENSE
+++ b/src/assets/LICENSE
@@ -1,21 +1,12 @@
-MIT License
+See the root LICENSE file for the full license text.
 
-Copyright (c) 2024 Alcova AI
+This software is licensed under the Business Source License 1.1 (BUSL-1.1).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensor: Alcova AI
+Change Date: Four years after each portion of the Licensed Work is first made publicly available.
+Change License: Apache License, Version 2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+For non-commercial and non-production use, you may use, copy, modify, and distribute this software.
+Commercial use requires a separate agreement with Alcova AI.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Full license: https://github.com/bkrupa/eso-log-aggregator/blob/main/LICENSE


### PR DESCRIPTION
## Summary

Prepares the repository for going public as an open source project.

## Changes

### Licensing
- **BSL 1.1** root \LICENSE\ with a rolling 4-year change window  each line of code automatically converts to Apache 2.0 four years after it is first publicly available
- Updated \src/assets/LICENSE\ from stale MIT to BSL 1.1
- Set \package.json\ \license\ field to \BUSL-1.1\

### Contributor License Agreement
- \CLA.md\  copyright + patent grant, BUSL-1.1 compatibility clause, signing instructions
- \.github/workflows/cla.yml\  automated CLA enforcement via \contributor-assistant/github-action@v2.6.1\; signatures stored in \cla-signatures\ branch
- \.github/workflows/pr-checks.yml\  added \check-cla-status\ job as a redundant enforcement gate
- \.github/pull_request_template.md\  CLA acknowledgement checklist on every PR

### Community Files
- \CONTRIBUTING.md\  dev setup, PR guidelines, code style
- \SECURITY.md\  responsible disclosure via GitHub private security advisories
- \CODE_OF_CONDUCT.md\  Contributor Covenant v2.1

## Post-merge GitHub setup required
- Create branch \cla-signatures\ (unprotected)
- Add \CLA Check / cla-assistant\ and \PR Checks / check-cla-status\ as required status checks in branch protection for \main\
- Confirm Actions have read/write permissions (\Settings  Actions  General\)