### PR TITLE
fix(roster-encoding): sync CompactDPS schema with structured DPS gear fields (ESO-683)

### DIFF
--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -569,9 +569,12 @@ const DPS_JAIL_LABELS: Record<string, string> = {
 
 const DPSRow: React.FC<DPSRowProps> = ({ slot, color, isDarkMode }) => {
   const skillLines = formatSkillLines(slot.skillLines);
-  const gearSets = slot.gearSets
-    ? formatGearSets({ set1: slot.gearSets[0], set2: slot.gearSets[1] })
-    : [];
+  const gearSets = formatGearSets({
+    set1: slot.set1,
+    set2: slot.set2,
+    monsterSet: slot.monsterSet,
+    additionalSets: slot.additionalSets,
+  });
 
   const isEmpty = !slot.playerName && !slot.roleNotes && !slot.labels?.length;
 

--- a/src/utils/rosterEncoding.ts
+++ b/src/utils/rosterEncoding.ts
@@ -89,10 +89,17 @@ export interface CompactDPS {
   sn: number; // slotNumber (required)
   pn?: string; // playerName
   pi?: number; // playerNumber
+  rl?: string; // roleLabel
   rn?: string; // roleNotes
   lb?: string[]; // labels
-  gs?: number[]; // gearSets
+  s1?: number; // set1 (primary 5-piece)
+  s2?: number; // set2 (secondary 5-piece)
+  ms?: number; // monsterSet
+  as?: number[]; // additionalSets
+  gs?: number[]; // legacy gearSets (backward compat decode only)
   sl?: CompactSkills; // skillLines
+  cp?: string; // championPoint
+  ul?: number | string; // ultimate: SupportUltimate index or custom string
   gr?: CompactGroup; // group
   no?: string; // notes
   jt?: number; // jailDDType index
@@ -300,11 +307,18 @@ function compactDPS(d: DPSSlot): CompactDPS {
   const c: CompactDPS = { sn: d.slotNumber };
   if (d.playerName) c.pn = d.playerName;
   if (d.playerNumber != null) c.pi = d.playerNumber;
+  if (d.roleLabel) c.rl = d.roleLabel;
   if (d.roleNotes) c.rn = d.roleNotes;
   if (d.labels?.length) c.lb = d.labels;
-  if (d.gearSets?.length) c.gs = d.gearSets as number[];
+  if (d.set1 != null) c.s1 = d.set1 as number;
+  if (d.set2 != null) c.s2 = d.set2 as number;
+  if (d.monsterSet != null) c.ms = d.monsterSet as number;
+  if (d.additionalSets?.length) c.as = d.additionalSets as number[];
   const sl = d.skillLines ? compactSkills(d.skillLines) : undefined;
   if (sl) c.sl = sl;
+  if (d.championPoint) c.cp = d.championPoint;
+  const ul = encodeUltimate(d.ultimate);
+  if (ul != null) c.ul = ul;
   const gr = compactGroup(d.group);
   if (gr) c.gr = gr;
   if (d.notes) c.no = d.notes;
@@ -317,14 +331,30 @@ function compactDPS(d: DPSSlot): CompactDPS {
 }
 
 function expandDPS(c: CompactDPS): DPSSlot {
+  // Migrate legacy flat gearSets (gs) to structured fields when no new fields present.
+  const legacyGear =
+    c.gs && !c.s1 && !c.s2
+      ? {
+          set1: (c.gs[0] as KnownSetIDs) ?? undefined,
+          set2: (c.gs[1] as KnownSetIDs) ?? undefined,
+          additionalSets: (c.gs.slice(2) as KnownSetIDs[]) || undefined,
+        }
+      : {};
   return {
     slotNumber: c.sn,
     playerName: c.pn,
     playerNumber: c.pi,
+    roleLabel: c.rl,
     roleNotes: c.rn,
     labels: c.lb,
-    gearSets: c.gs as KnownSetIDs[] | undefined,
+    set1: c.s1 as KnownSetIDs | undefined,
+    set2: c.s2 as KnownSetIDs | undefined,
+    monsterSet: c.ms as KnownSetIDs | undefined,
+    additionalSets: c.as as KnownSetIDs[] | undefined,
+    ...legacyGear,
     skillLines: c.sl ? expandSkills(c.sl) : undefined,
+    championPoint: c.cp || undefined,
+    ultimate: c.ul != null ? decodeUltimate(c.ul) : null,
     group: expandGroup(c.gr),
     notes: c.no,
     jailDDType: c.jt != null ? JAIL_DD_TYPE_LIST[c.jt] : undefined,
@@ -347,9 +377,16 @@ export function compactifyRoster(roster: RaidRoster): CompactRoster {
     (slot) =>
       slot.playerName ||
       slot.playerNumber != null ||
+      slot.roleLabel ||
       slot.roleNotes ||
       slot.labels?.length ||
+      slot.set1 != null ||
+      slot.set2 != null ||
+      slot.monsterSet != null ||
+      slot.additionalSets?.length ||
       slot.gearSets?.length ||
+      slot.championPoint ||
+      slot.ultimate ||
       slot.jailDDType ||
       slot.notes ||
       slot.group ||


### PR DESCRIPTION
## Summary

Fixes DPS gear data loss in shared roster links by syncing the `CompactDPS` encoding schema with the current `DPSSlot` data model, and fixes the `RosterViewPage` DPS row to display structured gear fields.

## Jira Ticket

[ESO-683](https://bkrupa.atlassian.net/browse/ESO-683)

## Problem

Roster share links generated via "Copy Link" silently lost all DPS gear data (sets, champion points, ultimates, role labels). The `/rv` read-only view also showed empty DPS gear sections even when a roster was correctly saved.

## Root Cause

PR #802 redesigned `DPSSlot` to use structured gear fields (`set1`, `set2`, `monsterSet`, `additionalSets`, `roleLabel`, `championPoint`, `ultimate`), but the shared `rosterEncoding.ts` `CompactDPS` interface was never updated — it only had the legacy flat `gs` (gearSets) array. Two separate issues resulted:

1. **Encoder** (`rosterEncoding.ts`): `compactDPS` only saved the legacy `gearSets` array, dropping all structured gear fields when generating share URLs via `handleCopyLink`.
2. **Viewer** (`RosterViewPage.tsx`): `DPSRow` only read from `slot.gearSets[0/1]` (legacy), so even a correctly-encoded URL would show empty DPS gear in the read-only view.

## Changes Made

### `src/utils/rosterEncoding.ts`
- Added `rl`, `s1`, `s2`, `ms`, `as`, `cp`, `ul` fields to the `CompactDPS` interface
- Updated `compactDPS` to encode all structured fields (roleLabel, set1, set2, monsterSet, additionalSets, championPoint, ultimate)
- Updated `expandDPS` with backward-compat migration: when a URL has legacy `gs` (flat array) but no `s1`/`s2`, maps `gs[0]→set1`, `gs[1]→set2`, `gs[2+]→additionalSets`
- Updated `compactifyRoster` filled-slot filter to detect slots with new structured gear fields

### `src/pages/RosterViewPage.tsx`
- Fixed `DPSRow` to build gear display from `slot.set1`, `slot.set2`, `slot.monsterSet`, `slot.additionalSets` instead of the legacy `slot.gearSets` array

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Unit tests pass (`npm test -- --watchAll=false`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-683]: https://bkrupa.atlassian.net/browse/ESO-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ