### PR TITLE
fix(ui): eliminate seam in nebula background

### DIFF
--- a/src/features/loadout-manager/components/NebulaBackground.tsx
+++ b/src/features/loadout-manager/components/NebulaBackground.tsx
@@ -170,8 +170,8 @@ export const NebulaBackground: React.FC = () => {
           inset: 0,
           zIndex: 3,
           backgroundImage: `
-            linear-gradient(rgba(0, 217, 255, 0.025) 1px, transparent 1px),
-            linear-gradient(90deg, rgba(0, 217, 255, 0.025) 1px, transparent 1px)
+            linear-gradient(transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px),
+            linear-gradient(90deg, transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px)
           `,
           backgroundSize: '50px 50px',
           opacity: 0.4,

--- a/src/features/loadout-manager/components/styles/textureStyles.ts
+++ b/src/features/loadout-manager/components/styles/textureStyles.ts
@@ -32,7 +32,7 @@ export const nebulaBackgroundBase: SxProps<Theme> = {
  * Use on top of dark backgrounds to add luminous depth
  */
 export const blendOverlayScreen: SxProps<Theme> = {
-  position: 'absolute',
+  position: 'fixed',
   inset: 0,
   background: `
     radial-gradient(circle at 30% 40%, rgba(167, 139, 250, 0.15) 0%, transparent 40%),
@@ -49,7 +49,7 @@ export const blendOverlayScreen: SxProps<Theme> = {
  * Use for ambient occlusion simulation
  */
 export const blendOverlayMultiply: SxProps<Theme> = {
-  position: 'absolute',
+  position: 'fixed',
   inset: 0,
   background: 'radial-gradient(circle at 50% 80%, transparent 0%, rgba(0, 0, 0, 0.3) 100%)',
   mixBlendMode: 'multiply' as const,


### PR DESCRIPTION
## Summary

Fixes a visible horizontal seam in the nebula background that appeared at the content/viewport boundary during scrolling.

### Root cause
`blendOverlayScreen` and `blendOverlayMultiply` were `position: absolute`, sizing them to the document content height rather than the viewport. The `blendOverlayMultiply` gradient darkens toward the bottom and cut off sharply, creating a hard seam line.

### Changes
- **`textureStyles.ts`**: Changed both blend overlays from `position: absolute` to `position: fixed` so they always cover the full viewport.
- **`NebulaBackground.tsx`**: Centered the grid line within each 50px tile (at 2425px) so tile repeat boundaries fall in transparent space, removing the double-line grid artifact.
