### PR TITLE
style(loadout-manager): remove redundant role from character dropdown

### DIFF
--- a/src/features/loadout-manager/components/CharacterSelector.tsx
+++ b/src/features/loadout-manager/components/CharacterSelector.tsx
@@ -97,7 +97,7 @@ export const CharacterSelector: React.FC = (): React.ReactElement => {
           renderValue={(value) => {
             const char = sortedCharacters.find((c) => c.id === value);
             if (!char) return 'Select character';
-            return `${char.name} · ${formatRole(char.role)}`;
+            return char.name;
           }}
           MenuProps={{
             slotProps: {


### PR DESCRIPTION
The character dropdown's selected value was showing `Name · Role` (e.g. "Brayd · DPS"), but the Role dropdown immediately next to it already displays the same information. Removed the role suffix so the character dropdown just shows the character name.

The role still appears in the per-character dropdown options (secondary text) and in the adjacent Role selector, so no information is lost.