### PR TITLE
feat(ESO-573): add Privacy Policy page footer links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,6 +49,8 @@ export const Footer: React.FC = React.memo(() => {
 
       { label: 'Privacy Settings', href: '/privacy-settings' },
 
+      { label: 'Privacy Policy', href: '/privacy' },
+
       { label: 'Join Discord', href: 'https://discord.gg/mMjwcQYFdc', external: true },
 
       { label: 'GitHub', href: 'https://github.com/ESO-Toolkit/eso-toolkit', external: true },
@@ -1067,6 +1069,20 @@ export const Footer: React.FC = React.memo(() => {
             Studios, Bethesda, or esologs.com. All trademarks are the property of their respective
             owners.
           </Typography>
+          <Link
+            component={RouterLink}
+            to="/privacy"
+            sx={{
+              fontSize: '0.8rem',
+              opacity: 0.6,
+              color: 'inherit',
+              textDecoration: 'none',
+              transition: 'opacity 0.2s ease',
+              '&:hover': { opacity: 1, color: accentColor },
+            }}
+          >
+            Privacy Policy
+          </Link>
         </Box>
       </Container>
     </Box>


### PR DESCRIPTION
## Summary

Implements ESO-573: Privacy Policy page.

The `PrivacyPolicyPage` component and `/privacy` route were already in place. This PR completes the ticket by surfacing the page through standard navigation entry points:

- **Footer Quick Links**: Added a "Privacy Policy" entry alongside Home, Latest Reports, etc.
- **Footer bottom row**: Added a discreet `Privacy Policy` link next to the trademark disclaimer (the standard pattern used by most websites).

## What the page covers

The existing `PrivacyPolicyPage` at `/privacy` is comprehensive and includes:
- What data is collected (essential local storage, optional analytics/error tracking)
- How data is stored (entirely client-side; no backend)
- Third-party services (Google Analytics 4, Sentry, ESO Logs OAuth, Google Fonts)
- User rights under GDPR (Articles 7, 15, 16, 17, 20)
- Data retention policies
- Contact information (GitHub repository)
- Inline consent management (change analytics/error-tracking preferences without re-prompting)
- Export data (Article 20) and delete all data (Article 17) controls

## Notes

- No fake company names introduced  all third-party references are real services actually used by the app.
- No backend exists; all data references are to browser `localStorage`.
