### PR TITLE
feat: shared OAuth redirect for dev-preview deployments

### DIFF
--- a/src/features/auth/auth.test.ts
+++ b/src/features/auth/auth.test.ts
@@ -4,7 +4,12 @@ import {
   CLIENT_ID,
   PKCE_CODE_VERIFIER_KEY,
   LOCAL_STORAGE_ACCESS_TOKEN_KEY,
+  getRedirectUri,
+  DEV_PREVIEW_OAUTH_RETURN_KEY,
 } from './auth';
+import { getBaseUrl } from '../../utils/envUtils';
+
+jest.mocked(getBaseUrl).mockReturnValue('https://esotk.com/');
 
 const mockLocalStorage = {
   getItem: jest.fn(),
@@ -51,6 +56,36 @@ describe('OAuth Basic Functions', () => {
     it('should have proper storage keys', () => {
       expect(PKCE_CODE_VERIFIER_KEY).toBe('eso_code_verifier');
       expect(LOCAL_STORAGE_ACCESS_TOKEN_KEY).toBe('access_token');
+    });
+  });
+
+  describe('getRedirectUri', () => {
+    it('should return production redirect URI for standard deployment', () => {
+      jest.mocked(getBaseUrl).mockReturnValue('https://esotk.com/');
+      expect(getRedirectUri()).toBe('https://esotk.com/oauth-redirect');
+    });
+
+    it('should return shared redirect URI for dev-preview deployments', () => {
+      jest.mocked(getBaseUrl).mockReturnValue('https://eso-toolkit.github.io/dev-previews/pr-790/');
+      expect(getRedirectUri()).toBe('https://eso-toolkit.github.io/dev-previews/oauth-redirect');
+    });
+
+    it('should return shared redirect URI for any PR number', () => {
+      jest
+        .mocked(getBaseUrl)
+        .mockReturnValue('https://eso-toolkit.github.io/dev-previews/pr-12345/');
+      expect(getRedirectUri()).toBe('https://eso-toolkit.github.io/dev-previews/oauth-redirect');
+    });
+
+    it('should not affect non-dev-preview subpaths', () => {
+      jest.mocked(getBaseUrl).mockReturnValue('https://example.com/some-other-path/');
+      expect(getRedirectUri()).toBe('https://example.com/some-other-path/oauth-redirect');
+    });
+  });
+
+  describe('DEV_PREVIEW_OAUTH_RETURN_KEY', () => {
+    it('should have the expected key value', () => {
+      expect(DEV_PREVIEW_OAUTH_RETURN_KEY).toBe('dev_preview_oauth_return_path');
     });
   });
 });

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -7,18 +7,30 @@ const logger = new Logger({
   contextPrefix: 'Auth',
 });
 
-// Compose redirect URI using Vite's BASE_URL
+// Compose redirect URI using Vite's BASE_URL.
+// For dev-preview deployments (e.g. /dev-previews/pr-790/), all PR previews
+// share a single registered redirect URI at /dev-previews/oauth-redirect so we
+// don't need to register a new URI with the OAuth provider for every PR.
 export const getRedirectUri = (): string => {
   const baseUrl = getBaseUrl();
-
-  // Remove trailing slash if it exists
   const cleanBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+
+  // Detect dev-preview deployment: URL contains /dev-previews/pr-<number>
+  const devPreviewMatch = cleanBaseUrl.match(/^(https?:\/\/[^/]+\/dev-previews)\/pr-\d+/);
+  if (devPreviewMatch) {
+    return `${devPreviewMatch[1]}/oauth-redirect`;
+  }
+
   return `${cleanBaseUrl}/oauth-redirect`;
 };
 // Replace with your actual ESO Logs client ID
 export const CLIENT_ID = '9fd28ffc-300a-44ce-8a0e-6167db47a7e1';
 export const PKCE_CODE_VERIFIER_KEY = 'eso_code_verifier';
 export const INTENDED_DESTINATION_KEY = 'eso_intended_destination';
+
+// Key used by the dev-preview OAuth bounce page to know which PR preview to
+// redirect back to after the OAuth provider callback.
+export const DEV_PREVIEW_OAUTH_RETURN_KEY = 'dev_preview_oauth_return_path';
 
 export const LOCAL_STORAGE_ACCESS_TOKEN_KEY = 'access_token';
 export const LOCAL_STORAGE_REFRESH_TOKEN_KEY = 'refresh_token';
@@ -91,6 +103,13 @@ export async function buildAuthUrl(verifier: string): Promise<string> {
 export async function startPKCEAuth(): Promise<void> {
   const verifier = generateCodeVerifier();
   setPkceCodeVerifier(verifier);
+
+  // For dev-preview deployments, store the current base path so the shared
+  // OAuth bounce page knows which PR preview to redirect back to.
+  const baseUrl = getBaseUrl();
+  if (baseUrl.includes('/dev-previews/pr-')) {
+    localStorage.setItem(DEV_PREVIEW_OAUTH_RETURN_KEY, baseUrl);
+  }
 
   let authUrl: string | undefined;
   try {


### PR DESCRIPTION
## Summary

Dev-preview PR deployments all live under different subpaths (`/dev-previews/pr-XXX/`), but OAuth providers require pre-registered redirect URIs. This adds a shared OAuth redirect mechanism so all PR previews can use a single registered redirect URI.

## Changes

### eso-toolkit (this repo)
- **`getRedirectUri()`**  detects dev-preview deployments and returns the shared redirect URI at `/dev-previews/oauth-redirect` instead of the PR-specific one
- **`startPKCEAuth()`**  stores the PR base path in `localStorage` before redirecting to esologs.com, so the bounce page knows where to return
- **Tests**  covers production, dev-preview, and non-matching subpath cases

### dev-previews repo (already deployed)
- **`oauth-redirect/index.html`**  static bounce page that reads the stored return path from `localStorage` and forwards the OAuth auth code to the correct PR preview

## How it works

1. User clicks Login on PR preview at `/dev-previews/pr-790/`
2. App stores `dev_preview_oauth_return_path = "https://eso-toolkit.github.io/dev-previews/pr-790/"` in localStorage
3. App redirects to esologs.com with `redirect_uri=https://eso-toolkit.github.io/dev-previews/oauth-redirect`
4. esologs.com redirects back to the shared bounce page with `?code=XXX`
5. Bounce page reads localStorage, redirects to `/dev-previews/pr-790/oauth-redirect?code=XXX`
6. PR preview's existing `OAuthRedirect` component exchanges the code for a token

## Required Setup

Add this redirect URI to the esologs.com OAuth client settings:
```
https://eso-toolkit.github.io/dev-previews/oauth-redirect
```
