### PR TITLE
chore(skills): auto-invoke workflow on bare Jira ticket number

### DIFF
--- a/.github/skills/workflow/SKILL.md
+++ b/.github/skills/workflow/SKILL.md
@@ -5,6 +5,20 @@ description: Enforce git workflow by checking the current branch before starting
 
 You are enforcing the ESO Log Aggregator git workflow. Follow these steps precisely.
 
+## Automatic Invocation (Self-Trigger)
+
+This skill MUST be automatically invoked — without waiting for the user to explicitly request it — whenever:
+
+- The user's message consists **solely** of a Jira ticket reference (e.g. `eso669`, `ESO-669`, `ESO-669`)
+- The user says "work on ESO-XXX", "implement ESO-XXX", "start ESO-XXX", or any similar phrasing that implies beginning implementation
+
+**Execute Steps 1–4 of this skill BEFORE:**
+- Reading any source files
+- Viewing the Jira ticket
+- Writing or proposing any code changes
+
+The branch must be confirmed correct before any implementation begins. Skipping this step is the primary cause of commits landing on `main`.
+
 ## Step 1 — Check Current Branch
 
 Run this command and capture the output:


### PR DESCRIPTION
## Summary

Updates the workflow skill so it automatically enforces branch hygiene when an agent receives a bare Jira ticket number (e.g. `eso669`). Previously the skill had to be explicitly invoked; this change makes it self-trigger before any code is read or written.

## Problem

When a user types only a ticket number, the agent would immediately look up the ticket and start implementing  skipping branch setup entirely. This caused changes to land on `main` (as happened with ESO-669 in this session).

## Changes

Added an **Automatic Invocation** section at the top of `.github/skills/workflow/SKILL.md` that:

- Lists the exact trigger conditions (bare ticket number, or intent phrases like "work on ESO-XXX")
- Requires Steps 14 of the skill to run **before** reading any source files, viewing the ticket, or writing code

## Testing

No code changes  documentation/skill update only.
