### PR TITLE
fix(roster-builder): add missing set IDs to resolve Unknown set ID errors (ESO-686)

### DIFF
--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -695,6 +695,7 @@ export enum KnownSetIDs {
   STONE_HUSK = 534, // Stone Husk
   ENCRATIS_BEHEMOTH = 577, // Encratis's Behemoth (Encratis)
   BARON_ZAUDRUS = 578, // Baron Zaudrus
+  GRYPHONS_REPRISAL = 620, // Gryphon's Reprisal
   SPAULDER_OF_RUIN = 627, // Spaulder of Ruin
   NAZARAY = 633, // Nazaray
   NUNATAK = 634, // Nunatak
@@ -725,6 +726,7 @@ export enum KnownSetIDs {
   CRUSHING_WALL = 373, // Crushing Wall
   PERFECTED_CRUSHING_WALL = 526, // Perfected Crushing Wall
   PERFECTED_GRAND_REJUVENATION = 533, // Perfected Grand Rejuvenation
+  PEACE_AND_SERENITY = 701, // Peace and Serenity
   ANSUULS_TORMENT = 702, // Ansuul's Torment (non-perfected)
   PERFECTED_ANSUULS_TORMENT = 707, // Perfected Ansuul's Torment
   SLIVERS_OF_THE_NULL_ARCA = 767, // Slivers of the Null Arca
@@ -771,6 +773,7 @@ export enum KnownSetIDs {
   KINRAS_WRATH = 570, // Kinras's Wrath
   DEATH_DEALERS_FETE = 596, // Death Dealer's Fete
   ORDERS_WRATH = 640, // Order's Wrath
+  SERPENTS_DISDAIN = 641, // Serpent's Disdain
   RUNECARVERS_BLAZE = 684, // Runecarver's Blaze
   MACABRE_VINTAGE = 758, // Macabre Vintage
   PYREBRAND = 776, // Pyrebrand
@@ -952,6 +955,8 @@ export enum KnownSetIDs {
   // ============================================================
   UNKNOWN_SET_845 = 845, // Unknown Set (ID 845)
   UNKNOWN_SET_846 = 846, // Unknown Set (ID 846)
+  UNKNOWN_SET_2268 = 2268, // Unknown Set (ID 2268) — newer ESO content
+  UNKNOWN_SET_2342 = 2342, // Unknown Set (ID 2342) — newer ESO content
 }
 
 /**

--- a/src/utils/setNameUtils.ts
+++ b/src/utils/setNameUtils.ts
@@ -20,7 +20,6 @@ export const UNSUPPORTED_SET_NAMES: Record<string, string> = {
   "Draugrkin's Grip": "Draugrkin's Grip",
   "Dro'Zakar's Claws": "Dro'Zakar's Claws",
   'Grisly Gourmet': 'Grisly Gourmet',
-  "Gryphon's Reprisal": "Gryphon's Reprisal",
   'Hew and Sunder': 'Hew and Sunder',
   "Hrothgar's Chill": "Hrothgar's Chill",
   'Icy Conjurer': 'Icy Conjurer',
@@ -79,6 +78,7 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   // ============================================================
   [KnownSetIDs.ENGINE_GUARDIAN]: 'Engine Guardian',
   [KnownSetIDs.VALKYN_SKORIA]: 'Valkyn Skoria',
+  [KnownSetIDs.GRYPHONS_REPRISAL]: "Gryphon's Reprisal",
   [KnownSetIDs.SLIMECRAW]: 'Slimecraw',
   [KnownSetIDs.EARTHGORE]: 'Earthgore',
   [KnownSetIDs.SYMPHONY_OF_BLADES]: 'Symphony of Blades',
@@ -108,6 +108,7 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   [KnownSetIDs.PERFECTED_CRUSHING_WALL]: 'Perfected Crushing Wall',
   [KnownSetIDs.PERFECTED_GRAND_REJUVENATION]: 'Perfected Grand Rejuvenation',
   [KnownSetIDs.CRYPTCANON_VESTMENTS]: 'Cryptcanon Vestments',
+  [KnownSetIDs.PEACE_AND_SERENITY]: 'Peace and Serenity',
   [KnownSetIDs.PERFECTED_ANSUULS_TORMENT]: "Perfected Ansuul's Torment",
   [KnownSetIDs.SLIVERS_OF_THE_NULL_ARCA]: 'Slivers of the Null Arca',
   [KnownSetIDs.PERFECTED_SLIVERS_OF_THE_NULL_ARCA]: 'Perfected Slivers of the Null Arca',
@@ -211,6 +212,7 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   [KnownSetIDs.RALLYING_CRY]: 'Rallying Cry',
   [KnownSetIDs.BARON_THIRSK]: 'Baron Thirsk',
   [KnownSetIDs.ORDERS_WRATH]: "Order's Wrath",
+  [KnownSetIDs.SERPENTS_DISDAIN]: "Serpent's Disdain",
   [KnownSetIDs.CORAL_RIPTIDE]: 'Coral Riptide',
   [KnownSetIDs.CORAL_RIPTIDE_PERFECTED]: 'Perfected Coral Riptide',
   [KnownSetIDs.MORAS_WHISPERS]: "Mora's Whispers",
@@ -298,6 +300,8 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   [KnownSetIDs.BLACK_GEM_MONSTROSITY]: 'Black Gem Monstrosity',
   [KnownSetIDs.COUP_DE_GRACE]: 'Coup De Grâce',
   [KnownSetIDs.UNKNOWN_SET_846]: 'Unknown',
+  [KnownSetIDs.UNKNOWN_SET_2268]: 'Unknown',
+  [KnownSetIDs.UNKNOWN_SET_2342]: 'Unknown',
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes "Unknown set ID detected" Rollbar errors (ESO-686) caused by gear set IDs in roster share links that weren't registered in `KnownSetIDs`.

## Root Cause

When users open roster share links containing newer gear sets, the encoded set IDs are decoded and passed to `getSetDisplayName()`. If the ID isn't in `SET_DISPLAY_NAMES`, the function calls `reportError()` creating Rollbar noise, then returns a fallback string.

## Sets Added

| ID | Name | Notes |
|----|------|-------|
| 620 | Gryphon's Reprisal | Was in `UNSUPPORTED_SET_NAMES`; now has verified ID from libsets data |
| 641 | Serpent's Disdain | Missing entry between Order's Wrath (640) and Druid's Braid (642) |
| 701 | Peace and Serenity | Missing entry adjacent to Ansuul's Torment (702) |
| 2268 | Unknown | Newer ESO content not yet in libsets data ? placeholder stops Rollbar spam |
| 2342 | Unknown | Newer ESO content not yet in libsets data ? placeholder stops Rollbar spam |

IDs 620, 641, and 701 were identified from `data/libsets-set-names.json`. IDs 2268 and 2342 are from ESO content newer than the December 2025 libsets export; they use the existing `UNKNOWN_SET_*` placeholder pattern until names can be confirmed.

## Changes

- `src/types/abilities.ts` ? Added 5 entries to `KnownSetIDs` enum
- `src/utils/setNameUtils.ts` ? Added display name entries to `SET_DISPLAY_NAMES`; removed Gryphon's Reprisal from `UNSUPPORTED_SET_NAMES`

## Testing

- `npm run typecheck` ? clean
- `npm test -- --watchAll=false` ? 587/587 tests pass (including `setNameUtils.test.ts`)

Fixes ESO-686.
