### PR TITLE
fix: correct badge branch refs from main to master

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Generate Coverage Badge JSON
         run: npm run coverage:badge-json
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
 
       - name: Generate Deploy Token
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         id: generate-deploy-token
         uses: actions/create-github-app-token@v2
         with:
@@ -63,7 +63,7 @@ jobs:
           repositories: eso-log-aggregator-reports
 
       - name: Deploy Coverage Badges to GitHub Pages
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           # Use personal_token (not github_token) when pushing to an external repository.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <!-- Status Badges -->
 
-[![Build Status](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/pr-checks.yml)
-[![Deploy Status](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/deploy.yml)
-[![Coverage Workflow](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/coverage.yml)
+[![Build Status](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/pr-checks.yml/badge.svg?branch=master)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/pr-checks.yml)
+[![Deploy Status](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/deploy.yml)
+[![Coverage Workflow](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/coverage.yml)
 [![Nightly Tests](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/nightly-tests.yml/badge.svg)](https://github.com/ESO-Toolkit/eso-toolkit/actions/workflows/nightly-tests.yml)
 
 <!-- Coverage Badges -->


### PR DESCRIPTION
## Problem

Several README badges were broken and the coverage badge JSON files were never being deployed.

### Root Causes

1. **README status badges** used \?branch=main\ but all three workflows (\pr-checks.yml\, \deploy.yml\, \coverage.yml\) trigger on \master\. The \main\ filter matched no runs, so badges showed no status.

2. **Coverage badge deploy never ran**  three steps in \coverage.yml\ had \if: github.ref == 'refs/heads/main'\ but the workflow only runs on \master\ pushes. This meant the badge JSON files were never deployed to \ESO-Toolkit/eso-log-aggregator-reports\, so all four coverage badge endpoints returned 404.

## Changes

- \README.md\: \?branch=main\  \?branch=master\ on Build Status, Deploy Status, and Coverage Workflow badges
- \.github/workflows/coverage.yml\: \efs/heads/main\  \efs/heads/master\ on the Generate Coverage Badge JSON, Generate Deploy Token, and Deploy Coverage Badges steps

## After Merging

Once this lands on \master\, the coverage workflow will trigger and deploy badge JSON to \gh-pages/badges/\ on \eso-log-aggregator-reports\. All badges will then display correctly.