### PR TITLE
feat: add local deploy-preview script and Copilot skill

### DIFF
--- a/.github/skills/deploy-preview/SKILL.md
+++ b/.github/skills/deploy-preview/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: deploy-preview
+description: Deploy a local build to the dev-previews GitHub Pages site with a custom alias, or remove an existing preview. Use this when asked to deploy a preview, push a local build to dev-previews, create a preview URL, or clean up a local preview deployment.
+---
+
+# Skill: Deploy Local Preview
+
+## Overview
+
+Deploy any local branch to the dev-previews GitHub Pages site at `https://eso-toolkit.github.io/dev-previews/<alias>/`. This uses the `scripts/deploy-preview.ps1` script which builds the project, pushes the output to the `ESO-Toolkit/dev-previews` repo, and updates the landing page.
+
+## Prerequisites
+
+- The `ESO-Toolkit/dev-previews` repo must be cloned as a sibling directory at `D:\code\dev-previews`. If it doesn't exist:
+  ```powershell
+  git clone git@github.com:ESO-Toolkit/dev-previews.git D:\code\dev-previews
+  ```
+- Node.js and npm dependencies must be installed (`npm ci`)
+
+## Deploy a Preview
+
+### With auto-generated alias (uses current branch name)
+
+```powershell
+.\scripts\deploy-preview.ps1
+```
+
+This derives the alias from the current git branch (sanitised to URL-safe lowercase).
+
+### With a custom alias
+
+```powershell
+.\scripts\deploy-preview.ps1 -Alias "my-feature"
+```
+
+The preview will be available at `https://eso-toolkit.github.io/dev-previews/my-feature/`.
+
+### Skip the build (push existing build/ directory)
+
+```powershell
+.\scripts\deploy-preview.ps1 -Alias "quick-test" -SkipBuild
+```
+
+Use this when the project was already built with the correct `VITE_BASE_URL`.
+
+## Remove a Preview
+
+```powershell
+.\scripts\deploy-preview.ps1 -Alias "my-feature" -Remove
+```
+
+This removes the preview directory and its entry from `previews.json`, then pushes the cleanup.
+
+## What the Script Does
+
+1. **Builds** the project with `VITE_BASE_URL=/dev-previews/<alias>/` so routing works correctly
+2. **Pulls** the latest dev-previews repo to avoid push conflicts
+3. **Copies** the `build/` output into the alias directory
+4. **Updates** `previews.json` with an entry including alias, branch, commit hash, and timestamp
+5. **Commits and pushes** to the dev-previews repo
+6. GitHub Pages automatically deploys the update
+
+## Output
+
+After a successful deploy, report to the user:
+- The preview URL: `https://eso-toolkit.github.io/dev-previews/<alias>/`
+- The branch and commit that was deployed
+- Note that GitHub Pages may take 1–2 minutes to update
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Push rejected | The dev-previews repo has new commits. Run `git -C D:\code\dev-previews pull --rebase origin main` and retry. |
+| dev-previews not found | Clone it: `git clone git@github.com:ESO-Toolkit/dev-previews.git D:\code\dev-previews` |
+| Build fails | Check for TypeScript errors (`npm run typecheck`) or missing dependencies (`npm ci`) |
+| Custom DevPreviewsPath | Pass `-DevPreviewsPath "C:\path\to\dev-previews"` if the repo is not at the default sibling location |
+
+## OAuth Note
+
+Login works on custom alias previews too — the OAuth redirect URI detection matches any path under `/dev-previews/`. The user must have `https://eso-toolkit.github.io/dev-previews/oauth-redirect` registered in their esologs.com OAuth client settings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ git checkout -b ESO-XXX/description-here
 
 **CI/CD & Debugging:**
 - **Debug CI Failure**: [.github/skills/debug-ci-failure/SKILL.md](.github/skills/debug-ci-failure/SKILL.md) - End-to-end CI failure debugging workflow
+- **Deploy Preview**: [.github/skills/deploy-preview/SKILL.md](.github/skills/deploy-preview/SKILL.md) - Deploy local builds to dev-previews with a custom alias
 - **GitHub Actions Logs**: [.github/skills/github-actions-logs/SKILL.md](.github/skills/github-actions-logs/SKILL.md) - Parse and analyze GH Actions logs
 - **Troubleshoot**: [.github/skills/troubleshoot/SKILL.md](.github/skills/troubleshoot/SKILL.md) - Quick-reference fixes for common dev issues
 
@@ -203,6 +204,14 @@ See: [.github/skills/class-skill-regen/SKILL.md](.github/skills/class-skill-rege
 @workspace Fix my mangled PR description
 ```
 See: [.github/skills/create-pr/SKILL.md](.github/skills/create-pr/SKILL.md)
+
+**Deploy Preview** (Local Preview Deployments):
+```
+@workspace Deploy a preview of my current branch
+@workspace Deploy a preview with alias "my-feature"
+@workspace Remove the "my-feature" preview
+```
+See: [.github/skills/deploy-preview/SKILL.md](.github/skills/deploy-preview/SKILL.md)
 
 **Debug CI Failure**:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ For HTTPS: `$env:PORT = "3002" ; $env:VITE_HTTPS = "true" ; npm run dev`
 |-------|----------|
 | `create-pr` | Creating pull requests (PowerShell-safe `--body-file` pattern) |
 | `debug-ci-failure` | End-to-end CI failure debugging |
+| `deploy-preview` | Deploy local builds to dev-previews with a custom alias |
 | `fix-lint` | Diagnosing and fixing ESLint errors |
 | `fix-types` | Diagnosing and fixing TypeScript type errors |
 | `github-actions-logs` | Parsing and analyzing GH Actions logs |

--- a/scripts/deploy-preview.ps1
+++ b/scripts/deploy-preview.ps1
@@ -1,0 +1,235 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Deploy a local build to the dev-previews GitHub Pages site with a custom alias.
+
+.DESCRIPTION
+  Builds the project with the correct base URL and pushes the output to the
+  ESO-Toolkit/dev-previews repo under the given alias directory. This lets you
+  test any local branch on the live preview site without opening a PR.
+
+.PARAMETER Alias
+  The subdirectory name for this preview (e.g. "my-feature", "debug-auth").
+  Defaults to the current git branch name (sanitised for URLs).
+
+.PARAMETER SkipBuild
+  Push the existing build/ directory without rebuilding.
+
+.PARAMETER Remove
+  Remove an existing preview instead of deploying.
+
+.PARAMETER DevPreviewsPath
+  Path to a local clone of ESO-Toolkit/dev-previews.
+  Defaults to ../dev-previews (sibling directory).
+
+.EXAMPLE
+  # Deploy current branch with auto-generated alias
+  .\scripts\deploy-preview.ps1
+
+  # Deploy with a custom alias
+  .\scripts\deploy-preview.ps1 -Alias "my-feature"
+
+  # Push an already-built output
+  .\scripts\deploy-preview.ps1 -Alias "quick-test" -SkipBuild
+
+  # Remove a preview
+  .\scripts\deploy-preview.ps1 -Alias "my-feature" -Remove
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Alias,
+
+    [switch]$SkipBuild,
+
+    [switch]$Remove,
+
+    [string]$DevPreviewsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+
+if (-not $DevPreviewsPath) {
+    $DevPreviewsPath = Join-Path (Split-Path -Parent $ProjectRoot) 'dev-previews'
+}
+
+if (-not (Test-Path (Join-Path $DevPreviewsPath '.git'))) {
+    Write-Error @"
+dev-previews repo not found at: $DevPreviewsPath
+
+Clone it first:
+  git clone git@github.com:ESO-Toolkit/dev-previews.git "$DevPreviewsPath"
+
+Or pass -DevPreviewsPath to point to your clone.
+"@
+}
+
+# ---------------------------------------------------------------------------
+# Resolve alias
+# ---------------------------------------------------------------------------
+if (-not $Alias) {
+    # Derive from current git branch, sanitised for URLs
+    $branch = (git -C $ProjectRoot branch --show-current) 2>$null
+    if (-not $branch) {
+        Write-Error 'Could not detect git branch. Pass -Alias explicitly.'
+    }
+    # Sanitise: lowercase, replace non-alphanumeric with hyphens, collapse runs
+    $Alias = ($branch -replace '[^a-zA-Z0-9-]', '-' -replace '-+', '-').Trim('-').ToLower()
+    if (-not $Alias) {
+        Write-Error 'Derived alias is empty. Pass -Alias explicitly.'
+    }
+}
+
+$PreviewDir = Join-Path $DevPreviewsPath $Alias
+$PreviewUrl = "https://eso-toolkit.github.io/dev-previews/$Alias/"
+$BaseUrl = "/dev-previews/$Alias/"
+
+Write-Host ""
+Write-Host "  Alias:   $Alias" -ForegroundColor Cyan
+Write-Host "  URL:     $PreviewUrl" -ForegroundColor Cyan
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Remove mode
+# ---------------------------------------------------------------------------
+if ($Remove) {
+    if (Test-Path $PreviewDir) {
+        Remove-Item -Recurse -Force $PreviewDir
+        Write-Host "  Removed: $PreviewDir" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "  Nothing to remove — $Alias does not exist." -ForegroundColor Yellow
+    }
+
+    # Update previews.json
+    $previewsJson = Join-Path $DevPreviewsPath 'previews.json'
+    if (Test-Path $previewsJson) {
+        $previews = Get-Content $previewsJson -Raw | ConvertFrom-Json
+        $previews = @($previews | Where-Object { $_.alias -ne $Alias })
+        $previews | ConvertTo-Json -Depth 10 | Set-Content $previewsJson -Encoding UTF8
+    }
+
+    # Commit and push
+    Push-Location $DevPreviewsPath
+    try {
+        git add -A
+        $status = git status --porcelain
+        if ($status) {
+            git commit -m "Remove local preview: $Alias"
+            git push
+            Write-Host "  Pushed removal to dev-previews." -ForegroundColor Green
+        }
+        else {
+            Write-Host "  No changes to push." -ForegroundColor Yellow
+        }
+    }
+    finally {
+        Pop-Location
+    }
+    return
+}
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+if (-not $SkipBuild) {
+    Write-Host "  Building with VITE_BASE_URL=$BaseUrl ..." -ForegroundColor Cyan
+    Push-Location $ProjectRoot
+    try {
+        $env:NODE_ENV = 'production'
+        $env:VITE_BASE_URL = $BaseUrl
+        $env:NODE_OPTIONS = '--max-old-space-size=8192'
+        npm run build
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error 'Build failed.'
+        }
+    }
+    finally {
+        # Clean up env vars so they don't leak into the user's shell
+        Remove-Item Env:\VITE_BASE_URL -ErrorAction SilentlyContinue
+        Remove-Item Env:\NODE_OPTIONS -ErrorAction SilentlyContinue
+        Pop-Location
+    }
+}
+
+$BuildDir = Join-Path $ProjectRoot 'build'
+if (-not (Test-Path $BuildDir)) {
+    Write-Error "Build directory not found at $BuildDir. Run without -SkipBuild."
+}
+
+# ---------------------------------------------------------------------------
+# Pull latest dev-previews to avoid push conflicts
+# ---------------------------------------------------------------------------
+Push-Location $DevPreviewsPath
+try {
+    git pull --rebase origin main 2>$null
+}
+finally {
+    Pop-Location
+}
+
+# ---------------------------------------------------------------------------
+# Copy build to dev-previews
+# ---------------------------------------------------------------------------
+if (Test-Path $PreviewDir) {
+    Remove-Item -Recurse -Force $PreviewDir
+}
+Copy-Item -Recurse -Force $BuildDir $PreviewDir
+Write-Host "  Copied build to $PreviewDir" -ForegroundColor Green
+
+# ---------------------------------------------------------------------------
+# Update previews.json
+# ---------------------------------------------------------------------------
+$previewsJson = Join-Path $DevPreviewsPath 'previews.json'
+if (Test-Path $previewsJson) {
+    $previews = Get-Content $previewsJson -Raw | ConvertFrom-Json
+}
+else {
+    $previews = @()
+}
+
+# Remove existing entry for this alias, add fresh one
+$previews = @($previews | Where-Object { $_.alias -ne $Alias })
+
+$branchName = (git -C $ProjectRoot branch --show-current) 2>$null
+$commitHash = (git -C $ProjectRoot rev-parse --short HEAD) 2>$null
+$updatedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+$entry = [PSCustomObject]@{
+    alias     = $Alias
+    branch    = $branchName
+    commit    = $commitHash
+    updatedAt = $updatedAt
+    local     = $true
+}
+$previews = @($previews) + @($entry)
+
+$previews | ConvertTo-Json -Depth 10 | Set-Content $previewsJson -Encoding UTF8
+
+# ---------------------------------------------------------------------------
+# Commit and push
+# ---------------------------------------------------------------------------
+Push-Location $DevPreviewsPath
+try {
+    git add -A
+    git commit -m "Deploy local preview: $Alias ($branchName@$commitHash)"
+    git push
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error 'Failed to push to dev-previews. You may need to resolve conflicts manually.'
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "  Deployed!" -ForegroundColor Green
+Write-Host "  $PreviewUrl" -ForegroundColor Cyan
+Write-Host ""


### PR DESCRIPTION
## Summary

Adds a local deploy-preview script and matching Copilot skill for deploying any branch to the dev-previews GitHub Pages site with a custom alias.

## Changes

### `scripts/deploy-preview.ps1`
PowerShell script that:
- Builds the project with the correct `VITE_BASE_URL` for the alias
- Copies the build output to the local dev-previews repo clone
- Updates `previews.json` with alias, branch, commit hash, and timestamp
- Commits and pushes to deploy

**Usage:**
```powershell
.\scripts\deploy-preview.ps1                          # Auto-alias from branch
.\scripts\deploy-preview.ps1 -Alias "my-feature"      # Custom alias
.\scripts\deploy-preview.ps1 -Alias "test" -SkipBuild # Push existing build
.\scripts\deploy-preview.ps1 -Alias "old" -Remove     # Remove a preview
```

### `.github/skills/deploy-preview/SKILL.md`
Copilot skill so agents can deploy previews via:
```
@workspace Deploy a preview with alias "my-feature"
@workspace Remove the "my-feature" preview
```

### `AGENTS.md` / `CLAUDE.md`
Registered the new skill in the skills index and usage patterns sections.

### dev-previews repo (already deployed separately)
The landing page at `index.html` was updated to display both PR-based and local alias-based previews (local ones show a green "Local" badge).
