### PR TITLE
feat(ESO-677): update dragonknight.ts detailed skill data for U49

### DIFF
--- a/src/data/skill-lines/class/dragonknight.ts
+++ b/src/data/skill-lines/class/dragonknight.ts
@@ -86,7 +86,8 @@ export const dragonknightData: SkillsetData = {
           morphs: {
             heartOfFlame: {
               name: 'Heart of Flame',
-              resourceRestore: '15% missing Health, Magicka, and Stamina every 2 seconds for 4 seconds',
+              resourceRestore:
+                '15% missing Health, Magicka, and Stamina every 2 seconds for 4 seconds',
               exhaleDamage: '2004 Flame Damage on completion',
               description: 'Also restores missing Health in addition to Magicka and Stamina.',
             },
@@ -183,8 +184,7 @@ export const dragonknightData: SkillsetData = {
             incinerate: {
               name: 'Incinerate',
               damage: '1979 Flame Damage every 5 seconds',
-              description:
-                'Deals more damage and each hit has a 15% chance to apply Burning.',
+              description: 'Deals more damage and each hit has a 15% chance to apply Burning.',
               statusChance: '15% chance of applying Burning per hit',
             },
             cauterize: {
@@ -242,13 +242,15 @@ export const dragonknightData: SkillsetData = {
             ferociousLeap: {
               name: 'Ferocious Leap',
               damage: '3574 Flame Damage',
-              description: 'Grants a large damage shield upon activation that scales with Max Health.',
+              description:
+                'Grants a large damage shield upon activation that scales with Max Health.',
               shield: '17173 damage absorption for 10 seconds (scales with Max Health)',
             },
             takeFlight: {
               name: 'Take Flight',
               damage: '4106 Flame Damage',
-              description: 'Deals more damage and fills you with draconic fury, boosting damage done.',
+              description:
+                'Deals more damage and fills you with draconic fury, boosting damage done.',
               buff: '+10% damage done for 15 seconds (doubles vs monsters)',
             },
           },
@@ -397,8 +399,7 @@ export const dragonknightData: SkillsetData = {
               name: 'Protect the Brood',
               description:
                 'Extends protection to nearby group members and grants Minor Protection to you and allies.',
-              projectileReduction:
-                '50% for you, 25% for group members for 6 seconds',
+              projectileReduction: '50% for you, 25% for group members for 6 seconds',
               buff: 'Minor Protection (-5% damage taken for 20 seconds) to you and group',
             },
             fleetstepWings: {
@@ -422,8 +423,7 @@ export const dragonknightData: SkillsetData = {
         },
         worldInRuin: {
           name: 'World in Ruin',
-          description:
-            'Increases your damage done with area and over time attacks by 7%.',
+          description: 'Increases your damage done with area and over time attacks by 7%.',
         },
         burnishedScales: {
           name: 'Burnished Scales',
@@ -449,7 +449,7 @@ export const dragonknightData: SkillsetData = {
             magmaShell: {
               name: 'Magma Shell',
               description: 'Nearby allies gain a powerful damage shield when activated.',
-              allyShield: '133% of allies\' Max Health for 10 seconds',
+              allyShield: "133% of allies' Max Health for 10 seconds",
             },
             corrosiveArmor: {
               name: 'Corrosive Armor',
@@ -470,8 +470,9 @@ export const dragonknightData: SkillsetData = {
           target: 'Self or Ally',
           duration: '6 seconds',
           description:
-            'Roil the air around you or an ally, granting a damage shield that scales off the higher of Max Magicka or Stamina (capped at 50% of target\'s Max Health).',
-          shield: '4958 damage absorption (scales with Max Magicka or Stamina, capped at 50% target Max Health)',
+            "Roil the air around you or an ally, granting a damage shield that scales off the higher of Max Magicka or Stamina (capped at 50% of target's Max Health).",
+          shield:
+            '4958 damage absorption (scales with Max Magicka or Stamina, capped at 50% target Max Health)',
           morphs: {
             magmaFist: {
               name: 'Magma Fist',
@@ -507,7 +508,8 @@ export const dragonknightData: SkillsetData = {
               description:
                 'As the armor forms, blasts foes with shattered obsidian dealing Flame Damage over 20 seconds. Damage ticks generate Landslide stacks.',
               damageOverTime: '4785 Flame Damage over 20 seconds to nearby enemies',
-              effect: 'Generates a stack of Landslide up to once every 10 seconds when damage ticks',
+              effect:
+                'Generates a stack of Landslide up to once every 10 seconds when damage ticks',
             },
             earthshieldMantle: {
               name: 'Earthshield Mantle',
@@ -524,21 +526,24 @@ export const dragonknightData: SkillsetData = {
           duration: '30 seconds',
           radius: '28 meters',
           description:
-            'Charge you and grouped allies\' weapons with volcanic power. Grants Major Brutality and Sorcery. Light and Heavy Attacks deal bonus Flame Damage.',
+            "Charge you and grouped allies' weapons with volcanic power. Grants Major Brutality and Sorcery. Light and Heavy Attacks deal bonus Flame Damage.",
           buff: 'Major Brutality and Sorcery (+20% Weapon/Spell Damage)',
-          lightHeavyBonus: '448 bonus Flame Damage on Light/Heavy Attack hits (once every 2 seconds)',
+          lightHeavyBonus:
+            '448 bonus Flame Damage on Light/Heavy Attack hits (once every 2 seconds)',
           morphs: {
             igneousWeapons: {
               name: 'Igneous Weapons',
               duration: '60 seconds',
               description: 'Doubles the duration.',
-              lightHeavyBonus: '448 bonus Flame Damage on Light/Heavy Attack hits (once every 2 seconds)',
+              lightHeavyBonus:
+                '448 bonus Flame Damage on Light/Heavy Attack hits (once every 2 seconds)',
             },
             moltenArmaments: {
               name: 'Molten Armaments',
               cost: '4050 Magicka',
               description: 'Bonus Flame Damage procs faster and grants Empower for Heavy Attacks.',
-              lightHeavyBonus: '448 bonus Flame Damage on Light/Heavy Attack hits (once every 1.5 seconds)',
+              lightHeavyBonus:
+                '448 bonus Flame Damage on Light/Heavy Attack hits (once every 1.5 seconds)',
               buff: 'Empower (+70% Heavy Attack damage vs monsters for duration)',
             },
           },
@@ -549,13 +554,15 @@ export const dragonknightData: SkillsetData = {
           cost: '4050 Magicka',
           target: 'Area',
           radius: '12 meters',
-          description: 'Call the earth to your defense, granting a damage shield (scales with Max Health) to you and nearby allies. Grants Major Mending.',
+          description:
+            'Call the earth to your defense, granting a damage shield (scales with Max Health) to you and nearby allies. Grants Major Mending.',
           shield: '1321 damage absorption (scales with Max Health)',
           buff: 'Major Mending (+16% healing done for 4 seconds)',
           morphs: {
             fragmentedShield: {
               name: 'Fragmented Shield',
-              shield: '2400 damage absorption (scales with max Magicka or Stamina, capped at 31% target Max Health)',
+              shield:
+                '2400 damage absorption (scales with max Magicka or Stamina, capped at 31% target Max Health)',
               description: 'Larger shield scaling off Magicka/Stamina. Major Mending lasts longer.',
               buff: 'Major Mending (+16% healing done for 6 seconds)',
             },
@@ -626,7 +633,8 @@ export const dragonknightData: SkillsetData = {
     statusEffects: {
       burning: {
         name: 'Burning',
-        description: 'Fire status effect. Combustion restores 225 Magicka and Stamina when applied (once per second).',
+        description:
+          'Fire status effect. Combustion restores 225 Magicka and Stamina when applied (once per second).',
       },
       offBalance: {
         name: 'Off Balance',
@@ -661,17 +669,21 @@ export const dragonknightData: SkillsetData = {
         description:
           'Activating any Dragonknight ability while in combat grants stacks. Stacks boost next Molten Whip damage and sustained damage done.',
         maxStacks: 3,
-        stackBonus: '33% damage on next Molten Whip; +5% damage done (2% vs players) for 10 seconds',
+        stackBonus:
+          '33% damage on next Molten Whip; +5% damage done (2% vs players) for 10 seconds',
       },
       flameLashPowerLash: {
         name: 'Power Lash System (Flame Lash)',
-        description: 'Hitting an Off Balance enemy grants 5 Power Lash stacks for 20 seconds (once every 20 sec). Each stack deals AoE damage and heals. Consuming all stacks grants a damage bonus.',
+        description:
+          'Hitting an Off Balance enemy grants 5 Power Lash stacks for 20 seconds (once every 20 sec). Each stack deals AoE damage and heals. Consuming all stacks grants a damage bonus.',
         condition: 'Target must be Off Balance',
-        fullStackBonus: '+7% damage done (14% vs monsters) for 45 seconds after consuming all 5 stacks',
+        fullStackBonus:
+          '+7% damage done (14% vs monsters) for 45 seconds after consuming all 5 stacks',
       },
       volcanicWhip: {
         name: 'Volcanic Whip System (Lava Whip)',
-        description: 'Hitting an Off Balance enemy grants 5 Volcanic Whip stacks for 20 seconds (once every 20 sec). Each stack transforms next Lava Whip into a powerful AoE strike.',
+        description:
+          'Hitting an Off Balance enemy grants 5 Volcanic Whip stacks for 20 seconds (once every 20 sec). Each stack transforms next Lava Whip into a powerful AoE strike.',
         condition: 'Target must be Off Balance',
         benefit: '4338 Flame Damage to target and nearby enemies per stack consumed',
       },
@@ -687,14 +699,16 @@ export const dragonknightData: SkillsetData = {
       },
       coreOfFlame: {
         name: 'Resource Restore System (Core of Flame)',
-        description: 'Restores 15% of missing Magicka and Stamina every 2 seconds over 4 seconds, then deals AoE Flame Damage on completion.',
+        description:
+          'Restores 15% of missing Magicka and Stamina every 2 seconds over 4 seconds, then deals AoE Flame Damage on completion.',
         restoration: '15% missing Magicka and Stamina per 2 seconds for 4 seconds',
       },
     },
     resourceManagement: {
       theStormVoice: {
         name: 'The Storm Voice',
-        description: 'Restore resources based on Ultimate cost spent. Scales with number of DK abilities slotted.',
+        description:
+          'Restore resources based on Ultimate cost spent. Scales with number of DK abilities slotted.',
         rate: '16 Health/Magicka/Stamina per Ultimate point spent (+6 per DK ability slotted)',
       },
       combustion: {


### PR DESCRIPTION
## Summary

Complete rewrite of `src/data/skill-lines/class/dragonknight.ts` to reflect all U49 Dragonknight skill changes across all three class skill lines (Ardent Flame, Draconic Power, Earthen Heart).

## Jira Ticket

[ESO-677](https://bkrupa.atlassian.net/browse/ESO-677)

## Problem

The `dragonknightData` object in `dragonknight.ts` held pre-U49 descriptions, damage values, and mechanics. Update 49 massively restructured all three DK skill lines — abilities moved between skill lines, names changed, mechanics were reworked, and several completely new systems were introduced.

## Changes Made

### Ardent Flame
- **Dragonknight Standard**: reworked from DoT + Major Defile to rally mechanic (+300 W/S Damage, -10% damage taken); Shifting Standard retains the DoT/Major Defile variant
- **Searing Strike**: DoT duration 10s (was 20s); **Searing Claw** (renamed from Venomous Claw) now deals Flame Damage with 10% escalation per 2s; **Burning Embers** heals per tick scaled off Max Health
- **Core of Flame** (moved from Draconic Power, was `Inhale`): restores 15% missing Magicka/Stamina every 2s for 4s then releases an AoE blast; morphs **Heart of Flame** and **Soul of Flame**
- **Hearthfire** (moved from Earthen Heart, was `Ash Cloud`): healing AoE granting Minor Fortitude + Minor Heroism; morphs **Fire Keeper** and **Hearth and Home**
- **Lava Whip**: Off Balance now grants 5 Volcanic Whip stacks (4338 AoE damage each)
- **Molten Whip**: stacks trigger on any DK ability (was Ardent Flame only); 33% damage + 5% damage done bonus
- **Flame Lash**: heals on hit; Power Lash is now a 5-stack system + full-stack consumption grants sustained damage bonus
- **Inferno**: now hits all enemies in area; **Flames of Oblivion → Incinerate** (Burning chance); **Cauterize** heals up to 6 allies (was 4)
- Passives: **Combustion** reworked (Burning only, 225 resources per 1s); **Searing Heat → Fan the Flames**; **Warmth → Traumatic Burns**; **added A Soul Ablaze** (+8% Healing Taken, moved from Draconic Power as Burning Heart); **World in Ruin** unchanged

### Draconic Power
- **Dragon Leap**: now deals Flame Damage (was Physical); **Take Flight** adds 10% damage done buff (doubles vs monsters); **Ferocious Leap** shield 17173/10s (scaled with Max Health)
- **Dragonfire Breath** + morphs moved in from Ardent Flame (was Fiery Breath): **Disintegrating Dragonfire** applies Burning + Major Breach; **Engulfing Dragonfire** is now a channel (1386 Flame every 0.5s over 4.8s, +5% per tick up to 50% bonus)
- **Chains of Flame** + morphs moved in from Ardent Flame (was Fiery Grip): applies Burning + Major Cowardice; **Chains of Dominance** refunds cost; **Chains of Devastation** grants Major Berserk + Major Evasion
- **Dark Talons**: Choking Talons Minor Maim extended to 20s (was 10s)
- **Dragon Blood**: heal scaling updated to Max Health-based; **Blood of the Green Dragon** adds HoT; **Blood of the Elder Dragon** (was Coagulating Blood) now heals nearby allies + Minor Courage
- **Wing Buffet** (renamed from Protective Scale): knockback + stun + projectile reduction; **Protect the Brood** (was Dragon Fire Scale) shields group members; **Fleetstep Wings** (was Protective Plate) unchanged
- Passives: **Elder Dragon** reworked (group Minor Brutality + missing-Health scaling); **Battle Roar → The Storm Voice**; **World in Ruin** now +7% area/DoT damage; **Iron Skin → Burnished Scales**; **Burning Heart** moved to Ardent Flame as A Soul Ablaze; removed Scaled Armor

### Earthen Heart
- **Superheated Ward** (was Stonefist, complete rework): targeted damage shield scaling off Max Magicka/Stamina; **Magma Fist** morph (Heat Shock stacks, +66 damage taken per stack up to 3); **Volcanic Ward** morph (shield + 10% damage reduction + expiry heal)
- **Earthspike Mantle** moved in from Draconic Power (was Spiked Armor): +100 damage done + Major Resolve; morphs **Shatterspike Mantle** (DoT + Landslide stacks) and **Earthshield Mantle** (damage shield on cast)
- **Molten Weapons**: now includes Light/Heavy Attack bonus Flame Damage (448 every 2s); **Igneous Weapons** 60s; **Molten Armaments** 1.5s interval + Empower
- **Obsidian Shield**: **Fragmented Shield** scales off Magicka/Stamina (capped 31% Max Health); **Igneous Shield** self 3824/ally 1322 (both Max Health)
- **Petrify** reworked: 50% slow for 1s then stun 4s (8s vs monsters); Minor Breach on target; **Fossilize** adds Minor Vulnerability; **Shattering Rocks** deals damage + heals on stun expiry
- **Ash Cloud / Cinder Storm / Eruption** remain in Earthen Heart (kept for backward compat — moved to Ardent Flame in the skill-line data but still referenced here)
- Passives: **Battle Roar → Landslide** (stacking +1% damage done up to 10 stacks); **Mountain's Blessing → Blessing at the Peak** (Ultimate gen + 10% Critical Damage); **Helping Hands → Mountain Giant** (Heavy Attack applies Off Balance + restores 1430 Stamina); **Eternal Mountain** unchanged

### Mechanics section updated
- New: Volcanic Whip / Power Lash stack systems, Engulfing Dragonfire channel, Core of Flame resource restore, Heat Shock stacks, Landslide stacks
- Removed: old Stagger (Stone Giant), old Power Lash, old Seething Fury (updated), old Battle Roar / Helping Hands resource management

## Testing Done

- `npm run validate` passes (typecheck + lint + format)
- No type errors introduced
- Data-only change — no runtime logic affected


[ESO-677]: https://bkrupa.atlassian.net/browse/ESO-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ