### PR TITLE
fix(discord): handle Jira prefix in PR title routing regex

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -305,7 +305,7 @@ jobs:
               build:    '1481787727614705685',
             };
 
-            const commitTypeMatch = pr.title.match(/^(\w+)(?:\(.+?\))?[!]?:/);
+            const commitTypeMatch = pr.title.match(/^(?:\w+-\d+\s+)?(\w+)(?:\(.+?\))?[!]?:/);
             const commitType = commitTypeMatch ? commitTypeMatch[1].toLowerCase() : 'chore';
             const threadId = THREAD_MAP[commitType] || THREAD_MAP['chore'];
             const postUrl = `${webhookUrl}?thread_id=${threadId}&wait=true`;


### PR DESCRIPTION
## What
Fix the forum thread routing regex to handle PR titles with Jira ticket prefixes (e.g. `ESO-710 feat(players): ...`).

## Why
PR titles like `ESO-710 feat(players): improve discoverability of stat chip filter button` (#867) were misrouted to the **Maintenance** thread instead of **Features**. The regex `^(\w+)(?:\(.+?\))?[!]?:` anchors to the start of the string, so the `ESO-710 ` prefix prevents it from finding the actual commit type, causing a silent fallback to `chore`.

## How
Changed the regex from:
```js
/^(\w+)(?:\(.+?\))?[!]?:/
```
to:
```js
/^(?:\w+-\d+\s+)?(\w+)(?:\(.+?\))?[!]?:/
```

The new `(?:\w+-\d+\s+)?` group optionally skips a Jira-style prefix (e.g. `ESO-710 `) before capturing the conventional commit type.

## Discord cleanup
- Deleted the misrouted PR #867 notification from the Maintenance thread
- Re-posted it in the Features thread

## Testing
Regex tested against all recent PR title formats:
| Title | Before | After |
|-------|--------|-------|
| `ESO-710 feat(players): ...` | `chore` (fallback) | `feat` |
| `fix(ESO-702): ...` | `fix` | `fix` |
| `refactor(discord): ...` | `refactor` | `refactor` |
| `feat(roster): ...` | `feat` | `feat` |