### PR TITLE
fix(insights): rename First Damage Dealer to Fight initiator (ESO-669)

### DIFF
--- a/src/features/report_details/insights/InsightsPanel.tsx
+++ b/src/features/report_details/insights/InsightsPanel.tsx
@@ -118,8 +118,8 @@ export const InsightsPanel: React.FC<InsightsPanelProps> = ({ fight, context }) 
     return result;
   }, [combatantInfoEvents, playerData?.playersById]);
 
-  // Find the first damage dealer
-  const firstDamageDealer = React.useMemo(() => {
+  // Find the fight initiator (the first friendly player to deal damage)
+  const fightInitiator = React.useMemo(() => {
     if (!damageEvents || damageEvents.length === 0 || !playerData?.playersById) {
       return null;
     }
@@ -150,7 +150,7 @@ export const InsightsPanel: React.FC<InsightsPanelProps> = ({ fight, context }) 
       durationMs={durationMs}
       abilityEquipped={abilityEquipped}
       buffActors={buffActors}
-      firstDamageDealer={firstDamageDealer}
+      fightInitiator={fightInitiator}
       selectedPlayerId={selectedFriendlyPlayerId ?? null}
       isLoading={isCombatantInfoEventsLoading || isDamageEventsLoading || isPlayerDataLoading}
     />

--- a/src/features/report_details/insights/InsightsPanelView.tsx
+++ b/src/features/report_details/insights/InsightsPanelView.tsx
@@ -17,7 +17,7 @@ interface InsightsPanelViewProps {
   durationMs: number;
   abilityEquipped: Partial<Record<KnownAbilities, string[]>>;
   buffActors: Partial<Record<KnownAbilities, Set<string>>>;
-  firstDamageDealer: string | null;
+  fightInitiator: string | null;
   selectedPlayerId: number | null;
   isLoading: boolean;
 }
@@ -71,7 +71,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
   durationMs,
   abilityEquipped,
   buffActors,
-  firstDamageDealer,
+  fightInitiator,
   selectedPlayerId,
   isLoading,
 }) => {
@@ -144,7 +144,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
               </Typography>
             </Box>
 
-            {firstDamageDealer && (
+            {fightInitiator && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1 }}>
                 <Box
                   sx={{
@@ -171,8 +171,8 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
                     fontSize: { xs: '0.875rem', sm: '0.9rem', md: '0.95rem' },
                   }}
                 >
-                  <strong>First Damage Dealer: </strong>
-                  <span>{firstDamageDealer}</span>
+                  <strong>Fight initiator: </strong>
+                  <span>{fightInitiator}</span>
                 </Typography>
               </Box>
             )}


### PR DESCRIPTION
## Summary

Fixes ESO-669. The Fight Insights panel incorrectly identified the "First Damage Dealer"  because the first damage event often comes from a tank (e.g. a taunt), not a true damage dealer. Per the acceptance criteria, the label is renamed to **"Fight initiator"** to accurately reflect what the field actually shows: the first friendly player to deal damage, regardless of role.

## Changes

- Renamed `firstDamageDealer`  `fightInitiator` throughout `InsightsPanel.tsx` and `InsightsPanelView.tsx`
- Updated display label from `"First Damage Dealer: "`  `"Fight initiator: "`

## Screenshots

![Fight initiator label in Fight Insights panel](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-8e4b26d1956d8068888d/fight-insights-initiator.png)

## Testing

- `npm run validate` 
- Unit tests pass (no related test files changed) 
