### PR TITLE
feat(ESO-707): add food to default visible chips on players panel

### DIFF
--- a/src/features/report_details/insights/statChipConfig.ts
+++ b/src/features/report_details/insights/statChipConfig.ts
@@ -148,6 +148,7 @@ export const DEFAULT_VISIBLE_CHIPS: StatChipId[] = [
   'dps',
   'critChance',
   'mundus',
+  'food',
   'potion',
   'deaths',
   'resurrects',


### PR DESCRIPTION
## Summary

Add the `food` chip to the default visible chips on the players panel.

## Jira Ticket

[ESO-707](https://bkrupa.atlassian.net/browse/ESO-707)

## Problem

The food/drink buff chip was available in the stat chip customization modal but was not shown by default on the players panel. Food buffs are an important part of player setup and should be visible without requiring manual configuration.

## Changes Made

- Added `'food'` to `DEFAULT_VISIBLE_CHIPS` in `statChipConfig.ts`, placed after `'mundus'` (both are passive buff chips)

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-707]: https://bkrupa.atlassian.net/browse/ESO-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ