### PR TITLE
feat(ESO-620): parse analysis fixes, polling, fight nav, setup instructions, disabled button

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -236,6 +236,11 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
                     ? '0 6px 25px rgba(56, 189, 248, 0.35)'
                     : '0 6px 25px rgba(3, 105, 161, 0.35)',
                 },
+                '&.Mui-disabled': {
+                  background: darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.12)',
+                  color: darkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.26)',
+                  boxShadow: 'none',
+                },
               },
               outlined: {
                 borderColor: darkMode ? 'rgba(56, 189, 248, 0.5)' : 'rgba(3, 105, 161, 0.5)',

--- a/src/hooks/events/useCastEvents.ts
+++ b/src/hooks/events/useCastEvents.ts
@@ -24,6 +24,7 @@ interface UseCastEventsOptions {
 export function useCastEvents(options?: UseCastEventsOptions): {
   castEvents: UnifiedCastEvent[];
   isCastEventsLoading: boolean;
+  isCastEventsLoaded: boolean;
   selectedFight: FightFragment | null;
 } {
   const dispatch = useAppDispatch();
@@ -37,6 +38,7 @@ export function useCastEvents(options?: UseCastEventsOptions): {
     selectCastEventsEntryForContext(state, context),
   );
   const isCastEventsLoading = castEntry?.status === 'loading';
+  const isCastEventsLoaded = castEntry?.status === 'succeeded' || castEntry?.status === 'failed';
 
   const restrictToFightWindow = options?.restrictToFightWindow ?? true;
 
@@ -64,7 +66,7 @@ export function useCastEvents(options?: UseCastEventsOptions): {
   ]);
 
   return React.useMemo(
-    () => ({ castEvents, isCastEventsLoading, selectedFight }),
-    [castEvents, isCastEventsLoading, selectedFight],
+    () => ({ castEvents, isCastEventsLoading, isCastEventsLoaded, selectedFight }),
+    [castEvents, isCastEventsLoading, isCastEventsLoaded, selectedFight],
   );
 }

--- a/src/pages/ParseAnalysisPage.test.tsx
+++ b/src/pages/ParseAnalysisPage.test.tsx
@@ -51,6 +51,7 @@ jest.mock('../hooks/events/useCastEvents', () => ({
   useCastEvents: () => ({
     castEvents: [],
     isCastEventsLoading: false,
+    isCastEventsLoaded: true,
     selectedFight: null,
   }),
 }));


### PR DESCRIPTION
## Summary

Bundles several Parse Analysis page improvements implemented in one session.

### Bug fixes

- **Loading hang**  `useCastEvents` now returns `isCastEventsLoaded` (status `succeeded | failed`) so the analysis effect no longer waits indefinitely when there are zero cast events after a successful fetch
- **No fight ID in URL**  `analyzeReport` now navigates to `/parse-analysis/<code>/<fightId>` after resolving the fight, ensuring `useFightForContext` can always find the fight in Redux
- **New fight from polling stuck**  `setReportData(report)` is dispatched immediately after each fetch so the Redux report store is always in sync before navigation

### Features

- **15 s auto-polling**  detects new supported fights in a live report and automatically triggers analysis on the newest fight
- **Fight navigation chips**  strip of chips (one per available fight) with a live "next check in Xs" countdown
- **Setup instructions card**  shown on the empty state; walks users through: download uploader  start live log  copy URL  `/encounterlog`  21 M dummy  wait for upload

### Styling

- **Disabled contained button fix**  `containedPrimary` in `ReduxThemeProvider` now has a `&.Mui-disabled` override that replaces the bright cyan gradient bleed-through with a neutral muted background and dimmed text

## Files changed

- `src/hooks/events/useCastEvents.ts`  add `isCastEventsLoaded`
- `src/pages/ParseAnalysisPage.tsx`  all fixes + features + instructions UI
- `src/pages/ParseAnalysisPage.test.tsx`  update mock to include `isCastEventsLoaded: true`
- `src/ReduxThemeProvider.tsx`  disabled button override

Jira: [ESO-620](https://bkrupa.atlassian.net/browse/ESO-620)
