### PR TITLE
docs: prepare repository for public contributors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,90 @@
-# ESO Logs Authentication
-# Get OAuth credentials from your ESO Logs account at https://www.esologs.com/profile
-OAUTH_CLIENT_ID=your_client_id_here
-OAUTH_CLIENT_SECRET=your_client_secret_here
+# ============================================================================
+# ESO Log Aggregator — Environment Variables
+# ============================================================================
+# Copy this file to .env and fill in the values you need.
+#   cp .env.example .env
+#
+# Lines starting with # are comments. Uncomment a variable to enable it.
+# Variables prefixed with VITE_ are exposed to the browser at build time.
+# ============================================================================
 
-# API Key Authentication (alternative to OAuth, recommended for testing)
-# Get your API key from ESO Logs and use it directly for authentication
-# ESO_LOGS_API_KEY=your_api_key_here
+# ----------------------------------------------------------------------------
+# ESO Logs API Authentication
+# ----------------------------------------------------------------------------
+# Create an OAuth application at https://www.esologs.com/profile to get these.
+# Required for: GraphQL codegen, fetching abilities, downloading reports,
+#               and any script that talks to the ESO Logs API.
 
-# Optional - ESO Logs API endpoint (defaults shown)
+OAUTH_CLIENT_ID=
+OAUTH_CLIENT_SECRET=
+
+# Cached bearer token (auto-populated by scripts after OAuth flow)
+# ESOLOGS_TOKEN=
+
+# Alternative: direct API key (get from ESO Logs profile)
+# ESO_LOGS_API_KEY=
+
+# OAuth token endpoint (default: https://www.esologs.com/oauth/token)
 # ESOLOGS_TOKEN_URL=https://www.esologs.com/oauth/token
 
-# Optional - GitHub gist ID for banlist enforcement
+# ----------------------------------------------------------------------------
+# Google Analytics
+# ----------------------------------------------------------------------------
+# GA4 Measurement ID — only needed for production builds.
+# Example: G-XXXXXXXXXX
+# VITE_GA_MEASUREMENT_ID=
+
+# ----------------------------------------------------------------------------
+# Sentry (Error Tracking)
+# ----------------------------------------------------------------------------
+# Only needed for production deploys and sourcemap uploads.
+# The client-side DSN is hardcoded in src/Constants.ts (public by design).
+# SENTRY_AUTH_TOKEN=
+# SENTRY_ORG=
+# SENTRY_PROJECT=
+# SENTRY_DSN=
+
+# ----------------------------------------------------------------------------
+# Development Server
+# ----------------------------------------------------------------------------
+# PORT=3000
+# STRICT_PORT=true
+
+# ----------------------------------------------------------------------------
+# Build Options
+# ----------------------------------------------------------------------------
+# VITE_BASE_URL=/
+# GENERATE_SOURCEMAP=false
+# FAST_REFRESH=true
+
+# ----------------------------------------------------------------------------
+# Feature Flags
+# ----------------------------------------------------------------------------
+# GitHub Gist ID for player banlist enforcement
 # VITE_BANLIST_GIST_ID=
 
-# Google Analytics Measurement ID
-# Set this as a repository secret for production deployments
-# Example: G-XXXXXXXXXX
-VITE_GA_MEASUREMENT_ID=
+# ----------------------------------------------------------------------------
+# E2E / Playwright Testing
+# ----------------------------------------------------------------------------
+# Test account credentials for authenticated E2E tests
+# ESO_LOGS_TEST_EMAIL=
+# ESO_LOGS_TEST_PASSWORD=
+
+# Base URLs (defaults shown — override for custom setups)
+# BASE_URL=http://localhost:3000
+# NIGHTLY_BASE_URL=https://esotk.com/
+
+# Worker tuning
+# PLAYWRIGHT_WORKERS=4
+# PLAYWRIGHT_MAX_WORKERS=8
+# PLAYWRIGHT_MEMORY_PER_WORKER=1000
+
+# ----------------------------------------------------------------------------
+# Scripts & Utilities
+# ----------------------------------------------------------------------------
+# Health-check URL after deployment
+# HEALTH_CHECK_URL=https://esotk.com
+
+# Abilities fetch tuning
+# FETCH_MAX_RETRIES=5
+# FETCH_RETRY_BASE_MS=500

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in ESO Log Aggregator
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: input
+    id: report-url
+    attributes:
+      label: Report URL (if applicable)
+      description: Link to the ESO Logs report where the issue occurs.
+      placeholder: https://esotk.com/#/report/...
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g. Windows 11, macOS 15, Ubuntu 24.04
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console Errors
+      description: Paste any errors from the browser console (F12 → Console tab).
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/ESO-Toolkit/eso-toolkit/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement for ESO Log Aggregator
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe the feature you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Motivation
+      description: What problem does this feature solve? Is it related to a frustration with the current tool?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or change you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the application does this relate to?
+      options:
+        - Combat Log Parsing
+        - Data Visualization / Charts
+        - Fight Replay (3D)
+        - UI / Navigation
+        - Performance
+        - Testing / Developer Experience
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any mockups, screenshots, or links that help illustrate the request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,7 @@
 <!-- AI Context: Primary reference for AI agents. Load feature-specific docs only when working on those features. -->
+
+> **Note for contributors**: This file is an operational reference for **project maintainers** and **AI coding agents** (GitHub Copilot, Claude, etc.). It references internal tools and private services that are not available to external contributors. For contributor guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 # ESO Log Aggregator - AI Agent Quick Reference
 
 **React-based ESO combat log analyzer** with data visualization, real-time analytics, and comprehensive testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,4 +59,11 @@ Please do **not** open a public issue for security vulnerabilities. See [SECURIT
 
 ## License
 
-By contributing you agree that your contributions will be licensed under the same terms as this project. See [LICENSE](LICENSE) and [CLA.md](CLA.md).
+This project uses the **Business Source License 1.1 (BUSL-1.1)**, which is _not_ an OSI-approved open source license. Key points for contributors:
+
+- Your contributions will be distributed under the same BUSL-1.1 terms (see [LICENSE](LICENSE)).
+- Non-production and non-commercial use is freely permitted.
+- Production / commercial use requires a separate agreement with the licensor until the code converts to Apache 2.0 (four years after each public release).
+- By signing the [CLA](CLA.md), you grant the project the right to distribute your contributions under these terms.
+
+If you have questions about how this affects your contribution, open a [discussion](https://github.com/ESO-Toolkit/eso-toolkit/discussions) before submitting your PR.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This project contains only the web application, built with React, TypeScript, Gr
 
 ## Useful Links
 
-- [Deployment](https://esotk.com/#/)
-- [Jira](https://bkrupa.atlassian.net/jira/software/projects/ESO/boards/1/)
-- [Sentry](https://bkrupa.sentry.io/dashboards/)
+- [Live Site](https://esotk.com/#/)
+- [Issue Tracker](https://github.com/ESO-Toolkit/eso-toolkit/issues)
+- [Storybook](https://eso-toolkit.github.io/eso-log-aggregator-reports/storybook/)
 
 ## Getting Started
 
@@ -282,6 +282,16 @@ The `sample-data/` folder is automatically ignored by Git to prevent accidental 
 - If you see module resolution errors, try deleting `node_modules` and `package-lock.json`, then run `npm ci`.
 - Ensure all required dependencies are installed.
 - For GraphQL errors, re-run `npm run codegen`.
+
+## License
+
+This project is licensed under the [Business Source License 1.1 (BUSL-1.1)](LICENSE).
+
+- **Non-production / non-commercial use** is permitted.
+- **Production and commercial use** requires a separate agreement with [Alcova AI](https://github.com/ESO-Toolkit).
+- Each portion of the code **automatically converts to [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)** four years after it is first publicly released.
+
+See the [LICENSE](LICENSE) file for full terms. If you have questions about permitted use, open a [discussion](https://github.com/ESO-Toolkit/eso-toolkit/discussions) or contact the maintainers.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6556,13 +6556,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.18",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.18.tgz",
-      "integrity": "sha512-0sW2eLb2UP3h0zbuoAxFK9N2BnYM5QkZIfVl9yQVDVg10wtpKKSSYHazs63so90FnoD8yXcT162qGvP9cn4eDA==",
+      "version": "9.1.19",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.19.tgz",
+      "integrity": "sha512-NidYsvbLig1zQjhSammTsbwc8KzYQ6vC07uZjfzarwSmTdhFp7j2II0nek8iMNMPnfP9sxugJL990UyV5Wbhug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.18",
+        "@storybook/csf-plugin": "9.1.19",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -6570,8 +6570,25 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.18",
+        "storybook": "^9.1.19",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+      "version": "9.1.19",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.19.tgz",
+      "integrity": "sha512-jQN9JAbyDxjcQ5r48/t/rb4RMow5V/WB7LUir1Sp5GSMMSg5QD2XlfVuSnxsUk2VjhKVZNmwCa8jMCTjBR3L9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^9.1.19"
       }
     },
     "node_modules/@storybook/csf-plugin": {
@@ -6613,14 +6630,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.18",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.18.tgz",
-      "integrity": "sha512-DOsIgr3Z+pAj18wwUBuQbJ+rxHOq1JgzehUesfFg6Yyitag1WtlRBsKgvVRzz47TpzOjypHLNsrzuRicW3q28A==",
+      "version": "9.1.19",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.19.tgz",
+      "integrity": "sha512-UuTGumzQ1/Nffm1rWjrfFefL1a7uZlJEk34Cjp8N5uA9qPEX68e1OEeFnHX3nBk+8yEadPfs77vJox76aeTC6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.18"
+        "@storybook/react-dom-shim": "9.1.19"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6632,7 +6649,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.18",
+        "storybook": "^9.1.19",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -6658,16 +6675,16 @@
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.18",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.18.tgz",
-      "integrity": "sha512-+jTiiGhX2O2o3VzPC4vGidgpp53ydCwO3FSJODdQoDyOspsd6RPDqj7Dp0IwOLnpDJNSVgAEhNOu5CPAMIINtw==",
+      "version": "9.1.19",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.19.tgz",
+      "integrity": "sha512-J7ikh6oWy+GMgEBuNkZ1uhrozHMUu2cQclmMivhm1kJSix9FsjcflFAaO9rzzBbtOVyX1afu+JStNpyOjfj5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.18",
-        "@storybook/react": "9.1.18",
+        "@storybook/builder-vite": "9.1.19",
+        "@storybook/react": "9.1.19",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -6684,8 +6701,24 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.18",
+        "storybook": "^9.1.19",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
+      "version": "9.1.19",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.19.tgz",
+      "integrity": "sha512-raIZEhHFQANSPBikc1Zn6cEHHnj+MbrUD3bbxj/abQHi/bqRIAf20ALOAfIuKk1oFD7lSP6J22h4FXYZm/TtFA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^9.1.19"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -12027,9 +12060,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

Prepare the repository for public contributors by addressing high and medium priority readiness issues identified during a repo audit.

### Changes

**High priority:**
- **GitHub Issue Templates**  Added `.github/ISSUE_TEMPLATE/` with bug report (YAML form), feature request (YAML form), and config (links security reports to Security Advisories)
- **License section in README**  Added a clear section explaining BUSL-1.1 terms: non-commercial use permitted, auto-converts to Apache 2.0 after 4 years
- **Removed private URLs from README**  Replaced Jira and Sentry links in "Useful Links" with public Issue Tracker and Storybook links

**Medium priority:**
- **CONTRIBUTING.md BUSL-1.1 note**  Expanded License section to explain that BUSL-1.1 is not OSI-approved and what it means for contributors
- **AGENTS.md maintainer note**  Added a note at the top clarifying this file is for maintainers and AI agents, not external contributors
- **npm audit fix**  Resolved non-breaking dependency updates; remaining 41 vulnerabilities are in dev-only transitive deps (eslint, graphql-codegen, npm-run-all) requiring breaking upgrades

**Also included (from prior session):**
- **`.env.example` expansion**  Comprehensive env var reference organized by category (API auth, Sentry, build, testing, scripts)

## Checklist

- [x] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
