### PR TITLE
feat(ESO-674): regenerate DK Draconic Power skill line for U49

### DIFF
--- a/src/data/skill-lines/class/draconicPower.ts
+++ b/src/data/skill-lines/class/draconicPower.ts
@@ -1,7 +1,7 @@
 /**
  * Draconic Power — Dragonknight Skill Line
  * Source: https://eso-hub.com/en/skills/dragonknight/draconic-power
- * Regenerated: 2025-11-14T20:33:08.786Z
+ * Regenerated: 2026-03-09T00:00:00.000Z
  */
 
 import { SkillLineData } from '@/data/types/skill-line-types';
@@ -21,7 +21,7 @@ export const draconicPower: SkillLineData = {
       type: 'ultimate',
       icon: 'ability_dragonknight_009',
       description:
-        'Launch yourself at an enemy, dealing 4241 Physical Damage to all enemies in the area, knocking them back 4 meters, and stunning them for 2 seconds.',
+        'Launch yourself at an enemy, dealing 3574 Flame Damage to all enemies in the area, knocking players back 4 meters and stunning them for 2 seconds. If the target is a monster they are instead knocked into the air and stunned for 3 seconds.',
       isUltimate: true,
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_LEAP,
     },
@@ -31,7 +31,7 @@ export const draconicPower: SkillLineData = {
       type: 'ultimate',
       icon: 'ability_dragonknight_009_a',
       description:
-        'Launch yourself at an enemy, dealing 4241 Flame Damage to all enemies in the area, knocking them back, and stunning them for 2 seconds.\n\nAfter leaping you gain a damage shield that absorbs 16528 damage for 6 seconds. This portion of the ability scales with your Max Health.',
+        'Launch yourself at an enemy, dealing 3574 Flame Damage to all enemies in the area, knocking players back 4 meters and stunning them for 2 seconds. If the target is a monster they are instead knocked into the air and stunned for 3 seconds. Upon activation you gain a damage shield that absorbs 17173 damage for 10 seconds. This portion of the ability scales with your Max Health.',
       isUltimate: true,
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_LEAP,
     },
@@ -41,36 +41,63 @@ export const draconicPower: SkillLineData = {
       type: 'ultimate',
       icon: 'ability_dragonknight_009_b',
       description:
-        'Launch yourself at an enemy, dealing 5037 Physical Damage to all enemies in the area, knocking them back, and stunning them for 2 seconds.',
+        "Launch yourself at an enemy, dealing 4106 Flame Damage to all enemies in the area, knocking them back 4 meters, and stunning them for 2 seconds. If the target is a monster they are instead knocked into the air and stunned for 3 seconds. Upon activation you are filled with draconic fury for 15 seconds, increasing your damage done by 10%. This effect's potency doubles against monsters.",
       isUltimate: true,
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_LEAP,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_SPIKED_ARMOR,
-      name: 'Spiked Armor',
+      id: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
+      name: 'Dragonfire Breath',
       type: 'active',
-      icon: 'ability_dragonknight_007',
+      icon: 'ability_dragonknight_004',
       description:
-        'Release your inner Dragon to gain Major Resolve, increasing your Physical and Spell Resistance by 5948 for 20 seconds.  \n\nWhile active, the armor returns 1 Flame Damage to any enemy that uses a direct damage attack against you in melee range, scaling off your Physical and Spell Resistance.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_SPIKED_ARMOR,
+        'Exhale a blast of draconic fire in front of you, dealing 1742 Flame Damage and an additional 2900 Flame Damage over 10 seconds to enemies in your path.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_VOLATILE_ARMOR,
-      name: 'Volatile Armor',
+      id: ClassSkillId.DRAGONKNIGHT_NOXIOUS_BREATH,
+      name: 'Disintegrating Dragonfire',
       type: 'active',
-      icon: 'ability_dragonknight_007_a',
+      icon: 'ability_dragonknight_004_a',
       description:
-        'Release your inner Dragon to gain Major Resolve, increasing your Physical and Spell Resistance by 5948 for 20 seconds. \n\nYou release a spray of fiery spikes around you, causing enemies hit to take 11 Flame Damage over 20 seconds.\n\nWhile active, the armor returns 1 Flame Damage to any enemy that uses a direct damage attack against you in melee range.\n\nThis ability scales off your Physical and Spell Resistance.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_SPIKED_ARMOR,
+        'Exhale a blast of draconic fire in front of you, dealing 1799 Flame Damage, applying the Burning status effect, and an additional 2995 Flame Damage over 10 seconds to enemies in your path. The initial hit liquifies the armor of your enemies, applying Major Breach to enemies for the duration, reducing Physical and Spell Resistance by 5948.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_HARDENED_ARMOR,
-      name: 'Hardened Armor',
+      id: ClassSkillId.DRAGONKNIGHT_ENGULFING_FLAMES,
+      name: 'Engulfing Dragonfire',
       type: 'active',
-      icon: 'ability_dragonknight_007_b',
+      icon: 'ability_dragonknight_004_b',
       description:
-        'Release your inner Dragon to gain Major Resolve, increasing your Physical and Spell Resistance by 5948 for 20 seconds. \n\nYou gain a damage shield that absorbs up to 5121 damage for 6 seconds, scaling off your Max Health.  \n\nWhile active, the armor returns 1 Flame Damage to any enemy that uses a direct damage attack against you in melee range, scaling off your Physical and Spell Resistance.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_SPIKED_ARMOR,
+        'Breathe forth an unending torrent of draconic fire, dealing 1386 Flame Damage every 0.5 seconds in a channeled attack over 4.8 seconds. Each tick increases the damage dealt by 5%, up to a maximum of 50%. While Take Flight is active you always deal maximum damage. This ability is considered direct damage.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+      name: 'Chains of Flame',
+      type: 'active',
+      icon: 'ability_dragonknight_005',
+      description:
+        'Lash out with a flaming chain, pulling an enemy to you. The searing metal deals 1392 Flame Damage, applies the Burning status effect, and taunts them for 15 seconds if they are not already taunted. This attack cannot be dodged or reflected. Also inflicts Major Cowardice on the enemy, reducing Weapon and Spell Damage by 430 for 10 seconds.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_UNRELENTING_GRIP,
+      name: 'Chains of Dominance',
+      type: 'active',
+      icon: 'ability_dragonknight_005_a',
+      description:
+        "Lash out with a chain bound in Draconic runes, pulling an enemy to you. The enchanted metal deals 1393 Flame Damage, applies the Burning status effect, and taunts them for 15 seconds if they are not already taunted. If the target cannot be pulled, you restore the ability's Magicka cost. This attack cannot be dodged or reflected. Also inflicts Major Cowardice on the enemy, reducing Weapon and Spell Damage by 430 for 15 seconds.",
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_CHAINS_OF_DEVASTATION,
+      name: 'Chains of Devastation',
+      type: 'active',
+      icon: 'ability_dragonknight_005_b',
+      description:
+        'Lash out with a chain bound in jagged links, pulling yourself to an enemy. The searing metal deals 1438 Flame Damage and applies the Burning status effect. This attack cannot be dodged or reflected. Hitting the target grants you Major Berserk for 6 seconds and Major Evasion for 10 seconds, increasing damage done by 10% reducing damage taken from area attacks by 20%.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_DARK_TALONS,
@@ -96,7 +123,7 @@ export const draconicPower: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_010_a',
       description:
-        'Call forth talons from the ground, dealing 1742 Flame Damage to enemies near you and immobilizing them for 4 seconds. \n\nEnemies hit are afflicted with Minor Maim, reducing their damage done by 5% for 10 seconds. \n\nAn ally near the talons can activate the Ignite synergy, dealing 2812 Flame Damage to all enemies held within them.',
+        'Call forth talons from the ground, dealing 1742 Flame Damage to enemies near you and immobilizing them for 4 seconds. Enemies hit are afflicted with Minor Maim, reducing damage done by 5% for 20 seconds. An ally near the talons can activate the Ignite synergy, dealing 2812 Flame Damage to all enemies held within them.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DARK_TALONS,
     },
     {
@@ -105,53 +132,52 @@ export const draconicPower: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_011',
       description:
-        'Draw on your draconic blood to heal for 33% of your missing Health.\n\nYou also gain Major Fortitude, increasing your Health Recovery by 30% for 20 seconds.',
+        'Draw on your draconic blood to heal for 4132 Health, increasing by up to 50% additional healing based on your missing Health. This ability scales off your Max Health. You also gain Major Fortitude, increasing your Health Recovery by 30% for 20 seconds.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_BLOOD,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_GREEN_DRAGON_BLOOD,
-      name: 'Green Dragon Blood',
+      name: 'Blood of the Green Dragon',
       type: 'active',
       icon: 'ability_dragonknight_011_b',
       description:
-        'Draw on your draconic blood to heal for 33% of your missing Health and an additional 511 Health every 1 second over 5 seconds. The heal over time scales off of your Max Health.\n\nYou also gain Major Fortitude, Major Endurance, and Minor Vitality, increasing your Health Recovery and Stamina Recovery by 30% and healing received and damage shield strength by 6% for 20 seconds.',
+        'Draw on your draconic blood to heal for 4131 Health, increasing by up to 50% additional healing based on your missing Health. Heals for an additional 2555 Health over 5 seconds. This ability scales off your Max Health. You also gain Major Endurance and Fortitude and Minor Vitality, increasing Health and Stamina Recovery by 30% and increasing healing received and damage shield strength by 6% for 20 seconds.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_BLOOD,
-      alternateIds: [32744],
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_COAGULATING_BLOOD,
-      name: 'Coagulating Blood',
+      name: 'Blood of the Elder Dragon',
       type: 'active',
       icon: 'ability_dragonknight_011_a',
       description:
-        'Draw on your draconic blood to heal for 2999, increasing by up to 50% additional healing based on your missing Health.\n\nYou also gain Major Fortitude, increasing your Health Recovery by 30% for 20 seconds.',
+        'Draw on your draconic blood to heal yourself for 2999 and nearby allies for 1998 Health, increasing by up to 50% additional healing based on missing Health. Healed targets gain Major Fortitude and Minor Courage, increasing Health Recovery by 30% and Weapon and Spell Damage by 215 for 20 seconds.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGON_BLOOD,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_SCALE,
-      name: 'Protective Scale',
+      name: 'Wing Buffet',
       type: 'active',
       icon: 'ability_dragonknight_008',
       description:
-        'Flex your scales, reducing your damage taken from projectiles by 50% for 6 seconds.',
+        'Unfurl draconic wings to knock back enemies around you 4 meters and stun them for 1.8 seconds. The winds from your buffet swirl around you, reducing your damage taken from projectiles by 50% for 6 seconds, while granting you Major Expedition for 4 seconds, increasing Movement Speed by 30%.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_SCALE,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_DRAGON_FIRE_SCALE,
-      name: 'Dragon Fire Scale',
+      name: 'Protect the Brood',
       type: 'active',
       icon: 'ability_dragonknight_008_a',
       description:
-        'Flex your scales, reducing damage taken from projectiles by 50% for 6 seconds. \n\nWhen you are hit with a projectile, you retaliate by launching a fiery orb at the attacker that deals 1799 Flame Damage. This effect can occur once every half second.',
+        'Unfurl draconic wings to safeguard you and nearby group members for 6 seconds, reducing damage taken from projectiles by 50% for you and 25% for group members. You and your brood gain Minor Protection for 20 seconds, reducing damage taken by 5%. You gain Major Expedition for 4 seconds, increasing Movement Speed by 30%.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_SCALE,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_PLATE,
-      name: 'Protective Plate',
+      name: 'Fleetstep Wings',
       type: 'active',
       icon: 'ability_dragonknight_008_b',
       description:
-        'Flex your scales, reducing damage taken from projectiles by 50% for 6 seconds.\n\nGain immunity to snares and immobilizations for 4 seconds.',
+        'Unfurl draconic wings to knock back enemies around you 4 meters and stun them for 1.8 seconds. The enchanted winds summoned by your wings coalesce around you, reducing your damage taken from projectiles by 50% for 6 seconds, while granting you immunity to snares and immobilizations and Major Expedition for 4 seconds, increasing Movement Speed by 30%.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_SCALE,
     },
     {
@@ -195,23 +221,35 @@ export const draconicPower: SkillLineData = {
       name: 'Elder Dragon',
       type: 'passive',
       icon: 'ability_dragonknight_025',
-      description: 'Increases your Health Recovery by 323 for each Draconic Power ability slotted.',
+      description:
+        'The eldest Dragons are forces of nature. As are you. Activating a Draconic Power ability grants you and group members Minor Brutality for 20 seconds, increasing Weapon Damage by 10%. Increases your Health Recovery by up to 700, based on your missing Health. Current amount: 0',
+      isPassive: true,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_BATTLE_ROAR,
+      name: 'The Storm Voice',
+      type: 'passive',
+      icon: 'ability_dragonknight_031',
+      description:
+        'The syllables of that ancient tongue live in the mouth of every Dragonknight. When you cast an Ultimate ability, you restore 16 Health 16 Magicka, and 16 Stamina for each point of the Ultimate spent. Each Dragonknight ability slotted increases this value by 6. Current amount: 16 Health 16 Magicka 16 Stamina',
+      isPassive: true,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_WORLD_IN_RUIN,
+      name: 'World in Ruin',
+      type: 'passive',
+      icon: 'ability_sorcerer_010',
+      description:
+        'Dragons leave naught but ash and ruin in their wake. Increases your damage done with area and over time attacks by 7%.',
       isPassive: true,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_IRON_SKIN,
-      name: 'Iron Skin',
-      type: 'passive',
-      icon: 'ability_dragonknight_021',
-      description: 'Increases the amount of damage you block by 10%.',
-      isPassive: true,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_SCALED_ARMOR,
-      name: 'Scaled Armor',
+      name: 'Burnished Scales',
       type: 'passive',
       icon: 'ability_dragonknight_020',
-      description: 'Increases your Physical and Spell Resistance by 2974.',
+      description:
+        "A Dragon's scales will turn aside arrow, fire, and blade. Increases the amount of damage you block by 10%.",
       isPassive: true,
     },
   ],


### PR DESCRIPTION
## Summary

Regenerates the DK Draconic Power skill line data for Update 49, applying all ability moves, renames, and description changes from ESO-Hub.

## Jira Ticket

[ESO-674](https://bkrupa.atlassian.net/browse/ESO-674)

## Changes Made

**Abilities moved IN** (from Ardent Flame):
- `Fiery Breath` → renamed `Dragonfire Breath` (now Stamina ability)
  - `Noxious Breath` → `Disintegrating Dragonfire`
  - `Engulfing Flames` → `Engulfing Dragonfire`
- `Fiery Grip` → renamed `Chains of Flame`
  - `Unrelenting Grip` → `Chains of Dominance`
  - `Chains of Devastation` (name unchanged)

**Abilities moved OUT** (to Earthen Heart):
- `Spiked Armor` (+ `Volatile Armor`, `Hardened Armor`)

**Renames within the skill line:**
- `Green Dragon Blood` → `Blood of the Green Dragon`
- `Coagulating Blood` → `Blood of the Elder Dragon`
- `Protective Scale` → `Wing Buffet`
- `Dragon Fire Scale` → `Protect the Brood`
- `Protective Plate` → `Fleetstep Wings`

**Passive updates:**
- `Iron Skin` → `Burnished Scales` (updated icon + description)
- `Scaled Armor` → `World in Ruin` (uses `DRAGONKNIGHT_WORLD_IN_RUIN` ID)
- `Battle Roar` → `The Storm Voice` (added to this skill line)
- `Elder Dragon`: reworked — now grants Minor Brutality to group on activation

**Description updates:**
- `Dragon Leap`, `Ferocious Leap`, `Take Flight` — now deal Flame Damage (was Physical)
- `Dragon Blood` — heal now scales with Max Health (was % missing Health)
- `Choking Talons` — Minor Maim duration extended to 20s

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)
- [x] Diff against ESO-Hub confirms 0 remaining description/icon changes after update


[ESO-674]: https://bkrupa.atlassian.net/browse/ESO-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ