### PR TITLE
fix(theme): suppress dark nebula background in light mode

### DIFF
--- a/src/components/shared/SiteBackground.tsx
+++ b/src/components/shared/SiteBackground.tsx
@@ -4,6 +4,7 @@
  * across the entire ESO Toolkit.
  */
 
+import { useTheme } from '@mui/material/styles';
 import React from 'react';
 
 import { NebulaBackground } from '../../features/loadout-manager/components/NebulaBackground';
@@ -12,7 +13,12 @@ import { NebulaBackground } from '../../features/loadout-manager/components/Nebu
  * SiteBackground - Global cosmic/nebula background for the entire site
  *
  * Place this component at the root level of the app, inside the theme provider.
+ * Only renders the nebula in dark mode; light mode relies on the plain theme background.
  */
 export const SiteBackground: React.FC = () => {
+  const theme = useTheme();
+  if (theme.palette.mode === 'light') {
+    return null;
+  }
   return <NebulaBackground />;
 };


### PR DESCRIPTION
## Summary

Fixes light mode by suppressing the dark nebula/starfield background when the theme is set to light.

## Jira Ticket

[ESO-631](https://bkrupa.atlassian.net/browse/ESO-631)

## Problem

Switching to light mode left the dark cosmic starfield background visible behind all pages. The header and panels correctly turned light, but the dark nebula persisted, making the UI look broken.

## Root Cause

`SiteBackground` unconditionally rendered `NebulaBackground`, which is a fixed-position dark starfield (`position: fixed, inset: 0`) with a hardcoded `#050810` base gradient and animated purple/cyan nebula clouds. It had no awareness of the current theme mode, so it always painted over the light `#f8fafc` body background.

## Changes Made

- `src/components/shared/SiteBackground.tsx` — reads `theme.palette.mode` via `useTheme()` and returns `null` in light mode. In dark mode, behaviour is unchanged. The MUI `CssBaseline` and the light-mode `bg` token (`#f8fafc`) from `ReduxThemeProvider` then paint the background correctly.

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Visually verified: switching to light mode no longer shows the dark starfield
- [ ] Unit tests pass (`npm test -- --watchAll=false`)
- [ ] Pre-commit validation passes (`npm run validate`)


[ESO-631]: https://bkrupa.atlassian.net/browse/ESO-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ