### PR TITLE
docs: enforce pre-PR quality gate before creating PRs

### DIFF
--- a/.github/skills/workflow/SKILL.md
+++ b/.github/skills/workflow/SKILL.md
@@ -71,9 +71,27 @@ Tell the user:
 - That they are now safe to begin implementation
 - Any twig setup that was performed
 
-## Step 6 — Update Ticket Status When Work Is Complete
+## Step 6 — Pre-PR Quality Gate (MANDATORY)
 
-When implementation is finished and changes are committed/pushed, update the Jira ticket status to reflect completion:
+**Before creating a PR or marking a ticket as In Review**, run all quality checks and ensure they pass:
+
+```powershell
+# 1. Type-check, lint, and format — must all pass with zero errors/warnings
+npm run validate
+
+# 2. Unit tests — must all pass
+npm test -- --watchAll=false
+```
+
+**Do NOT create a PR if either command exits with a non-zero code.**
+
+- Fix any TypeScript errors before continuing.
+- Run `npm run lint:fix` and `npm run format` to auto-fix lint/format issues, then re-run `npm run validate`.
+- Fix any failing unit tests before continuing.
+
+## Step 7 — Update Ticket Status When Work Is Complete
+
+When implementation is finished, all quality checks pass, and changes are committed/pushed, update the Jira ticket status:
 
 ```
 @workspace Move ESO-XXX to "In Review"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ npm run typecheck        # TypeScript compilation check
 npm run lint:fix         # Auto-fix linting issues
 ```
 
+> **⚠️ Before creating any PR**: run `npm run validate` AND `npm test -- --watchAll=false` — both must pass with zero errors/warnings. Do not open a PR or move a ticket to "In Review" until they do.
+
 **E2E Testing**: Use VS Code MCP Playwright tool (structured testing) or Agent Skills (exploratory)  
 **Full Command Reference**: See [AGENTS_COMMANDS.md](AGENTS_COMMANDS.md)
 


### PR DESCRIPTION
## Summary

Enforces a mandatory pre-PR quality gate in agent guidance so that both `npm run validate` and `npm test -- --watchAll=false` must pass before opening a PR or moving a Jira ticket to In Review.

## Changes

- **`.github/skills/workflow/SKILL.md`**  adds new **Step 6  Pre-PR Quality Gate (MANDATORY)** between "Confirm and Report" and the ticket status update step:
  - Requires `npm run validate` (typecheck + lint + format) with zero errors/warnings
  - Requires `npm test -- --watchAll=false` with all tests passing
  - Provides remediation commands (`npm run lint:fix`, `npm run format`) for auto-fixable issues
  - Renumbers the previous Step 6 (ticket status update) to Step 7

- **`AGENTS.md`**  existing ` Before creating any PR` callout preserved; no duplicate added

## Test Plan

Docs-only change  no code affected. `npm run validate` and unit tests pass.
