### PR TITLE
fix(error-tracking): fix Rollbar rate limit flooding from unknown set IDs (ESO-689)

### DIFF
--- a/src/config/errorTrackingConfig.ts
+++ b/src/config/errorTrackingConfig.ts
@@ -21,6 +21,9 @@ export const ERROR_TRACKING_CONFIG = Object.freeze({
 
   // Verbose SDK logging (disable in production)
   verbose: false,
+
+  // Rate limiting — cap items per page load to prevent Rollbar flooding (ESO-689)
+  maxItems: 10,
 } as const);
 
 // Bug report categories

--- a/src/utils/errorTracking.ts
+++ b/src/utils/errorTracking.ts
@@ -68,6 +68,8 @@ export const initializeErrorTracking = (): void => {
     captureUncaught: isProduction && ERROR_TRACKING_CONFIG.captureUncaught,
     captureUnhandledRejections: isProduction && ERROR_TRACKING_CONFIG.captureUnhandledRejections,
     verbose: ERROR_TRACKING_CONFIG.verbose,
+    // Cap items per page load to prevent Rollbar flooding (ESO-689)
+    maxItems: ERROR_TRACKING_CONFIG.maxItems,
 
     // Filter out browser extension errors (ESO-559)
     checkIgnore: (_isUncaught, args, payload) => {

--- a/src/utils/setNameUtils.test.ts
+++ b/src/utils/setNameUtils.test.ts
@@ -38,22 +38,32 @@ describe('setNameUtils', () => {
     });
 
     it('should report error to error tracking when unknown set is detected', () => {
-      const unknownSetId = 99999 as KnownSetIDs;
+      // Use a unique ID (88888) — 99999 was already added to the dedup Set by the previous test
+      const unknownSetId = 88888 as KnownSetIDs;
       getSetDisplayName(unknownSetId);
 
       expect(errorTracking.reportError).toHaveBeenCalledTimes(1);
       expect(errorTracking.reportError).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: 'Unknown set ID detected: 99999',
+          message: 'Unknown set ID detected: 88888',
         }),
         expect.objectContaining({
-          setId: 99999,
+          setId: 88888,
           setIdType: 'number',
           component: 'setNameUtils',
           function: 'getSetDisplayName',
           availableSetCount: expect.any(Number),
         }),
       );
+    });
+
+    it('should not report the same unknown set ID more than once (ESO-689)', () => {
+      const unknownSetId = 77777 as KnownSetIDs;
+      getSetDisplayName(unknownSetId);
+      getSetDisplayName(unknownSetId);
+      getSetDisplayName(unknownSetId);
+
+      expect(errorTracking.reportError).toHaveBeenCalledTimes(1);
     });
 
     it('should include context data in error tracking report', () => {

--- a/src/utils/setNameUtils.ts
+++ b/src/utils/setNameUtils.ts
@@ -2,6 +2,9 @@ import { KnownSetIDs } from '../types/abilities';
 
 import { reportError } from './errorTracking';
 
+// Tracks unknown set IDs already reported this session — prevents Rollbar flooding (ESO-689)
+const reportedUnknownSetIds = new Set<number>();
+
 /**
  * Sets that are not currently supported for calculations due to missing verified API IDs.
  * These sets will be marked with "(unsupported)" in the UI.
@@ -312,15 +315,18 @@ export function getSetDisplayName(setId: KnownSetIDs | undefined | null): string
 
   const displayName = SET_DISPLAY_NAMES[setId];
 
-  // If set is not found, report to error tracking
+  // If set is not found, report to error tracking (once per unknown ID to avoid flooding)
   if (!displayName) {
-    reportError(new Error(`Unknown set ID detected: ${setId}`), {
-      setId,
-      setIdType: typeof setId,
-      availableSetCount: Object.keys(SET_DISPLAY_NAMES).length,
-      component: 'setNameUtils',
-      function: 'getSetDisplayName',
-    });
+    if (!reportedUnknownSetIds.has(setId)) {
+      reportedUnknownSetIds.add(setId);
+      reportError(new Error(`Unknown set ID detected: ${setId}`), {
+        setId,
+        setIdType: typeof setId,
+        availableSetCount: Object.keys(SET_DISPLAY_NAMES).length,
+        component: 'setNameUtils',
+        function: 'getSetDisplayName',
+      });
+    }
     return `Unknown Set (${setId})`;
   }
 


### PR DESCRIPTION
## Summary

Fix Rollbar rate limit flooding caused by repeated reports of the same unknown set IDs during a single page load.

## Jira Ticket

[ESO-689](https://bkrupa.atlassian.net/browse/ESO-689)

## Problem

When a roster link contains set IDs not yet present in `SET_DISPLAY_NAMES`, the app calls `reportError` for every render/call that encounters the unknown ID. This can fire dozens of times in a single session, quickly exhausting the Rollbar rate limit and flooding the error dashboard with duplicate items.

## Root Cause

Two independent sources of flooding:

1. `setNameUtils.ts` → `getSetDisplayName`: no deduplication — the same unknown set ID fires a new Rollbar event on every call.
2. `errorTrackingConfig.ts`: no `maxItems` cap configured, so Rollbar has no hard ceiling per page load.

## Changes Made

- **`src/config/errorTrackingConfig.ts`**: add `maxItems: 10` to the Rollbar init config to cap total items reported per page load.
- **`src/utils/setNameUtils.ts`**: introduce a module-level `reportedUnknownSetIds: Set<number>` that tracks which unknown IDs have already been reported this session; subsequent calls for the same ID are silently skipped.
- **`src/utils/setNameUtils.test.ts`**: add unit tests confirming that a repeated unknown set ID only triggers one error report.

## Testing Done

- [ ] TypeScript compiles (`npm run typecheck`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Formatting passes (`npm run format:check`)
- [ ] Unit tests pass (`npm test -- --watchAll=false`)
- [ ] Pre-commit validation passes (`npm run validate`)


[ESO-689]: https://bkrupa.atlassian.net/browse/ESO-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ