### PR TITLE
fix(ci): add merge_group trigger to deploy-reports workflow

### DIFF
--- a/.github/workflows/deploy-reports.yml
+++ b/.github/workflows/deploy-reports.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   # Allow manual triggering
   workflow_dispatch:
 
@@ -22,15 +25,24 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip coverage in merge queue (already verified on PR)
+        # The job must still run so the required status check reports back to GitHub
+        # instead of timing out and ejecting the PR from the merge queue.
+        if: github.event_name == 'merge_group'
+        run: echo "✅ Coverage check skipped in merge queue — already verified on the PR."
+
       - name: Checkout Repository
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: github.event_name != 'merge_group'
         uses: ./.github/actions/setup-node-with-cache
 
       - name: Run Tests with Coverage
+        if: github.event_name != 'merge_group'
         run: npm run test:coverage:ci
         env:
           # Increase Node.js memory limit to prevent OOM errors
@@ -49,17 +61,17 @@ jobs:
 
       - name: Generate Coverage Badges
         run: npm run coverage:badges
-        if: always()
+        if: always() && github.event_name != 'merge_group'
 
       - name: Generate Coverage Badge JSON
         run: npm run coverage:badge-json
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        if: (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event_name != 'merge_group'
 
       # Consumed by the deploy job for the combined gh-pages push.
       # Short retention since this is an intermediate build artifact.
       - name: Upload Coverage Badge JSON
         uses: actions/upload-artifact@v6
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        if: (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && github.event_name != 'merge_group'
         with:
           name: coverage-badge-json
           path: coverage/badge-json/
@@ -67,7 +79,7 @@ jobs:
 
       - name: Upload Coverage Badges (SVG)
         uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         with:
           name: coverage-badges-${{ github.run_number }}
           path: coverage/badges/*.svg
@@ -75,7 +87,7 @@ jobs:
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         with:
           name: coverage-report-${{ github.run_number }}
           path: |


### PR DESCRIPTION
## Problem

The `Coverage and Storybook Reports` workflow (`deploy-reports.yml`) has no `merge_group` trigger. When a PR enters the merge queue, the `coverage` job (a required status check) never fires  GitHub waits for a response that never comes, then ejects the PR with "no response for status checks."

This is the same root cause as #719, which fixed `check-do-not-merge-label` in `pr-checks.yml`.

## Fix

- Add `merge_group` trigger to `deploy-reports.yml`
- Short-circuit all expensive steps in the `coverage` job with `if: github.event_name != 'merge_group'` so the full test suite is not re-run (it was already verified on the PR)
- Add a single informational step that runs only in `merge_group` so the job always reports a result back to GitHub

The job still runs and reports `success`  the required check contract is fulfilled without weakening branch protection or re-running ~3 mins of tests.

## Pattern

Identical to the fix in #719 (`check-do-not-merge-label` step-level short-circuit).

## Unblocks

Re-adding #703 to the merge queue after this merges should succeed.
