### PR TITLE
chore: remove broken cloudflare MCP server config

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -1,13 +1,1 @@
-{
-  "mcpServers": {
-    "cloudflare": {
-      "type": "stdio",
-      "command": "C:\\Program Files\\nodejs\\node.EXE",
-      "args": [
-        "C:\\Users\\brayd\\AppData\\Local\\npm-cache\\_npx\\384319a4c8dff50b\\node_modules\\@cloudflare\\mcp-server-cloudflare\\dist\\index.js",
-        "run",
-        "75620f084ea25ade5ee57a71a830bba2"
-      ]
-    }
-  }
-}
+{}


### PR DESCRIPTION
## Summary
- Removed broken Cloudflare MCP server definition from `.claude.json` — it referenced a non-existent path (`C:\Users\brayd\...`) from a previous machine setup
- Also cleaned up orphaned MCP permissions in `settings.local.json` (gitignored, not in this diff) for `perplexity-mcp` and `chrome-devtools` servers that were never defined

## Test plan
- [x] Verified no other MCP configs depend on the removed entry
- [x] Confirmed cloud-based integrations (Atlassian, Stripe) are unaffected
- [x] All 27 agent skills verified present and correctly referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)