### PR TITLE
chore(ci): add Discord notifications for PR merges

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -236,6 +236,7 @@ jobs:
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
                 username: 'ESO Toolkit',
+                avatar_url: 'https://esotk.com/android-chrome-512x512.png',
                 embeds,
               }),
             });


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that sends rich Discord embed notifications to the `#pr-updates` channel whenever a PR is merged into `main`.

## Why
The team wants visibility into merged PRs directly in Discord without leaving the server. This replaces the need to manually check GitHub for merge activity.

## How
- **Trigger**: `pull_request` closed event, filtered to `merged == true` on `main`
- **Data extraction**: Uses `actions/github-script@v8` to fetch PR details, issue comments, and review comments via the GitHub API
- **Screenshot detection**: Regex-based extraction of images from PR body and all comments — handles markdown images (`![](url)`), HTML `<img>` tags, GitHub user-uploaded assets, and user-attachments URLs
- **Discord formatting**: Converts GitHub markdown to Discord-compatible markdown (headers → bold, HTML removal, checkbox → emoji)
- **Embed structure**: Main embed with PR title, description, author avatar, labels, change stats, and timestamp. Screenshots are attached as additional embeds sharing the same URL (Discord renders these as a gallery)
- **Webhook**: Stored as `DISCORD_WEBHOOK_PR_UPDATES` repo secret

### Discord embed includes:
- PR title + number as clickable link
- Author with GitHub avatar
- PR description (converted to Discord markdown)
- Labels as inline code badges
- `+additions` / `-deletions` stats
- Branch info and file count in footer
- Merged timestamp
- Up to 9 screenshots from PR body and comments

## Testing
- YAML validated with yaml-lint
- Webhook created and secret stored in repo
- Will be tested live on next PR merge to main (this PR itself will trigger it once merged)