### PR TITLE
ESO-668 docs(penetration): explain arena weapon bar-swap Max vs CMX in dialog

### DIFF
--- a/src/features/report_details/penetration/PenetrationPanelView.tsx
+++ b/src/features/report_details/penetration/PenetrationPanelView.tsx
@@ -170,12 +170,23 @@ export const PenetrationPanelView: React.FC<PenetrationPanelViewProps> = ({
           </Typography>
 
           <Typography variant="subtitle2" gutterBottom>
+            Arena weapon set penetration
+          </Typography>
+          <Typography variant="body2" paragraph>
+            ESO TK tracks arena weapon set penetration (e.g. Perfected Merciless Charge, Perfected
+            Crushing Wall) per weapon bar, applying it only during the timestamps when that bar is
+            active. CMX does not track arena weapon pen by bar — it applies a single fixed value for
+            the whole fight. This means our MAX may be higher than CMX&apos;s when you spend time on
+            the arena weapon bar, but our ACTIVE average will be lower (and more accurate).
+          </Typography>
+
+          <Typography variant="subtitle2" gutterBottom>
             Base penetration snapshots
           </Typography>
           <Typography variant="body2" paragraph>
             CMX reads your penetration stat in real time and sees changes on weapon bar swaps. ESO
             TK uses a single snapshot from the combat log&apos;s combatant info, which may not
-            reflect bar-swap variations.
+            reflect bar-swap variations in other stats.
           </Typography>
 
           <Typography variant="subtitle2" gutterBottom>


### PR DESCRIPTION
## Summary

Updates the "Why is my value different from CMX?" dialog in the Penetration panel
to explain the arena weapon bar-swap behaviour introduced in #816.

## Jira Ticket

[ESO-668](https://bkrupa.atlassian.net/browse/ESO-668)

## Problem

After the arena weapon bar-dependency fix landed, our MAX can legitimately exceed
CMX's value for players who have an arena weapon set on only one bar. Without an
explanation, this looks like a bug to users.

## Changes Made

- **`PenetrationPanelView.tsx`** — Added "Arena weapon set penetration" section to
  the CMX dialog explaining that ESO TK applies arena weapon pen only while that
  bar is active, whereas CMX uses a fixed value for the whole fight. This means our
  MAX may be higher than CMX's but our ACTIVE average is lower and more accurate.

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-668]: https://bkrupa.atlassian.net/browse/ESO-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ