### PR TITLE
feat(ESO-632): add dev:https npm script and dev-https.cjs node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "coverage:badge-json:upload": "npm run coverage:badge-json",
     "coverage:open": "npx open-cli coverage/lcov-report/index.html",
     "dev": "node scripts/generate-version.cjs && vite",
+    "dev:https": "node scripts/dev-https.cjs",
     "download-report-data": "npm run script -- scripts/download-report-data.ts",
     "download-test-data": "npm run script -- scripts/download-test-data.ts",
     "fetch-abilities": "npm run script -- scripts/fetchAbilitiesToJson.ts",

--- a/scripts/dev-https.cjs
+++ b/scripts/dev-https.cjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Start the Vite development server in HTTPS mode.
+ *
+ * Usage:
+ *   node scripts/dev-https.cjs            # HTTPS on port 3001, HTTP proxy on 3000
+ *   PORT=3002 node scripts/dev-https.cjs  # HTTPS on port 3003, HTTP proxy on 3002
+ *
+ * What this does:
+ *   1. Generates the version.json file (same as `npm run dev`).
+ *   2. Spawns Vite with VITE_HTTPS=true so vite.config.mjs enables mkcert + the
+ *      HTTP→HTTPS reverse-proxy that also serves the CA-cert install page.
+ *
+ * Port allocation (mirrors the worktree port table in CLAUDE.md):
+ *   The HTTP proxy binds to PORT (even).
+ *   Vite HTTPS binds to PORT + 1 (odd).
+ *   Default PORT is 3000, yielding HTTP :3000 → HTTPS :3001.
+ */
+
+'use strict';
+
+const { execFileSync, spawn } = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+
+// ── 1. Generate version.json (same step as `npm run dev`) ─────────────────────
+try {
+  execFileSync(process.execPath, [path.join(__dirname, 'generate-version.cjs')], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+} catch (err) {
+  console.error('Failed to generate version:', err.message);
+  process.exit(1);
+}
+
+// ── 2. Resolve the HTTP proxy port from the environment ───────────────────────
+const rawPort = process.env.PORT || '3000';
+const parsedPort = Number.parseInt(rawPort, 10);
+const port = Number.isNaN(parsedPort) ? 3000 : parsedPort;
+
+console.info(
+  `\n  Starting HTTPS dev server — HTTP proxy :${port} → HTTPS :${port + 1}\n`,
+);
+
+// ── 3. Spawn Vite with VITE_HTTPS=true ────────────────────────────────────────
+const env = {
+  ...process.env,
+  VITE_HTTPS: 'true',
+  PORT: String(port),
+};
+
+// Resolve the vite binary from the local node_modules
+const viteBin = path.join(root, 'node_modules', '.bin', 'vite');
+
+const child = spawn(viteBin, [], {
+  cwd: root,
+  env,
+  stdio: 'inherit',
+  shell: process.platform === 'win32', // required on Windows to find .cmd shims
+});
+
+child.on('error', (err) => {
+  console.error('Failed to start Vite:', err.message);
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  process.exit(code ?? 0);
+});
+
+// Forward SIGINT / SIGTERM so the child process can clean up
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    child.kill(sig);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `dev:https` npm script and the backing `scripts/dev-https.cjs` Node.js script to make it easy to start the Vite dev server in HTTPS mode from the command line.

## Jira Ticket

[ESO-632](https://bkrupa.atlassian.net/browse/ESO-632)

## Problem

There was no dedicated npm script for starting the dev server in HTTPS mode. Developers had to remember to set `VITE_HTTPS=true` manually before running `npm run dev`.

## Changes Made

- **`scripts/dev-https.cjs`** — New Node script that:
  1. Runs `generate-version.cjs` first (mirrors `npm run dev` behaviour)
  2. Spawns Vite with `VITE_HTTPS=true` set in the environment
  3. Reads `PORT` from the environment (defaults to `3000`), so the HTTP proxy binds to `PORT` and Vite HTTPS binds to `PORT+1`, matching the existing worktree port table
  4. Forwards `SIGINT`/`SIGTERM` so Ctrl+C cleanly shuts down Vite
  5. Uses `shell: true` on Windows for correct `.cmd` shim resolution

- **`package.json`** — Added `dev:https` script:
  ```
  npm run dev:https                   # HTTP proxy :3000, HTTPS :3001
  PORT=3002 npm run dev:https         # HTTP proxy :3002, HTTPS :3003 (worktree 1)
  ```

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`


[ESO-632]: https://bkrupa.atlassian.net/browse/ESO-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ