### PR TITLE
fix(ci): fix merge queue ejection due to skipped required status check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,9 +21,11 @@ on:
 jobs:
   check-do-not-merge-label:
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group'
     steps:
       - name: Check for Do Not Merge or Waiting on Parent labels
+        # Skip label check in merge_group (labels already verified on PR) — job must still run
+        # so the required status check reports back to GitHub instead of timing out.
+        if: github.event_name != 'merge_group'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Summary

Fixes the merge queue ejecting PRs with "no response for status checks".

## Root Cause

`check-do-not-merge-label` had a job-level condition:
```yaml
if: github.event_name != 'merge_group'
```
When the merge queue fires, the entire job is **skipped**. GitHub's merge queue requires every required status check to post a result  a skipped job never does  so after a timeout it ejected the PR.

This is why PR #703 was removed from the merge queue despite all other checks passing.

## Fix

Moved the `if` condition from the **job level** to the **step level**. The job now always runs (reporting a success to GitHub), but the label-validation step is skipped during `merge_group` since labels were already verified during PR review.

## Testing

Re-add PR #703 to the merge queue after this merges to verify the fix.
