### PR TITLE
infra: fix CLA Check stalling the merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: write
@@ -41,3 +43,10 @@ jobs:
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-allsigned-prcomment: All contributors have signed the CLA. Thank you.
           lock-pullrequest-aftermerge: true
+
+  cla-merge-queue:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
+    steps:
+      - name: CLA already verified on PR
+        run: echo "CLA was verified when the PR was opened. Bypassing for merge queue."


### PR DESCRIPTION
## Problem

`cla-assistant` is a required status check in the "Protect main" ruleset, but `cla.yml` only triggered on `issue_comment` and `pull_request_target`  never on `merge_group`. The merge queue would wait indefinitely for the check to report, timing out after 60 minutes.

Confirmed via:
```
gh api repos/ESO-Toolkit/eso-toolkit/rulesets/7624925
```

## Fix

- Add `merge_group: checks_requested` trigger to `cla.yml`
- The existing `cla-assistant` job runs but skips its CLA step (step-level `if` only targets PR/comment events)  job succeeds  required check satisfied
- Add a `cla-merge-queue` bypass job for clear intent: CLA was already verified when the PR was opened
