### PR TITLE
fix(ci): prevent deploy job skip on pull_request events

### DIFF
--- a/.github/workflows/deploy-reports.yml
+++ b/.github/workflows/deploy-reports.yml
@@ -204,40 +204,47 @@ jobs:
   # in-flight deploy rather than queuing behind it.
   deploy:
     needs: [coverage, build-storybook]
+    # Must always evaluate to true so the required status check reports back to
+    # GitHub. Without this, skipped jobs report nothing and the merge queue
+    # times out waiting for a status that never arrives.
     if: |
-      github.event_name == 'merge_group' ||
+      always() &&
       (
-        (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
-        needs.coverage.result == 'success' &&
-        needs.build-storybook.result == 'success'
+        github.event_name == 'merge_group' ||
+        github.event_name == 'pull_request' ||
+        (
+          (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
+          needs.coverage.result == 'success' &&
+          needs.build-storybook.result == 'success'
+        )
       )
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-reports-gh-pages
       cancel-in-progress: true
     steps:
-      - name: Skip deploy in merge queue (only needed on main)
+      - name: Skip deploy (non-deployment context)
         # The job must still run so the required status check reports back to GitHub
         # instead of timing out and ejecting the PR from the merge queue.
-        if: github.event_name == 'merge_group'
-        run: echo "✅ Deploy skipped in merge queue — only runs on main push."
+        if: github.event_name == 'merge_group' || github.event_name == 'pull_request'
+        run: echo "✅ Deploy skipped — only runs on main push."
 
       - name: Download Coverage Badge JSON
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
         uses: actions/download-artifact@v4
         with:
           name: coverage-badge-json
           path: deploy-staging/badges/
 
       - name: Download Storybook
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
         uses: actions/download-artifact@v4
         with:
           name: storybook-static
           path: deploy-staging/storybook/
 
       - name: Generate Deploy Token
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
         id: generate-deploy-token
         uses: actions/create-github-app-token@v2
         with:
@@ -247,7 +254,7 @@ jobs:
           repositories: eso-log-aggregator-reports
 
       - name: Deploy to GitHub Pages
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
           # Use personal_token (not github_token) when pushing to an external repository.


### PR DESCRIPTION
## Problem

PR #703 is stuck at "16/17 checks OK" and cannot enter the merge queue despite having auto-merge enabled and approval.

The `deploy` job in `deploy-reports.yml` has a job-level `if:` condition that evaluates to false for `pull_request` events:

```yaml
if: |
  github.event_name == 'merge_group' ||
  (
    (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
    needs.coverage.result == 'success' &&
    needs.build-storybook.result == 'success'
  )
```

For `pull_request` events, none of these conditions are true, so the job is **skipped at job level**. Skipped jobs don't report a status check to GitHub. If `deploy` is configured as a required check, auto-merge cannot queue the PR.

This is the same pattern as:
- PR #719: `check-do-not-merge-label` skipped at job level during `merge_group`
- PR #724: `build-storybook` skipped at job level during `merge_group`

## Fix

- Added `github.event_name == 'pull_request'` to the deploy job's `if:` condition (wrapped in `always()` to ensure it runs even if upstream jobs are skipped)
- Changed all step-level conditions from `!= 'merge_group'` to `!= 'merge_group' && != 'pull_request'`
- Added a no-op echo step that runs for both `merge_group` and `pull_request` contexts

The deploy job now always reports a successful status check for every event type, while only performing actual deployment on `main` push / `workflow_dispatch`.

## Evidence

| Commit | Checks Status | Context |
|--------|--------------|---------|
| `d7f52ba` (before #724) | 15/17 | Both `build-storybook` and `deploy` skipped |
| `609c3c6` (after #724 merged) | 16/17 | `build-storybook` fixed, `deploy` still skipped |
| `3e53099` (latest) | 16/17 | Only `deploy` remains skipped |
