### PR TITLE
fix(ESO-712): prevent accordions from jumping up when expanded

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -386,6 +386,20 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
               },
             },
           },
+          MuiAccordionSummary: {
+            styleOverrides: {
+              root: {
+                '&.Mui-expanded': {
+                  minHeight: 48, // Prevent height jump from 48→64 on expand
+                },
+              },
+              content: {
+                '&.Mui-expanded': {
+                  margin: '12px 0', // Prevent margin jump from 12px→20px on expand
+                },
+              },
+            },
+          },
         },
       }),
     [darkMode, tokens],

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -3521,12 +3521,6 @@ const CalculatorComponent: React.FC = () => {
           '&:last-child': {
             mb: 2,
           },
-          '&.Mui-expanded': {
-            mb: 4,
-            '&:last-child': {
-              mb: 3,
-            },
-          },
         }}
       >
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>


### PR DESCRIPTION
## Summary
Fix MUI Accordion layout shift that causes accordions to appear to "move up" when expanded.

## Jira Ticket
[ESO-712](https://bkrupa.atlassian.net/browse/ESO-712)

## Changes Made
- **ReduxThemeProvider.tsx**: Added `MuiAccordionSummary` theme overrides to prevent expand-related layout shifts:
  - `minHeight: 48` on `.Mui-expanded` — prevents the default MUI growth from 48px to 64px
  - `margin: '12px 0'` on content `.Mui-expanded` — prevents margin growth from 12px to 20px
- **Calculator.tsx**: Removed explicit `&.Mui-expanded` margin increase (`mb: 3→4`) that was overriding the theme-level fix

## Root Cause
MUI Accordion has three default behaviors on expand that cause layout shifts:
1. **Accordion root**: Adds `margin: 16px 0` (already fixed in theme via `margin: 0`)
2. **AccordionSummary root**: Increases `min-height` from 48px to 64px (**newly fixed**)
3. **AccordionSummary content**: Increases margin from `12px 0` to `20px 0` (**newly fixed**)

These shifts total ~24px of height change before any content appears, causing the browser to adjust scroll position — making the accordion appear to "jump up."

## Testing Done
- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Unit tests pass (`npm test -- --watchAll=false`)
- [x] Pre-commit validation passes (`npm run validate`)


[ESO-712]: https://bkrupa.atlassian.net/browse/ESO-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ