### PR TITLE
feat(ESO-612): add Minor Resolve to buff uptime panel

### DIFF
--- a/src/features/report_details/insights/BuffUptimesPanel.test.ts
+++ b/src/features/report_details/insights/BuffUptimesPanel.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for BuffUptimesPanel - Gear set proc buff tracking (ESO-608)
+ * Tests for BuffUptimesPanel - Gear set proc buff tracking (ESO-608, ESO-612)
  *
  * Verifies that:
  * 1. IMPORTANT_BUFF_ABILITIES includes Pillager's Profit proc buff (172055)
@@ -32,6 +32,7 @@ describe('BuffUptimesPanel', () => {
         KnownAbilities.LUCENT_ECHOES_WEARER,
         KnownAbilities.MAJOR_COURAGE,
         KnownAbilities.MAJOR_RESOLVE,
+        KnownAbilities.MINOR_RESOLVE,
         KnownAbilities.ENLIVENING_OVERFLOW_BUFF,
         KnownAbilities.MINOR_BERSERK,
         KnownAbilities.MINOR_COURAGE,

--- a/src/features/report_details/insights/BuffUptimesPanel.tsx
+++ b/src/features/report_details/insights/BuffUptimesPanel.tsx
@@ -33,6 +33,7 @@ export const IMPORTANT_BUFF_ABILITIES = new Set([
   KnownAbilities.MAJOR_COURAGE,
 
   KnownAbilities.MAJOR_RESOLVE,
+  KnownAbilities.MINOR_RESOLVE,
   KnownAbilities.ENLIVENING_OVERFLOW_BUFF,
   KnownAbilities.MINOR_BERSERK,
   KnownAbilities.MINOR_COURAGE,


### PR DESCRIPTION
## Summary

Adds `Minor Resolve` (ability 61693) to the buff uptime panel, alongside the existing `Major Resolve` entry.

## Changes

- Added `KnownAbilities.MINOR_RESOLVE` to `IMPORTANT_BUFF_ABILITIES` in `BuffUptimesPanel.tsx`
- Updated `BuffUptimesPanel.test.ts` to include `MINOR_RESOLVE` in the expected buffs list

## Motivation

Minor Resolve is used in damage reduction calculations and is surfaced by other tools alongside Major Resolve. Both should be tracked in the buff uptime panel for parity.

## Testing

All existing tests pass (21/21).

Closes ESO-612
