### PR TITLE
fix(ESO-623): filter cross-player CIE auras in class detection

### DIFF
--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -1133,9 +1133,19 @@ export const SYNERGY_ABILITY_IDS = Object.freeze(
   ]),
 );
 
-// Aura ability IDs that should be ignored for class detection to prevent false positives
+// Aura ability IDs that should be ignored for class detection to prevent false positives.
+// These are active skills whose lingering pre-buff zones/effects appear in CIE self-auras
+// even though the player never used that skill line during the actual fight.
 export const AURA_EXCLUDED_ABILITIES = Object.freeze(
-  new Set<number>([KnownAbilities.UNNERVING_BONEYARD]),
+  new Set<number>([
+    KnownAbilities.UNNERVING_BONEYARD, // 117815 — Necro Grave Lord (Avid Boneyard morph)
+    117860, // Avid Boneyard zone (alternate ID for Necro Grave Lord pre-buff)
+    23206, // Lightning Flood puddle (Sorc Storm Calling pre-buff AoE)
+    23203, // Liquid Lightning variant (Sorc Storm Calling pre-buff AoE)
+    102329, // Summon Charged Atronach zone (Sorc ultimate pre-buff zone effect)
+    32950, // Standard of Might zone (DK ultimate pre-buff ground effect)
+    32956, // Standard of Might zone variant (DK ultimate pre-buff)
+  ]),
 );
 
 // Major Maim debuff ability IDs (mitigation debuff: -10% damage done by enemy)

--- a/src/utils/classDetectionUtils.test.ts
+++ b/src/utils/classDetectionUtils.test.ts
@@ -217,6 +217,28 @@ describe('classDetectionUtils', () => {
       expect(result).toEqual(new Set());
     });
 
+    it('should ignore auras sourced by other players', () => {
+      const crossPlayerAuraEvents = [
+        {
+          type: 'combatantinfo',
+          sourceID: 123,
+          auras: [
+            {
+              ability: 1001,
+              source: 999, // different player
+              stacks: 1,
+              icon: '',
+              name: '',
+            },
+          ],
+        },
+      ];
+
+      const result = extractPlayerAbilityIds(playerId, crossPlayerAuraEvents, [], [], [], []);
+
+      expect(result).toEqual(new Set());
+    });
+
     it('should extract ability IDs from cast events', () => {
       const result = extractPlayerAbilityIds(playerId, [], mockCastEvents, [], [], []);
 


### PR DESCRIPTION
## Summary

Fixes false positive class skill line detection where players were showing 4+ skill lines instead of the expected 3.

**Jira**: [ESO-623](https://bkrupa.atlassian.net/browse/ESO-623)
**Repro**: [Fight 39 - Players Panel](https://esotk.com/report/F4f2bMwWtgVKxjB9/fight/39/players)

## Root Cause

Two sources of false positives in CombatantInfoEvent (CIE) aura processing:

1. **Cross-player AoE contamination**: Pre-buff ground AoEs (Lightning Flood, Liquid Lightning, etc.) placed by other players appeared as auras on bystanders. The class detector counted these as the bystander's own abilities, matching wrong skill lines.

2. **Self-sourced pre-fight residuals**: A player's own pre-buff ground zones (e.g. Avid Boneyard, Standard of Might) lingered in CIE auras and matched skill lines from other classes.

## Fix

**Layer 1**  Filter CIE auras by `aura.source === playerIdNum` to exclude cross-player effects.

**Layer 2**  Expand `AURA_EXCLUDED_ABILITIES` with 6 additional ground zone effect IDs:
- `117860` (Avid Boneyard zone)
- `23206` (Lightning Flood puddle)
- `23203` (Liquid Lightning)
- `102329` (Summon Charged Atronach zone)
- `32950`/`32956` (Standard of Might variants)

All 7 excluded IDs verified as active/effect abilities (not passives). Passives like Energized (`45190`) intentionally NOT excluded  they only appear in CIE and are legitimate skill line indicators.

## Testing

- Added unit test for cross-player aura filtering
- All 159 test suites pass (2327 tests)
- Verified correct skill line detection for all 12 players in the repro fight
