### PR TITLE
fix: skip do-not-merge label check in merge_group context

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   check-do-not-merge-label:
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
       - name: Check for Do Not Merge or Waiting on Parent labels
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of undefined (reading 'labels')` thrown by the `check-do-not-merge-label` job when triggered via the merge queue.

## Root Cause

The `merge_group` event does not include a `pull_request` payload, so `context.payload.pull_request` is `undefined`. Accessing `.labels` on it crashes the job.

## Fix

Added `if: github.event_name != 'merge_group'` to skip the job entirely for merge queue runs. This is safe because:
- The label check already runs on `pull_request` events (opened, labeled, unlabeled, etc.)
- A PR must pass all required checks  including this one  before it is allowed into the merge queue

## Changes

- `.github/workflows/pr-checks.yml`  added condition to `check-do-not-merge-label` job
