### PR TITLE
fix(routing): remove redux-first-history, fix Redux error #3

### DIFF
--- a/src/store/selectors/eventsSelectors.test.ts
+++ b/src/store/selectors/eventsSelectors.test.ts
@@ -89,6 +89,7 @@ const createMockState = (overrides: Partial<RootState> = {}): RootState => {
       accessOrder: [],
     },
     router: {
+      // Will be stripped by 'as RootState' but kept for override use
       location: {
         pathname: '/report/test-report/fight/1',
         search: '',
@@ -243,56 +244,34 @@ describe('Buff Lookup Selectors', () => {
     });
   });
 
-  describe('Router-based selectors', () => {
-    it('should extract fight ID from router state', () => {
+  describe('ActiveContext-based selectors', () => {
+    it('should extract fight ID from activeContext', () => {
       const state = createMockState({
-        router: {
-          location: {
-            pathname: '/report/test-report/fight/123',
-            search: '',
-            hash: '',
-            state: {},
-            key: 'test-key',
-          },
-          action: null,
+        report: {
+          ...createMockState().report,
+          activeContext: { reportId: 'test-report', fightId: 123 },
         },
-      });
+      } as any);
 
       const fightId = selectSelectedFightId(state);
       expect(fightId).toBe('123');
     });
 
-    it('should return null for invalid paths', () => {
+    it('should return null when activeContext has no fightId', () => {
       const state = createMockState({
-        router: {
-          location: {
-            pathname: '/report/test-report',
-            search: '',
-            hash: '',
-            state: {},
-            key: 'test-key',
-          },
-          action: null,
+        report: {
+          ...createMockState().report,
+          activeContext: { reportId: 'test-report', fightId: null },
         },
-      });
+      } as any);
 
       const fightId = selectSelectedFightId(state);
       expect(fightId).toBeNull();
     });
 
-    it('should select current fight using router state', () => {
-      const state = createMockState({
-        router: {
-          location: {
-            pathname: '/report/test-report/fight/1',
-            search: '',
-            hash: '',
-            state: {},
-            key: 'test-key',
-          },
-          action: null,
-        },
-      });
+    it('should select current fight using activeContext', () => {
+      // Default mock state has activeContext.fightId = 1 and fight id 1 in the report
+      const state = createMockState();
 
       const currentFight = selectCurrentFight(state);
       expect(currentFight).toEqual({

--- a/src/store/selectors/eventsSelectors.ts
+++ b/src/store/selectors/eventsSelectors.ts
@@ -165,21 +165,11 @@ export const selectResourceEventsError = createSelector(
   },
 );
 
-// Selector to get the currently selected fight ID from router state
+// Selector to get the currently selected fight ID from the active report context.
+// Uses state.report.activeContext which is kept in sync by ReportFightProvider.
 export const selectSelectedFightId = (state: RootState): string | null => {
-  const location = state.router?.location;
-  if (!location?.pathname) return null;
-
-  // Parse the pathname to extract fightId
-  // Expected format: /report/:reportId/fight/:fightId
-  const pathParts = location.pathname.split('/').filter(Boolean);
-  const fightIndex = pathParts.indexOf('fight');
-
-  if (fightIndex !== -1 && fightIndex + 1 < pathParts.length) {
-    return pathParts[fightIndex + 1];
-  }
-
-  return null;
+  const fightId = state.report.activeContext.fightId;
+  return fightId !== null ? String(fightId) : null;
 };
 
 // Helper selector to get the currently selected fight from Redux state

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -5,8 +5,6 @@ import {
   Action,
   ThunkDispatch,
 } from '@reduxjs/toolkit';
-import { createBrowserHistory } from 'history';
-import { createReduxHistoryContext, LOCATION_CHANGE } from 'redux-first-history';
 import {
   persistStore,
   persistReducer,
@@ -34,12 +32,6 @@ import uiReducer, { UIState } from './ui/uiSlice';
 import userReportsReducer from './user_reports';
 import { workerResultsReducer } from './worker_results';
 
-// Create history
-export const history = createBrowserHistory();
-const { createReduxHistory, routerMiddleware, routerReducer } = createReduxHistoryContext({
-  history,
-});
-
 // Root reducer - adding essential slices
 const rootReducer = combineReducers({
   dashboard: dashboardReducer,
@@ -49,7 +41,6 @@ const rootReducer = combineReducers({
   parseAnalysis: parseAnalysisReducer,
   playerData: playerDataReducer,
   report: reportReducer,
-  router: routerReducer,
   ui: uiReducer,
   userReports: userReportsReducer,
   workerResults: workerResultsReducer,
@@ -132,13 +123,13 @@ const createStoreWithClient = (esoLogsClient: EsoLogsClient): AppStore => {
         },
         serializableCheck: {
           // Only ignore Redux persist actions since thunk actions are now serializable
-          ignoredActions: [FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE, LOCATION_CHANGE],
+          ignoredActions: [FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE],
           // State paths that contain large datasets or computed data
           ignoredPaths: ['events', 'playerData.playersById', 'workerResults'],
           // Increase warning threshold for better performance
           warnAfter: 128,
         },
-      }).concat(routerMiddleware), // Add router middleware
+      }),
     devTools: process.env.NODE_ENV !== 'production' && {
       name: 'ESO Toolkit',
       trace: false,
@@ -160,8 +151,5 @@ export const initializeStoreWithClient = (esoLogsClient: EsoLogsClient): AppStor
 export const getStore = (): AppStore => store;
 
 export const persistor = persistStore(store);
-
-// Create the redux history instance
-export const reduxHistory = createReduxHistory(store);
 
 export default store;

--- a/src/test/utils/createMockStore.ts
+++ b/src/test/utils/createMockStore.ts
@@ -1,6 +1,4 @@
 import { configureStore, type EnhancedStore } from '@reduxjs/toolkit';
-import { createMemoryHistory } from 'history';
-import { createReduxHistoryContext } from 'redux-first-history';
 import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
 
 import { eventsReducer } from '../../store/events_data';
@@ -19,11 +17,6 @@ export interface MockStoreOptions {
     ui?: Partial<UIState>;
     // Add other slice initial states as needed
   };
-  /**
-   * Initial URL entries for the memory router
-   * @default ['/']
-   */
-  initialEntries?: string[];
   /**
    * Whether to disable serializable check completely
    * @default false (uses production-like configuration)
@@ -48,25 +41,7 @@ export interface MockStoreOptions {
  * consistent store configuration across all testing environments.
  */
 export function createMockStore(options: MockStoreOptions = {}): EnhancedStore {
-  const {
-    initialState = {},
-    initialEntries = ['/'],
-    disableSerializableCheck = false,
-    enableReduxDevTools = true,
-  } = options;
-
-  // Create redux-first-history context with memory history for testing
-  const { routerMiddleware, routerReducer } = createReduxHistoryContext({
-    history: createMemoryHistory({
-      initialEntries,
-    }),
-    // Same batching strategy as production
-    batch: (callback: () => void) => {
-      callback();
-    },
-    // Redux devtools time travel for debugging
-    reduxTravelling: enableReduxDevTools,
-  });
+  const { initialState = {}, disableSerializableCheck = false } = options;
 
   const serializableCheckConfig = disableSerializableCheck
     ? false
@@ -77,7 +52,6 @@ export function createMockStore(options: MockStoreOptions = {}): EnhancedStore {
 
   return configureStore({
     reducer: {
-      router: routerReducer, // Include router reducer like production
       events: eventsReducer,
       ui: uiReducer, // Use plain reducer (no persistence in testing)
       masterData: masterDataReducer,
@@ -89,7 +63,7 @@ export function createMockStore(options: MockStoreOptions = {}): EnhancedStore {
       const defaultMiddleware = getDefaultMiddleware({
         serializableCheck: serializableCheckConfig,
       });
-      return defaultMiddleware.concat(routerMiddleware);
+      return defaultMiddleware;
     },
     preloadedState: {
       ui: {


### PR DESCRIPTION
## Summary

Removes `redux-first-history` entirely and replaces it with React Router v6 native hooks (`useSearchParams` / `useNavigate`). This is the current industry standard for React + Redux Toolkit apps and eliminates the root cause of two Sentry error classes.

Closes ESO-563.

## Root cause  Redux error #3

`redux-first-history` created its own `createBrowserHistory()` instance alongside the `<BrowserRouter>` already used by React Router. When `useUrlParamSync` called `dispatch(push(url))` / `dispatch(replace(url))`:

1. `routerMiddleware` synchronously called `history.replace()` on the RFHS instance
2. That fired RFHS's `history.listen()` callback
3. Which dispatched `LOCATION_CHANGE` back into the store

This nested dispatch (dispatching while already dispatching) is what triggers **Redux error #3** (`Reducers may not dispatch actions`). React 18's `useSyncExternalStore`-based `useSelector` is particularly sensitive to this because it reads from the store during the render phase.

## Secondary fix  Maximum update depth exceeded (ESO-LOGS-8K, 8M, 8N)

`useUrlParamSync` tracked initial-sync state with `useState(hasInitialSync)` and called `setHasInitialSync(true)` inside a `useEffect` that listed `hasInitialSync` in its dependencies. This caused:

> `setTimeout` fires  `setHasInitialSync(true)`  `hasInitialSync` changes  effect re-runs with 0ms delay  dispatches same state updates  repeat

Replaced with `useRef`  the flag is read/written without triggering a re-render.

## Changes

| File | What changed |
|---|---|
| `storeWithHistory.ts` | Remove `history`, `createReduxHistoryContext`, `LOCATION_CHANGE`, `routerReducer`, `routerMiddleware`, `reduxHistory` |
| `useUrlParamSync.ts` | Rewrite navigation to use `useSearchParams` + `setSearchParams`; fix re-render loop with `useRef` |
| `eventsSelectors.ts` | `selectSelectedFightId` reads `state.report.activeContext.fightId` instead of `state.router.location.pathname` |
| `createMockStore.ts` | Remove `redux-first-history` / `createMemoryHistory` setup |
| `eventsSelectors.test.ts` | Update tests to match the new `activeContext`-based selector |

## Testing

- `npm run validate`  passes (typecheck + lint + format)
- `npm test -- --watchAll=false`  all 359 tests pass
