### PR TITLE
ESO-661 ci: skip deploy preview for Dependabot PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   deploy-preview:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary

Skip the Deploy PR Preview workflow for Dependabot PRs, which don't need preview deployments.

## Jira Ticket

[ESO-661](https://bkrupa.atlassian.net/browse/ESO-661)

## Problem

The `deploy-preview.yml` workflow runs on every pull request, including Dependabot dependency update PRs. These PRs only bump package versions and don't have meaningful visual changes, so deploying a preview wastes CI minutes and generates unnecessary GitHub App tokens.

## Changes Made

- Added `if: github.actor != 'dependabot[bot]'` condition to the `deploy-preview` job in `.github/workflows/deploy-preview.yml`

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-661]: https://bkrupa.atlassian.net/browse/ESO-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ