### PR TITLE
ESO-668 fix(penetration): fix FoN and arena weapon pen overcounting

### DIFF
--- a/src/features/report_details/penetration/PenetrationPanelView.tsx
+++ b/src/features/report_details/penetration/PenetrationPanelView.tsx
@@ -179,21 +179,34 @@ export const PenetrationPanelView: React.FC<PenetrationPanelViewProps> = ({
           </Typography>
 
           <Typography variant="subtitle2" gutterBottom>
+            Force of Nature CP detection
+          </Typography>
+          <Typography variant="body2" paragraph>
+            Force of Nature (CP 276) grants 660 penetration per unique active status effect on the
+            target. ESO TK detects whether you have Force of Nature slotted by checking your
+            combatant-info aura data — the same mechanism used for other slottable CP passives. If
+            the aura is absent, status-effect penetration is not counted. CMX reads your CP loadout
+            directly from the combat log. Both tools should agree on this source; if they
+            don&apos;t, it may reflect a difference in which status effects are being tracked.
+          </Typography>
+
+          <Typography variant="subtitle2" gutterBottom>
             What is tracked the same
           </Typography>
           <Typography variant="body2" paragraph>
-            Both tools track the same debuff and buff sources — Major &amp; Minor Breach, Crusher
+            Both tools track the same debuff sources — Major &amp; Minor Breach, Crusher
             enchantment, Crimson Oath&apos;s Rive, Night Mother&apos;s Gaze, Alkosh, and CP passive
-            penetration (Piercing, Force of Nature via status effects). Differences from these
-            sources are typically negligible.
+            penetration (Piercing). Differences from these sources are typically negligible.
           </Typography>
 
           <Typography variant="subtitle2" gutterBottom>
             Typical variance
           </Typography>
           <Typography variant="body2">
-            In practice, the difference between ESO TK and CMX is usually less than 0.1% — well
-            within the margin caused by the averaging method difference.
+            In practice, the averaging-method difference causes less than 0.1% variance. When Force
+            of Nature is slotted, additional variance can appear if the tracked status effects
+            differ between tools (up to several thousand penetration when three or more are
+            simultaneously active).
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/src/hooks/workerTasks/usePenetrationDataTask.ts
+++ b/src/hooks/workerTasks/usePenetrationDataTask.ts
@@ -12,6 +12,8 @@ import {
   selectWorkerTaskError,
   selectWorkerTaskProgress,
 } from '../../store/worker_results/selectors';
+import { KnownAbilities } from '../../types/abilities';
+import { useCastEvents } from '../events/useCastEvents';
 import { useCombatantInfoRecord } from '../events/useCombatantInfoRecord';
 import { useDamageEvents } from '../events/useDamageEvents';
 import { useCurrentFight } from '../useCurrentFight';
@@ -40,7 +42,22 @@ export function usePenetrationDataTask(_options?: UsePenetrationDataTaskOptions)
   const { buffLookupData, isBuffLookupLoading } = useBuffLookupTask();
   const { debuffLookupData, isDebuffLookupLoading } = useDebuffLookupTask();
   const { damageEvents, isDamageEventsLoading } = useDamageEvents();
+  const { castEvents, isCastEventsLoaded } = useCastEvents();
   const selectedTargetIds = useSelectedTargetIds();
+
+  // Pre-filter cast events to SWAP_WEAPONS events grouped by sourceID so the worker
+  // can determine the active weapon bar at any given timestamp per player.
+  const swapEventsByPlayerId = React.useMemo(() => {
+    const result: Record<number, (typeof castEvents)[number][]> = {};
+    for (const event of castEvents) {
+      if (event.abilityGameID === KnownAbilities.SWAP_WEAPONS) {
+        const id = event.sourceID;
+        if (!result[id]) result[id] = [];
+        result[id].push(event);
+      }
+    }
+    return result;
+  }, [castEvents]);
 
   // Execute task only when ALL dependencies are completely ready
   React.useEffect(() => {
@@ -56,7 +73,8 @@ export function usePenetrationDataTask(_options?: UsePenetrationDataTaskOptions)
       !isDebuffLookupLoading &&
       debuffLookupData !== null &&
       !isDamageEventsLoading &&
-      damageEvents.length > 0;
+      damageEvents.length > 0 &&
+      isCastEventsLoaded;
 
     if (allDependenciesReady) {
       const promise = dispatch(
@@ -68,6 +86,7 @@ export function usePenetrationDataTask(_options?: UsePenetrationDataTaskOptions)
           debuffsLookup: debuffLookupData,
           damageEvents: damageEvents,
           selectedTargetIds: Array.from(selectedTargetIds),
+          swapEventsByPlayerId,
         }),
       );
       return () => {
@@ -88,6 +107,8 @@ export function usePenetrationDataTask(_options?: UsePenetrationDataTaskOptions)
     isDebuffLookupLoading,
     isBuffLookupLoading,
     isPlayerDataLoading,
+    isCastEventsLoaded,
+    swapEventsByPlayerId,
   ]);
 
   const penetrationData = useSelector(selectPenetrationDataResult);

--- a/src/utils/PenetrationUtils.test.ts
+++ b/src/utils/PenetrationUtils.test.ts
@@ -165,7 +165,7 @@ describe('PenetrationUtils', () => {
     it('should return always-active penetration for null combatant info', () => {
       const result = calculateStaticPenetration(null, undefined);
       // Only Piercing is always assumed active since it cannot be detected from log data.
-      // Status effect penetration (Wrath of Nature) is now tracked dynamically via debuffs.
+      // Force of Nature penetration is tracked dynamically via debuffs + player aura detection.
       expect(result).toBe(PenetrationValues.PIERCING_PENETRATION);
     });
 
@@ -380,7 +380,7 @@ describe('PenetrationUtils', () => {
       expect(resultAfterRemoval).toBe(0);
     });
 
-    it('should track Wrath of Nature penetration from status effect debuffs on target', () => {
+    it('should track Force of Nature penetration from status effect debuffs on target', () => {
       const targetId = 60;
       const debuffEvents = [
         // Burning active 1000-4000
@@ -456,6 +456,24 @@ describe('PenetrationUtils', () => {
 
       const debuffLookup = createDebuffLookup(debuffEvents);
 
+      // Player has Force of Nature slotted
+      const mockCombatantInfo: CombatantInfoEvent = {
+        timestamp: 0,
+        type: 'combatantinfo',
+        sourceID: 1,
+        fight: 1,
+        gear: [],
+        auras: [
+          {
+            source: 1,
+            ability: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
+            name: 'Force of Nature',
+            icon: 'icon',
+            stacks: 1,
+          } as CombatantAura,
+        ],
+      };
+
       // Before any status effects: 0 pen
       const resultBefore = calculateDynamicPenetrationAtTimestamp(
         null,
@@ -463,6 +481,7 @@ describe('PenetrationUtils', () => {
         500,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultBefore).toBe(0);
 
@@ -473,6 +492,7 @@ describe('PenetrationUtils', () => {
         1500,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultOneBuff).toBe(PenetrationValues.FORCE_OF_NATURE_PER_STATUS);
 
@@ -483,6 +503,7 @@ describe('PenetrationUtils', () => {
         2500,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultTwoBuffs).toBe(PenetrationValues.FORCE_OF_NATURE_PER_STATUS * 2);
 
@@ -493,6 +514,7 @@ describe('PenetrationUtils', () => {
         3500,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultThreeBuffs).toBe(PenetrationValues.FORCE_OF_NATURE_PER_STATUS * 3);
 
@@ -503,6 +525,7 @@ describe('PenetrationUtils', () => {
         4500,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultTwoRemaining).toBe(PenetrationValues.FORCE_OF_NATURE_PER_STATUS * 2);
 
@@ -513,8 +536,60 @@ describe('PenetrationUtils', () => {
         7000,
         null,
         targetId,
+        mockCombatantInfo,
       );
       expect(resultAfter).toBe(0);
+    });
+
+    it('should not count Force of Nature penetration when player does not have it slotted', () => {
+      const targetId = 61;
+      const debuffEvents = [
+        {
+          timestamp: 1000,
+          type: 'applydebuff',
+          sourceID: 5,
+          sourceIsFriendly: true,
+          targetID: targetId,
+          targetIsFriendly: false,
+          abilityGameID: KnownAbilities.BURNING,
+          fight: 1,
+          extraAbilityGameID: 0,
+        },
+        {
+          timestamp: 4000,
+          type: 'removedebuff',
+          sourceID: 5,
+          sourceIsFriendly: true,
+          targetID: targetId,
+          targetIsFriendly: false,
+          abilityGameID: KnownAbilities.BURNING,
+          fight: 1,
+          extraAbilityGameID: 0,
+        },
+      ] as unknown as DebuffEvent[];
+
+      const debuffLookup = createDebuffLookup(debuffEvents);
+
+      // Player does NOT have Force of Nature slotted (no aura for 174250)
+      const mockCombatantInfoNoFoN: CombatantInfoEvent = {
+        timestamp: 0,
+        type: 'combatantinfo',
+        sourceID: 1,
+        fight: 1,
+        gear: [],
+        auras: [],
+      };
+
+      const resultWithBurning = calculateDynamicPenetrationAtTimestamp(
+        null,
+        debuffLookup,
+        1500,
+        null,
+        targetId,
+        mockCombatantInfoNoFoN,
+      );
+      // Burning is active on target but player doesn't have Force of Nature — no pen
+      expect(resultWithBurning).toBe(0);
     });
   });
 

--- a/src/utils/PenetrationUtils.ts
+++ b/src/utils/PenetrationUtils.ts
@@ -5,7 +5,7 @@ import {
   PenetrationValues,
   PenetrationComputedSourceKey,
 } from '../types/abilities';
-import { CombatantInfoEvent, CombatantAura } from '../types/combatlogEvents';
+import { CombatantInfoEvent, CombatantAura, UnifiedCastEvent } from '../types/combatlogEvents';
 
 import { getArmorWeightCounts } from './armorUtils';
 import {
@@ -15,6 +15,7 @@ import {
 } from './BuffLookupUtils';
 import {
   getSetCount,
+  getSetCountForBar,
   countOneHandedSharpenedWeapons,
   hasTwoHandedSharpenedWeapon,
   hasTwoHandedMaulEquipped,
@@ -112,6 +113,8 @@ export interface PenetrationDebuffSource extends BasePenetrationSource {
   value: PenetrationValues;
   ability: KnownAbilities;
   source: 'debuff';
+  /** If set, this debuff's penetration only applies when the player has this aura active (e.g. Force of Nature CP slotted). */
+  requiredPlayerAura?: KnownAbilities;
 }
 
 export interface PenetrationComputedSource extends BasePenetrationSource {
@@ -246,66 +249,73 @@ export const PENETRATION_SOURCES = Object.freeze<PenetrationSource[]>([
     description: '620 penetration per stack per Herald of the Tome ability slotted',
     source: 'computed',
   },
-  // Status effect debuff sources (Wrath of Nature CP passive)
-  // Each active status effect on the target provides 660 penetration when the player has
-  // Wrath of Nature (CP 276) slotted. We cannot detect CP data from combat logs, so we
-  // assume it is always slotted (standard in endgame trial builds).
-  // Reference: CMX (Combat Metrics) uses fight.CP[1]["slotted"][276] for this check.
+  // Status effect debuff sources (Force of Nature CP passive)
+  // Each unique active status effect on the target provides 660 penetration when the player has
+  // Force of Nature (CP 276) slotted. Detection: Force of Nature (ability 174250) appears as an
+  // aura in combatantInfo when slotted. If the aura is absent, these sources are not counted.
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.BURNING,
-    name: 'Wrath of Nature (Burning)',
-    description: '660 penetration when Burning is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Burning)',
+    description: '660 penetration when Burning is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.CHILL,
-    name: 'Wrath of Nature (Chill)',
-    description: '660 penetration when Chill is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Chill)',
+    description: '660 penetration when Chill is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.CONCUSSION,
-    name: 'Wrath of Nature (Concussion)',
-    description: '660 penetration when Concussion is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Concussion)',
+    description: '660 penetration when Concussion is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.DISEASED,
-    name: 'Wrath of Nature (Diseased)',
-    description: '660 penetration when Diseased is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Diseased)',
+    description: '660 penetration when Diseased is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.HEMMORRHAGING,
-    name: 'Wrath of Nature (Hemorrhaging)',
-    description: '660 penetration when Hemorrhaging is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Hemorrhaging)',
+    description: '660 penetration when Hemorrhaging is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.OVERCHARGED,
-    name: 'Wrath of Nature (Overcharged)',
-    description: '660 penetration when Overcharged is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Overcharged)',
+    description: '660 penetration when Overcharged is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.POISONED,
-    name: 'Wrath of Nature (Poisoned)',
-    description: '660 penetration when Poisoned is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Poisoned)',
+    description: '660 penetration when Poisoned is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     value: PenetrationValues.FORCE_OF_NATURE_PER_STATUS,
     ability: KnownAbilities.SUNDERED,
-    name: 'Wrath of Nature (Sundered)',
-    description: '660 penetration when Sundered is active on target (Wrath of Nature CP)',
+    name: 'Force of Nature (Sundered)',
+    description: '660 penetration when Sundered is active on target (Force of Nature CP)',
     source: 'debuff',
+    requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE,
   },
   {
     key: AlwaysOnPenetrationSources.PIERCING,
@@ -655,13 +665,16 @@ export function getAllPenetrationSourcesWithActiveState(
         break;
       case 'debuff':
         if (debuffLookup) {
-          if (targetIds && targetIds.length > 0) {
-            wasActive = targetIds.some((targetId) =>
-              isBuffActiveOnTarget(debuffLookup, source.ability, undefined, targetId),
-            );
-          } else {
-            wasActive = isBuffActiveAtTimestamp(debuffLookup, source.ability);
-          }
+          const debuffActive =
+            targetIds && targetIds.length > 0
+              ? targetIds.some((targetId) =>
+                  isBuffActiveOnTarget(debuffLookup, source.ability, undefined, targetId),
+                )
+              : isBuffActiveAtTimestamp(debuffLookup, source.ability);
+          const playerAuraActive = source.requiredPlayerAura
+            ? isAuraActive(combatantInfo, source.requiredPlayerAura)
+            : true;
+          wasActive = debuffActive && playerAuraActive;
         }
         value = source.value;
         break;
@@ -717,6 +730,9 @@ export function calculateStaticPenetration(
         }
         break;
       case 'computed':
+        // ARMOR_SETS_1190 (arena weapon sets) are bar-dependent; skip here and compute per
+        // timestamp in the worker using getArenaWeaponPenetrationForBar instead.
+        if (source.key === PenetrationComputedSourceKey.ARMOR_SETS_1190) break;
         isActive = isComputedSourceActive(combatantInfo, source, playerData);
         if (isActive) {
           computedPenetration += getPenetrationFromComputedSource(
@@ -742,6 +758,7 @@ export function calculateDynamicPenetrationAtTimestamp(
   timestamp: number,
   playerId: number | null, // For checking buffs applied to the player
   targetId: number | null, // For checking debuffs applied to the target
+  combatantInfo?: CombatantInfoEvent | null, // For checking requiredPlayerAura on debuff sources
 ): number {
   let buffPenetration = 0;
   let debuffPenetration = 0;
@@ -767,12 +784,16 @@ export function calculateDynamicPenetrationAtTimestamp(
       case 'debuff':
         // Debuffs: Check if active on the selected target (enemy who has reduced resistances)
         if (debuffLookup) {
-          isActive = isBuffActiveOnTarget(
+          const debuffActive = isBuffActiveOnTarget(
             debuffLookup,
             source.ability,
             timestamp,
             targetId !== null ? targetId : undefined,
           );
+          const playerAuraActive = source.requiredPlayerAura
+            ? isAuraActive(combatantInfo ?? null, source.requiredPlayerAura)
+            : true;
+          isActive = debuffActive && playerAuraActive;
         }
         if (isActive) {
           debuffPenetration += source.value;
@@ -783,6 +804,46 @@ export function calculateDynamicPenetrationAtTimestamp(
   }
 
   return buffPenetration + debuffPenetration;
+}
+
+/**
+ * Returns the active weapon bar (1 or 2) at a given fight timestamp for a player.
+ * Assumes the player starts on bar 1. Each SWAP_WEAPONS cast event toggles the bar.
+ * `swapEvents` must be pre-filtered to SWAP_WEAPONS events for this specific player,
+ * sorted ascending by timestamp.
+ */
+export function getActiveWeaponBarAtTimestamp(
+  swapEvents: UnifiedCastEvent[],
+  timestamp: number,
+): 1 | 2 {
+  let swapCount = 0;
+  for (const event of swapEvents) {
+    if (event.timestamp <= timestamp) swapCount++;
+    else break; // events are sorted ascending
+  }
+  return swapCount % 2 === 0 ? 1 : 2;
+}
+
+/**
+ * Returns the penetration contribution from ARMOR_SETS_1190 (arena weapon sets)
+ * considering only the weapon slots that correspond to the player's active bar.
+ * Bar 1 = main hand / off hand slots; Bar 2 = backup main / backup off hand slots.
+ */
+export function getArenaWeaponPenetrationForBar(
+  combatantInfo: CombatantInfoEvent | null,
+  activeBar: 1 | 2,
+): number {
+  if (!combatantInfo?.gear) return 0;
+  const setsConfig = ARMOR_SET_PENETRATION_CONFIG[PenetrationComputedSourceKey.ARMOR_SETS_1190];
+  const penetrationValue =
+    ARMOR_SET_PENETRATION_VALUES[PenetrationComputedSourceKey.ARMOR_SETS_1190];
+  let activeSetCount = 0;
+  for (const { setId, requiredPieces } of setsConfig) {
+    if (getSetCountForBar(combatantInfo.gear, setId, activeBar) >= requiredPieces) {
+      activeSetCount++;
+    }
+  }
+  return activeSetCount * penetrationValue;
 }
 
 export function calculatePenetrationAtTimestamp(
@@ -801,6 +862,7 @@ export function calculatePenetrationAtTimestamp(
     timestamp,
     playerId,
     targetId,
+    combatantInfo,
   );
 
   return staticPenetration + dynamicPenetration;

--- a/src/utils/gearUtilities.ts
+++ b/src/utils/gearUtilities.ts
@@ -68,6 +68,32 @@ export const getSetCount = (gear: PlayerGear[] | undefined, setID: number): numb
   return totalPieces;
 };
 
+/**
+ * Counts set pieces for a given set ID considering only the weapon slots of the
+ * specified active bar (bar 1 = main hand / off hand, bar 2 = backup main / backup off).
+ * Used to determine if a weapon set passive is active at a given bar state.
+ */
+export function getSetCountForBar(
+  gear: PlayerGear[] | undefined,
+  setID: number,
+  bar: 1 | 2,
+): number {
+  if (!gear) return 0;
+  const mainSlot = bar === 1 ? GearSlot.MAIN_HAND : GearSlot.BACKUP_MAIN_HAND;
+  const offSlot = bar === 1 ? GearSlot.OFF_HAND : GearSlot.BACKUP_OFF_HAND;
+  let totalPieces = 0;
+  for (const slot of [mainSlot, offSlot]) {
+    const g = gear[slot];
+    if (g?.setID === setID) {
+      totalPieces++;
+      if (isDoubleSetCount(g, slot, gear)) {
+        totalPieces++;
+      }
+    }
+  }
+  return totalPieces;
+}
+
 // Helpers for gear classification and chip coloring
 export const normalizeGearName = (name?: string): string =>
   (name || '')

--- a/src/workers/calculations/CalculatePenetration.ts
+++ b/src/workers/calculations/CalculatePenetration.ts
@@ -1,5 +1,5 @@
 import { PlayerDetailsWithRole } from '@/store/player_data/playerDataSlice';
-import { CombatantInfoEvent, DamageEvent } from '@/types/combatlogEvents';
+import { CombatantInfoEvent, DamageEvent, UnifiedCastEvent } from '@/types/combatlogEvents';
 import {
   calculateActiveCombatTime,
   filterDataPointsByActiveCombat,
@@ -9,6 +9,8 @@ import {
   calculateDynamicPenetrationAtTimestamp,
   calculateStaticPenetration,
   getAllPenetrationSourcesWithActiveState,
+  getActiveWeaponBarAtTimestamp,
+  getArenaWeaponPenetrationForBar,
   PenetrationSourceWithActiveState,
 } from '@/utils/PenetrationUtils';
 
@@ -47,6 +49,8 @@ export interface PenetrationCalculationTask {
   debuffsLookup: BuffLookupData;
   selectedTargetIds: number[];
   damageEvents: DamageEvent[];
+  /** SWAP_WEAPONS cast events grouped by player ID, sorted by timestamp ascending */
+  swapEventsByPlayerId?: Record<number, UnifiedCastEvent[]>;
 }
 
 export function calculatePenetrationData(
@@ -61,6 +65,7 @@ export function calculatePenetrationData(
     debuffsLookup,
     selectedTargetIds,
     damageEvents,
+    swapEventsByPlayerId = {},
   } = data;
 
   // BuffLookupData is now a POJO, no deserialization needed
@@ -106,6 +111,7 @@ export function calculatePenetrationData(
       );
 
       const playerBasePenetration = calculateStaticPenetration(playerCombatantInfo, player);
+      const swapEvents = swapEventsByPlayerId[player.id] ?? [];
 
       // Report progress for static calculations
       if (index % 5 === 0 || index === Object.keys(players).length - 1) {
@@ -119,6 +125,7 @@ export function calculatePenetrationData(
         playerCombatantInfo,
         allSources,
         playerBasePenetration,
+        swapEvents,
         dataPoints: [] as PenetrationDataPoint[],
         timeAtCapCount: 0,
       };
@@ -158,8 +165,16 @@ export function calculatePenetrationData(
         null, // No target needed for player buffs
       );
 
+      // Arena weapon sets (ARMOR_SETS_1190) are only active on the bar they are equipped on.
+      const activeBar = getActiveWeaponBarAtTimestamp(playerData.swapEvents, voxelTimestamp);
+      const arenaWeaponPenetration = getArenaWeaponPenetrationForBar(
+        playerData.playerCombatantInfo,
+        activeBar,
+      );
+
       const totalDynamicPenetration = playerBuffPenetration + targetDebuffPenetration;
-      const totalPenetration = playerData.playerBasePenetration + totalDynamicPenetration;
+      const totalPenetration =
+        playerData.playerBasePenetration + totalDynamicPenetration + arenaWeaponPenetration;
 
       playerData.dataPoints.push({
         timestamp: voxelTimestamp,


### PR DESCRIPTION
## Summary

Two penetration accuracy fixes that together close a 3,170-point gap between the
app MAX and the CMX MAX for a reference fight (Yolnahkriin, Sunspire). Old MAX:
23,347 vs CMX: 20,177. After both fixes the app matches CMX exactly.

## Jira Ticket

[ESO-668](https://bkrupa.atlassian.net/browse/ESO-668)

## Problem

The Penetration Analysis panel over-counted by 3,170 penetration compared to CMX for
a test player (@Cerberus0803) on Sunspire Yolnahkriin. Two independent root causes were found:

- **Force of Nature (+1,980)** — code always included FoN CP debuffs even when the player's
  aura confirmed the passive was not slotted.
- **Arena weapon sets (+1,190)** — Perfected Crushing Wall / Perfected Merciless Charge pen
  was calculated once as a static value (always-on), ignoring weapon bar swaps.

## Root Cause

### Force of Nature CP

`PENETRATION_DEBUFF_SOURCES` listed the 8 FoN debuff entries without a `requiredPlayerAura`
gate. Any player who had some FoN CP debuff in their log — even when CW/FoN passive was not
actually active — would have the full 1,980 pen counted.

**Fix**: All 8 FoN `PenetrationDebuffSource` entries now carry
`requiredPlayerAura: KnownAbilities.FORCE_OF_NATURE_PASSIVE (174250)`. If that aura is absent
from the player's aura set, the debuff contribution is skipped.

### Arena Weapon Bar Dependency

`calculateStaticPenetration` aggregated `ARMOR_SETS_1190` (the 1,190-penetration arena weapon
set group) once per player at the start of the fight, regardless of which weapon bar was
currently active. A player wielding Perfected Merciless Charge only on bar 2 would see 1,190
pen added even during the ~76 % of the fight spent on bar 1.

**Fix**: Moved `ARMOR_SETS_1190` evaluation out of the static pass and into the per-voxel
loop. Each voxel timestamp now derives the active bar from a pre-filtered list of
`SWAP_WEAPONS` cast events and queries only the weapon slots of that bar.

## Changes Made

- **`src/utils/gearUtilities.ts`** — Added `getSetCountForBar(gear, setID, bar: 1|2)`: counts
  set pieces only in the weapon slots belonging to the given bar (bar 1 = slots 10/11,
  bar 2 = slots 12/13), including `isDoubleSetCount` handling for 2H weapons.

- **`src/utils/PenetrationUtils.ts`** — Added:
  - `getActiveWeaponBarAtTimestamp(swapEvents, timestamp)` — counts `SWAP_WEAPONS` cast events
    at or before the timestamp; odd count → bar 2, even → bar 1.
  - `getArenaWeaponPenetrationForBar(combatantInfo, activeBar)` — evaluates `ARMOR_SETS_1190`
    using only the weapon slots of `activeBar`.
  - `calculateStaticPenetration` now skips `ARMOR_SETS_1190` entirely (computed per-voxel).

- **`src/workers/calculations/CalculatePenetration.ts`** — Added optional
  `swapEventsByPlayerId` to `PenetrationCalculationTask`. Per-voxel loop now calls
  `getActiveWeaponBarAtTimestamp` + `getArenaWeaponPenetrationForBar` for each player.

- **`src/hooks/workerTasks/usePenetrationDataTask.ts`** — Added `useCastEvents` hook call;
  pre-filters to `SWAP_WEAPONS` events grouped by `sourceID`; gates task dispatch on
  `isCastEventsLoaded`; passes `swapEventsByPlayerId` into the worker task.

- **`src/features/report_details/penetration/PenetrationPanelView.tsx`** — Updated
  "Why is my value different from CMX?" dialog: added a "Force of Nature CP detection"
  section explaining aura-based detection; updated "Base penetration snapshots" to
  mention known bar-swap limitations.

- **`src/utils/PenetrationUtils.test.ts`** — Updated tests to reflect the FoN aura gate
  and new bar-specific penetration helpers.

## Screenshots

### Penetration panel — @Cerberus0803 MAX corrected from 23,347 → 22,306

![Penetration panel showing corrected values](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-349cad88fdd7b8ff18b6/penetration-panel.png)

### Expanded @Cerberus0803 sources — Force of Nature absent, Arena Weapon Sets present

![Cerberus0803 expanded row with Penetration Sources list](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-349cad88fdd7b8ff18b6/cerberus-sources.png)

### Updated "Why is my value different from CMX?" dialog

![CMX explanation dialog with new FoN and bar-swap sections](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-349cad88fdd7b8ff18b6/cmx-dialog.png)

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Unit tests pass (`npm test -- --watchAll=false`) — 2,361 passed, 0 failed
- [x] Pre-commit validation passes (`npm run validate`)
- [x] Screenshots captured for UI changes
- [x] Validated against reference fight: app MAX now matches CMX MAX (20,177) exactly


[ESO-668]: https://bkrupa.atlassian.net/browse/ESO-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ