### PR TITLE
docs: note branch naming requirement for Jira sync in skill files

### DIFF
--- a/.github/skills/git/SKILL.md
+++ b/.github/skills/git/SKILL.md
@@ -20,10 +20,12 @@ Install twig if missing: `npm install -g @gittwig/twig`
 
 ## Branch Naming Conventions
 
-- Jira tickets: `ESO-XXX/short-description-in-kebab-case`
+- Jira tickets: `ESO-XXX/short-description-in-kebab-case` ← **required for Jira sync**
 - Features: `feature/descriptive-name`
 - Bug fixes: `fix/bug-description`
 - Refactors: `refactor/what-changed`
+
+> **Jira sync requirement**: The `npm run sync-jira` script detects ticket status from remote branches by matching branch names that **start with `ESO-\d+`** (e.g. `ESO-569/...`). Branches that use the `feature/`, `fix/`, or `refactor/` prefixes are not recognised and will not trigger any Jira status updates. Always use the `ESO-XXX/description` format when working on a tracked ticket.
 
 ## Creating a Branch (with twig)
 

--- a/.github/skills/workflow/SKILL.md
+++ b/.github/skills/workflow/SKILL.md
@@ -39,6 +39,8 @@ Examples of valid names:
 - `ESO-449/structure-redux-state`
 - `ESO-372/fix-aria-labels`
 
+> **Why this matters**: The `npm run sync-jira` script reads all remote branches and moves Jira tickets to *In Progress* or *Done* automatically. It only detects branches whose name **starts with the Jira ticket key** (`ESO-\d+`). A branch named `feature/remove-duplicate-roles` will be invisible to the sync and its ticket will never be updated.
+
 Run these commands in sequence:
 
 ```powershell


### PR DESCRIPTION
## Summary

Documents the branch naming requirement for the `sync-jira` script in both agent skill files.

`npm run sync-jira` matches remote branches using the regex `ESO-\d+`  only branches starting with a Jira ticket key (e.g. `ESO-569/...`) are recognised. Branches named with `feature/`, `fix/`, or `refactor/` prefixes are silently skipped.

## Changes

- `.github/skills/git/SKILL.md`  added a callout under **Branch Naming Conventions** explaining the sync restriction
- `.github/skills/workflow/SKILL.md`  added the same note after the naming examples in Step 3
