### PR TITLE
refactor(ui) Replace CSS variables with theme-aware gradients in TextEditor

### DIFF
--- a/.agents/skills/vercel-react-view-transitions/SKILL.md
+++ b/.agents/skills/vercel-react-view-transitions/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: vercel-react-view-transitions
+description: Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.
+license: MIT
+metadata:
+  author: vercel
+  version: "1.0.0"
+---
+
+# React View Transitions
+
+Animate between UI states using the browser's native `document.startViewTransition`. Declare *what* with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, control *how* with CSS classes. Unsupported browsers skip animations gracefully.
+
+## When to Animate
+
+Every `<ViewTransition>` should communicate a spatial relationship or continuity. If you can't articulate what it communicates, don't add it.
+
+Implement **all** applicable patterns from this list, in this order:
+
+| Priority | Pattern | What it communicates |
+|----------|---------|---------------------|
+| 1 | **Shared element** (`name`) | "Same thing — going deeper" |
+| 2 | **Suspense reveal** | "Data loaded" |
+| 3 | **List identity** (per-item `key`) | "Same items, new arrangement" |
+| 4 | **State change** (`enter`/`exit`) | "Something appeared/disappeared" |
+| 5 | **Route change** (page-level) | "Going to a new place" |
+
+This is an implementation order, not a "pick one" list. Implement every pattern that fits the app. Only skip a pattern if the app has no use case for it.
+
+### Choosing Animation Style
+
+| Context | Animation | Why |
+|---------|-----------|-----|
+| Hierarchical navigation (list → detail) | Type-keyed `nav-forward` / `nav-back` | Communicates spatial depth |
+| Lateral navigation (tab-to-tab) | Bare `<ViewTransition>` (fade) or `default="none"` | No depth to communicate |
+| Suspense reveal | `enter`/`exit` string props | Content arriving |
+| Revalidation / background refresh | `default="none"` | Silent — no animation needed |
+
+Reserve directional slides for hierarchical navigation (list → detail) and ordered sequences (prev/next photo, carousel, paginated results). For ordered sequences, the direction communicates position: "next" slides from right, "previous" from left. Lateral/unordered navigation (tab-to-tab) should not use directional slides — it falsely implies spatial depth.
+
+---
+
+## Availability
+
+- **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
+- **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
+- Browser support: Chromium 111+, Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
+
+---
+
+## Implementation Workflow
+
+When adding view transitions to an existing app, **follow `references/implementation.md` step by step.** Start with the audit — do not skip it. Copy the CSS recipes from `references/css-recipes.md` into the global stylesheet — do not write your own animation CSS.
+
+---
+
+## Core Concepts
+
+### The `<ViewTransition>` Component
+
+```jsx
+import { ViewTransition } from 'react';
+
+<ViewTransition>
+  <Component />
+</ViewTransition>
+```
+
+React auto-assigns a unique `view-transition-name` and calls `document.startViewTransition` behind the scenes. Never call `startViewTransition` yourself.
+
+### Animation Triggers
+
+| Trigger | When it fires |
+|---------|--------------|
+| **enter** | `<ViewTransition>` first inserted during a Transition |
+| **exit** | `<ViewTransition>` first removed during a Transition |
+| **update** | DOM mutations inside a `<ViewTransition>`. With nested VTs, mutation applies to the innermost one |
+| **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
+
+Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
+
+### Critical Placement Rule
+
+`<ViewTransition>` only activates enter/exit if it appears **before any DOM nodes**:
+
+```jsx
+// Works
+<ViewTransition enter="auto" exit="auto">
+  <div>Content</div>
+</ViewTransition>
+
+// Broken — div wraps the VT, suppressing enter/exit
+<div>
+  <ViewTransition enter="auto" exit="auto">
+    <div>Content</div>
+  </ViewTransition>
+</div>
+```
+
+---
+
+## Styling with View Transition Classes
+
+### Props
+
+Values: `"auto"` (browser cross-fade), `"none"` (disabled), `"class-name"` (custom CSS), or `{ [type]: value }` for type-specific animations.
+
+```jsx
+<ViewTransition default="none" enter="slide-in" exit="slide-out" share="morph" />
+```
+
+If `default` is `"none"`, all triggers are off unless explicitly listed.
+
+### CSS Pseudo-Elements
+
+- `::view-transition-old(.class)` — outgoing snapshot
+- `::view-transition-new(.class)` — incoming snapshot
+- `::view-transition-group(.class)` — container
+- `::view-transition-image-pair(.class)` — old + new pair
+
+See `references/css-recipes.md` for ready-to-use animation recipes.
+
+---
+
+## Transition Types
+
+Tag transitions with `addTransitionType` so VTs can pick different animations based on context. Call it multiple times to stack types — different VTs in the tree react to different types:
+
+```jsx
+startTransition(() => {
+  addTransitionType('nav-forward');
+  addTransitionType('select-item');
+  router.push('/detail/1');
+});
+```
+
+Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
+
+```jsx
+<ViewTransition
+  enter={{ 'nav-forward': 'slide-from-right', 'nav-back': 'slide-from-left', default: 'none' }}
+  exit={{ 'nav-forward': 'slide-to-left', 'nav-back': 'slide-to-right', default: 'none' }}
+  share={{ 'nav-forward': 'morph-forward', 'nav-back': 'morph-back', default: 'morph' }}
+  default="none"
+>
+  <Page />
+</ViewTransition>
+```
+
+`enter` and `exit` don't have to be symmetric. For example, fade in but slide out directionally:
+
+```jsx
+<ViewTransition
+  enter={{ 'nav-forward': 'fade-in', 'nav-back': 'fade-in', default: 'none' }}
+  exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+  default="none"
+>
+```
+
+**TypeScript:** `ViewTransitionClassPerType` requires a `default` key in the object.
+
+For apps with multiple pages, extract the type-keyed VT into a reusable wrapper:
+
+```jsx
+export function DirectionalTransition({ children }: { children: React.ReactNode }) {
+  return (
+    <ViewTransition
+      enter={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      default="none"
+    >
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+### `router.back()` and Browser Back Button
+
+`router.back()` and the browser's back/forward buttons do **not** trigger view transitions (`popstate` is synchronous, incompatible with `startViewTransition`). This is a current platform limitation — back/forward navigations will work but skip animation.
+
+**Do not** replace `router.back()` with `router.push()` to force an animation. That corrupts browser history: every "back" action becomes a new history entry, trapping users in duplicate pages. If an animated back-navigation is critical to the UX, use `router.push()` with the explicit previous URL **and** document it as a deliberate history tradeoff, not the default pattern.
+
+### Types and Suspense
+
+Types are available during navigation but **not** during subsequent Suspense reveals (separate transitions, no type). Use type maps for page-level enter/exit; use simple string props for Suspense reveals.
+
+---
+
+## Shared Element Transitions
+
+Same `name` on two VTs — one unmounting, one mounting — creates a shared element morph:
+
+```jsx
+<ViewTransition name="hero-image">
+  <img src="/thumb.jpg" onClick={() => startTransition(() => onSelect())} />
+</ViewTransition>
+
+// On the other view — same name
+<ViewTransition name="hero-image">
+  <img src="/full.jpg" />
+</ViewTransition>
+```
+
+- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
+- `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
+- Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
+
+---
+
+## Common Patterns
+
+### Enter/Exit
+
+```jsx
+{show && (
+  <ViewTransition enter="fade-in" exit="fade-out"><Panel /></ViewTransition>
+)}
+```
+
+### List Reorder
+
+```jsx
+{items.map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
+```
+
+Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
+
+### Composing Shared Elements with List Identity
+
+Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element (e.g., an image that morphs into a detail view), use two nested `<ViewTransition>` boundaries:
+
+```jsx
+{items.map(item => (
+  <ViewTransition key={item.id}>                                      {/* list identity */}
+    <Link href={`/items/${item.id}`}>
+      <ViewTransition name={`item-image-${item.id}`} share="morph">   {/* shared element */}
+        <Image src={item.image} />
+      </ViewTransition>
+      <p>{item.name}</p>
+    </Link>
+  </ViewTransition>
+))}
+```
+
+The outer VT handles list reorder/enter animations. The inner VT handles the cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
+
+### Force Re-Enter with `key`
+
+```jsx
+<ViewTransition key={searchParams.toString()} enter="slide-up" default="none">
+  <ResultsGrid />
+</ViewTransition>
+```
+
+**Caution:** If wrapping `<Suspense>`, changing `key` remounts the boundary and refetches.
+
+### Suspense Fallback to Content
+
+Simple cross-fade:
+```jsx
+<ViewTransition>
+  <Suspense fallback={<Skeleton />}><Content /></Suspense>
+</ViewTransition>
+```
+
+Directional reveal:
+```jsx
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition enter="slide-up" default="none"><Content /></ViewTransition>
+</Suspense>
+```
+
+For more patterns, see `references/patterns.md`.
+
+---
+
+## How Multiple VTs Interact
+
+Every VT matching the trigger fires simultaneously in a single `document.startViewTransition`. VTs in **different** transitions (navigation vs later Suspense resolve) don't compete.
+
+### Use `default="none"` Liberally
+
+Without it, every VT fires the browser cross-fade on **every** transition — Suspense resolves, `useDeferredValue` updates, background revalidations. Always use `default="none"` and explicitly enable only desired triggers.
+
+### Two Patterns Coexist
+
+**Pattern A — Directional slides:** Type-keyed VT on each page, fires during navigation.
+**Pattern B — Suspense reveals:** Simple string props, fires when data loads (no type).
+
+They coexist because they fire at different moments. `default="none"` on both prevents cross-interference. Always pair `enter` with `exit`. Place directional VTs in page components, not layouts.
+
+### Nested VT Limitation
+
+When a parent VT exits, nested VTs inside it do **not** fire their own enter/exit — only the outermost VT animates. Per-item staggered animations during page navigation are not possible today. See [react#36135](https://github.com/facebook/react/pull/36135) for an experimental opt-in fix.
+
+---
+
+## Next.js Integration
+
+For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see `references/nextjs.md`.
+
+---
+
+## Accessibility
+
+Always add the reduced motion CSS from `references/css-recipes.md` to your global stylesheet.
+
+---
+
+## Reference Files
+
+- **`references/implementation.md`** — Step-by-step implementation workflow.
+- **`references/patterns.md`** — Patterns, animation timing, events API, troubleshooting.
+- **`references/css-recipes.md`** — Ready-to-use CSS animation recipes.
+- **`references/nextjs.md`** — Next.js App Router patterns and Server Component details.
+
+## Full Compiled Document
+
+For the complete guide with all reference files expanded: `AGENTS.md`

--- a/.agents/skills/vercel-react-view-transitions/references/patterns.md
+++ b/.agents/skills/vercel-react-view-transitions/references/patterns.md
@@ -1,0 +1,262 @@
+# Patterns and Guidelines
+
+## Searchable Grid with `useDeferredValue`
+
+`useDeferredValue` makes filter updates a transition, activating `<ViewTransition>`:
+
+```tsx
+'use client';
+
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
+
+export default function SearchableGrid({ itemsPromise }) {
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search);
+
+  return (
+    <>
+      <input value={search} onChange={(e) => setSearch(e.currentTarget.value)} />
+      <ViewTransition default="none" enter="fade-in" update="none">
+        <Suspense fallback={<GridSkeleton />}>
+          <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
+        </Suspense>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+Per-item `<ViewTransition name={...}>` inside a deferred list triggers cross-fades on every keystroke. Fix with `default="none"`:
+
+```tsx
+{filteredItems.map(item => (
+  <ViewTransition key={item.id} name={`item-${item.id}`} share="morph" default="none">
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
+```
+
+## Card Expand/Collapse with `startTransition`
+
+Toggle between grid and detail view with shared element morph:
+
+```tsx
+'use client';
+
+import { useState, useRef, startTransition, ViewTransition } from 'react';
+
+export default function ItemGrid({ items }) {
+  const [expandedId, setExpandedId] = useState(null);
+  const scrollRef = useRef(0);
+
+  return expandedId ? (
+    <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
+      <ItemDetail
+        item={items.find(i => i.id === expandedId)}
+        onClose={() => {
+          startTransition(() => {
+            setExpandedId(null);
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
+          });
+        }}
+      />
+    </ViewTransition>
+  ) : (
+    <div className="grid grid-cols-3 gap-4">
+      {items.map(item => (
+        <ViewTransition key={item.id} name={`item-${item.id}`}>
+          <ItemCard
+            item={item}
+            onSelect={() => {
+              scrollRef.current = window.scrollY;
+              startTransition(() => setExpandedId(item.id));
+            }}
+          />
+        </ViewTransition>
+      ))}
+    </div>
+  );
+}
+```
+
+## Type-Safe Transition Helpers
+
+Use `as const` arrays and derived types to prevent ID clashes:
+
+```tsx
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right'] as const;
+
+type TransitionType = (typeof transitionTypes)[number];
+type AnimationType = (typeof animationTypes)[number];
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
+
+export function HorizontalTransition({ children, enter, exit }: {
+  children: React.ReactNode;
+  enter: TransitionMap;
+  exit: TransitionMap;
+}) {
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
+}
+```
+
+## Cross-Fade Without Remount
+
+Omit `key` to trigger an update (cross-fade) instead of exit + enter. Avoids Suspense remount/refetch:
+
+```jsx
+<ViewTransition>
+  <TabPanel tab={activeTab} />
+</ViewTransition>
+```
+
+Use `key` when content identity changes (state resets). Omit for cross-fades (tabs, panels, carousel).
+
+## Isolate Elements from Parent Animations
+
+### Persistent Layout Elements
+
+Persistent elements (headers, navbars, sidebars) get captured in the page's transition snapshot. Fix with `viewTransitionName`:
+
+```jsx
+<nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
+```
+
+Then add the persistent element isolation CSS from `css-recipes.md`. For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md`.
+
+### Floating Elements
+
+Give popovers/tooltips their own `viewTransitionName`:
+
+```jsx
+<SelectPopover style={{ viewTransitionName: 'popover' }}>{options}</SelectPopover>
+```
+
+Global fix: see persistent element isolation in `css-recipes.md`.
+
+## Shared Controls Between Skeleton and Content
+
+Give matching controls in fallback and content the same `viewTransitionName`:
+
+```jsx
+// Fallback
+<input disabled placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
+// Content
+<input placeholder="Search..." style={{ viewTransitionName: 'search-input' }} />
+```
+
+Don't put manual `viewTransitionName` on the root DOM node inside `<ViewTransition>` — React's auto-generated name overrides it.
+
+## Reusable Animated Collapse
+
+```jsx
+function AnimatedCollapse({ open, children }) {
+  if (!open) return null;
+  return (
+    <ViewTransition enter="expand-in" exit="collapse-out">
+      {children}
+    </ViewTransition>
+  );
+}
+
+// Usage: toggle with startTransition
+<button onClick={() => startTransition(() => setOpen(o => !o))}>Toggle</button>
+<AnimatedCollapse open={open}><SectionContent /></AnimatedCollapse>
+```
+
+## Preserve State with Activity
+
+```jsx
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out">
+    <Sidebar />
+  </ViewTransition>
+</Activity>
+```
+
+## Exclude Elements with `useOptimistic`
+
+`useOptimistic` values update before the transition snapshot, excluding them from animation. Use for controls (labels); use committed state for animated content:
+
+```tsx
+const [sort, setSort] = useState('newest');
+const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
+
+function cycleSort() {
+  const nextSort = getNextSort(optimisticSort);
+  startTransition(() => {
+    setOptimisticSort(nextSort);  // before snapshot — no animation
+    setSort(nextSort);            // between snapshots — animates
+  });
+}
+
+<button>Sort: {LABELS[optimisticSort]}</button>
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
+```
+
+---
+
+## View Transition Events
+
+Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return a cleanup function. `onShare` takes precedence over `onEnter`/`onExit`.
+
+```jsx
+<ViewTransition
+  onEnter={(instance, types) => {
+    const anim = instance.new.animate(
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
+    );
+    return () => anim.cancel();
+  }}
+>
+  <Component />
+</ViewTransition>
+```
+
+The `instance` object: `instance.old`, `instance.new`, `instance.group`, `instance.imagePair`, `instance.name`.
+
+The `types` array (second argument) lets you vary animation based on transition type.
+
+---
+
+## Animation Timing
+
+| Interaction | Duration |
+|------------|----------|
+| Direct toggle (expand/collapse) | 100–200ms |
+| Route transition (slide) | 150–250ms |
+| Suspense reveal (skeleton → content) | 200–400ms |
+| Shared element morph | 300–500ms |
+
+---
+
+## Troubleshooting
+
+**VT not activating:** Ensure `<ViewTransition>` comes before any DOM node. Ensure state update is inside `startTransition`.
+
+**"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
+
+**`router.back()` and browser back/forward skip animation:** This is a platform limitation — the navigation works but skips animation. Do not replace `router.back()` with `router.push()` as it corrupts browser history. See SKILL.md "router.back() and Browser Back Button."
+
+**`flushSync` skips animations:** Use `startTransition` instead.
+
+**Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
+
+**Layout VT prevents page VTs from animating:** Nested VTs never fire enter/exit inside a parent VT. If your layout has a VT wrapping `{children}`, page-level enter/exit will silently not work. Remove the layout VT.
+
+**List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
+
+**TS error "Property 'default' is missing":** Type-keyed objects require a `default` key.
+
+**Hash fragments cause scroll jumps:** Navigate without hash; scroll programmatically after navigation.
+
+**Backdrop-blur flickers:** Use the backdrop-blur workaround from `css-recipes.md`.
+
+**`border-radius` lost during transitions:** Apply `border-radius` directly to the captured element.
+
+**Skeleton controls slide away:** Give matching controls the same `viewTransitionName`.
+
+**Batching:** Multiple updates during animation are batched. A→B→C→D becomes B→D.

--- a/.github/actions/build-and-deploy/action.yml
+++ b/.github/actions/build-and-deploy/action.yml
@@ -44,7 +44,7 @@ runs:
         export NODE_ENV=production
         npm run build
       env:
-        VITE_BASE_URL: '${{steps.setup.outputs.base_url}}'
+        VITE_BASE_URL: '${{steps.setup.outputs.base_path}}'
         VITE_GA_MEASUREMENT_ID: ${{ inputs.vite_ga_measurement_id }}
         VITE_ROSTER_HUB_API_URL: ${{ inputs.vite_roster_hub_api_url }}
 
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: |
         export DISABLE_ESLINT_PLUGIN=true
-        export STORYBOOK_BASE_PATH="${{steps.setup.outputs.base_url}}storybook/"
+        export STORYBOOK_BASE_PATH="${{steps.setup.outputs.base_path}}storybook/"
         npm run build-storybook
 
     - name: Move Storybook to build directory

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "python",
+      "args": ["-m", "code_review_graph", "serve"]
+    },
+    "chrome": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@0.21.0", "--isolated", "true"]
+    }
+  }
+}

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -12,12 +12,8 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-// text-editor-page-background.css import removed — no longer using background image
 import '../styles/texteditor-theme-bridge.css';
 import { HexColorPicker } from 'react-colorful';
-
-// usePageBackground import removed — page now uses plain theme background
-// The background image is located in public/text-editor/text-editor-bg-light.jpg
 
 // Styled Components
 const TextEditorContainer = styled(Box)(({ theme }) => ({
@@ -44,7 +40,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
   color: 'var(--text)',
   boxShadow:
     theme.palette.mode === 'dark'
-      ? '0 8px 30px rgba(0, 0, 0, 0.6)'
+      ? '0 4px 16px rgba(0, 0, 0, 0.4)'
       : '0 8px 30px rgba(0, 0, 0, 0.15)',
   transition: 'all 0.3s ease',
   backdropFilter: 'blur(12px) saturate(180%)',
@@ -502,8 +498,6 @@ const presetColors = ['#FFFF00', '#00FF00', '#FF0000', '#0080FF', '#FF8000', '#F
 // Main Component
 export const TextEditor: React.FC = () => {
   const theme = useTheme();
-  // Page background: use plain theme default (no background image)
-  // usePageBackground is intentionally not called so the page matches the reports page
   const [charCount, setCharCount] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState('');
   const [showColorPicker, setShowColorPicker] = useState(false);
@@ -562,9 +556,6 @@ export const TextEditor: React.FC = () => {
 
     return { x, y };
   }, []);
-
-  // Background image removal: no longer setting body background image
-  // The page now uses the plain MUI theme default background like the reports page
 
   // Add this useEffect AFTER your existing theme/background useEffects
   useEffect(() => {

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -32,19 +32,12 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.15 : 0.4),
+  background: 'transparent',
   padding: '24px',
   borderRadius: '14px',
-  border: '1px solid var(--border)',
   fontFamily: 'Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
   color: 'var(--text)',
-  boxShadow:
-    theme.palette.mode === 'dark'
-      ? '0 8px 30px rgba(0, 0, 0, 0.6)'
-      : '0 8px 30px rgba(0, 0, 0, 0.15)',
   transition: 'all 0.3s ease',
-  backdropFilter: 'blur(12px) saturate(180%)',
-  WebkitBackdropFilter: 'blur(12px) saturate(180%)',
   position: 'relative',
   zIndex: 1,
 
@@ -57,8 +50,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
     padding: '16px', // Reduce padding
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
-    backdropFilter: 'blur(8px) saturate(160%)',
-    background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.6 : 0.8),
+    background: 'transparent',
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -32,7 +32,7 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background: 'var(--panel)',
+  background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.12)} 0%, ${alpha(theme.palette.secondary.main, 0.12)} 100%)`,
   padding: '24px',
   borderRadius: '14px',
   border: '1px solid var(--border)',
@@ -58,7 +58,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
     backdropFilter: 'blur(8px) saturate(160%)',
-    background: 'var(--panel)',
+    background: theme.palette.background.paper,
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -37,7 +37,10 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background: 'var(--panel)',
+  background:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%)'
+      : 'linear-gradient(135deg, rgba(219, 234, 254, 0.5) 0%, rgba(224, 242, 254, 0.5) 100%)',
   padding: '24px',
   borderRadius: '14px',
   border: '1px solid var(--border)',
@@ -45,8 +48,8 @@ const EditorTool = styled(Box)(({ theme }) => ({
   color: 'var(--text)',
   boxShadow:
     theme.palette.mode === 'dark'
-      ? '0 4px 16px rgba(0, 0, 0, 0.4)'
-      : '0 8px 30px rgba(0, 0, 0, 0.15)',
+      ? theme.shadows[6]
+      : theme.shadows[4],
   transition: 'all 0.3s ease',
   backdropFilter: 'blur(12px) saturate(180%)',
   WebkitBackdropFilter: 'blur(12px) saturate(180%)',
@@ -63,7 +66,10 @@ const EditorTool = styled(Box)(({ theme }) => ({
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
     backdropFilter: 'blur(8px) saturate(160%)',
-    background: 'var(--panel)',
+    background:
+      theme.palette.mode === 'dark'
+        ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%)'
+        : 'linear-gradient(135deg, rgba(219, 234, 254, 0.5) 0%, rgba(224, 242, 254, 0.5) 100%)',
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -70,7 +70,7 @@ const Toolbar = styled(Box)(({ theme }) => ({
   gap: '12px',
   marginBottom: '20px',
   padding: '16px',
-  background: 'var(--panel2)',
+  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
   borderRadius: '12px',
   border: '1px solid var(--border)',
   alignItems: 'center',
@@ -161,16 +161,16 @@ const FormatContainer = styled(Box)({
   },
 });
 
-const FormatRow = styled(Box)({
+const FormatRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   gap: '8px',
   padding: '12px',
-  background: 'var(--panel2)',
+  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
   borderRadius: '12px',
   border: '1px solid var(--border)',
   alignItems: 'center',
   flexWrap: 'nowrap',
-});
+}));
 
 const ColorSection = styled(Box)({
   display: 'none', // Hidden on desktop
@@ -304,12 +304,12 @@ const WysiwygEditor = styled('div')(({ theme }) => ({
   },
 }));
 
-const StatusBar = styled(Box)(({ theme: _theme }) => ({
+const StatusBar = styled(Box)(({ theme }) => ({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '16px 20px',
-  background: 'var(--panel2)',
+  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
   border: '1px solid var(--border)',
   borderTop: 'none',
   borderBottomLeftRadius: '12px',

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -40,7 +40,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
   color: 'var(--text)',
   boxShadow:
     theme.palette.mode === 'dark'
-      ? '0 4px 16px rgba(0, 0, 0, 0.4)'
+      ? '0 8px 30px rgba(0, 0, 0, 0.6)'
       : '0 8px 30px rgba(0, 0, 0, 0.15)',
   transition: 'all 0.3s ease',
   backdropFilter: 'blur(12px) saturate(180%)',

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -32,11 +32,16 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background: 'transparent',
+  background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.12)} 0%, ${alpha(theme.palette.secondary.main, 0.12)} 100%)`,
   padding: '24px',
   borderRadius: '14px',
+  border: '1px solid var(--border)',
   fontFamily: 'Inter, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
   color: 'var(--text)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 8px 30px rgba(0, 0, 0, 0.6)'
+      : '0 8px 30px rgba(0, 0, 0, 0.15)',
   transition: 'all 0.3s ease',
   position: 'relative',
   zIndex: 1,
@@ -50,7 +55,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
     padding: '16px', // Reduce padding
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
-    background: 'transparent',
+    background: theme.palette.background.paper,
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },
@@ -70,8 +75,6 @@ const Toolbar = styled(Box)(({ theme }) => ({
   boxShadow:
     theme.palette.mode === 'dark' ? '0 2px 8px rgba(0, 0, 0, 0.4)' : '0 2px 8px rgba(0, 0, 0, 0.1)',
   overflowX: 'auto',
-  backdropFilter: 'blur(8px) saturate(150%)',
-  WebkitBackdropFilter: 'blur(8px) saturate(150%)',
   // Mobile styles
   [theme.breakpoints.down('sm')]: {
     display: 'none', // Hide on mobile, use grid containers instead
@@ -309,8 +312,6 @@ const StatusBar = styled(Box)(({ theme }) => ({
   fontSize: '14px',
   fontWeight: 500,
   transition: 'all 0.15s ease-in-out',
-  backdropFilter: 'blur(8px) saturate(150%)',
-  WebkitBackdropFilter: 'blur(8px) saturate(150%)',
 }));
 
 const CharCounter = styled(Box)(({ theme }) => ({

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -12,17 +12,16 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import '../styles/text-editor-page-background.css';
+// text-editor-page-background.css import removed — no longer using background image
 import '../styles/texteditor-theme-bridge.css';
 import { HexColorPicker } from 'react-colorful';
 
-import { usePageBackground } from '../hooks/usePageBackground';
+// usePageBackground import removed — page now uses plain theme background
 // The background image is located in public/text-editor/text-editor-bg-light.jpg
 
 // Styled Components
 const TextEditorContainer = styled(Box)(({ theme }) => ({
   minHeight: '100vh',
-  backgroundColor: 'transparent',
   paddingTop: theme.spacing(3),
   paddingBottom: theme.spacing(3),
   position: 'relative',
@@ -37,10 +36,7 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background:
-    theme.palette.mode === 'dark'
-      ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%)'
-      : 'linear-gradient(135deg, rgba(219, 234, 254, 0.5) 0%, rgba(224, 242, 254, 0.5) 100%)',
+  background: 'var(--panel)',
   padding: '24px',
   borderRadius: '14px',
   border: '1px solid var(--border)',
@@ -48,8 +44,8 @@ const EditorTool = styled(Box)(({ theme }) => ({
   color: 'var(--text)',
   boxShadow:
     theme.palette.mode === 'dark'
-      ? theme.shadows[6]
-      : theme.shadows[4],
+      ? '0 8px 30px rgba(0, 0, 0, 0.6)'
+      : '0 8px 30px rgba(0, 0, 0, 0.15)',
   transition: 'all 0.3s ease',
   backdropFilter: 'blur(12px) saturate(180%)',
   WebkitBackdropFilter: 'blur(12px) saturate(180%)',
@@ -66,10 +62,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
     backdropFilter: 'blur(8px) saturate(160%)',
-    background:
-      theme.palette.mode === 'dark'
-        ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%)'
-        : 'linear-gradient(135deg, rgba(219, 234, 254, 0.5) 0%, rgba(224, 242, 254, 0.5) 100%)',
+    background: 'var(--panel)',
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },
@@ -509,8 +502,8 @@ const presetColors = ['#FFFF00', '#00FF00', '#FF0000', '#0080FF', '#FF8000', '#F
 // Main Component
 export const TextEditor: React.FC = () => {
   const theme = useTheme();
-  // Apply page-specific background and theme management
-  usePageBackground('text-editor-page', theme.palette.mode === 'dark');
+  // Page background: use plain theme default (no background image)
+  // usePageBackground is intentionally not called so the page matches the reports page
   const [charCount, setCharCount] = useState(0);
   const [copyFeedback, setCopyFeedback] = useState('');
   const [showColorPicker, setShowColorPicker] = useState(false);
@@ -570,21 +563,8 @@ export const TextEditor: React.FC = () => {
     return { x, y };
   }, []);
 
-  // Simple fix for light mode background loading
-  useEffect(() => {
-    // Simple fix for light mode background loading
-    if (theme.palette.mode === 'light') {
-      const body = document.body;
-      // Force light mode background image
-      setTimeout(() => {
-        body.style.backgroundImage = `url("${import.meta.env.BASE_URL}text-editor/text-editor-bg-light.jpg")`;
-        body.style.backgroundSize = 'cover';
-        body.style.backgroundPosition = 'center';
-        body.style.backgroundRepeat = 'no-repeat';
-        body.style.backgroundAttachment = 'fixed';
-      }, 100); // Small delay to ensure it applies
-    }
-  }, [theme.palette.mode]);
+  // Background image removal: no longer setting body background image
+  // The page now uses the plain MUI theme default background like the reports page
 
   // Add this useEffect AFTER your existing theme/background useEffects
   useEffect(() => {

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -32,7 +32,7 @@ const TextEditorContainer = styled(Box)(({ theme }) => ({
 const EditorTool = styled(Box)(({ theme }) => ({
   maxWidth: 900,
   margin: '2rem auto 2rem auto',
-  background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.12)} 0%, ${alpha(theme.palette.secondary.main, 0.12)} 100%)`,
+  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.15 : 0.4),
   padding: '24px',
   borderRadius: '14px',
   border: '1px solid var(--border)',
@@ -58,7 +58,7 @@ const EditorTool = styled(Box)(({ theme }) => ({
     borderRadius: '0', // Remove border radius for full-width
     border: 'none', // Remove border
     backdropFilter: 'blur(8px) saturate(160%)',
-    background: theme.palette.background.paper,
+    background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.6 : 0.8),
     minHeight: '100vh', // Full height on mobile
     maxWidth: '100%', // Full width
   },
@@ -70,7 +70,7 @@ const Toolbar = styled(Box)(({ theme }) => ({
   gap: '12px',
   marginBottom: '20px',
   padding: '16px',
-  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
+  background: theme.palette.background.paper,
   borderRadius: '12px',
   border: '1px solid var(--border)',
   alignItems: 'center',
@@ -165,7 +165,7 @@ const FormatRow = styled(Box)(({ theme }) => ({
   display: 'flex',
   gap: '8px',
   padding: '12px',
-  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
+  background: theme.palette.background.paper,
   borderRadius: '12px',
   border: '1px solid var(--border)',
   alignItems: 'center',
@@ -309,7 +309,7 @@ const StatusBar = styled(Box)(({ theme }) => ({
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '16px 20px',
-  background: alpha(theme.palette.background.paper, theme.palette.mode === 'dark' ? 0.5 : 0.6),
+  background: theme.palette.background.paper,
   border: '1px solid var(--border)',
   borderTop: 'none',
   borderBottomLeftRadius: '12px',


### PR DESCRIPTION
## Summary

Updated the `EditorTool` styled component to use Material-UI theme values instead of CSS variables for backgrounds and shadows. This change improves theme consistency by:

- Replacing hardcoded `var(--panel)` CSS variable with theme-aware linear gradients that adapt to light/dark modes
- Using Material-UI's `theme.shadows` instead of custom shadow values for better design system consistency
- Applying the same gradient styling to both desktop and mobile responsive breakpoints

The new gradients provide a subtle blue-tinted appearance that complements the editor interface while respecting the user's theme preference.

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`

https://claude.ai/code/session_01YSDUcvKqfwm34m7HEjNew9