### PR TITLE
fix(routing): prevent landing page flash on deep link reload (ESO-701)

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,64 @@
       rel="stylesheet"
     />
     <title>ESO Toolkit</title>
+    <script>
+      // SPA deep-link restoration — runs synchronously before React mounts so the
+      // router sees the correct URL on its very first render, preventing the
+      // landing-page flash that would otherwise occur when reloading a deep link.
+      //
+      // Flow: when a deep link is requested, GitHub Pages serves 404.html which
+      // stores the intended path in sessionStorage (with a ?redirect= URL param
+      // as fallback) and redirects to the root. Without this script, React would
+      // render the Landing Page for one frame before HashRouteRedirect's useEffect
+      // fires and navigates away. By patching window.location synchronously here
+      // we ensure BrowserRouter reads the correct URL from the very first render.
+      (function () {
+        function isValidPath(p) {
+          return (
+            typeof p === 'string' &&
+            p.length > 1 &&
+            p.charAt(0) === '/' &&
+            p.charAt(1) !== '/' &&
+            p.indexOf('://') === -1
+          );
+        }
+
+        // Method 1: sessionStorage set by 404.html
+        var redirectPath = null;
+        try {
+          redirectPath = sessionStorage.getItem('redirectPath');
+        } catch (_) {
+          // SecurityError – sessionStorage unavailable (e.g. restricted iframe)
+        }
+
+        if (redirectPath && isValidPath(redirectPath)) {
+          try {
+            history.replaceState(null, '', redirectPath);
+            // Remove only after a successful replaceState so that HashRouteRedirect
+            // can still act as a fallback if replaceState threw a SecurityError.
+            try {
+              sessionStorage.removeItem('redirectPath');
+            } catch (_) {}
+            return;
+          } catch (_) {
+            // SecurityError – history.replaceState not permitted; leave sessionStorage
+            // intact so HashRouteRedirect can handle it (with the flash fallback).
+          }
+        }
+
+        // Method 2: ?redirect= URL param (written by 404.html when sessionStorage
+        // is unavailable, e.g. cookies/storage blocked by the browser).
+        try {
+          var params = new URLSearchParams(window.location.search);
+          var paramPath = params.get('redirect');
+          if (paramPath && isValidPath(paramPath)) {
+            history.replaceState(null, '', paramPath);
+          }
+        } catch (_) {
+          // URLSearchParams or replaceState unavailable – HashRouteRedirect will handle it.
+        }
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary

Adds a synchronous inline script to `index.html` that patches the browser URL to the correct deep link **before React renders**, eliminating the Landing Page flash when reloading deep linked URLs.

## Jira Ticket

[ESO-701](https://bkrupa.atlassian.net/browse/ESO-701)

## Problem

When a user reloads or navigates directly to a deep linked URL (e.g. `/report/abc123/fight/1`), the app momentarily flashes the Landing Page before jumping to the correct page.

## Root Cause

GitHub Pages serves `404.html` for any URL that isn't a real file. The `404.html` script stores the intended path in `sessionStorage['redirectPath']` (with a `?redirect=` URL param as fallback) and redirects the browser to `/`.

React then boots at `/`, which matches `<Route path="/" element={<MainApp />}` — so the Landing Page renders. Only **after** that first render does `HashRouteRedirect`'s `useEffect` run, read the stored redirect, and navigate to the correct page. The flash is structural: `useEffect` always fires post-render.

## Changes Made

- **`index.html`** — Added a synchronous IIFE `<script>` in `<head>` that runs before React mounts:
  1. Reads `sessionStorage.getItem('redirectPath')` (written by `404.html`)
  2. Falls back to the `?redirect=` URL param if sessionStorage is unavailable
  3. Validates the path (relative, no `://`, no `//` prefix)
  4. Calls `history.replaceState(null, '', path)` to rewrite the browser URL
  5. `BrowserRouter` then reads the correct URL on its very first render — the Landing Page never appears

`HashRouteRedirect` is kept unchanged as a safety net for:
- The legacy hash-URL migration path (`/#/report/...` → `/report/...`)
- Environments where `history.replaceState` throws a `SecurityError` (sessionStorage left intact for `HashRouteRedirect` to retry)

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Unit tests pass (`npm test -- --watchAll=false`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-701]: https://bkrupa.atlassian.net/browse/ESO-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ