### PR TITLE
fix(ESO-589): retry and report network-level fetch failures

### DIFF
--- a/src/esologsClient.test.ts
+++ b/src/esologsClient.test.ts
@@ -245,4 +245,56 @@ describe('EsoLogsClient', () => {
       expect(mockQuery).toHaveBeenCalledWith(mockOperation);
     });
   });
+
+  describe('Network error handling', () => {
+    it('should surface a user-friendly message when a network error occurs (no statusCode)', async () => {
+      const client = new EsoLogsClient(mockAccessToken);
+      const apolloClient = client.getClient();
+
+      // Simulate a network-level failure (no HTTP response — statusCode undefined)
+      const networkError = new Error('NetworkError when attempting to fetch resource.');
+      apolloClient.query = jest.fn().mockRejectedValue(networkError);
+
+      await expect(client.query({ query: {} as DocumentNode })).rejects.toThrow(
+        'Network error: Could not connect to the ESO Logs API.',
+      );
+    });
+
+    it('should surface a user-friendly message when statusCode is 0', async () => {
+      const client = new EsoLogsClient(mockAccessToken);
+      const apolloClient = client.getClient();
+
+      // Simulate a status-0 network failure
+      const networkError = Object.assign(new Error('Network request failed'), { statusCode: 0 });
+      apolloClient.query = jest.fn().mockRejectedValue(networkError);
+
+      await expect(client.query({ query: {} as DocumentNode })).rejects.toThrow(
+        'Network error: Could not connect to the ESO Logs API.',
+      );
+    });
+
+    it('should surface a user-friendly message when a 429 rate-limit error occurs', async () => {
+      const client = new EsoLogsClient(mockAccessToken);
+      const apolloClient = client.getClient();
+
+      const rateLimitError = Object.assign(new Error('Too Many Requests'), { statusCode: 429 });
+      apolloClient.query = jest.fn().mockRejectedValue(rateLimitError);
+
+      await expect(client.query({ query: {} as DocumentNode })).rejects.toThrow(
+        'API rate limit exceeded.',
+      );
+    });
+
+    it('should rethrow other errors unchanged', async () => {
+      const client = new EsoLogsClient(mockAccessToken);
+      const apolloClient = client.getClient();
+
+      const serverError = Object.assign(new Error('Internal Server Error'), { statusCode: 500 });
+      apolloClient.query = jest.fn().mockRejectedValue(serverError);
+
+      await expect(client.query({ query: {} as DocumentNode })).rejects.toThrow(
+        'Internal Server Error',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a production error ([ESO-589](https://bkrupa.atlassian.net/browse/ESO-589) / Sentry ESO-LOGS-8J) where a transient network failure on the ESO Logs API (`www.esologs.com`) caused an unhandled promise rejection that surfaced as a blank error state in the UI.

### Root Cause

The `RetryLink` in `EsoLogsClient` only retried HTTP 429 responses. A network-level failure (status code `0` / no `statusCode`  caused by CORS drops, DNS failures, or dropped connections, as seen on Firefox) bypassed retry entirely and propagated immediately as an unhandled rejection.

### Changes

- **`retryLink.retryIf`**  extended to retry when `statusCode` is `undefined` (i.e. no HTTP response was received), using the same 3-attempt exponential-backoff already in place for 429s.
- **`EsoLogsClient.query()` catch block**  added a user-friendly error message for `statusCode === undefined || statusCode === 0` so UI components receive an actionable string (`"Network error: Could not connect to the ESO Logs API..."`) instead of an opaque stack trace.
- **Tests**  added four new unit tests covering: no-statusCode network error, status-0 error, 429 rate-limit, and passthrough of unrelated errors (500, etc.).

### Files Changed

- `src/esologsClient.ts`
- `src/esologsClient.test.ts`
