### PR TITLE
fix(auth): prevent error flash on page load with existing session

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -85,7 +85,14 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [isBanned, setIsBanned] = useState<boolean>(false);
   const [banReason, setBanReason] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
-  const [userLoading, setUserLoading] = useState<boolean>(false);
+  // Initialize userLoading to true when a valid token exists in localStorage.
+  // This prevents child components (e.g. HeaderBar) from prematurely calling
+  // refetchUser() before AuthProvider's effects have synced the token to the
+  // EsoLogsClient — child effects run before parent effects in React.
+  const [userLoading, setUserLoading] = useState<boolean>(() => {
+    const token = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY) || '';
+    return !!token && tokenHasUserSubject(token) && !isAccessTokenExpired(token);
+  });
   const [userError, setUserError] = useState<string | null>(null);
 
   const { client: esoLogsClient, setAuthToken, clearAuthToken } = useEsoLogsClientContext();


### PR DESCRIPTION
## Summary

Fixes a race condition that caused a brief error flash when loading a page with an already logged-in user.

## Problem

When a user with a valid token in localStorage loads the page, child component effects (e.g. `HeaderBar`) run **before** `AuthProvider`'s effects. This caused:

1. `AuthProvider` immediately computes `isLoggedIn = true` from the localStorage token
2. `EsoLogsClient` starts with an **empty token** (synced via `useEffect`, which hasn't run yet)
3. `HeaderBar`'s effect sees `isLoggedIn=true, userLoading=false, currentUser=null` and prematurely calls `refetchUser()`
4. The GraphQL query fires with no auth token  **API error shown to user**
5. `AuthProvider`'s effects then sync the token and retry successfully  page renders correctly

## Fix

Initialize `userLoading` to `true` when localStorage contains a valid, non-expired token with a user subject. This prevents child components from triggering premature refetch attempts before the client is ready.

## Testing

- All 159 test suites pass (2272 tests, 0 failures)
- Typecheck, lint, and format all pass
