### PR TITLE
fix: install dependencies before generating What's New data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-with-cache
+
       - name: Generate What's New data
         run: node scripts/generate-whats-new.cjs
         env:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+      
+      - name: Setup Node.js and Install Dependencies
+        uses: ./.github/actions/setup-node-with-cache
       
       - name: Generate What's New data
         run: node scripts/generate-whats-new.cjs


### PR DESCRIPTION
## Problem

The What's New page on production shows empty content because the `generate-whats-new.cjs` script fails during deployment.

**Root Cause:**  
The script requires `@octokit/rest` to fetch recent merged PRs from GitHub, but it was running **before** npm dependencies were installed.

**Error from logs:**
```
 Failed to fetch PRs: Cannot find module '@octokit/rest'
   Using existing whats-new.json file.
```

## Solution

Add the `setup-node-with-cache` step before running the What's New generation script in both deploy workflows:
- `.github/workflows/deploy.yml`
- `.github/workflows/manual-deploy.yml`

Also updated `manual-deploy.yml` to use `fetch-depth: 0` (matching `deploy.yml`) to ensure full git history is available for PR fetching.

## Testing

-  Verified `@octokit/rest` is available in local environment
-  Workflows updated to install dependencies before script execution
- Next production deploy will populate `whats-new.json` with recent PRs

## Related

- Jira: [ESO-600](https://bkrupa.atlassian.net/browse/ESO-600)
