### PR TITLE
chore: add .github/tmp-pr-body.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ Icon?
 *.pid
 .playwright-mcp/
 tmp/
+.github/tmp-pr-body.md
 
 # Debug and test files in root
 /debug-*.js


### PR DESCRIPTION
## Summary

Adds `.github/tmp-pr-body.md` to `.gitignore` so the temporary PR body file created by the `create-pr` agent skill is never accidentally committed.

## Changes Made

- Added `.github/tmp-pr-body.md` to the "Temporary files" section of `.gitignore`

## Testing Done

- No functional code changed; `.gitignore` update only
