### PR TITLE
test(setNameUtils): add KnownSetIDs coverage regression test (ESO-684)

### DIFF
--- a/src/utils/setNameUtils.test.ts
+++ b/src/utils/setNameUtils.test.ts
@@ -131,4 +131,43 @@ describe('setNameUtils', () => {
       expect(isUnsupportedSet('Some Random Set')).toBe(false);
     });
   });
+
+  describe('KnownSetIDs coverage (ESO-684 regression)', () => {
+    /**
+     * Regression test for ESO-684 / ESO-686: ensures every value in the
+     * KnownSetIDs enum has a corresponding entry in SET_DISPLAY_NAMES.
+     *
+     * "Unknown set ID detected" Rollbar errors (counters 7, 12) were triggered
+     * when users opened roster share links whose gear sets had valid KnownSetIDs
+     * values (e.g. 641 Serpent's Disdain, 620 Gryphon's Reprisal, 701 Peace and
+     * Serenity) that were missing from SET_DISPLAY_NAMES at build time.
+     *
+     * Adding a new entry to KnownSetIDs without a matching SET_DISPLAY_NAMES
+     * entry will fail this test and prevent a repeat of the incident.
+     */
+    it('every KnownSetIDs value must have a SET_DISPLAY_NAMES entry', () => {
+      const missingIds: Array<{ name: string; id: number }> = [];
+
+      for (const [name, value] of Object.entries(KnownSetIDs)) {
+        // KnownSetIDs is a numeric enum — filter out the reverse-mapping strings
+        if (typeof value !== 'number') continue;
+
+        const displayName = getSetDisplayName(value as KnownSetIDs);
+        if (!displayName) {
+          missingIds.push({ name, id: value });
+        }
+      }
+
+      // Clear reportError calls generated above so they don't leak into other tests
+      jest.clearAllMocks();
+
+      if (missingIds.length > 0) {
+        const formatted = missingIds.map(({ name, id }) => `  ${name} = ${id}`).join('\n');
+        throw new Error(
+          `${missingIds.length} KnownSetIDs value(s) have no SET_DISPLAY_NAMES entry.\n` +
+            `Add them to SET_DISPLAY_NAMES in setNameUtils.ts:\n${formatted}`,
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a regression test ensuring every `KnownSetIDs` value has a matching entry in `SET_DISPLAY_NAMES`. This prevents a repeat of the original bug where adding a new set ID to the enum without a display name mapping caused `"Unknown set ID detected"` errors in production.

## Jira Ticket

[ESO-684](https://bkrupa.atlassian.net/browse/ESO-684)

## Problem

Rollbar recorded several `"Unknown set ID detected: NNN"` errors (counters 7–12) from a dev preview build. The errors were thrown by `getSetDisplayName()` in `setNameUtils.ts` when it received valid `KnownSetIDs` values (620 Gryphon's Reprisal, 641 Serpent's Disdain, 701 Peace and Serenity, 2268, 2342) that had no entry in `SET_DISPLAY_NAMES`.

```
Error: Unknown set ID detected: 641
  at getSetDisplayName (src/utils/setNameUtils.ts:317)
```

## Root Cause

The `KnownSetIDs` enum and `SET_DISPLAY_NAMES` map were out of sync. Five IDs were added to the enum but their display name entries were omitted. ESO-686 (#852) already fixed this by adding the missing entries. This PR adds a regression test to catch the same class of bug in the future.

## Changes Made

- `src/utils/setNameUtils.test.ts`: Added a `KnownSetIDs coverage (ESO-684 regression)` describe block that iterates every numeric value in `KnownSetIDs` and asserts `getSetDisplayName()` returns a non-empty string. Adding a new set ID to the enum without a matching `SET_DISPLAY_NAMES` entry will now fail CI.

## Testing Done

- New test passes with all 16 tests in `setNameUtils.test.ts` green
- `npm run validate` exits 0 (typecheck + lint + format)


[ESO-684]: https://bkrupa.atlassian.net/browse/ESO-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ