### PR TITLE
fix(ESO-706): validate decoded roster data and wrap non-Error exceptions

### DIFF
--- a/src/utils/__tests__/rosterEncoding.test.ts
+++ b/src/utils/__tests__/rosterEncoding.test.ts
@@ -168,4 +168,13 @@ describeWithStreams('encodeRosterToURL / decodeRosterFromURL – DPS gear round-
     const result = await decodeRosterFromURL('');
     expect(result).toBeNull();
   });
+
+  it('returns null for v1 payload that decodes to a JSON primitive — ESO-706 regression', async () => {
+    // btoa("32") = "MzI=" — JSON.parse("32") produces a number, not a roster object
+    expect(await decodeRosterFromURL(btoa('32'))).toBeNull();
+    expect(await decodeRosterFromURL(btoa('"hello"'))).toBeNull();
+    expect(await decodeRosterFromURL(btoa('true'))).toBeNull();
+    expect(await decodeRosterFromURL(btoa('null'))).toBeNull();
+    expect(await decodeRosterFromURL(btoa('[1,2,3]'))).toBeNull();
+  });
 });

--- a/src/utils/rosterEncoding.ts
+++ b/src/utils/rosterEncoding.ts
@@ -474,7 +474,10 @@ export async function deflateString(str: string): Promise<Uint8Array> {
   const writeAndClose = writer.write(input).then(() => writer.close());
   // Await both sides so neither rejection goes unhandled (ESO-705).
   const [, readResult] = await Promise.allSettled([writeAndClose, readAllChunks(cs.readable)]);
-  if (readResult.status === 'rejected') throw readResult.reason as Error;
+  if (readResult.status === 'rejected') {
+    const reason = readResult.reason;
+    throw reason instanceof Error ? reason : new Error(String(reason));
+  }
   return readResult.value;
 }
 
@@ -487,7 +490,10 @@ export async function inflateBytes(bytes: Uint8Array): Promise<string> {
   const writeAndClose = writer.write(bytes).then(() => writer.close());
   // Await both sides so neither rejection goes unhandled (ESO-705).
   const [, readResult] = await Promise.allSettled([writeAndClose, readAllChunks(ds.readable)]);
-  if (readResult.status === 'rejected') throw readResult.reason as Error;
+  if (readResult.status === 'rejected') {
+    const reason = readResult.reason;
+    throw reason instanceof Error ? reason : new Error(String(reason));
+  }
   return new TextDecoder().decode(readResult.value);
 }
 
@@ -529,7 +535,11 @@ export const decodeRosterFromURL = async (encoded: string): Promise<RaidRoster |
   // Try v1: btoa(encodeURIComponent(json))
   try {
     const json = decodeURIComponent(atob(encoded));
-    return JSON.parse(json) as RaidRoster;
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as RaidRoster;
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
Fix "Error: 32" / "Error: 135" Rollbar errors (Rollbar item ESOTK/28) originating from `rosterEncoding` and `RosterBuilderPage`.

## Jira Ticket
[ESO-706](https://bkrupa.atlassian.net/browse/ESO-706)

## Root Cause
Two issues in `rosterEncoding.ts`:

1. **v1 decode returned unvalidated JSON primitives** — `decodeRosterFromURL` v1 fallback called `JSON.parse(json) as RaidRoster` without checking the result was actually an object. If someone navigated to `?r=MzI=` (base64 for `"32"`), `JSON.parse("32")` returns the number `32`, which is truthy, so `setRoster(32)` was called, corrupting component state and crashing during render.

2. **Non-Error rejection reasons thrown as-is** — `inflateBytes`/`deflateString` used `throw readResult.reason as Error`, but some browsers' `DecompressionStream` rejects with non-Error values (e.g., numeric zlib codes), producing confusing "Error: 32" messages in Rollbar instead of proper Error objects.

## Changes Made
- `decodeRosterFromURL` v1 path now validates that `JSON.parse` output is a non-null, non-array object before returning it; primitives and arrays return `null`
- `inflateBytes` and `deflateString` now wrap non-Error rejection reasons in `new Error(String(reason))` before rethrowing
- Added regression test verifying JSON primitives (number, string, boolean, null, array) all return `null`

## Testing Done
- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Unit tests pass (`npm test -- --watchAll=false`)
- [x] Pre-commit validation passes (`npm run validate`)
- [x] New regression test covers all JSON primitive types


[ESO-706]: https://bkrupa.atlassian.net/browse/ESO-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ