### PR TITLE
docs(skills): add worktree-awareness guidance to prevent unnecessary stash disruption

### DIFF
--- a/.github/skills/git/SKILL.md
+++ b/.github/skills/git/SKILL.md
@@ -17,6 +17,19 @@ twig --version 2>$null
 if ($LASTEXITCODE -ne 0) { Write-Host "twig not installed — using plain git fallbacks" }
 ```
 
+## ⚠️ Worktree Awareness
+
+This project uses **git worktrees** — multiple branches checked out simultaneously in separate directories (e.g. `D:\code\eso-log-aggregator-635`). **Always check worktrees before any branch operation**:
+
+```powershell
+git worktree list
+```
+
+If the target branch is already checked out in another worktree:
+- **Navigate there directly** (`Set-Location <path>`) instead of using `git checkout`
+- Attempting `git checkout <branch>` when that branch is open in another worktree will fail with `"already used by worktree"` — but worse, you may have already stashed unrelated in-progress work unnecessarily before discovering the error
+- **Never stash to switch branches** when a worktree exists for that branch
+
 Install twig (optional): `npm install -g @gittwig/twig`
 
 ## Branch Naming Conventions

--- a/.github/skills/rebase-conflicts/SKILL.md
+++ b/.github/skills/rebase-conflicts/SKILL.md
@@ -19,6 +19,26 @@ Rebasing replays your branch's commits on top of another branch (usually `main`)
 - `twig cascade` (or manual branch cascade) hits conflicts
 - Developer is stuck mid-rebase and doesn't know how to continue
 
+## ⚠️ Worktree Check (Do First)
+
+**Always** run this before touching any branch:
+
+```powershell
+git worktree list
+```
+
+If the target branch is already checked out in another worktree (e.g. `D:\code\eso-log-aggregator-635`), **navigate there directly** — do NOT attempt `git checkout` in the current worktree:
+
+```powershell
+# Right: go to the worktree where the branch lives
+Set-Location D:\code\eso-log-aggregator-635
+
+# Wrong: git checkout ESO-635/... will fail with "already used by worktree"
+# and forces an unnecessary stash of unrelated in-progress work
+```
+
+---
+
 ## Prerequisites
 
 - Working directory is clean (`git status` shows no uncommitted changes)
@@ -59,6 +79,14 @@ This makes Git accept the default commit message without opening an editor.
 ---
 
 ## Step-by-Step: Simple Rebase
+
+### Step 0: Check Worktrees
+
+```powershell
+# Find which worktree has the branch already checked out
+git worktree list
+# If it appears in another worktree path, cd there and skip Step 1
+```
 
 ### Step 1: Ensure Clean Working Directory
 


### PR DESCRIPTION
## Summary

Adds explicit worktree-awareness guidance to two agent skills to prevent a class of mistake where an agent attempts `git checkout` on a branch already open in another worktree, unnecessarily stashing unrelated in-progress work.

### Changes

- **`.github/skills/rebase-conflicts/SKILL.md`**  added a ** Worktree Check (Do First)** section before Prerequisites that instructs agents to run `git worktree list` first and navigate directly to the existing worktree via `Set-Location` rather than checking out; also added a **Step 0** to the step-by-step guide
- **`.github/skills/git/SKILL.md`**  added a ** Worktree Awareness** section explaining the multi-worktree pattern, why checking first is required, and that stashing to switch branches when a worktree already exists for that branch is always wrong

### Motivation

An agent rebased `ESO-635/add-remove-set-button-roster-manager` by first attempting `git checkout` from the main worktree (which was on ESO-634 with unstaged work). Git rejected the checkout because the branch was already open in `D:\code\eso-log-aggregator-635`, but only after the agent had already stashed the ESO-634 in-progress changes  causing a stash-pop conflict that required manual recovery.

## Checklist

- [x] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
