### PR TITLE
feat(ESO-673): regenerate DK Ardent Flame skill line for U49

### DIFF
--- a/src/data/skill-lines/class/ardentFlame.ts
+++ b/src/data/skill-lines/class/ardentFlame.ts
@@ -1,7 +1,7 @@
 /**
  * Ardent Flame — Dragonknight Skill Line
  * Source: https://eso-hub.com/en/skills/dragonknight/ardent-flame
- * Regenerated: 2025-11-14T20:33:08.778Z
+ * Regenerated: 2026-03-09T00:00:00.000Z
  */
 
 import { SkillLineData } from '@/data/types/skill-line-types';
@@ -21,7 +21,7 @@ export const ardentFlame: SkillLineData = {
       type: 'ultimate',
       icon: 'ability_dragonknight_006',
       description:
-        'Call down a battle standard, dealing 870 Flame Damage every 1 second for 16 seconds to enemies and applying Major Defile to them, reducing their healing received and damage shield strength by 12%. \n\nAn ally near the standard can activate the Shackle synergy, dealing 3375 Flame Damage to enemies in the area and immobilizing them for 5 seconds.',
+        'Call down a battle standard for 15 seconds, rallying you and allies inside the area, increasing Weapon and Spell Damage by 300 and reducing damage taken by 10%. An ally near the standard can activate the Shackle synergy, dealing 3375 Flame Damage to enemies in the area and immobilizing them for 5 seconds.',
       isUltimate: true,
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGONKNIGHT_STANDARD,
     },
@@ -41,36 +41,9 @@ export const ardentFlame: SkillLineData = {
       type: 'ultimate',
       icon: 'ability_dragonknight_006_b',
       description:
-        'Call down a battle standard, dealing 870 Flame Damage every 1 second for 16 seconds to enemies and applying Major Defile to them, reducing their healing received and damage shield strength by 12%. \n\nStanding in the area increases your damage done and reduces damage taken by 15%.\n\nAn ally near the standard can activate the Shackle synergy, dealing 3375 Flame Damage to enemies in the area and immobilizing them for 5 seconds.',
+        'Call down a battle standard for 15 seconds, rallying you and allies inside the area, increasing Weapon and Spell Damage by 300 and reducing damage taken by 10%. You gain an additional 15% damage done and reduced damage taken and 300 Weapon and Spell Damage. An ally near the standard can activate the Shackle synergy, dealing 3375 Flame Damage to enemies in the area and immobilizing them for 5 seconds.',
       isUltimate: true,
       baseSkillId: ClassSkillId.DRAGONKNIGHT_DRAGONKNIGHT_STANDARD,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
-      name: 'Fiery Breath',
-      type: 'active',
-      icon: 'ability_dragonknight_004',
-      description:
-        'Exhale a flaming blast to enemies in front of you, dealing 1742 Flame Damage and an additional 2900 Flame Damage over 20 seconds.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_NOXIOUS_BREATH,
-      name: 'Noxious Breath',
-      type: 'active',
-      icon: 'ability_dragonknight_004_a',
-      description:
-        'Exhale a corrosive blast to enemies in front of you, dealing 1799 Poison Damage immediately, applying the Poisoned status effect, and an additional 2980 Poison Damage over 20 seconds. \n\nThe initial hit applies the Major Breach to enemies for the duration, reducing their Physical and Spell Resistance by 5948.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_ENGULFING_FLAMES,
-      name: 'Engulfing Flames',
-      type: 'active',
-      icon: 'ability_dragonknight_004_b',
-      description:
-        'Exhale a flaming blast to enemies in front of you, dealing 1799 Flame Damage and an additional 2980 Flame Damage over 20 seconds. \n\nAffected enemies take more damage from all Flame Damage attacks based on your Weapon or Spell Damage, and Max Magicka or Stamina, with a maximum of 6% bonus damage taken.\n\nCurrent value 2%.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_BREATH,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_SEARING_STRIKE,
@@ -78,16 +51,16 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_003',
       description:
-        'Slash an enemy with flame, dealing 1161 Flame Damage and an additional 3470 Flame Damage over 20 seconds.\n\nEnemies hit by the initial hit are afflicted with the Burning status effect.',
+        'Slash your foe with a fiery claw, dealing 1161 Flame Damage and an additional 3475 Flame Damage over 10 seconds. The initial hit always applies the Burning status effect.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_SEARING_STRIKE,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_VENOMOUS_CLAW,
-      name: 'Venomous Claw',
+      name: 'Searing Claw',
       type: 'active',
       icon: 'ability_dragonknight_003_a',
       description:
-        'Rake an enemy with your claw, dealing 1161 Poison Damage and an additional 3470 Poison Damage over 20 seconds.\n\nThe poison seeps into the target and deals increased damage the longer it lasts, dealing 12% more damage every 2 seconds.\n\nEnemies hit by the initial hit are afflicted with the Poisoned status effect.',
+        'Slash your foe with a fiery claw, dealing 1161 Flame Damage and an additional 3480 Flame Damage over 10 seconds. The flame sears into the target, dealing 10% more damage every 2 seconds. The initial hit always applies the Burning status effect.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_SEARING_STRIKE,
     },
     {
@@ -96,35 +69,62 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_003_b',
       description:
-        'Slash an enemy with flame, dealing 1161 Flame Damage and an additional 3470 Flame Damage over 20 seconds. \n\nYou heal for 100% of the damage done with this ability.  \n\nEnemies hit by the initial hit are afflicted with the Burning status effect.',
+        'Slash your foe with a fiery claw, dealing 1161 Flame Damage and an additional 3480 Flame Damage over 10 seconds. You heal for 3414 Health from the initial hit and 511 Health each subsequent tick, scaling off your Max Health. The initial hit always applies the Burning status effect.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_SEARING_STRIKE,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
-      name: 'Fiery Grip',
+      id: ClassSkillId.DRAGONKNIGHT_INHALE,
+      name: 'Core of Flame',
       type: 'active',
-      icon: 'ability_dragonknight_005',
+      icon: 'ability_dragonknight_012',
       description:
-        'Launch a fiery chain to grasp and pull an enemy to you, dealing 1392 Flame Damage and taunting them for 15 seconds if they are not already taunted.\n\nHitting the target grants you Major Expedition, increasing your Movement Speed by 30% for 4 seconds.\n\nThis attack cannot be dodged or reflected.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+        'Let the fire within draw heat to your core, restoring 15% of your missing Magicka and Stamina every 2 seconds over 4 seconds. When this ability completes, you release this heat as a blast of fire that deals 2002 Flame Damage to nearby enemies.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_UNRELENTING_GRIP,
-      name: 'Unrelenting Grip',
+      id: ClassSkillId.DRAGONKNIGHT_DRAW_ESSENCE,
+      name: 'Heart of Flame',
       type: 'active',
-      icon: 'ability_dragonknight_005_a',
+      icon: 'ability_dragonknight_012_b',
       description:
-        "Launch a fiery chain to grasp and pull an enemy to you, dealing 1438 Flame Damage and taunting them for 15 seconds if they are not already taunted.\n\nHitting the target grants you Major Expedition, increasing your Movement Speed by 30% for 4 seconds.\n\nIf the target cannot be pulled, you restore 100% of the ability's cost as Magicka.\n\nThis attack cannot be dodged or reflected.",
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+        'Let the fire within draw heat to your heart, restoring 15% of your missing Health and 15% of your missing Magicka and Stamina every 2 seconds over 4 seconds. When this ability completes, you release this heat as a blast of fire that deals 2004 Flame Damage to nearby enemies.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_CHAINS_OF_DEVASTATION,
-      name: 'Chains of Devastation',
+      id: ClassSkillId.DRAGONKNIGHT_DEEP_BREATH,
+      name: 'Soul of Flame',
       type: 'active',
-      icon: 'ability_dragonknight_005_b',
+      icon: 'ability_dragonknight_012_a',
       description:
-        'Launch a fiery chain to grasp and pull yourself to an enemy, dealing 1438 Flame Damage.\n\nHitting the target grants you Major Expedition and Major Berserk, increasing your Movement Speed by 30% and your damage done by 10% for 4 seconds.\n\nThis attack cannot be dodged or reflected.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_FIERY_GRIP,
+        'Let the fire within draw heat to your soul, restoring 15% of your missing Magicka and Stamina every 2 seconds over 4 seconds. Much of this heat is drawn from enemies around you. Those that are casting are interrupted, set Off Balance, and stunned for 2 seconds. When this ability completes, you release this heat as a blast of fire that deals 2760 Flame Damage to nearby enemies.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
+      name: 'Hearthfire',
+      type: 'active',
+      icon: 'ability_dragonknight_016',
+      description:
+        'Throw out a kindled flame, filling a large area with warmth for 15 seconds. This fire heals you and your allies at the target location for 434 Health every 1 second. Healed targets gain Minor Fortitude and Minor Heroism while inside, increasing Health Recovery by 15% and generating 1 Ultimate every 1.5 seconds.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_CINDER_STORM,
+      name: 'Fire Keeper',
+      type: 'active',
+      icon: 'ability_dragonknight_016a',
+      description:
+        'Throw out a purifying flame, filling a large area with warmth for 15 seconds. This fire heals you and your allies at the target location for 449 Health every 1 second. This healing increases by 50% if you are in the area. Healed targets gain Minor Fortitude and Minor Heroism for 15 seconds, increasing Health Recovery by 15% and generating 1 Ultimate every 1.5 seconds.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_ERUPTION,
+      name: 'Hearth and Home',
+      type: 'active',
+      icon: 'ability_dragonknight_016b',
+      description:
+        'Throw out a protective flame for 15 seconds, healing you and allies inside for 619 Health every 1 second, scaling off your Max Health. Healed targets gain Minor Fortitude and Minor Heroism while inside, increasing Health Recovery by 15% and generating 1 Ultimate every 1.5 seconds. You gain Major Protection while inside, reducing damage taken by 10%. Enemies inside have their Movement Speed reduced by 70%.',
+      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_LAVA_WHIP,
@@ -132,7 +132,7 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_001',
       description:
-        'Lash an enemy with flame, dealing 2323 Flame Damage.\n\nIf you strike an enemy that is immobilized or stunned, you set them Off Balance.',
+        'Lash an enemy with flame, dealing 2323 Flame Damage. Hitting an Off Balance enemy grants 5 stacks of Volcanic Whip for 20 seconds, up to once every 20 seconds. Volcanic Whip replaces this ability and consumes a stack to instead deal 4338 Flame Damage to your target and all nearby enemies.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_LAVA_WHIP,
     },
     {
@@ -141,7 +141,7 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_001_b',
       description:
-        'Lash an enemy with flame, dealing 2323 Flame Damage.\n\nIf you strike an enemy that is is immobilized or stunned, you set them Off Balance.\n\nWhenever you activate a different Ardent Flame ability while in combat, you gain a stack of Seething Fury, increasing the damage of your next Molten Whip by 20% and your Weapon and Spell Damage by 100 for 15 seconds. This effect stacks up to 3 times.',
+        'Lash an enemy with flame, dealing 2399 Flame Damage. Activating a different Dragonknight ability while in combat grants a stack of Seething Fury up to 3 times, increasing the damage of your next Molten Whip by 33% and your damage done by 5%, or 2% against players, for 10 seconds. The damage done only activates if you are a Dragonknight.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_LAVA_WHIP,
     },
     {
@@ -150,7 +150,7 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_001_a',
       description:
-        'Lash an enemy with flame, dealing 2323 Flame Damage.\n\nIf you strike an enemy that is immobilized or stunned, you set them Off Balance.\n\nTargeting an Off Balance or immobilized enemy changes this ability into Power Lash, allowing you to lash an enemy at half cost to deal 2760 Flame Damage and healing you for 2760 Health.',
+        'Lash an enemy with flame, dealing 2323 Flame Damage and healing for 799 Health. Hitting an Off Balance enemy grants 5 stacks of Power Lash for 20 seconds, up to once every 20 seconds. Activating again consumes a stack to deal 4337 Flame Damage to your target and all nearby enemies and heals for 3200 Health. Consuming all stacks as a Dragonknight increases your damage done by 7%, double against monsters, for 45 seconds.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_LAVA_WHIP,
     },
     {
@@ -159,16 +159,16 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_002',
       description:
-        'Activate an aura of flames which launches a fireball at the nearest enemy every 5 seconds, dealing 1742 Flame Damage.\n\nWhile slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
+        'Activate an aura of flames which launches a wave of flame around you every 5 seconds, dealing 1742 Flame Damage to enemies inside. While slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_INFERNO,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_FLAMES_OF_OBLIVION,
-      name: 'Flames of Oblivion',
+      name: 'Incinerate',
       type: 'active',
       icon: 'ability_dragonknight_002_a',
       description:
-        'Activate an aura of flames which launches a fireball at 3 enemies every 5 seconds, dealing 1799 Flame Damage.\n\nWhile slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
+        'Activate an aura of flames which launches a wave of flames every 5 seconds, dealing 1979 Flame Damage to enemies inside. Each hit has a 15% chance of applying Burning. While slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_INFERNO,
     },
     {
@@ -177,7 +177,7 @@ export const ardentFlame: SkillLineData = {
       type: 'active',
       icon: 'ability_dragonknight_002_b',
       description:
-        'Activate an aura of embers which cauterizes the wounds of you or up to 4 nearby allies every 3 seconds, healing for 1199 Health.\n\nWhile slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
+        'Activate an aura of embers which cauterizes the wounds of you or up to 6 nearby allies every 3 seconds, healing for 1199 Health. While slotted on either bar, you gain Major Prophecy and Savagery, increasing your Spell and Weapon Critical rating by 2629.',
       baseSkillId: ClassSkillId.DRAGONKNIGHT_INFERNO,
     },
     {
@@ -186,25 +186,34 @@ export const ardentFlame: SkillLineData = {
       type: 'passive',
       icon: 'ability_sorcerer_011',
       description:
-        'Increases the damage of your Burning and Poisoned status effects by 33%. When you apply Burning or Poisoned to an enemy, you restore 423 Magicka and Stamina. This effect can occur once every 3 seconds.',
+        'To you, flame is fuel. When you apply Burning to an enemy, you restore 225 Magicka and Stamina. This effect can occur once every 1 second.',
       isPassive: true,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_SEARING_HEAT,
-      name: 'Searing Heat',
+      name: 'Fan the Flames',
       type: 'passive',
       icon: 'ability_dragonknight_028',
       description:
-        'Increases the damage over time of your Fiery Breath, Searing Strike, and Dragonknight Standard abilities by 25% and the duration by 4 seconds.',
+        'Tend to your garden of flame, that it may flourish. Increases your chances of applying the Burning status effect by 50% and its damage done by 25%. These values are influenced by the number of Dragonknight abilities slotted.',
       isPassive: true,
     },
     {
       id: ClassSkillId.DRAGONKNIGHT_WARMTH,
-      name: 'Warmth',
+      name: 'Traumatic Burns',
       type: 'passive',
       icon: 'ability_dragonknight_023',
       description:
-        'When you deal direct damage with an Ardent Flame ability, your damage over time attacks deal 6% increased damage to the target, and reduce their Movement Speed by 30% for 3 seconds.',
+        'Fire cares not for love, or coin, or creed. It consumes. Dealing direct damage with an Ardent Flame ability causes the target to take 5% increased Flame Damage and reduces their Movement Speed by 30% for 5 seconds.',
+      isPassive: true,
+    },
+    {
+      id: ClassSkillId.DRAGONKNIGHT_BURNING_HEART,
+      name: 'A Soul Ablaze',
+      type: 'passive',
+      icon: 'ability_weapon_001',
+      description:
+        'The will to survive burns bright in your chest. Increases your Healing Taken by 8%.',
       isPassive: true,
     },
     {

--- a/src/data/skill-lines/class/draconicPower.ts
+++ b/src/data/skill-lines/class/draconicPower.ts
@@ -155,42 +155,6 @@ export const draconicPower: SkillLineData = {
       baseSkillId: ClassSkillId.DRAGONKNIGHT_PROTECTIVE_SCALE,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_INHALE,
-      name: 'Inhale',
-      type: 'active',
-      icon: 'ability_dragonknight_012',
-      description:
-        'Channel draconic energy to suck in the air around you, dealing 870 Flame Damage to nearby enemies and healing you for 100% of the damage caused.\n\nAfter 2.5 seconds, you exhale fire, dealing 1742 Flame Damage to nearby enemies.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_DEEP_BREATH,
-      name: 'Deep Breath',
-      type: 'active',
-      icon: 'ability_dragonknight_012_a',
-      description:
-        'Channel draconic energy to suck in the air around you, dealing 870 Flame Damage to nearby enemies and healing you for 100% of the damage caused.\n\nAny enemy hit that is casting is interrupted, set Off Balance, and stunned for 2 seconds.\n\nAfter 2.5 seconds, you exhale fire, dealing 2249 Flame Damage to nearby enemies.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_DRAW_ESSENCE,
-      name: 'Draw Essence',
-      type: 'active',
-      icon: 'ability_dragonknight_012_b',
-      description:
-        "Channel draconic energy to suck in the air around you, dealing 870 Flame Damage to nearby enemies and healing you for 150% of the damage caused.\n\nAfter 2.5 seconds, you exhale fire, dealing 1742 Flame Damage to nearby enemies and restoring 10% of the ability's cost for each enemy hit as Magicka.",
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_INHALE,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_BURNING_HEART,
-      name: 'Burning Heart',
-      type: 'passive',
-      icon: 'ability_dragonknight_032',
-      description:
-        'While a Draconic Power ability is active, your healing received is increased by 9%.',
-      isPassive: true,
-    },
-    {
       id: ClassSkillId.DRAGONKNIGHT_ELDER_DRAGON,
       name: 'Elder Dragon',
       type: 'passive',

--- a/src/data/skill-lines/class/earthenHeart.ts
+++ b/src/data/skill-lines/class/earthenHeart.ts
@@ -154,34 +154,6 @@ export const earthenHeart: SkillLineData = {
       baseSkillId: ClassSkillId.DRAGONKNIGHT_PETRIFY,
     },
     {
-      id: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
-      name: 'Ash Cloud',
-      type: 'active',
-      icon: 'ability_dragonknight_016',
-      description:
-        'Summon a scorching cloud of ash at the target location for 15 seconds, reducing enemy Movement Speed by 70% and healing you and your allies for 434 Health every 1 second.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_CINDER_STORM,
-      name: 'Cinder Storm',
-      type: 'active',
-      icon: 'ability_dragonknight_016a',
-      description:
-        'Summon a scorching cloud of ash at the target location for 15 seconds, reducing enemy Movement Speed by 70% and healing you and your allies for 674 every 1 second.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
-    },
-    {
-      id: ClassSkillId.DRAGONKNIGHT_ERUPTION,
-      name: 'Eruption',
-      type: 'active',
-      icon: 'ability_dragonknight_016b',
-      description:
-        'Summon a scorching cloud of ash at the target location for 15 seconds, dealing 1799 Flame Damage immediately, reducing enemy Movement Speed by 70%, and dealing 319 Flame Damage in the area every 1 second.\n\nThe eruptive damage can occur once every 10 seconds.',
-      baseSkillId: ClassSkillId.DRAGONKNIGHT_ASH_CLOUD,
-      alternateIds: [32710],
-    },
-    {
       id: ClassSkillId.DRAGONKNIGHT_BATTLE_ROAR,
       name: 'Battle Roar',
       type: 'passive',


### PR DESCRIPTION
## Summary

ESO-673: Regenerate DK Ardent Flame skill line data for U49.

U49 massively restructured the Ardent Flame skill line. Skills moved between DK skill lines and many abilities were renamed.

## Changes

### ardentFlame.ts
**Removed** (moved to Draconic Power):
- Fiery Breath, Noxious Breath, Engulfing Flames

**Added** (moved from Draconic Power):
- Core of Flame (was Inhale), Heart of Flame (was Draw Essence), Soul of Flame (was Deep Breath)
- A Soul Ablaze passive (was Burning Heart)

**Added** (moved from Earthen Heart):
- Hearthfire (was Ash Cloud), Fire Keeper (was Cinder Storm), Hearth and Home (was Eruption)

**Renames in place:**
- Venomous Claw ? Searing Claw
- Flames of Oblivion ? Incinerate
- Searing Heat ? Fan the Flames
- Warmth ? Traumatic Burns

**Updated descriptions** (10 skills auto-applied via `refresh-class-skills.mjs`):
Burning Embers, Cauterize, Combustion, Dragonknight Standard, Flame Lash, Inferno, Lava Whip, Molten Whip, Searing Strike, Standard of Might

### draconicPower.ts
Removed Inhale group (Core of Flame/Heart of Flame/Soul of Flame) and Burning Heart passive ? now in Ardent Flame.

### earthenHeart.ts
Removed Ash Cloud group (Hearthfire/Fire Keeper/Hearth and Home) ? now in Ardent Flame.

## Testing

- `npm run typecheck` ? passes clean
- `node scripts/refresh-class-skills.mjs --line ardent-flame` ? 0 remaining diffs
