### PR TITLE
fix: clamp roster import events limit to API maximum of 10000

### DIFF
--- a/src/pages/RosterBuilderPage.tsx
+++ b/src/pages/RosterBuilderPage.tsx
@@ -161,7 +161,7 @@ const GET_PLAYERS_FOR_REPORT = gql`
     reportData {
       report(code: $code) {
         playerDetails(includeCombatantInfo: true, fightIDs: $fightIDs)
-        events(fightIDs: $fightIDs, dataType: CombatantInfo, useActorIDs: true, limit: 1000000) {
+        events(fightIDs: $fightIDs, dataType: CombatantInfo, useActorIDs: true, limit: 10000) {
           data
         }
       }


### PR DESCRIPTION
## Summary

The **Import Roster from ESO Logs** feature was failing with:

> "Failed to import from URL: Network error: Could not connect to the ESO Logs API."

## Root Cause

The `GET_PLAYERS_FOR_REPORT` GraphQL query requested `limit: 1000000` for `CombatantInfo` events. According to the ESO Logs API schema, the allowed range is **10010000**. The API rejected the over-limit query, and Apollo Client surfaced the rejection as a network-level error with no status code, triggering the generic "Could not connect" message.

## Fix

Changed `limit: 1000000`  `limit: 10000` (the allowed maximum) in the `events` field of the query. For `CombatantInfo` events (one record per player per fight), even a few hundred would be sufficient.
