### PR TITLE
fix: correct branch name in coverage and storybook workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Generate Coverage Badge JSON
         run: npm run coverage:badge-json
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
 
       - name: Generate Deploy Token
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         id: generate-deploy-token
         uses: actions/create-github-app-token@v2
         with:
@@ -63,7 +63,7 @@ jobs:
           repositories: eso-log-aggregator-reports
 
       - name: Deploy Coverage Badges to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           # Use personal_token (not github_token) when pushing to an external repository.

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -3,7 +3,7 @@ name: Deploy Storybook
 on:
   push:
     branches:
-      - master
+      - main
   # Allow manual triggering
   workflow_dispatch:
 


### PR DESCRIPTION
﻿## Problem

Several README badges were showing resource not found because the workflows publishing them were silently skipped.

- coverage.yml triggers on pushes to main, but the three badge-related steps all had if: github.ref == 'refs/heads/master' so they never ran, leaving the eso-log-aggregator-reports repo empty and causing the four custom endpoint badges to 404.
- deploy-storybook.yml was triggering on master instead of main, so Storybook was never deployed either.

## Changes

- coverage.yml: changed all three refs/heads/master conditions to refs/heads/main
- deploy-storybook.yml: changed the push trigger branch from master to main
