### PR TITLE
fix(roster-encoding): eliminate unhandled promise rejections from stream write/close (ESO-698)

### DIFF
--- a/src/pages/RosterBuilderPage.tsx
+++ b/src/pages/RosterBuilderPage.tsx
@@ -719,19 +719,34 @@ async function readAllChunks(readable: ReadableStream<Uint8Array>): Promise<Uint
 
 async function deflateString(str: string): Promise<Uint8Array> {
   const input = new TextEncoder().encode(str);
-  const stream = new CompressionStream('deflate-raw');
-  const writer = stream.writable.getWriter();
-  writer.write(input);
-  writer.close();
-  return readAllChunks(stream.readable);
+  // Use pipeThrough to avoid floating promise rejections from unawaited write/close calls.
+  const inputStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(input);
+      controller.close();
+    },
+  });
+  return readAllChunks(
+    inputStream.pipeThrough(
+      new CompressionStream('deflate-raw') as unknown as TransformStream<Uint8Array, Uint8Array>,
+    ),
+  );
 }
 
 async function inflateBytes(bytes: Uint8Array): Promise<string> {
-  const stream = new DecompressionStream('deflate-raw');
-  const writer = stream.writable.getWriter();
-  writer.write(bytes as Uint8Array<ArrayBuffer>);
-  writer.close();
-  const output = await readAllChunks(stream.readable);
+  // Use pipeThrough to avoid floating promise rejections from unawaited write/close calls.
+  // Decompression errors propagate cleanly through the pipeline to the caller.
+  const inputStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  const output = await readAllChunks(
+    inputStream.pipeThrough(
+      new DecompressionStream('deflate-raw') as unknown as TransformStream<Uint8Array, Uint8Array>,
+    ),
+  );
   return new TextDecoder().decode(output);
 }
 

--- a/src/utils/rosterEncoding.ts
+++ b/src/utils/rosterEncoding.ts
@@ -428,19 +428,34 @@ async function readAllChunks(readable: ReadableStream<Uint8Array>): Promise<Uint
 
 export async function deflateString(str: string): Promise<Uint8Array> {
   const input = new TextEncoder().encode(str);
-  const stream = new CompressionStream('deflate-raw');
-  const writer = stream.writable.getWriter();
-  writer.write(input);
-  writer.close();
-  return readAllChunks(stream.readable);
+  // Use pipeThrough to avoid floating promise rejections from unawaited write/close calls.
+  const inputStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(input);
+      controller.close();
+    },
+  });
+  return readAllChunks(
+    inputStream.pipeThrough(
+      new CompressionStream('deflate-raw') as unknown as TransformStream<Uint8Array, Uint8Array>,
+    ),
+  );
 }
 
 export async function inflateBytes(bytes: Uint8Array): Promise<string> {
-  const stream = new DecompressionStream('deflate-raw');
-  const writer = stream.writable.getWriter();
-  writer.write(bytes as Uint8Array<ArrayBuffer>);
-  writer.close();
-  const output = await readAllChunks(stream.readable);
+  // Use pipeThrough to avoid floating promise rejections from unawaited write/close calls.
+  // Decompression errors propagate cleanly through the pipeline to the caller.
+  const inputStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  const output = await readAllChunks(
+    inputStream.pipeThrough(
+      new DecompressionStream('deflate-raw') as unknown as TransformStream<Uint8Array, Uint8Array>,
+    ),
+  );
   return new TextDecoder().decode(output);
 }
 


### PR DESCRIPTION
## Summary

Fixes **Rollbar ESOTK/22** ("Error: 620") ? unhandled promise rejections emitted by `deflateString` and `inflateBytes` in the roster URL encoding/decoding pipeline.

## Root Cause

Both `deflateString` and `inflateBytes` obtained a `WritableStreamDefaultWriter` and called `writer.write()` / `writer.close()` **without awaiting the returned promises**. When the `DecompressionStream` encountered invalid or truncated data (e.g. a mangled `?r=` URL parameter), the un-awaited write promise rejected silently. Rollbar ? configured with `captureUnhandledRejections: true` ? captured these floating rejections and reported them as "Error: 620".

## Fix

Replace the manual writer pattern with **`ReadableStream.pipeThrough()`** in both functions. This eliminates all floating promise rejections:

- **`deflateString`** ? wraps the input bytes in a `ReadableStream` and pipes through `CompressionStream('deflate-raw')`
- **`inflateBytes`** ? wraps the input bytes in a `ReadableStream` and pipes through `DecompressionStream('deflate-raw')`

Stream errors now propagate cleanly through the pipeline's readable side directly into the existing `try/catch` callers in `decodeRosterFromURL` and `encodeRosterToURL` ? no unhandled rejections remain.

The same fix is applied to the locally-duplicated copies inside `RosterBuilderPage.tsx` so both encoding paths are consistent.

## Files Changed

- `src/utils/rosterEncoding.ts` ? fix `deflateString` and `inflateBytes`
- `src/pages/RosterBuilderPage.tsx` ? fix duplicate local copies of the same functions

## Testing

- `npm run validate` passes (typecheck + lint + format)
- `npm test -- --watchAll=false` passes
- No regressions in roster encode/decode round-trips
