### PR TITLE
ESO-638 docs(skills): add UI screenshot workflow to create-pr skill

### DIFF
--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-pr
-description: 'Create pull requests using gh CLI with automatic PR template population. Always use --body-file to avoid PowerShell mangling markdown. Use after completing work on a feature branch.'
+description: 'Create pull requests using gh CLI with automatic PR template population. Always use --body-file to avoid PowerShell mangling markdown. Automatically captures screenshots for UI changes. Use after completing work on a feature branch.'
 ---
 
 # Skill: Pull Request Creation
 
 ## Overview
 
-Create pull requests using the GitHub CLI. **Always use a temp file for the PR body** to avoid PowerShell mangling markdown.
+Create pull requests using the GitHub CLI. **Always use a temp file for the PR body** to avoid PowerShell mangling markdown. **Automatically detect UI changes and include screenshots** in the PR description.
 
 ## When to Use
 
@@ -50,6 +50,32 @@ npm run validate
 npm test -- --watchAll=false
 ```
 
+### 4. Check for UI Changes (Screenshot Detection)
+
+Before writing the PR body, determine whether the PR includes visual/UI changes:
+
+```powershell
+# Get changed files relative to base branch
+$baseBranch = (twig branch parent 2>$null) -replace '\s',''
+if (-not $baseBranch -or $baseBranch -eq '') {
+    $baseBranch = (git config "branch.$(git branch --show-current).parent") 2>$null
+}
+if (-not $baseBranch -or $baseBranch -eq '') { $baseBranch = 'main' }
+
+$changedFiles = git diff --name-only "$baseBranch...HEAD"
+```
+
+**UI changes are present if ANY changed file matches these patterns:**
+- `src/components/**/*.tsx` — shared UI components
+- `src/features/**/*.tsx` — feature components with visual changes
+- `src/ReduxThemeProvider.tsx` — theme/design token changes
+- `src/utils/roleColors.ts` — role color changes
+- Any `.tsx` file with changes to: `styled()`, `sx` prop, CSS-in-JS, `className`, layout JSX, MUI component usage
+
+**If UI changes are detected → proceed to the [Screenshots for UI Changes](#screenshots-for-ui-changes) section before writing the PR body.**
+
+If no UI changes are detected (e.g., pure logic, tests, config, data files), skip the screenshots section entirely.
+
 ## Command
 
 ```powershell
@@ -65,6 +91,123 @@ gh pr create --title "ESO-#### type(scope): description" --body-file ".github/tm
 ```
 
 > **Stacked branches**: The base branch should be the parent branch (e.g., `ESO-449/feature-a`), not `main`. The command above auto-detects this via twig or git config.
+
+---
+
+## Screenshots for UI Changes
+
+When the PR includes visual changes, **always capture screenshots** and include them in the PR description. This provides reviewers with immediate visual context and creates a historical record of UI evolution.
+
+### Step 1 — Identify Affected Pages
+
+Review the changed `.tsx` files and determine which pages/views are visually affected. Map changed files to their routes:
+
+| Changed file pattern | Likely affected page |
+|---------------------|---------------------|
+| `src/features/fight_replay/` | Fight replay view (`/report/ID/fight/N/replay`) |
+| `src/features/loadout_manager/` | Loadout manager page |
+| `src/features/scribing/` | Scribing-related views |
+| `src/components/shared/` | Multiple pages (capture representative ones) |
+| `src/components/Report/` | Report pages |
+| `src/ReduxThemeProvider.tsx` | Entire app (capture 2–3 representative pages) |
+
+### Step 2 — Capture Screenshots
+
+Use the **MCP Playwright browser tool** to navigate to affected pages and take screenshots.
+
+**Setup:**
+
+1. Ensure the dev server is running (`npm run dev`)
+2. Use the MCP browser tool to navigate and capture
+
+**Capture process using MCP Playwright browser:**
+
+```
+# Navigate to the affected page
+browser_navigate → http://localhost:3000/path/to/affected/page
+
+# Wait for the page to fully load (wait for skeletons to disappear)
+browser_wait_for → Wait for page content to be ready
+
+# Take a screenshot and save it
+browser_take_screenshot → Save to scratch/pr-screenshots/
+```
+
+**Screenshot naming convention:**
+
+```
+scratch/pr-screenshots/{area}-{description}.png
+```
+
+Examples:
+- `scratch/pr-screenshots/report-damage-tab.png`
+- `scratch/pr-screenshots/loadout-manager-dark.png`
+- `scratch/pr-screenshots/fight-replay-controls.png`
+- `scratch/pr-screenshots/theme-change-homepage.png`
+
+**Ensure the `scratch/pr-screenshots/` directory exists:**
+
+```powershell
+New-Item -ItemType Directory -Path scratch/pr-screenshots -Force
+```
+
+### Step 3 — Upload Screenshots to GitHub
+
+Screenshots in `scratch/` are gitignored and cannot be referenced by URL in the PR body. Use a **GitHub draft release** to host the images:
+
+```powershell
+$branch = git branch --show-current
+$ticket = if ($branch -match '(ESO-\d+)') { $Matches[1] } else { 'screenshots' }
+$tag = "pr-assets/$ticket"
+
+# Create a draft release to host screenshot assets
+gh release create $tag --draft --title "PR Screenshots: $ticket" --notes "Temporary asset host for PR screenshots. Safe to delete after PR is merged."
+
+# Upload all screenshots from scratch/pr-screenshots/
+Get-ChildItem scratch/pr-screenshots/*.png | ForEach-Object {
+    gh release upload $tag $_.FullName --clobber
+}
+
+# Retrieve the download URLs for each uploaded asset
+$assets = gh release view $tag --json assets | ConvertFrom-Json
+$assets.assets | ForEach-Object {
+    Write-Output "![$($_.name)]($($_.url))"
+}
+```
+
+The output gives you markdown image references like:
+```
+![report-damage-tab.png](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/pr-assets/ESO-XXX/report-damage-tab.png)
+```
+
+Use these URLs directly in the `## Screenshots` section of the PR body.
+
+### Step 4 — Include in PR Body
+
+Add the `## Screenshots` section to the PR body (see [PR Body Template](#pr-body-template) below). Place it after `## Changes Made` and before `## Testing Done`.
+
+### Cleanup (Post-Merge)
+
+After the PR is merged, delete the draft release to keep the repo tidy:
+
+```powershell
+$ticket = "ESO-XXX"   # Replace with actual ticket
+gh release delete "pr-assets/$ticket" --yes
+```
+
+> **Note**: Deleting the release will break the image links in the closed PR description. This is acceptable — the screenshots served their purpose during review. If you want permanent records, leave the draft release in place.
+
+### Alternative: Manual Screenshot Upload (Fallback)
+
+If the MCP browser tool or draft release approach is unavailable:
+
+1. Save screenshots to `scratch/pr-screenshots/`
+2. Create the PR **without** the Screenshots section (or with a placeholder)
+3. Open the PR in a browser
+4. Edit the PR description and **drag-and-drop** the screenshot files from `scratch/pr-screenshots/` directly into the edit box
+5. GitHub will upload them to its CDN and insert `![image](https://github.com/user-attachments/assets/...)` URLs automatically
+
+---
 
 ## 🚨 CRITICAL: Always Use --body-file, Never --body
 
@@ -138,7 +281,7 @@ Remove-Item ".github/tmp-pr-body.md" -ErrorAction SilentlyContinue
 
 ## PR Body Template
 
-When writing the temp PR body file, use this structure:
+When writing the temp PR body file, use this structure. **Include the Screenshots section only when UI changes are present** (see [Prerequisites Step 4](#4-check-for-ui-changes-screenshot-detection)).
 
 ```markdown
 ## Summary
@@ -163,6 +306,29 @@ Technical explanation of why the issue occurred.
 - Change 2
 - Change 3
 
+## Screenshots
+
+<!-- ONLY include this section when the PR contains UI/visual changes.
+     Delete this entire section for non-UI PRs. -->
+
+| Before | After |
+|--------|-------|
+| ![Before: description](URL) | ![After: description](URL) |
+
+<!-- For changes with no meaningful "before" state (new UI), use a simple layout: -->
+
+### New Feature Name
+
+![Description of the new UI](URL)
+
+<!-- For theme/global changes affecting multiple pages, show multiple screenshots: -->
+
+### Page/View Name
+![Description](URL)
+
+### Another Page/View Name
+![Description](URL)
+
 ## Testing Done
 
 - [ ] TypeScript compiles (`npm run typecheck`)
@@ -170,6 +336,7 @@ Technical explanation of why the issue occurred.
 - [ ] Formatting passes (`npm run format:check`)
 - [ ] Unit tests pass (`npm test -- --watchAll=false`)
 - [ ] Pre-commit validation passes (`npm run validate`)
+- [ ] Screenshots captured for UI changes (if applicable)
 ```
 
 ## Expected Output
@@ -204,6 +371,13 @@ git log main..HEAD --oneline
 gh pr edit --title "ESO-#### type(scope): updated description" --body-file ".github/tmp-pr-body.md"
 ```
 
+### Issue: Screenshots not loading in PR description
+
+**Possible causes:**
+- Draft release was deleted before PR was reviewed — re-upload with `gh release create`
+- Wrong URL format — ensure you use the `url` field from `gh release view --json assets`, not the `apiUrl`
+- Release is still in draft — draft release assets are still accessible via direct URL
+
 ## Post-PR Steps
 
 After the PR is created:
@@ -213,8 +387,21 @@ After the PR is created:
 acli jira workitem transition --key ESO-#### --status "In Review"
 ```
 
+After the PR is merged (optional cleanup):
+
+```powershell
+# Delete the temporary screenshot hosting release
+$ticket = "ESO-####"
+gh release delete "pr-assets/$ticket" --yes 2>$null
+
+# Clean up local screenshots
+Remove-Item -Recurse -Force scratch/pr-screenshots -ErrorAction SilentlyContinue
+```
+
 ## Related Skills
 
 - [workflow](../workflow/SKILL.md) — branch creation and Jira integration
 - [testing](../testing/SKILL.md) — pre-PR validation
 - [jira](../jira/SKILL.md) — Jira ticket management
+- [ui-updates](../ui-updates/SKILL.md) — theme-consistent UI changes (when making visual changes)
+- [playwright](../playwright/SKILL.md) — E2E test execution (for verifying visual behavior)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ git checkout -b ESO-XXX/description-here
 - **UI Updates**: [.github/skills/ui-updates/SKILL.md](.github/skills/ui-updates/SKILL.md) - Theme-consistent UI changes (glassmorphism, colors, typography, patterns)
 
 **Workflow & Git:**
-- **Create PR**: [.github/skills/create-pr/SKILL.md](.github/skills/create-pr/SKILL.md) - PR creation with PowerShell-safe `--body-file` pattern
+- **Create PR**: [.github/skills/create-pr/SKILL.md](.github/skills/create-pr/SKILL.md) - PR creation with PowerShell-safe `--body-file` pattern and automatic UI screenshots
 - **Git Operations**: [.github/skills/git/SKILL.md](.github/skills/git/SKILL.md) - Branch management (twig with plain git fallbacks)
 - **Git Workflow Enforcement**: [.github/skills/workflow/SKILL.md](.github/skills/workflow/SKILL.md) - **Use this FIRST**
 - **Post-Squash Rebase**: [.github/skills/rebase/SKILL.md](.github/skills/rebase/SKILL.md) - Recovery after squash-merge of stacked branches


### PR DESCRIPTION
## Summary

Updates the `create-pr` skill to automatically detect UI changes and capture screenshots for inclusion in PR descriptions. This ensures visual changes are always documented with before/after evidence for reviewers.

## Jira Ticket

[ESO-638](https://bkrupa.atlassian.net/browse/ESO-638)

## Changes Made

### New Prerequisite: UI Change Detection (Step 4)
- Checks `git diff` against the base branch for changed `.tsx` files in `src/components/`, `src/features/`, theme files, etc.
- Determines whether the PR includes visual changes that need screenshots

### New Section: "Screenshots for UI Changes"
Complete 4-step workflow:
1. **Identify affected pages** — maps changed files to their routes/views
2. **Capture screenshots** — uses MCP Playwright browser tool, saves to `scratch/pr-screenshots/`
3. **Upload to GitHub** — uses a draft release (`pr-assets/ESO-XXX`) as a lightweight image host
4. **Include in PR body** — markdown image references in a `## Screenshots` section

### Updated PR Body Template
- Added conditional `## Screenshots` section with three layout options:
  - Before/after table for modifications
  - Single image for new features
  - Multiple images for theme/global changes
- Added "Screenshots captured for UI changes" checkbox to Testing Done

### Fallback & Cleanup
- Manual drag-and-drop fallback when MCP tools are unavailable
- Post-merge cleanup instructions (delete draft release + local files)
- Troubleshooting for screenshot loading issues

### Other
- Added `ui-updates` and `playwright` to Related Skills
- Updated skill description in `AGENTS.md`

## Testing Done

- [x] Markdown renders correctly (verified structure and links)
- [x] No code changes — docs/skill only


[ESO-638]: https://bkrupa.atlassian.net/browse/ESO-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ