### PR TITLE
chore: simplify CLAUDE.md to one-liner reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-All agent instructions are maintained in [AGENTS.md](AGENTS.md). Read that file for the complete reference — commands, architecture, skills, workflow rules, and guidelines.
-
-This project uses the [Agent Skills specification](https://agentskills.io) with skills in `.agents/skills/`.
+All agent instructions are maintained in [AGENTS.md](AGENTS.md). Read that file for the complete reference.


### PR DESCRIPTION
## Summary
- Reduce CLAUDE.md to a single line that redirects to AGENTS.md
- Removes redundant heading, preamble, and Agent Skills spec mention

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm AGENTS.md link resolves properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)