### PR TITLE
feat(router): agentic model router with TUI, device auth, and tool calling

### DIFF
--- a/tools/router/.gitignore
+++ b/tools/router/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.router/
+*.log

--- a/tools/router/README.md
+++ b/tools/router/README.md
@@ -1,0 +1,111 @@
+# router
+
+Agentic model router with a TUI, device-based auth, and runtime escalation.
+
+Classifies each task by complexity, dispatches it to the right model tier,
+and escalates to a deeper tier mid-run if the worker gets stuck. Prioritization
+is driven entirely by `router.config.ts` so behavior can be tuned without
+touching code.
+
+## Quick start
+
+```bash
+cd tools/router
+npm install
+
+# First-time auth
+npm run dev -- auth login --provider anthropic
+
+# Check every tier is reachable
+npm run dev -- auth doctor
+
+# Interactive TUI
+npm run dev
+
+# One-shot prompt
+npm run dev -- run "explain what WorkerPool does"
+```
+
+## Configuration
+
+Copy `router.config.example.ts` to your repo root as `router.config.ts` and
+edit. The schema is validated on load; bad config fails fast with a precise
+error message pointing at the offending field.
+
+Key sections:
+
+- **`providers`** — where models are hosted (Anthropic API, OAuth device flow, …)
+- **`tiers`** — named tiers mapping to a `(provider, model)` pair
+- **`heuristics`** — fast, deterministic rules that can skip LLM triage
+- **`triage`** — LLM triage fallback (cheap model, editable rubric)
+- **`escalation`** — mid-run tier bumps on self-doubt, loops, or validation failures
+- **`budgets`** — hard caps on tool calls, tokens, and USD per task/session
+
+## Architecture
+
+```
+CLI (commander)
+  ↓
+TUI (Ink)                 auth commands (auth login/status/doctor)
+  ↓                                 ↓
+Dispatcher  ←  Triage  ←  Config loader (cosmiconfig + Zod)
+  ↓              ↓
+Providers ←  Credential store (@napi-rs/keyring)
+```
+
+All cross-module contracts live in `src/types.ts`. Every dispatch goes
+through the **`TaskEnvelope`** — a serialized handoff contract that survives
+across model boundaries when escalation mints a fresh worker at a higher tier.
+
+## Auth
+
+Credentials live in the **native system keychain** via `@napi-rs/keyring`
+(Rust-based N-API bindings to macOS Keychain, Windows Credential Manager,
+and Linux Secret Service). Router never writes plaintext secrets to disk.
+A small plaintext index file at `~/.config/eso-router/accounts.json` tracks
+which providers have credentials stored (no secrets, just provider ids).
+
+Each provider declares an **auth strategy**:
+
+- `api-key` — paste an API key, validated against the provider before storing
+- `oauth-device` — RFC 8628 device authorization grant (user code + polling)
+
+The TUI renders the same event stream for both strategies, so adding a new
+auth type is just implementing the `Provider.login()` async iterator.
+
+## Escalation
+
+Mid-run, workers can request escalation by emitting a self-doubt signal.
+The dispatcher also auto-escalates on:
+
+- repeated validation failures (test/validate tool returning `ok: false`)
+- tool loops (same tool + same args called N times in a row)
+- budget exceeded (token/USD/tool-call caps)
+
+On trigger, the current worker is cancelled, a new envelope is minted at the
+next tier up with the prior attempt's digest attached, and a fresh worker is
+dispatched. The old session is NOT resumed on a new model — cold-start with a
+digest is the only safe handoff.
+
+## Adding a provider
+
+1. Create `src/providers/my-provider.ts`.
+2. Implement the `Provider` interface from `src/types.ts`.
+3. Call `registerProvider("my-kind", (opts) => new MyProvider(opts))` at module scope.
+4. Add the import to `src/providers/index.ts`.
+5. Reference it in `router.config.ts` via `providers: { myprov: { kind: "my-kind" } }`.
+
+## Environment variables
+
+- `ROUTER_NO_KEYRING=1` — use in-memory credential store (tests, CI)
+- `ROUTER_DEBUG=1` — print full stack traces on errors
+- `ROUTER_NO_PROMPT=1` — fail fast on interactive prompts (CI mode)
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | success |
+| 1    | generic error |
+| 2    | config error |
+| 3    | router runtime error (see `code` field) |

--- a/tools/router/README.md
+++ b/tools/router/README.md
@@ -87,6 +87,60 @@ next tier up with the prior attempt's digest attached, and a fresh worker is
 dispatched. The old session is NOT resumed on a new model — cold-start with a
 digest is the only safe handoff.
 
+## Consultation and delegation (cheap-shell pattern)
+
+In addition to escalation (bottom-up handoff), the router supports two
+top-down decomposition primitives that let cheaper models stay in the driver's
+seat while borrowing expensive reasoning surgically:
+
+- **`consult_expert(question, tier?)`** — A tool the worker can call to ask a
+  one-shot question of a higher-tier model. The expert runs as a child
+  envelope with NO tools and NO further escalation — pure reasoning. The
+  digest comes back as a tool result and the cheap shell stays in control.
+  Use for: architectural decisions, naming, "is this safe?" questions.
+
+- **`delegate_subtask(prompt, tier?)`** — A tool that spawns a fully
+  autonomous sub-worker (typically at a lower tier) to handle a focused
+  sub-task. The sub-worker has its own tool loop and runs to completion.
+  Use for: planner→executor patterns where an expensive planner parcels out
+  mechanical work.
+
+Both patterns roll their cost into the parent task's budget. Consultation is
+capped per task by `maxConsultationsPerTask` (default 5) to keep over-eager
+shells from running away with cost.
+
+The system prompt instructs cheap-shell workers: *consult before any
+architectural, naming, or refactoring decision you're not confident about*.
+The contract distinction:
+
+| Verb | Direction | Loses control? | Has tools? | Use case |
+|---|---|---|---|---|
+| escalation | up | yes | yes | "I'm out of my depth, take over" |
+| consultation | up | no | no | "Hold on, I need a second opinion" |
+| delegation | down | no (parent waits) | yes | "You handle this, report back" |
+
+## Cost analysis
+
+```bash
+router cost                      # last 30 days, table output
+router cost --since 2026-04-01   # filter by date
+router cost --top 20             # top N most expensive envelopes
+router cost --json               # machine-readable
+```
+
+`router cost` reads `.router/logs/*.jsonl` and produces:
+
+- **Realized spend** broken down by tier, provider, and day
+- **Counterfactual baselines** — what your tasks would have cost at every
+  configured tier (e.g. "always-deep would have cost $X, you saved $Y")
+- **Top N most expensive envelopes** for rubric-tuning targets
+- **Consultation overhead** — fraction of total cost spent on `consult_expert`
+  vs main worker turns
+
+The counterfactual is the headline. It tells you what the router actually
+saved — without it you can't tell whether the routing rules are pulling
+their weight.
+
 ## Adding a provider
 
 1. Create `src/providers/my-provider.ts`.

--- a/tools/router/bin/router.mjs
+++ b/tools/router/bin/router.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Thin launcher that uses tsx to run the TypeScript entrypoint directly.
+// This lets users run `router` without a separate build step.
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const entry = resolve(__dirname, "..", "src", "index.ts");
+
+const tsxBin = resolve(
+  __dirname,
+  "..",
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+const child = spawn(tsxBin, [entry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env: process.env,
+});
+
+child.on("exit", (code) => process.exit(code ?? 0));
+child.on("error", (err) => {
+  console.error("Failed to launch router:", err.message);
+  process.exit(1);
+});

--- a/tools/router/package-lock.json
+++ b/tools/router/package-lock.json
@@ -1,0 +1,2527 @@
+{
+  "name": "@eso-toolkit/router",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@eso-toolkit/router",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "@anthropic-ai/sdk": "^0.40.0",
+        "@napi-rs/keyring": "^1.1.6",
+        "commander": "^12.1.0",
+        "cosmiconfig": "^9.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "ink": "^5.1.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
+        "pino": "^9.5.0",
+        "react": "^18.3.1",
+        "ulid": "^2.3.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "router": "bin/router.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/react": "^18.3.3",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
+      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
+      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5",
+        "react": ">=18"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/router/package.json
+++ b/tools/router/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@eso-toolkit/router",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agentic model router with TUI, device auth, and runtime escalation",
+  "type": "module",
+  "bin": {
+    "router": "./bin/router.mjs"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --experimental-vm-modules --import tsx/esm --test test/**/*.test.ts",
+    "lint": "eslint src test"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/sdk": "^0.40.0",
+    "@napi-rs/keyring": "^1.1.6",
+    "commander": "^12.1.0",
+    "cosmiconfig": "^9.0.0",
+    "cosmiconfig-typescript-loader": "^6.1.0",
+    "ink": "^5.1.0",
+    "ink-spinner": "^5.0.0",
+    "ink-text-input": "^6.0.0",
+    "pino": "^9.5.0",
+    "react": "^18.3.1",
+    "ulid": "^2.3.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.3",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/router/package.json
+++ b/tools/router/package.json
@@ -15,8 +15,10 @@
     "lint": "eslint src test"
   },
   "dependencies": {
+    "@anthropic-ai/bedrock-sdk": "^0.27.0",
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
     "@anthropic-ai/sdk": "^0.40.0",
+    "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@napi-rs/keyring": "^1.1.6",
     "commander": "^12.1.0",
     "cosmiconfig": "^9.0.0",

--- a/tools/router/router.config.example.ts
+++ b/tools/router/router.config.example.ts
@@ -1,0 +1,116 @@
+import { defineConfig } from "./src/config/defineConfig.js";
+
+/**
+ * Example router configuration. Copy to `router.config.ts` at your repo
+ * root and customize. Every field except `tiers` has sensible defaults.
+ *
+ * Run `router auth login --provider anthropic` before the first task.
+ */
+export default defineConfig({
+  rubricVersion: "1",
+
+  providers: {
+    anthropic: {
+      kind: "anthropic-api",
+    },
+    // Example: OAuth device-flow provider. Fill in real endpoint URLs and
+    // client id for your identity provider before using.
+    // claude: {
+    //   kind: "oauth-device",
+    //   options: {
+    //     deviceAuthorizationUrl: "https://auth.example.com/oauth/device/code",
+    //     tokenUrl: "https://auth.example.com/oauth/token",
+    //     clientId: "router-cli",
+    //     scope: "messages:read messages:write",
+    //     apiBaseURL: "https://api.anthropic.com",
+    //   },
+    // },
+  },
+
+  tiers: {
+    fast: {
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      maxTokens: 8_000,
+      description: "trivial reads, lookups, formatting",
+    },
+    default: {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      maxTokens: 32_000,
+      description: "normal coding work",
+    },
+    deep: {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      maxTokens: 200_000,
+      description: "architecture, hard bugs, research",
+    },
+  },
+
+  defaultTier: "default",
+
+  heuristics: [
+    {
+      name: "trivial-reads",
+      when: { promptTokens: { lt: 200 }, verbClass: "read" },
+      tier: "fast",
+    },
+    {
+      name: "wide-file-impact",
+      when: { fileGlobBreadth: { gt: 20 } },
+      tier: "deep",
+    },
+    {
+      name: "design-keywords",
+      when: {
+        keywords: ["refactor", "architecture", "migrate", "design", "rewrite"],
+      },
+      tier: "deep",
+    },
+    {
+      name: "mechanical-edits",
+      when: { keywords: ["typo", "rename", "format"] },
+      tier: "fast",
+    },
+  ],
+
+  triage: {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    minConfidence: 0.6,
+  },
+
+  weights: {
+    ambiguity: 0.35,
+    multiFileEdits: 0.25,
+    reasoningDepth: 0.2,
+    codebaseExplore: 0.1,
+    promptLength: 0.1,
+  },
+
+  escalation: {
+    enabled: true,
+    triggers: {
+      validationFailures: 2,
+      toolLoopThreshold: 5,
+      selfDoubt: true,
+    },
+    maxBumps: 2,
+  },
+
+  budgets: {
+    perTask: { usd: 2.0, toolCalls: 50 },
+    perSession: { usd: 20.0 },
+  },
+
+  fallback: {
+    deep: ["default"],
+  },
+
+  project: {
+    rootGlobs: ["src/**", "scripts/**"],
+    excludeGlobs: ["**/*.generated.*", "**/node_modules/**"],
+    contextFiles: ["AGENTS.md"],
+  },
+});

--- a/tools/router/src/auth/commands.ts
+++ b/tools/router/src/auth/commands.ts
@@ -1,0 +1,137 @@
+import { render } from "ink";
+import React from "react";
+import type { RouterConfig } from "../config/schema.js";
+import type { CredentialStore } from "../credentials/store.js";
+import { PreflightCache, preflight } from "../dispatch/preflight.js";
+import { AuthFlow } from "../tui/components/AuthFlow.js";
+import type { Credential, Provider } from "../types.js";
+
+/**
+ * `router auth` subcommand implementations. Each function is independent of
+ * the main TUI — they render their own Ink app for the duration of the
+ * operation and exit cleanly. This keeps `router auth login` usable as a
+ * one-shot even when the user doesn't want the full interactive TUI.
+ */
+
+export interface AuthCommandDeps {
+  config: RouterConfig;
+  providers: Map<string, Provider>;
+  store: CredentialStore;
+  cache: PreflightCache;
+}
+
+export async function authLogin(
+  providerId: string,
+  deps: AuthCommandDeps,
+): Promise<void> {
+  const provider = deps.providers.get(providerId);
+  if (!provider) {
+    throw new Error(
+      `Unknown provider "${providerId}". Configured: ${[...deps.providers.keys()].join(", ")}`,
+    );
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const { unmount } = render(
+      React.createElement(AuthFlow, {
+        provider,
+        onComplete: async (event) => {
+          const credential = (event as { credential: Credential }).credential;
+          await deps.store.set(providerId, credential);
+          deps.cache.invalidate(providerId);
+          unmount();
+          resolve();
+        },
+        onCancel: () => {
+          unmount();
+          reject(new Error("Authentication cancelled."));
+        },
+        onError: (message) => {
+          unmount();
+          reject(new Error(message));
+        },
+      }),
+    );
+  });
+}
+
+export async function authLogout(
+  providerId: string,
+  deps: AuthCommandDeps,
+): Promise<void> {
+  const provider = deps.providers.get(providerId);
+  if (provider?.logout) {
+    const credential = await deps.store.get(providerId);
+    if (credential) {
+      try {
+        await provider.logout(credential);
+      } catch {
+        // Server-side logout is best-effort.
+      }
+    }
+  }
+  await deps.store.delete(providerId);
+  deps.cache.invalidate(providerId);
+  console.log(`✓ Logged out of "${providerId}".`);
+}
+
+export async function authStatus(deps: AuthCommandDeps): Promise<void> {
+  const stored = await deps.store.list();
+  const configured = [...deps.providers.keys()];
+  const all = new Set([...stored, ...configured]);
+
+  if (all.size === 0) {
+    console.log("No providers configured.");
+    return;
+  }
+
+  console.log("Providers:");
+  for (const id of [...all].sort()) {
+    const provider = deps.providers.get(id);
+    const credential = await deps.store.get(id);
+    const status = !provider
+      ? "✗ not in config"
+      : !credential
+        ? "✗ no credential"
+        : credential.expiresAt && credential.expiresAt < Date.now()
+          ? "⚠ expired"
+          : "✓ authenticated";
+    const strategy = provider?.authStrategy ?? "?";
+    console.log(`  ${id.padEnd(20)} ${status.padEnd(20)} (${strategy})`);
+  }
+}
+
+export async function authDoctor(deps: AuthCommandDeps): Promise<void> {
+  console.log("Running auth doctor...\n");
+  let failures = 0;
+
+  for (const [tierName, tier] of Object.entries(deps.config.tiers)) {
+    const provider = deps.providers.get(tier.provider);
+    if (!provider) {
+      console.log(`✗ tier "${tierName}" → provider "${tier.provider}" not instantiated`);
+      failures += 1;
+      continue;
+    }
+    const result = await preflight({
+      provider,
+      model: tier.model,
+      store: deps.store,
+      cache: deps.cache,
+    });
+    if (result.result.ok) {
+      console.log(
+        `✓ tier "${tierName}" → ${tier.provider}:${tier.model} authorized`,
+      );
+    } else {
+      console.log(
+        `✗ tier "${tierName}" → ${tier.provider}:${tier.model}: ${result.result.reason} (${result.result.message ?? "no detail"})`,
+      );
+      failures += 1;
+    }
+  }
+
+  console.log(
+    `\n${failures === 0 ? "✓ all tiers authorized" : `✗ ${failures} tier(s) unauthorized`}`,
+  );
+  if (failures > 0) process.exitCode = 1;
+}

--- a/tools/router/src/auth/preflight-error.ts
+++ b/tools/router/src/auth/preflight-error.ts
@@ -1,0 +1,166 @@
+import type { ProbeFailureReason } from "../types.js";
+
+export interface ErrorPanelContent {
+  title: string;
+  body: string[];
+  actions: Array<{ key: string; label: string; action: ErrorAction }>;
+}
+
+export type ErrorAction =
+  | { type: "auth_login"; providerId: string }
+  | { type: "auth_refresh"; providerId: string }
+  | { type: "downgrade" }
+  | { type: "retry" }
+  | { type: "cancel" }
+  | { type: "open_url"; url: string };
+
+/**
+ * Map a preflight failure into a renderable error panel. Every case offers
+ * at least one forward action so the user is never stuck staring at an
+ * error with no way out.
+ */
+export function renderPreflightError(
+  reason: ProbeFailureReason,
+  providerId: string,
+  model: string,
+  message?: string,
+): ErrorPanelContent {
+  switch (reason) {
+    case "missing_credential":
+      return {
+        title: `Cannot use ${model}`,
+        body: [
+          `⚠  No credentials configured for provider "${providerId}".`,
+          "",
+          "This tier requires authentication before it can run workers.",
+        ],
+        actions: [
+          { key: "a", label: "Authenticate now", action: { type: "auth_login", providerId } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "expired_credential":
+      return {
+        title: `Credential expired for ${providerId}`,
+        body: [
+          `⚠  Your stored credential for "${providerId}" has expired.`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "Re-authenticate to continue, or downgrade to a tier that's still valid.",
+        ].filter(Boolean),
+        actions: [
+          { key: "r", label: "Refresh / re-login", action: { type: "auth_refresh", providerId } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "invalid_credential":
+      return {
+        title: `Credential rejected by ${providerId}`,
+        body: [
+          `⚠  The stored credential for "${providerId}" was rejected.`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "This usually means the key was revoked or is malformed. Re-authenticate to continue.",
+        ].filter(Boolean),
+        actions: [
+          { key: "a", label: "Re-authenticate", action: { type: "auth_login", providerId } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "entitlement_denied":
+      return {
+        title: `${model} not available on your plan`,
+        body: [
+          `⚠  Your account for "${providerId}" does not have access to ${model}.`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "You can upgrade your plan, switch to a different provider that has this model,",
+          "or downgrade this task to a tier you do have access to.",
+        ].filter(Boolean),
+        actions: [
+          { key: "u", label: "Open upgrade page", action: { type: "open_url", url: "https://console.anthropic.com/settings/plans" } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "model_not_found":
+      return {
+        title: `Model ${model} not found`,
+        body: [
+          `⚠  Provider "${providerId}" does not recognize model "${model}".`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "Check your router.config.ts — the model id may be wrong or the provider",
+          "may not serve this model in your region.",
+        ].filter(Boolean),
+        actions: [
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "region_unavailable":
+      return {
+        title: `${model} unavailable in this region`,
+        body: [
+          `⚠  ${model} is not available in the configured region for "${providerId}".`,
+          message ? `   Detail: ${message}` : "",
+        ].filter(Boolean),
+        actions: [
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "rate_limited":
+      return {
+        title: `Rate limited on ${providerId}`,
+        body: [
+          `⏳ ${providerId} is rate-limiting ${model}.`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "You can retry in a moment, or downgrade to a less-loaded tier.",
+        ].filter(Boolean),
+        actions: [
+          { key: "r", label: "Retry", action: { type: "retry" } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    case "network_error":
+      return {
+        title: `Network error reaching ${providerId}`,
+        body: [
+          `⚠  Could not reach "${providerId}".`,
+          message ? `   Detail: ${message}` : "",
+          "",
+          "Check your connection and try again.",
+        ].filter(Boolean),
+        actions: [
+          { key: "r", label: "Retry", action: { type: "retry" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+
+    default:
+      return {
+        title: `Preflight failed for ${providerId}:${model}`,
+        body: [
+          message ?? "An unknown error occurred during preflight.",
+        ],
+        actions: [
+          { key: "r", label: "Retry", action: { type: "retry" } },
+          { key: "d", label: "Downgrade tier", action: { type: "downgrade" } },
+          { key: "esc", label: "Cancel", action: { type: "cancel" } },
+        ],
+      };
+  }
+}

--- a/tools/router/src/commands/cost.ts
+++ b/tools/router/src/commands/cost.ts
@@ -1,0 +1,285 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { RouterConfig } from "../config/schema.js";
+
+/**
+ * `router cost` — analyze JSONL telemetry from .router/logs/ and produce
+ * cost summaries plus counterfactual baselines.
+ *
+ * The router already logs every envelope and every dispatch outcome to
+ * .router/logs/<date>.jsonl, so this command needs no new instrumentation —
+ * it just parses what's already there. The interesting numbers are:
+ *
+ *   1. Realized cost broken down by tier/provider/day
+ *   2. Counterfactual: "what would this have cost if you'd run every task
+ *      at always-deep / always-default / always-fast?"
+ *   3. Top-N most expensive envelopes (rubric-tuning targets)
+ *   4. Consultation overhead: how much was spent on consult/delegate calls
+ *      vs main worker turns
+ *
+ * The counterfactual is the headline. It tells the user: "the router saved
+ * you $X this week vs running everything on Opus." That's the only number
+ * that proves the router is worth running.
+ */
+
+// USD per 1M tokens. Mirrors src/dispatch/budget.ts so the analyzer doesn't
+// need to import dispatch internals; if you change one, change both.
+const COST_TABLE: Record<string, { input: number; output: number }> = {
+  "claude-haiku-4-5": { input: 1, output: 5 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
+  "claude-opus-4-6": { input: 15, output: 75 },
+};
+
+interface EnvelopeRecord {
+  ts: string;
+  kind: "envelope";
+  envelopeId: string;
+  tier: string;
+  provider: string;
+  model: string;
+  complexity: string;
+  confidence: number;
+  source: string;
+  escalated: boolean;
+}
+
+interface DoneRecord {
+  ts: string;
+  kind: "done";
+  envelopeId: string;
+  status: string;
+  budget: {
+    inputTokens: number;
+    outputTokens: number;
+    toolCalls: number;
+    usd: number;
+    escalations: number;
+    startedAt: number;
+  };
+}
+
+interface ConsultationRecord {
+  ts: string;
+  kind: "consultation" | "consultation_done";
+  envelopeId: string;
+  parentEnvelopeId?: string;
+  tier?: string;
+  model?: string;
+  cost?: number;
+}
+
+type LogRecord = EnvelopeRecord | DoneRecord | ConsultationRecord | { ts: string; kind: string };
+
+export interface CostReport {
+  totalUsd: number;
+  totalEnvelopes: number;
+  totalConsultations: number;
+  byTier: Record<string, { count: number; usd: number }>;
+  byProvider: Record<string, { count: number; usd: number }>;
+  byDay: Record<string, { count: number; usd: number }>;
+  topN: Array<{ envelopeId: string; tier: string; model: string; usd: number }>;
+  counterfactuals: Record<string, { usd: number; saving: number; savingPct: number }>;
+  consultationOverheadUsd: number;
+  consultationOverheadPct: number;
+}
+
+export interface CostOptions {
+  logsDir?: string;
+  since?: string; // YYYY-MM-DD
+  until?: string;
+  topN?: number;
+  config: RouterConfig;
+}
+
+/**
+ * Read every JSONL file in the logs directory, parse all records, and roll
+ * them up into a CostReport. Skips malformed lines silently — telemetry
+ * should never crash an analysis tool.
+ */
+export function analyzeCost(opts: CostOptions): CostReport {
+  const dir = opts.logsDir ?? join(process.cwd(), ".router", "logs");
+  const records = loadRecords(dir, opts.since, opts.until);
+
+  // Pair envelopes with their done records so we have both the metadata
+  // (tier, provider, model) AND the final budget (cost). One pass to index
+  // envelopes, second pass to attach budget.
+  const envelopes = new Map<string, EnvelopeRecord & { budget?: DoneRecord["budget"] }>();
+  const consultations: ConsultationRecord[] = [];
+
+  for (const r of records) {
+    if (r.kind === "envelope") {
+      envelopes.set((r as EnvelopeRecord).envelopeId, r as EnvelopeRecord);
+    } else if (r.kind === "done") {
+      const done = r as DoneRecord;
+      const env = envelopes.get(done.envelopeId);
+      if (env) env.budget = done.budget;
+    } else if (r.kind === "consultation" || r.kind === "consultation_done") {
+      consultations.push(r as ConsultationRecord);
+    }
+  }
+
+  // Roll up the realized totals.
+  const byTier: Record<string, { count: number; usd: number }> = {};
+  const byProvider: Record<string, { count: number; usd: number }> = {};
+  const byDay: Record<string, { count: number; usd: number }> = {};
+  const items: Array<{ envelopeId: string; tier: string; model: string; usd: number }> = [];
+  let totalUsd = 0;
+  let totalEnvelopes = 0;
+
+  for (const env of envelopes.values()) {
+    const usd = env.budget?.usd ?? 0;
+    totalUsd += usd;
+    totalEnvelopes += 1;
+    bump(byTier, env.tier, usd);
+    bump(byProvider, env.provider, usd);
+    bump(byDay, env.ts.slice(0, 10), usd);
+    items.push({
+      envelopeId: env.envelopeId,
+      tier: env.tier,
+      model: env.model,
+      usd,
+    });
+  }
+
+  items.sort((a, b) => b.usd - a.usd);
+  const topN = items.slice(0, opts.topN ?? 10);
+
+  // Compute consultation overhead.
+  let consultationOverheadUsd = 0;
+  for (const c of consultations) {
+    if (c.kind === "consultation_done" && typeof c.cost === "number") {
+      consultationOverheadUsd += c.cost;
+    }
+  }
+  const consultationOverheadPct =
+    totalUsd > 0 ? (consultationOverheadUsd / totalUsd) * 100 : 0;
+
+  // Counterfactual baselines: what would each tier have cost?
+  // We need a per-envelope token count to multiply by each tier's price.
+  const counterfactuals: CostReport["counterfactuals"] = {};
+  for (const tierName of Object.keys(opts.config.tiers)) {
+    const tierConfig = opts.config.tiers[tierName]!;
+    const price = COST_TABLE[tierConfig.model];
+    if (!price) continue;
+    let totalAt = 0;
+    for (const env of envelopes.values()) {
+      const inTok = env.budget?.inputTokens ?? 0;
+      const outTok = env.budget?.outputTokens ?? 0;
+      totalAt +=
+        (inTok * price.input) / 1_000_000 +
+        (outTok * price.output) / 1_000_000;
+    }
+    const saving = totalAt - totalUsd;
+    counterfactuals[tierName] = {
+      usd: totalAt,
+      saving,
+      savingPct: totalAt > 0 ? (saving / totalAt) * 100 : 0,
+    };
+  }
+
+  return {
+    totalUsd,
+    totalEnvelopes,
+    totalConsultations: consultations.filter(
+      (c) => c.kind === "consultation",
+    ).length,
+    byTier,
+    byProvider,
+    byDay,
+    topN,
+    counterfactuals,
+    consultationOverheadUsd,
+    consultationOverheadPct,
+  };
+}
+
+function bump(
+  map: Record<string, { count: number; usd: number }>,
+  key: string,
+  usd: number,
+): void {
+  const cur = map[key] ?? { count: 0, usd: 0 };
+  cur.count += 1;
+  cur.usd += usd;
+  map[key] = cur;
+}
+
+function loadRecords(
+  dir: string,
+  since?: string,
+  until?: string,
+): LogRecord[] {
+  if (!existsSync(dir)) return [];
+  const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  const records: LogRecord[] = [];
+  for (const file of files) {
+    // Filename is YYYY-MM-DD.jsonl; quick filter before reading.
+    const day = file.replace(".jsonl", "");
+    if (since && day < since) continue;
+    if (until && day > until) continue;
+    const text = readFileSync(join(dir, file), "utf8");
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        records.push(JSON.parse(line) as LogRecord);
+      } catch {
+        // Skip malformed lines.
+      }
+    }
+  }
+  return records;
+}
+
+/**
+ * Pretty-print a CostReport to stdout. Used by `router cost` when --json is
+ * not passed. Lays out the headline counterfactual first because that's the
+ * number the user actually wants to see.
+ */
+export function printCostReport(report: CostReport): void {
+  const fmt = (n: number) => `$${n.toFixed(4)}`;
+  const fmtPct = (n: number) =>
+    `${n >= 0 ? "+" : ""}${n.toFixed(1)}%`;
+
+  console.log(`\nrouter cost report`);
+  console.log(`──────────────────`);
+  console.log(`Envelopes:        ${report.totalEnvelopes}`);
+  console.log(`Consultations:    ${report.totalConsultations}`);
+  console.log(`Realized spend:   ${fmt(report.totalUsd)}`);
+  console.log(
+    `Consult overhead: ${fmt(report.consultationOverheadUsd)} (${report.consultationOverheadPct.toFixed(1)}% of total)`,
+  );
+
+  if (Object.keys(report.counterfactuals).length > 0) {
+    console.log(`\nCounterfactual baselines (vs realized ${fmt(report.totalUsd)}):`);
+    for (const [tier, c] of Object.entries(report.counterfactuals)) {
+      const sign = c.saving >= 0 ? "saved" : "cost extra";
+      console.log(
+        `  always-${tier.padEnd(8)} ${fmt(c.usd).padStart(10)}   ${sign} ${fmt(Math.abs(c.saving))}  (${fmtPct(c.savingPct)})`,
+      );
+    }
+  }
+
+  if (Object.keys(report.byTier).length > 0) {
+    console.log(`\nBy tier:`);
+    for (const [tier, agg] of Object.entries(report.byTier)) {
+      console.log(`  ${tier.padEnd(12)} ${agg.count} envelopes  ${fmt(agg.usd)}`);
+    }
+  }
+
+  if (Object.keys(report.byDay).length > 0) {
+    console.log(`\nBy day:`);
+    for (const [day, agg] of Object.entries(report.byDay).sort()) {
+      console.log(`  ${day}   ${agg.count} envelopes  ${fmt(agg.usd)}`);
+    }
+  }
+
+  if (report.topN.length > 0) {
+    console.log(`\nTop ${report.topN.length} most expensive envelopes:`);
+    for (const item of report.topN) {
+      console.log(
+        `  ${item.envelopeId.padEnd(28)} ${item.tier.padEnd(8)} ${item.model.padEnd(20)} ${fmt(item.usd)}`,
+      );
+    }
+  }
+  console.log("");
+}

--- a/tools/router/src/commands/init.ts
+++ b/tools/router/src/commands/init.ts
@@ -1,0 +1,35 @@
+import { copyFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * `router init` — copy the example config to the current working directory.
+ * Refuses to overwrite an existing router.config.ts unless --force is given.
+ */
+export function runInit(opts: { force?: boolean; cwd?: string }): void {
+  const cwd = opts.cwd ?? process.cwd();
+  const target = join(cwd, "router.config.ts");
+
+  if (existsSync(target) && !opts.force) {
+    console.error(
+      `router.config.ts already exists at ${target}. Use --force to overwrite.`,
+    );
+    process.exit(1);
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/commands/init.ts → tools/router/router.config.example.ts
+  const source = resolve(here, "..", "..", "router.config.example.ts");
+
+  if (!existsSync(source)) {
+    console.error(`Could not find example config at ${source}`);
+    process.exit(1);
+  }
+
+  copyFileSync(source, target);
+  console.log(`✓ Wrote ${target}`);
+  console.log("Next steps:");
+  console.log("  1. Edit router.config.ts to match your project");
+  console.log("  2. Run `router auth login --provider anthropic`");
+  console.log("  3. Run `router auth doctor` to verify authorization");
+}

--- a/tools/router/src/config/defineConfig.ts
+++ b/tools/router/src/config/defineConfig.ts
@@ -1,0 +1,15 @@
+import type { RouterConfig } from "./schema.js";
+
+/**
+ * Typed config helper for `router.config.ts`. Acts as an identity function at
+ * runtime but gives users full IntelliSense + type-checking at author time.
+ *
+ * Accepts a partial config because the Zod schema fills in defaults on load.
+ */
+export type UserRouterConfig = Omit<Partial<RouterConfig>, "tiers"> & {
+  tiers: RouterConfig["tiers"];
+};
+
+export function defineConfig(config: UserRouterConfig): UserRouterConfig {
+  return config;
+}

--- a/tools/router/src/config/load.ts
+++ b/tools/router/src/config/load.ts
@@ -1,0 +1,109 @@
+import { cosmiconfig } from "cosmiconfig";
+import { TypeScriptLoader } from "cosmiconfig-typescript-loader";
+import { ConfigError } from "../types.js";
+import { RouterConfigSchema, type RouterConfig } from "./schema.js";
+
+const MODULE_NAME = "router";
+
+/**
+ * Discover and validate a `router.config.{ts,js,mjs,json}` file starting from
+ * the provided directory (or cwd). Returns the parsed, defaulted config.
+ *
+ * Throws ConfigError with a helpful message if:
+ *   - No config file is found (rather than silently using defaults, we require
+ *     explicit opt-in so users know where the behavior is coming from).
+ *   - The config fails Zod validation.
+ */
+export async function loadConfig(cwd: string = process.cwd()): Promise<{
+  config: RouterConfig;
+  filepath: string;
+}> {
+  const explorer = cosmiconfig(MODULE_NAME, {
+    searchPlaces: [
+      "router.config.ts",
+      "router.config.mts",
+      "router.config.js",
+      "router.config.mjs",
+      "router.config.cjs",
+      "router.config.json",
+      ".routerrc",
+      ".routerrc.json",
+      ".routerrc.yaml",
+      ".routerrc.yml",
+      "package.json",
+    ],
+    loaders: {
+      ".ts": TypeScriptLoader(),
+      ".mts": TypeScriptLoader(),
+    },
+  });
+
+  const result = await explorer.search(cwd);
+
+  if (!result || result.isEmpty) {
+    throw new ConfigError(
+      "No router.config.{ts,js,json} found. Create one at your repo root, or run `router init` to scaffold a starter.",
+      { searchedFrom: cwd },
+    );
+  }
+
+  const parsed = RouterConfigSchema.safeParse(result.config);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  • ${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("\n");
+    throw new ConfigError(
+      `Invalid router config at ${result.filepath}:\n${issues}`,
+      { filepath: result.filepath, issues: parsed.error.issues },
+    );
+  }
+
+  validateReferences(parsed.data, result.filepath);
+
+  return { config: parsed.data, filepath: result.filepath };
+}
+
+/**
+ * Cross-field validation that Zod can't express easily: every tier must refer
+ * to a provider that actually exists in config.providers, the defaultTier must
+ * exist, and fallback chain entries must point at real tiers/providers.
+ */
+function validateReferences(config: RouterConfig, filepath: string): void {
+  const errors: string[] = [];
+
+  if (!config.tiers[config.defaultTier]) {
+    errors.push(
+      `defaultTier "${config.defaultTier}" is not defined in tiers.`,
+    );
+  }
+
+  for (const [tierName, tier] of Object.entries(config.tiers)) {
+    if (!config.providers[tier.provider]) {
+      errors.push(
+        `tiers.${tierName}.provider "${tier.provider}" is not defined in providers.`,
+      );
+    }
+  }
+
+  for (const [tierName, chain] of Object.entries(config.fallback)) {
+    if (!config.tiers[tierName]) {
+      errors.push(`fallback.${tierName}: source tier does not exist.`);
+    }
+    for (const entry of chain) {
+      // Fallback entries are either "provider:model" or a tier name.
+      if (entry.includes(":")) continue;
+      if (!config.tiers[entry]) {
+        errors.push(
+          `fallback.${tierName}: entry "${entry}" is neither a tier nor a provider:model pair.`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new ConfigError(
+      `Invalid router config at ${filepath}:\n${errors.map((e) => "  • " + e).join("\n")}`,
+      { filepath, errors },
+    );
+  }
+}

--- a/tools/router/src/config/schema.ts
+++ b/tools/router/src/config/schema.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for router.config.{ts,js,json}. The schema is the single source
+ * of truth for config validation and is re-exported as TypeScript types via
+ * `z.infer` so there is no drift between runtime and compile-time contracts.
+ */
+
+export const HeuristicCondition = z.object({
+  promptTokens: z
+    .object({ lt: z.number().optional(), gt: z.number().optional() })
+    .partial()
+    .optional(),
+  fileGlobBreadth: z
+    .object({ lt: z.number().optional(), gt: z.number().optional() })
+    .partial()
+    .optional(),
+  verbClass: z.enum(["read", "write", "design", "unknown"]).optional(),
+  keywords: z.array(z.string()).optional(),
+  hasMultiStepMarkers: z.boolean().optional(),
+});
+
+export const HeuristicRule = z.object({
+  name: z.string().optional(),
+  when: HeuristicCondition,
+  tier: z.string(),
+});
+
+export const TierConfigSchema = z.object({
+  provider: z.string(),
+  model: z.string(),
+  maxTokens: z.number().int().positive().optional(),
+  description: z.string().optional(),
+});
+
+export const ProviderConfigSchema = z.object({
+  kind: z.string(),
+  baseURL: z.string().url().optional(),
+  region: z.string().optional(),
+  // Free-form provider-specific options. Providers validate their own slice.
+  options: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const EscalationConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  triggers: z
+    .object({
+      validationFailures: z.number().int().nonnegative().default(2),
+      toolLoopThreshold: z.number().int().nonnegative().default(5),
+      selfDoubt: z.boolean().default(true),
+    })
+    .default({
+      validationFailures: 2,
+      toolLoopThreshold: 5,
+      selfDoubt: true,
+    }),
+  maxBumps: z.number().int().nonnegative().default(2),
+});
+
+export const BudgetConfigSchema = z.object({
+  perTask: z
+    .object({
+      usd: z.number().positive().optional(),
+      toolCalls: z.number().int().positive().optional(),
+      tokens: z.number().int().positive().optional(),
+    })
+    .optional(),
+  perSession: z
+    .object({
+      usd: z.number().positive().optional(),
+      tokens: z.number().int().positive().optional(),
+    })
+    .optional(),
+});
+
+export const TriageConfigSchema = z.object({
+  provider: z.string().default("anthropic"),
+  model: z.string().default("claude-haiku-4-5"),
+  rubricPath: z.string().optional(),
+  minConfidence: z.number().min(0).max(1).default(0.6),
+});
+
+export const WeightsSchema = z
+  .object({
+    ambiguity: z.number().default(0.35),
+    multiFileEdits: z.number().default(0.25),
+    reasoningDepth: z.number().default(0.2),
+    codebaseExplore: z.number().default(0.1),
+    promptLength: z.number().default(0.1),
+  })
+  .default({
+    ambiguity: 0.35,
+    multiFileEdits: 0.25,
+    reasoningDepth: 0.2,
+    codebaseExplore: 0.1,
+    promptLength: 0.1,
+  });
+
+export const ProjectConfigSchema = z
+  .object({
+    rootGlobs: z.array(z.string()).default(["**/*"]),
+    excludeGlobs: z.array(z.string()).default([]),
+    contextFiles: z.array(z.string()).default([]),
+  })
+  .default({
+    rootGlobs: ["**/*"],
+    excludeGlobs: [],
+    contextFiles: [],
+  });
+
+export const RouterConfigSchema = z.object({
+  rubricVersion: z.string().default("1"),
+  providers: z.record(z.string(), ProviderConfigSchema).default({}),
+  tiers: z.record(z.string(), TierConfigSchema),
+  defaultTier: z.string().default("default"),
+  heuristics: z.array(HeuristicRule).default([]),
+  triage: TriageConfigSchema.default({
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    minConfidence: 0.6,
+  }),
+  weights: WeightsSchema,
+  escalation: EscalationConfigSchema.default({
+    enabled: true,
+    triggers: {
+      validationFailures: 2,
+      toolLoopThreshold: 5,
+      selfDoubt: true,
+    },
+    maxBumps: 2,
+  }),
+  budgets: BudgetConfigSchema.default({}),
+  fallback: z.record(z.string(), z.array(z.string())).default({}),
+  project: ProjectConfigSchema,
+  hooks: z
+    .object({
+      beforeTriage: z.string().optional(),
+      afterDispatch: z.string().optional(),
+      onEscalation: z.string().optional(),
+    })
+    .default({}),
+});
+
+export type RouterConfig = z.infer<typeof RouterConfigSchema>;
+export type HeuristicRuleType = z.infer<typeof HeuristicRule>;

--- a/tools/router/src/credentials/keyring-store.ts
+++ b/tools/router/src/credentials/keyring-store.ts
@@ -1,0 +1,140 @@
+import { Entry } from "@napi-rs/keyring";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import type { Credential } from "../types.js";
+import type { CredentialStore } from "./store.js";
+
+const SERVICE = "eso-router";
+
+/**
+ * System keychain credential store backed by `@napi-rs/keyring` (Rust N-API
+ * bindings to macOS Keychain, Windows Credential Manager, and Linux Secret
+ * Service / libsecret).
+ *
+ * Why we don't just call the OS directly: Node has no built-in API for the
+ * platform keychains. `@napi-rs/keyring` ships prebuilt native binaries for
+ * all three platforms so there's no build step, and the actual storage is
+ * still the native keychain — the library is only a thin bridge.
+ *
+ * Account index
+ * -------------
+ * Keyring APIs are lookup-by-(service, account). We need to enumerate stored
+ * credentials (for `router auth status`) but the platform keychains don't
+ * expose a portable "list entries" API. We maintain a small index file at
+ * ~/.config/eso-router/accounts.json listing the provider ids that have
+ * credentials stored in the keychain. The index contains NO secrets — only
+ * provider identifiers — and is safe to lose (we recreate it on next login).
+ */
+export class KeyringCredentialStore implements CredentialStore {
+  private readonly indexPath: string;
+
+  constructor(indexPath?: string) {
+    this.indexPath =
+      indexPath ?? join(configDir(), "eso-router", "accounts.json");
+  }
+
+  async get(providerId: string): Promise<Credential | null> {
+    const entry = new Entry(SERVICE, providerId);
+    let raw: string | null;
+    try {
+      raw = entry.getPassword();
+    } catch (err) {
+      // `getPassword` throws on Linux when the entry doesn't exist; treat
+      // that as a cache miss rather than a fatal error.
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as Credential;
+    } catch {
+      // Corrupt entry — treat as missing and let the caller re-auth.
+      return null;
+    }
+  }
+
+  async set(providerId: string, credential: Credential): Promise<void> {
+    const entry = new Entry(SERVICE, providerId);
+    entry.setPassword(JSON.stringify(credential));
+    this.addToIndex(providerId);
+  }
+
+  async delete(providerId: string): Promise<void> {
+    const entry = new Entry(SERVICE, providerId);
+    try {
+      entry.deletePassword();
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+    }
+    this.removeFromIndex(providerId);
+  }
+
+  async list(): Promise<string[]> {
+    if (!existsSync(this.indexPath)) return [];
+    try {
+      const raw = readFileSync(this.indexPath, "utf8");
+      const parsed = JSON.parse(raw) as { providers: string[] };
+      return Array.isArray(parsed.providers) ? parsed.providers : [];
+    } catch {
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Account index (plaintext, no secrets)
+  // -------------------------------------------------------------------------
+
+  private addToIndex(providerId: string): void {
+    const current = new Set(this.readIndex());
+    current.add(providerId);
+    this.writeIndex([...current]);
+  }
+
+  private removeFromIndex(providerId: string): void {
+    const current = new Set(this.readIndex());
+    current.delete(providerId);
+    this.writeIndex([...current]);
+  }
+
+  private readIndex(): string[] {
+    if (!existsSync(this.indexPath)) return [];
+    try {
+      return (
+        (JSON.parse(readFileSync(this.indexPath, "utf8")) as {
+          providers?: string[];
+        }).providers ?? []
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  private writeIndex(providers: string[]): void {
+    mkdirSync(dirname(this.indexPath), { recursive: true });
+    writeFileSync(
+      this.indexPath,
+      JSON.stringify({ providers: providers.sort() }, null, 2),
+      { mode: 0o600 },
+    );
+  }
+}
+
+function configDir(): string {
+  if (process.platform === "win32") {
+    return process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support");
+  }
+  return process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+}
+
+function isNotFoundError(err: unknown): boolean {
+  if (!err) return false;
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /no matching entry|not found|no such|does not exist/i.test(message) ||
+    /NoEntry|NotFound/i.test(message)
+  );
+}

--- a/tools/router/src/credentials/memory-store.ts
+++ b/tools/router/src/credentials/memory-store.ts
@@ -1,0 +1,23 @@
+import type { Credential } from "../types.js";
+import type { CredentialStore } from "./store.js";
+
+/** In-memory credential store for tests and `ROUTER_NO_KEYRING=1` mode. */
+export class MemoryCredentialStore implements CredentialStore {
+  private readonly map = new Map<string, Credential>();
+
+  async get(providerId: string): Promise<Credential | null> {
+    return this.map.get(providerId) ?? null;
+  }
+
+  async set(providerId: string, credential: Credential): Promise<void> {
+    this.map.set(providerId, credential);
+  }
+
+  async delete(providerId: string): Promise<void> {
+    this.map.delete(providerId);
+  }
+
+  async list(): Promise<string[]> {
+    return [...this.map.keys()];
+  }
+}

--- a/tools/router/src/credentials/store.ts
+++ b/tools/router/src/credentials/store.ts
@@ -1,0 +1,17 @@
+import type { Credential } from "../types.js";
+
+/**
+ * Credential storage abstraction. Implementations persist opaque credentials
+ * keyed by providerId. Everything that touches secrets goes through this
+ * interface so the rest of the router never sees platform-specific code.
+ */
+export interface CredentialStore {
+  /** Return the stored credential for a provider, or null if none. */
+  get(providerId: string): Promise<Credential | null>;
+  /** Persist (or overwrite) the credential for a provider. */
+  set(providerId: string, credential: Credential): Promise<void>;
+  /** Remove the stored credential. Idempotent. */
+  delete(providerId: string): Promise<void>;
+  /** List all provider ids that currently have stored credentials. */
+  list(): Promise<string[]>;
+}

--- a/tools/router/src/dispatch/budget.ts
+++ b/tools/router/src/dispatch/budget.ts
@@ -1,0 +1,92 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { BudgetState, DispatchEvent } from "../types.js";
+
+/**
+ * Per-session budget tracker. Observes DispatchEvents and maintains running
+ * totals for tokens, tool calls, and estimated USD cost. Also exposes a
+ * `shouldEscalate()` predicate the controller calls after each event.
+ */
+
+// Rough USD per 1M tokens. Keep this conservative and user-overridable.
+const DEFAULT_COST_TABLE: Record<string, { input: number; output: number }> = {
+  "claude-haiku-4-5": { input: 1, output: 5 },
+  "claude-sonnet-4-6": { input: 3, output: 15 },
+  "claude-opus-4-6": { input: 15, output: 75 },
+};
+
+export class BudgetTracker {
+  readonly state: BudgetState = {
+    inputTokens: 0,
+    outputTokens: 0,
+    toolCalls: 0,
+    usd: 0,
+    escalations: 0,
+    startedAt: Date.now(),
+  };
+
+  constructor(
+    private readonly config: RouterConfig,
+    private readonly costTable: Record<
+      string,
+      { input: number; output: number }
+    > = DEFAULT_COST_TABLE,
+  ) {}
+
+  observe(event: DispatchEvent, model: string): void {
+    switch (event.type) {
+      case "tool_call":
+        this.state.toolCalls += 1;
+        break;
+      case "token_usage":
+        this.state.inputTokens += event.inputTokens;
+        this.state.outputTokens += event.outputTokens;
+        this.state.usd += this.estimateCost(
+          model,
+          event.inputTokens,
+          event.outputTokens,
+        );
+        break;
+      case "escalation_requested":
+        this.state.escalations += 1;
+        break;
+    }
+  }
+
+  /**
+   * Returns a reason string if a hard cap has been exceeded. Callers treat
+   * a non-null return as a trigger to abort or escalate.
+   */
+  exceeded(): string | null {
+    const task = this.config.budgets.perTask;
+    if (task?.toolCalls && this.state.toolCalls > task.toolCalls) {
+      return `tool call cap exceeded (${this.state.toolCalls}/${task.toolCalls})`;
+    }
+    if (
+      task?.tokens &&
+      this.state.inputTokens + this.state.outputTokens > task.tokens
+    ) {
+      return `token cap exceeded`;
+    }
+    if (task?.usd && this.state.usd > task.usd) {
+      return `USD cap exceeded ($${this.state.usd.toFixed(4)}/$${task.usd})`;
+    }
+    const session = this.config.budgets.perSession;
+    if (session?.usd && this.state.usd > session.usd) {
+      return `session USD cap exceeded`;
+    }
+    return null;
+  }
+
+  private estimateCost(
+    model: string,
+    inputTokens: number,
+    outputTokens: number,
+  ): number {
+    const row = this.costTable[model];
+    if (!row) return 0;
+    return (
+      (inputTokens * row.input) / 1_000_000 +
+      (outputTokens * row.output) / 1_000_000
+    );
+  }
+}

--- a/tools/router/src/dispatch/dispatcher.ts
+++ b/tools/router/src/dispatch/dispatcher.ts
@@ -1,0 +1,269 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { CredentialStore } from "../credentials/store.js";
+import type { JsonlLogger } from "../telemetry/jsonl-logger.js";
+import { escalateEnvelope } from "../triage/envelope.js";
+import {
+  AuthError,
+  RouterError,
+  type DispatchEvent,
+  type EscalationReason,
+  type Provider,
+  type TaskEnvelope,
+} from "../types.js";
+import { BudgetTracker } from "./budget.js";
+import { EscalationController } from "./escalation.js";
+import { PreflightCache, preflight } from "./preflight.js";
+
+/**
+ * Top-level dispatcher. Orchestrates the full lifecycle of a single task:
+ *
+ *   1. Preflight the chosen (provider, model) to verify entitlement.
+ *   2. If preflight fails → surface a typed error up to the TUI for handling.
+ *   3. Otherwise, start the provider's dispatch() and forward events.
+ *   4. Watch for escalation triggers; if one fires, cancel the current worker,
+ *      mint an escalated envelope, and respawn recursively.
+ *   5. Log every envelope + outcome to JSONL for rubric tuning.
+ *
+ * The dispatcher is intentionally decoupled from the TUI — it takes an
+ * onEvent callback and pushes events out. The TUI renders them, but the
+ * dispatcher could equally well be driven from a headless CLI run.
+ */
+
+export interface DispatcherDeps {
+  config: RouterConfig;
+  providers: Map<string, Provider>;
+  store: CredentialStore;
+  cache: PreflightCache;
+  logger: JsonlLogger;
+}
+
+export interface DispatchInput {
+  envelope: TaskEnvelope;
+  signal: AbortSignal;
+  onEvent: (event: DispatcherEvent) => void;
+}
+
+export type DispatcherEvent =
+  | { type: "envelope"; envelope: TaskEnvelope }
+  | { type: "preflight_failed"; envelope: TaskEnvelope; reason: string }
+  | { type: "dispatch_event"; envelope: TaskEnvelope; event: DispatchEvent }
+  | { type: "budget_update"; tracker: BudgetTracker }
+  | {
+      type: "escalating";
+      from: TaskEnvelope;
+      reason: EscalationReason;
+      digest: string;
+    }
+  | {
+      type: "done";
+      envelope: TaskEnvelope;
+      status: "success" | "failure" | "aborted";
+      digest: string;
+    };
+
+export class Dispatcher {
+  private readonly tracker: BudgetTracker;
+
+  constructor(private readonly deps: DispatcherDeps) {
+    this.tracker = new BudgetTracker(deps.config);
+  }
+
+  get budget(): BudgetTracker {
+    return this.tracker;
+  }
+
+  async run(input: DispatchInput): Promise<void> {
+    await this.runInternal(input.envelope, input.signal, input.onEvent);
+  }
+
+  private async runInternal(
+    envelope: TaskEnvelope,
+    parentSignal: AbortSignal,
+    onEvent: (e: DispatcherEvent) => void,
+  ): Promise<void> {
+    onEvent({ type: "envelope", envelope });
+    this.deps.logger.log({
+      kind: "envelope",
+      envelopeId: envelope.id,
+      tier: envelope.triage.tier,
+      provider: envelope.triage.provider,
+      model: envelope.triage.model,
+      complexity: envelope.triage.complexity,
+      confidence: envelope.triage.confidence,
+      source: envelope.triage.source,
+      escalated: Boolean(envelope.escalation),
+    });
+
+    const provider = this.deps.providers.get(envelope.triage.provider);
+    if (!provider) {
+      throw new RouterError(
+        `Provider "${envelope.triage.provider}" is not instantiated.`,
+        "PROVIDER_MISSING",
+      );
+    }
+
+    // -- Preflight -----------------------------------------------------------
+    const pre = await preflight({
+      provider,
+      model: envelope.triage.model,
+      store: this.deps.store,
+      cache: this.deps.cache,
+    });
+    if (!pre.result.ok) {
+      onEvent({
+        type: "preflight_failed",
+        envelope,
+        reason: pre.result.message ?? pre.result.reason ?? "unknown",
+      });
+      this.deps.logger.log({
+        kind: "preflight_failed",
+        envelopeId: envelope.id,
+        reason: pre.result.reason,
+        message: pre.result.message,
+      });
+      throw new AuthError(
+        pre.result.message ?? "Preflight failed.",
+        pre.result.reason ?? "unknown",
+        { provider: provider.id, model: envelope.triage.model },
+      );
+    }
+
+    const credential = await this.deps.store.get(provider.id);
+    if (!credential) {
+      // Should be caught by preflight, but defensive.
+      throw new AuthError(
+        `Credential disappeared between preflight and dispatch.`,
+        "missing_credential",
+      );
+    }
+
+    // -- Escalation wiring ---------------------------------------------------
+    const escalationPromise = this.setupEscalation(envelope);
+    const controller = new AbortController();
+    const forwarded = () => controller.abort();
+    parentSignal.addEventListener("abort", forwarded, { once: true });
+
+    // -- Dispatch ------------------------------------------------------------
+    let finalDigest = "";
+    let finalStatus: "success" | "failure" | "aborted" = "success";
+
+    try {
+      await provider.dispatch(
+        {
+          envelope,
+          signal: controller.signal,
+          onEvent: (event) => {
+            this.tracker.observe(event, envelope.triage.model);
+            escalationPromise.controller.observe(event);
+            onEvent({ type: "dispatch_event", envelope, event });
+            onEvent({ type: "budget_update", tracker: this.tracker });
+
+            if (event.type === "worker_done") {
+              finalDigest = event.digest;
+              finalStatus = event.status;
+            }
+
+            const exceeded = this.tracker.exceeded();
+            if (exceeded) {
+              escalationPromise.controller.triggerManually(
+                "budget_exceeded",
+                `Budget exceeded: ${exceeded}`,
+              );
+            }
+          },
+        },
+        credential,
+      );
+    } catch (err) {
+      if (controller.signal.aborted) {
+        finalStatus = "aborted";
+      } else {
+        finalStatus = "failure";
+        finalDigest =
+          err instanceof Error ? err.message : String(err);
+      }
+    } finally {
+      parentSignal.removeEventListener("abort", forwarded);
+    }
+
+    // -- Handle escalation (if triggered mid-dispatch) -----------------------
+    const escalation = await Promise.race([
+      escalationPromise.promise,
+      Promise.resolve(null),
+    ]);
+
+    if (escalation) {
+      // Cancel current worker if still running.
+      controller.abort();
+
+      try {
+        const next = escalateEnvelope(
+          envelope,
+          this.deps.config,
+          escalation.reason,
+          escalation.digest,
+        );
+        onEvent({
+          type: "escalating",
+          from: envelope,
+          reason: escalation.reason,
+          digest: escalation.digest,
+        });
+        this.deps.logger.log({
+          kind: "escalation",
+          fromEnvelope: envelope.id,
+          toEnvelope: next.id,
+          reason: escalation.reason,
+          bumpCount: next.escalation?.bumpCount,
+        });
+        return this.runInternal(next, parentSignal, onEvent);
+      } catch (err) {
+        // Escalation cap hit — surface as a done event with failure status.
+        finalStatus = "failure";
+        finalDigest =
+          err instanceof Error ? err.message : "Escalation failed.";
+      }
+    }
+
+    onEvent({
+      type: "done",
+      envelope,
+      status: finalStatus,
+      digest: finalDigest,
+    });
+    this.deps.logger.log({
+      kind: "done",
+      envelopeId: envelope.id,
+      status: finalStatus,
+      budget: this.tracker.state,
+    });
+  }
+
+  /**
+   * Set up an escalation controller that resolves a promise when any trigger
+   * fires. The dispatcher awaits this promise after provider.dispatch returns
+   * (or races it if the provider is still running). Keeping it promise-based
+   * lets us express "stop the worker when escalation fires" cleanly.
+   */
+  private setupEscalation(envelope: TaskEnvelope): {
+    controller: EscalationController;
+    promise: Promise<{ reason: EscalationReason; digest: string } | null>;
+  } {
+    let resolve!: (
+      value: { reason: EscalationReason; digest: string } | null,
+    ) => void;
+    const promise = new Promise<
+      { reason: EscalationReason; digest: string } | null
+    >((r) => {
+      resolve = r;
+    });
+    const controller = new EscalationController(
+      this.deps.config,
+      envelope,
+      (trigger) => resolve(trigger),
+    );
+    // Auto-resolve null if nothing fires by the time dispatch exits normally.
+    // The race() call in runInternal ensures we don't block forever.
+    return { controller, promise };
+  }
+}

--- a/tools/router/src/dispatch/dispatcher.ts
+++ b/tools/router/src/dispatch/dispatcher.ts
@@ -50,6 +50,12 @@ export interface DispatcherDeps {
    * triage. Used by `router run --tier <name>`.
    */
   forcedTier?: string;
+  /**
+   * Per-task cap on how many times consult_expert can fire. Defaults to 5.
+   * Hard cap to keep cheap-shell workers from running away with consultation
+   * cost. Independent of the broader budget caps in config.
+   */
+  maxConsultationsPerTask?: number;
 }
 
 export interface DispatchInput {
@@ -78,6 +84,8 @@ export type DispatcherEvent =
 
 export class Dispatcher {
   private readonly tracker: BudgetTracker;
+  /** Per-root-task consultation counts, keyed by root envelope id. */
+  private readonly consultationCounts = new Map<string, number>();
 
   constructor(private readonly deps: DispatcherDeps) {
     this.tracker = new BudgetTracker(deps.config);
@@ -89,6 +97,214 @@ export class Dispatcher {
 
   async run(input: DispatchInput): Promise<void> {
     await this.runInternal(input.envelope, input.signal, input.onEvent);
+  }
+
+  /**
+   * Borrow expertise from a higher-tier model for a single self-contained
+   * question. Runs as a one-shot worker with NO tools and NO escalation —
+   * pure reasoning that returns a digest. Cost rolls into the parent task's
+   * BudgetTracker.
+   *
+   * Throws if the consultation cap for the parent root task has been reached.
+   */
+  async consult(
+    parent: TaskEnvelope,
+    question: string,
+    tierName?: string,
+    parentSignal?: AbortSignal,
+  ): Promise<{ digest: string; cost: number }> {
+    const rootId = parent.parentEnvelopeId ?? parent.id;
+    const cap = this.deps.maxConsultationsPerTask ?? 5;
+    const current = this.consultationCounts.get(rootId) ?? 0;
+    if (current >= cap) {
+      throw new RouterError(
+        `Consultation cap reached for this task (${cap}). The cheap shell is consulting too aggressively — refine its prompt or raise maxConsultationsPerTask.`,
+        "CONSULTATION_CAP",
+      );
+    }
+    this.consultationCounts.set(rootId, current + 1);
+
+    const targetTier = tierName ?? this.bumpTierName(parent.triage.tier);
+    const tier = this.deps.config.tiers[targetTier];
+    if (!tier) {
+      throw new RouterError(
+        `Consultation tier "${targetTier}" is not defined in config.`,
+        "TIER_UNKNOWN",
+      );
+    }
+
+    const consultationEnvelope: TaskEnvelope = {
+      id: `${parent.id}-c${current + 1}`,
+      createdAt: new Date().toISOString(),
+      parentSessionId: parent.parentSessionId,
+      parentEnvelopeId: rootId,
+      decompositionMode: "consultation",
+      goal: `Expert consultation: ${question.slice(0, 80)}`,
+      originalPrompt: question,
+      triage: {
+        ...parent.triage,
+        tier: targetTier,
+        provider: tier.provider,
+        model: tier.model,
+        source: "user-override",
+        rationale: `Consultation requested by ${parent.triage.tier} worker`,
+      },
+      context: { files: [], constraints: ["pure-reasoning", "no-tools"] },
+      budget: {
+        maxTokens: tier.maxTokens ?? 2048,
+        escalationAllowed: false,
+      },
+    };
+
+    return this.runOneShot(consultationEnvelope, parentSignal);
+  }
+
+  /**
+   * Spawn a child sub-task envelope as a full autonomous worker. Unlike
+   * consultation, the sub-task can use tools, has its own escalation budget,
+   * and runs to completion. Used by planner/executor patterns where an
+   * expensive planner parcels out work to cheaper executors.
+   */
+  async delegate(
+    parent: TaskEnvelope,
+    prompt: string,
+    tierName?: string,
+    parentSignal?: AbortSignal,
+  ): Promise<{ digest: string; status: "success" | "failure"; cost: number }> {
+    const rootId = parent.parentEnvelopeId ?? parent.id;
+    const targetTier =
+      tierName ?? this.dropTierName(parent.triage.tier);
+    const tier = this.deps.config.tiers[targetTier];
+    if (!tier) {
+      throw new RouterError(
+        `Delegation tier "${targetTier}" is not defined in config.`,
+        "TIER_UNKNOWN",
+      );
+    }
+
+    const subtaskEnvelope: TaskEnvelope = {
+      id: `${parent.id}-d-${Date.now()}`,
+      createdAt: new Date().toISOString(),
+      parentEnvelopeId: rootId,
+      decompositionMode: "delegation",
+      goal: prompt.split("\n")[0]?.slice(0, 120) ?? "delegated subtask",
+      originalPrompt: prompt,
+      triage: {
+        ...parent.triage,
+        tier: targetTier,
+        provider: tier.provider,
+        model: tier.model,
+        source: "user-override",
+        rationale: `Delegated by ${parent.triage.tier} worker`,
+      },
+      context: { files: [], constraints: [] },
+      budget: {
+        maxTokens: tier.maxTokens,
+        escalationAllowed: true,
+      },
+    };
+
+    const startUsd = this.tracker.state.usd;
+    let digest = "";
+    let status: "success" | "failure" = "success";
+    try {
+      await this.runInternal(
+        subtaskEnvelope,
+        parentSignal ?? new AbortController().signal,
+        (event) => {
+          if (event.type === "done") {
+            digest = event.digest;
+            status = event.status === "success" ? "success" : "failure";
+          }
+        },
+      );
+    } catch (err) {
+      status = "failure";
+      digest = err instanceof Error ? err.message : String(err);
+    }
+    return { digest, status, cost: this.tracker.state.usd - startUsd };
+  }
+
+  /**
+   * Run a one-shot envelope (consultation form): no tools, no escalation,
+   * single provider.dispatch call. Returns the final assistant text and the
+   * incremental cost.
+   */
+  private async runOneShot(
+    envelope: TaskEnvelope,
+    parentSignal?: AbortSignal,
+  ): Promise<{ digest: string; cost: number }> {
+    const provider = this.deps.providers.get(envelope.triage.provider);
+    if (!provider) {
+      throw new RouterError(
+        `Provider "${envelope.triage.provider}" not instantiated.`,
+        "PROVIDER_MISSING",
+      );
+    }
+    const credential = await this.deps.store.get(provider.id);
+    if (!credential) {
+      throw new AuthError(
+        `No credential for provider "${provider.id}".`,
+        "missing_credential",
+      );
+    }
+
+    this.deps.logger.log({
+      kind: "consultation",
+      envelopeId: envelope.id,
+      parentEnvelopeId: envelope.parentEnvelopeId,
+      tier: envelope.triage.tier,
+      model: envelope.triage.model,
+    });
+
+    const startUsd = this.tracker.state.usd;
+    const controller = new AbortController();
+    const fwd = () => controller.abort();
+    parentSignal?.addEventListener("abort", fwd, { once: true });
+
+    let digest = "";
+    try {
+      await provider.dispatch(
+        {
+          envelope,
+          signal: controller.signal,
+          // Deliberately no tools and no executeTool — consultation is
+          // pure reasoning. The provider will return after one round.
+          onEvent: (event) => {
+            this.tracker.observe(event, envelope.triage.model);
+            if (event.type === "worker_done") {
+              digest = event.digest;
+            }
+          },
+        },
+        credential,
+      );
+    } finally {
+      parentSignal?.removeEventListener("abort", fwd);
+    }
+
+    const cost = this.tracker.state.usd - startUsd;
+    this.deps.logger.log({
+      kind: "consultation_done",
+      envelopeId: envelope.id,
+      cost,
+      digestLength: digest.length,
+    });
+    return { digest, cost };
+  }
+
+  private bumpTierName(current: string): string {
+    const tiers = Object.keys(this.deps.config.tiers);
+    const idx = tiers.indexOf(current);
+    if (idx === -1 || idx === tiers.length - 1) return current;
+    return tiers[idx + 1] ?? current;
+  }
+
+  private dropTierName(current: string): string {
+    const tiers = Object.keys(this.deps.config.tiers);
+    const idx = tiers.indexOf(current);
+    if (idx <= 0) return current;
+    return tiers[idx - 1] ?? current;
   }
 
   private async runInternal(
@@ -194,6 +410,13 @@ export class Dispatcher {
             requestEscalation: (reason, digest) => {
               escalationPromise.controller.triggerManually(reason, digest);
             },
+            // Wire consult/delegate so worker tools can call back into the
+            // dispatcher. The current envelope is the parent for any
+            // child envelopes spawned during this turn.
+            consultExpert: (question, tier) =>
+              this.consult(envelope, question, tier, controller.signal),
+            delegateSubtask: (prompt, tier) =>
+              this.delegate(envelope, prompt, tier, controller.signal),
           });
           return result;
         }

--- a/tools/router/src/dispatch/dispatcher.ts
+++ b/tools/router/src/dispatch/dispatcher.ts
@@ -1,6 +1,7 @@
 import type { RouterConfig } from "../config/schema.js";
 import type { CredentialStore } from "../credentials/store.js";
 import type { JsonlLogger } from "../telemetry/jsonl-logger.js";
+import type { ToolRegistry } from "../tools/index.js";
 import { escalateEnvelope } from "../triage/envelope.js";
 import {
   AuthError,
@@ -9,9 +10,11 @@ import {
   type EscalationReason,
   type Provider,
   type TaskEnvelope,
+  type ToolSpec,
 } from "../types.js";
 import { BudgetTracker } from "./budget.js";
 import { EscalationController } from "./escalation.js";
+import { runHook } from "./hooks.js";
 import { PreflightCache, preflight } from "./preflight.js";
 
 /**
@@ -35,6 +38,18 @@ export interface DispatcherDeps {
   store: CredentialStore;
   cache: PreflightCache;
   logger: JsonlLogger;
+  tools?: ToolRegistry;
+  /**
+   * Optional policy hook. When non-null, controls whether the dispatcher is
+   * allowed to downgrade a task on preflight failure. CI mode sets this to
+   * "never" so auth errors become hard failures instead of silent downgrades.
+   */
+  downgradePolicy?: "auto" | "never" | "ask";
+  /**
+   * When set, forces the dispatcher to use this exact tier name, ignoring
+   * triage. Used by `router run --tier <name>`.
+   */
+  forcedTier?: string;
 }
 
 export interface DispatchInput {
@@ -121,6 +136,11 @@ export class Dispatcher {
         reason: pre.result.reason,
         message: pre.result.message,
       });
+
+      // Try the fallback chain for this tier before surfacing the error.
+      const fallback = await this.tryFallback(envelope, parentSignal, onEvent);
+      if (fallback) return;
+
       throw new AuthError(
         pre.result.message ?? "Preflight failed.",
         pre.result.reason ?? "unknown",
@@ -147,11 +167,45 @@ export class Dispatcher {
     let finalDigest = "";
     let finalStatus: "success" | "failure" | "aborted" = "success";
 
+    // Snapshot the tool registry so mutations mid-worker don't leak between
+    // dispatches. Build ToolSpecs to hand to the provider.
+    const toolRegistry = this.deps.tools?.snapshot();
+    const toolSpecs: ToolSpec[] | undefined = toolRegistry
+      ? toolRegistry.list().map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        }))
+      : undefined;
+
+    const executeTool = toolRegistry
+      ? async (
+          name: string,
+          input: unknown,
+        ): Promise<{ content: string; isError?: boolean }> => {
+          const tool = toolRegistry.get(name);
+          if (!tool) {
+            return { isError: true, content: `Unknown tool: ${name}` };
+          }
+          const result = await tool.execute(input, {
+            cwd: process.cwd(),
+            signal: controller.signal,
+            config: this.deps.config,
+            requestEscalation: (reason, digest) => {
+              escalationPromise.controller.triggerManually(reason, digest);
+            },
+          });
+          return result;
+        }
+      : undefined;
+
     try {
       await provider.dispatch(
         {
           envelope,
           signal: controller.signal,
+          tools: toolSpecs,
+          executeTool,
           onEvent: (event) => {
             this.tracker.observe(event, envelope.triage.model);
             escalationPromise.controller.observe(event);
@@ -216,12 +270,49 @@ export class Dispatcher {
           reason: escalation.reason,
           bumpCount: next.escalation?.bumpCount,
         });
+        if (this.deps.config.hooks.onEscalation) {
+          try {
+            await runHook(this.deps.config.hooks.onEscalation, {
+              event: "onEscalation",
+              from: envelope,
+              to: next,
+              reason: escalation.reason,
+              digest: escalation.digest,
+            });
+          } catch (err) {
+            this.deps.logger.log({
+              kind: "hook_error",
+              hook: "onEscalation",
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
         return this.runInternal(next, parentSignal, onEvent);
       } catch (err) {
         // Escalation cap hit — surface as a done event with failure status.
         finalStatus = "failure";
         finalDigest =
           err instanceof Error ? err.message : "Escalation failed.";
+      }
+    }
+
+    // Fire the afterDispatch hook. Best-effort; hook errors are logged but
+    // never propagate — the dispatcher's job is done at this point.
+    if (this.deps.config.hooks.afterDispatch) {
+      try {
+        await runHook(this.deps.config.hooks.afterDispatch, {
+          event: "afterDispatch",
+          envelope,
+          status: finalStatus,
+          digest: finalDigest,
+          budget: this.tracker.state,
+        });
+      } catch (err) {
+        this.deps.logger.log({
+          kind: "hook_error",
+          hook: "afterDispatch",
+          message: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 
@@ -237,6 +328,82 @@ export class Dispatcher {
       status: finalStatus,
       budget: this.tracker.state,
     });
+  }
+
+  /**
+   * Walk `config.fallback[envelope.triage.tier]` trying each entry until one
+   * passes preflight. Returns true if a fallback dispatched successfully
+   * (caller should stop); false if no fallback was configured or none worked.
+   *
+   * Fallback entries are either:
+   *   - a tier name (looked up in config.tiers)
+   *   - a "provider:model" pair (built ad-hoc without a named tier)
+   *
+   * The downgradePolicy gates this behavior: "never" skips fallback entirely
+   * (caller surfaces the auth error), "auto" walks the chain silently, "ask"
+   * is treated as "auto" at the dispatcher level — the TUI handles prompting
+   * before calling the dispatcher.
+   */
+  private async tryFallback(
+    envelope: TaskEnvelope,
+    parentSignal: AbortSignal,
+    onEvent: (e: DispatcherEvent) => void,
+  ): Promise<boolean> {
+    if (this.deps.downgradePolicy === "never") return false;
+
+    const chain = this.deps.config.fallback[envelope.triage.tier];
+    if (!chain || chain.length === 0) return false;
+
+    for (const entry of chain) {
+      const fallbackTier = this.resolveFallbackEntry(entry);
+      if (!fallbackTier) continue;
+
+      const fallbackEnvelope: TaskEnvelope = {
+        ...envelope,
+        triage: {
+          ...envelope.triage,
+          tier: fallbackTier.tierName,
+          provider: fallbackTier.provider,
+          model: fallbackTier.model,
+          rationale: `${envelope.triage.rationale} [fallback: ${entry}]`,
+          source: "user-override",
+        },
+      };
+
+      const provider = this.deps.providers.get(fallbackTier.provider);
+      if (!provider) continue;
+      const pre = await preflight({
+        provider,
+        model: fallbackTier.model,
+        store: this.deps.store,
+        cache: this.deps.cache,
+      });
+      if (!pre.result.ok) continue;
+
+      this.deps.logger.log({
+        kind: "fallback",
+        fromEnvelope: envelope.id,
+        toTier: fallbackTier.tierName,
+        entry,
+      });
+      await this.runInternal(fallbackEnvelope, parentSignal, onEvent);
+      return true;
+    }
+    return false;
+  }
+
+  private resolveFallbackEntry(
+    entry: string,
+  ): { tierName: string; provider: string; model: string } | null {
+    // "provider:model" form bypasses named tiers entirely.
+    if (entry.includes(":")) {
+      const [provider, model] = entry.split(":", 2) as [string, string];
+      return { tierName: `${provider}:${model}`, provider, model };
+    }
+    // Named tier form.
+    const tier = this.deps.config.tiers[entry];
+    if (!tier) return null;
+    return { tierName: entry, provider: tier.provider, model: tier.model };
   }
 
   /**

--- a/tools/router/src/dispatch/escalation.ts
+++ b/tools/router/src/dispatch/escalation.ts
@@ -1,0 +1,90 @@
+import type { RouterConfig } from "../config/schema.js";
+import type {
+  DispatchEvent,
+  EscalationReason,
+  TaskEnvelope,
+} from "../types.js";
+
+/**
+ * Escalation controller. Watches dispatch events and decides whether the
+ * current worker should be cancelled and respawned at a higher tier.
+ *
+ * Design: this class is pure state machine. It does NOT respawn workers
+ * itself — it raises a signal (via the onTrigger callback) and leaves the
+ * actual envelope-minting and re-dispatch to the top-level dispatcher.
+ * Keeps cancellation ownership in one place.
+ */
+
+export interface EscalationTrigger {
+  reason: EscalationReason;
+  digest: string;
+}
+
+export class EscalationController {
+  private validationFailures = 0;
+  private recentTools: string[] = [];
+  private fired = false;
+
+  constructor(
+    private readonly config: RouterConfig,
+    private readonly envelope: TaskEnvelope,
+    private readonly onTrigger: (trigger: EscalationTrigger) => void,
+  ) {}
+
+  /** Inspect a dispatch event; trigger escalation if a condition matches. */
+  observe(event: DispatchEvent): void {
+    if (this.fired) return;
+    if (!this.config.escalation.enabled) return;
+    if (!this.envelope.budget.escalationAllowed) return;
+
+    const triggers = this.config.escalation.triggers;
+
+    switch (event.type) {
+      case "escalation_requested":
+        if (triggers.selfDoubt) {
+          this.trigger({ reason: event.reason, digest: event.digest });
+        }
+        break;
+      case "tool_call":
+        this.recentTools.push(JSON.stringify({ n: event.name, i: event.input }));
+        if (this.recentTools.length > triggers.toolLoopThreshold) {
+          this.recentTools.shift();
+        }
+        if (this.detectLoop(triggers.toolLoopThreshold)) {
+          this.trigger({
+            reason: "loop_detected",
+            digest: `Detected tool loop: ${event.name} called ${triggers.toolLoopThreshold} times with identical arguments.`,
+          });
+        }
+        break;
+      case "tool_result":
+        if (!event.ok && /test|validate/i.test(event.name)) {
+          this.validationFailures += 1;
+          if (this.validationFailures >= triggers.validationFailures) {
+            this.trigger({
+              reason: "validation_failed",
+              digest: `Validation tool "${event.name}" failed ${this.validationFailures} times in a row.`,
+            });
+          }
+        }
+        break;
+    }
+  }
+
+  /** External trigger (e.g. budget tracker says we blew the cap). */
+  triggerManually(reason: EscalationReason, digest: string): void {
+    if (this.fired) return;
+    this.trigger({ reason, digest });
+  }
+
+  private detectLoop(threshold: number): boolean {
+    if (this.recentTools.length < threshold) return false;
+    const last = this.recentTools[this.recentTools.length - 1];
+    return this.recentTools.every((t) => t === last);
+  }
+
+  private trigger(trigger: EscalationTrigger): void {
+    this.fired = true;
+    this.onTrigger(trigger);
+  }
+}

--- a/tools/router/src/dispatch/hooks.ts
+++ b/tools/router/src/dispatch/hooks.ts
@@ -1,0 +1,61 @@
+import { pathToFileURL } from "node:url";
+import { isAbsolute, resolve } from "node:path";
+
+/**
+ * Lifecycle hook runner. A hook is an ESM file that default-exports either
+ * a function or an object with an `onEvent` method. The dispatcher invokes
+ * hooks at beforeTriage / afterDispatch / onEscalation points, passing a
+ * payload object that includes the event name.
+ *
+ * Hooks run in-process via dynamic import. They share the same module cache
+ * so repeated invocations don't re-parse the file. Errors are the caller's
+ * concern — this module just throws on failure and leaves logging to the
+ * dispatcher.
+ */
+
+export interface HookPayload {
+  event: "beforeTriage" | "afterDispatch" | "onEscalation";
+  [key: string]: unknown;
+}
+
+type HookFn = (payload: HookPayload) => void | Promise<void>;
+type HookModule = HookFn | { default?: HookFn; onEvent?: HookFn };
+
+const cache = new Map<string, HookFn>();
+
+export async function runHook(
+  hookPath: string,
+  payload: HookPayload,
+): Promise<void> {
+  const fn = await loadHook(hookPath);
+  await fn(payload);
+}
+
+async function loadHook(hookPath: string): Promise<HookFn> {
+  const absolute = isAbsolute(hookPath)
+    ? hookPath
+    : resolve(process.cwd(), hookPath);
+  const key = absolute;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const url = pathToFileURL(absolute).href;
+  const mod = (await import(url)) as HookModule;
+
+  let fn: HookFn | undefined;
+  if (typeof mod === "function") {
+    fn = mod;
+  } else if (typeof (mod as { default?: HookFn }).default === "function") {
+    fn = (mod as { default: HookFn }).default;
+  } else if (typeof (mod as { onEvent?: HookFn }).onEvent === "function") {
+    fn = (mod as { onEvent: HookFn }).onEvent;
+  }
+
+  if (!fn) {
+    throw new Error(
+      `Hook at ${hookPath} does not export a function or an { onEvent } object.`,
+    );
+  }
+  cache.set(key, fn);
+  return fn;
+}

--- a/tools/router/src/dispatch/preflight.ts
+++ b/tools/router/src/dispatch/preflight.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { CredentialStore } from "../credentials/store.js";
+import type { ProbeResult, Provider } from "../types.js";
+
+/**
+ * Entitlement preflight: before dispatching a worker, probe the
+ * (provider, model) pair with the current credential. Caches the result
+ * for a short TTL so we don't probe on every prompt.
+ *
+ * The cache file lives under .router/cache/entitlements.json in the repo
+ * where router was invoked. It's safe to delete at any time.
+ */
+
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+
+interface CacheEntry extends ProbeResult {
+  provider: string;
+  model: string;
+}
+
+interface CacheFile {
+  version: 1;
+  entries: CacheEntry[];
+}
+
+export class PreflightCache {
+  private entries: Map<string, CacheEntry> = new Map();
+
+  constructor(
+    private readonly path: string,
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+  ) {
+    this.load();
+  }
+
+  static default(cwd: string = process.cwd()): PreflightCache {
+    return new PreflightCache(join(cwd, ".router", "cache", "entitlements.json"));
+  }
+
+  get(provider: string, model: string): ProbeResult | null {
+    const key = `${provider}:${model}`;
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.checkedAt > this.ttlMs) {
+      this.entries.delete(key);
+      return null;
+    }
+    return entry;
+  }
+
+  set(provider: string, model: string, result: ProbeResult): void {
+    this.entries.set(`${provider}:${model}`, { ...result, provider, model });
+    this.persist();
+  }
+
+  invalidate(provider: string, model?: string): void {
+    if (model) {
+      this.entries.delete(`${provider}:${model}`);
+    } else {
+      for (const key of [...this.entries.keys()]) {
+        if (key.startsWith(`${provider}:`)) this.entries.delete(key);
+      }
+    }
+    this.persist();
+  }
+
+  private load(): void {
+    if (!existsSync(this.path)) return;
+    try {
+      const raw = readFileSync(this.path, "utf8");
+      const parsed = JSON.parse(raw) as CacheFile;
+      if (parsed.version !== 1) return;
+      for (const e of parsed.entries) {
+        this.entries.set(`${e.provider}:${e.model}`, e);
+      }
+    } catch {
+      // Corrupt cache is recoverable — just start fresh.
+    }
+  }
+
+  private persist(): void {
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+      const file: CacheFile = {
+        version: 1,
+        entries: [...this.entries.values()],
+      };
+      writeFileSync(this.path, JSON.stringify(file, null, 2));
+    } catch {
+      // Cache persistence is best-effort.
+    }
+  }
+}
+
+export interface PreflightInput {
+  provider: Provider;
+  model: string;
+  store: CredentialStore;
+  cache: PreflightCache;
+}
+
+export interface PreflightOutput {
+  result: ProbeResult;
+  /** Null means no credential was found in the store at all. */
+  hadCredential: boolean;
+}
+
+export async function preflight(
+  input: PreflightInput,
+): Promise<PreflightOutput> {
+  const cached = input.cache.get(input.provider.id, input.model);
+  const credential = await input.store.get(input.provider.id);
+
+  if (!credential) {
+    return {
+      result: {
+        ok: false,
+        reason: "missing_credential",
+        message: `No credentials stored for provider "${input.provider.id}".`,
+        checkedAt: Date.now(),
+      },
+      hadCredential: false,
+    };
+  }
+
+  if (cached && cached.ok) {
+    return { result: cached, hadCredential: true };
+  }
+
+  const result = await input.provider.probe(input.model, credential);
+  input.cache.set(input.provider.id, input.model, result);
+  return { result, hadCredential: true };
+}

--- a/tools/router/src/index.ts
+++ b/tools/router/src/index.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { render } from "ink";
+import React from "react";
+import { loadConfig } from "./config/load.js";
+import { KeyringCredentialStore } from "./credentials/keyring-store.js";
+import { MemoryCredentialStore } from "./credentials/memory-store.js";
+import type { CredentialStore } from "./credentials/store.js";
+import { PreflightCache } from "./dispatch/preflight.js";
+import "./providers/index.js"; // self-registers built-in providers
+import { resolveProviders } from "./providers/resolve.js";
+import { JsonlLogger } from "./telemetry/jsonl-logger.js";
+import { App } from "./tui/App.js";
+import {
+  authDoctor,
+  authLogin,
+  authLogout,
+  authStatus,
+  type AuthCommandDeps,
+} from "./auth/commands.js";
+import { ConfigError, RouterError } from "./types.js";
+
+/**
+ * CLI entrypoint. Wires commander subcommands to the core modules:
+ *
+ *   router                → interactive TUI
+ *   router run "prompt"   → one-shot TUI seeded with a prompt
+ *   router auth login     → device/api-key auth for a provider
+ *   router auth status    → show stored credentials
+ *   router auth logout    → delete stored credential
+ *   router auth doctor    → probe every configured tier
+ */
+
+async function buildDeps(): Promise<{
+  deps: AuthCommandDeps;
+  logger: JsonlLogger;
+  configPath: string;
+}> {
+  const { config, filepath } = await loadConfig();
+  const providers = resolveProviders(config);
+  const store: CredentialStore =
+    process.env.ROUTER_NO_KEYRING === "1"
+      ? new MemoryCredentialStore()
+      : new KeyringCredentialStore();
+  const cache = PreflightCache.default();
+  const logger = JsonlLogger.default();
+  return {
+    deps: { config, providers, store, cache },
+    logger,
+    configPath: filepath,
+  };
+}
+
+function handleError(err: unknown): never {
+  if (err instanceof ConfigError) {
+    console.error("\x1b[31mConfiguration error:\x1b[0m");
+    console.error(err.message);
+    process.exit(2);
+  }
+  if (err instanceof RouterError) {
+    console.error(`\x1b[31m${err.code}:\x1b[0m ${err.message}`);
+    process.exit(3);
+  }
+  if (err instanceof Error) {
+    console.error(`\x1b[31mError:\x1b[0m ${err.message}`);
+    if (process.env.ROUTER_DEBUG === "1") console.error(err.stack);
+    process.exit(1);
+  }
+  console.error("Unknown error:", err);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const program = new Command();
+  program
+    .name("router")
+    .description(
+      "Agentic model router with TUI, device auth, and runtime escalation",
+    )
+    .version("0.1.0");
+
+  // Default command: interactive TUI
+  program
+    .command("tui", { isDefault: true })
+    .description("Launch the interactive TUI")
+    .argument("[prompt...]", "Optional initial prompt")
+    .action(async (promptWords: string[]) => {
+      try {
+        const { deps, logger } = await buildDeps();
+        const initialPrompt = promptWords.length
+          ? promptWords.join(" ")
+          : undefined;
+        const { waitUntilExit } = render(
+          React.createElement(App, {
+            config: deps.config,
+            providers: deps.providers,
+            store: deps.store,
+            cache: deps.cache,
+            logger,
+            initialPrompt,
+          }),
+        );
+        await waitUntilExit();
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  // `router run "..."`
+  program
+    .command("run")
+    .description("Run a one-shot prompt (opens the TUI)")
+    .argument("<prompt...>", "Prompt to dispatch")
+    .option("--tier <name>", "Force a specific tier")
+    .option("--require-tier <name>", "Fail if the given tier is unauthorized")
+    .action(async (promptWords: string[]) => {
+      try {
+        const { deps, logger } = await buildDeps();
+        const { waitUntilExit } = render(
+          React.createElement(App, {
+            config: deps.config,
+            providers: deps.providers,
+            store: deps.store,
+            cache: deps.cache,
+            logger,
+            initialPrompt: promptWords.join(" "),
+          }),
+        );
+        await waitUntilExit();
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  // `router auth <subcommand>`
+  const auth = program.command("auth").description("Manage provider credentials");
+
+  auth
+    .command("login")
+    .description("Authenticate a provider")
+    .option("--provider <id>", "Provider id (from router.config.ts)")
+    .action(async (opts: { provider?: string }) => {
+      try {
+        const { deps } = await buildDeps();
+        const providerId =
+          opts.provider ??
+          (await pickProviderInteractively([...deps.providers.keys()]));
+        await authLogin(providerId, deps);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  auth
+    .command("logout")
+    .description("Remove a stored credential")
+    .requiredOption("--provider <id>", "Provider id")
+    .action(async (opts: { provider: string }) => {
+      try {
+        const { deps } = await buildDeps();
+        await authLogout(opts.provider, deps);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  auth
+    .command("status")
+    .description("Show credential status for all providers")
+    .action(async () => {
+      try {
+        const { deps } = await buildDeps();
+        await authStatus(deps);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  auth
+    .command("doctor")
+    .description("Probe every configured tier and report authorization")
+    .action(async () => {
+      try {
+        const { deps } = await buildDeps();
+        await authDoctor(deps);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  await program.parseAsync(process.argv);
+}
+
+async function pickProviderInteractively(ids: string[]): Promise<string> {
+  if (ids.length === 0) throw new Error("No providers configured.");
+  if (ids.length === 1) return ids[0]!;
+  // Minimal non-TTY-safe picker: read from stdin.
+  console.log("Configured providers:");
+  ids.forEach((id, i) => console.log(`  [${i + 1}] ${id}`));
+  process.stdout.write("Pick a number: ");
+  const answer = await new Promise<string>((resolve) => {
+    process.stdin.setEncoding("utf8");
+    process.stdin.once("data", (data) => resolve(data.toString().trim()));
+  });
+  const idx = parseInt(answer, 10) - 1;
+  if (isNaN(idx) || idx < 0 || idx >= ids.length) {
+    throw new Error("Invalid selection.");
+  }
+  return ids[idx]!;
+}
+
+main().catch(handleError);

--- a/tools/router/src/index.ts
+++ b/tools/router/src/index.ts
@@ -20,6 +20,7 @@ import {
   type AuthCommandDeps,
 } from "./auth/commands.js";
 import { runInit } from "./commands/init.js";
+import { analyzeCost, printCostReport } from "./commands/cost.js";
 import { ConfigError, RouterError } from "./types.js";
 
 /**
@@ -136,6 +137,40 @@ async function main(): Promise<void> {
     .action((opts: { force?: boolean }) => {
       runInit({ force: opts.force });
     });
+
+  // `router cost`
+  program
+    .command("cost")
+    .description("Analyze JSONL telemetry and report cost vs counterfactuals")
+    .option("--since <date>", "Earliest day to include (YYYY-MM-DD)")
+    .option("--until <date>", "Latest day to include (YYYY-MM-DD)")
+    .option("--top <n>", "Top N most expensive envelopes to show", "10")
+    .option("--json", "Emit a machine-readable JSON report instead of a table")
+    .action(
+      async (opts: {
+        since?: string;
+        until?: string;
+        top?: string;
+        json?: boolean;
+      }) => {
+        try {
+          const { deps } = await buildDeps();
+          const report = analyzeCost({
+            config: deps.config,
+            since: opts.since,
+            until: opts.until,
+            topN: opts.top ? parseInt(opts.top, 10) : 10,
+          });
+          if (opts.json) {
+            console.log(JSON.stringify(report, null, 2));
+          } else {
+            printCostReport(report);
+          }
+        } catch (err) {
+          handleError(err);
+        }
+      },
+    );
 
   // Default command: interactive TUI
   program

--- a/tools/router/src/index.ts
+++ b/tools/router/src/index.ts
@@ -10,6 +10,7 @@ import { PreflightCache } from "./dispatch/preflight.js";
 import "./providers/index.js"; // self-registers built-in providers
 import { resolveProviders } from "./providers/resolve.js";
 import { JsonlLogger } from "./telemetry/jsonl-logger.js";
+import { createDefaultRegistry } from "./tools/index.js";
 import { App } from "./tui/App.js";
 import {
   authDoctor,
@@ -18,6 +19,7 @@ import {
   authStatus,
   type AuthCommandDeps,
 } from "./auth/commands.js";
+import { runInit } from "./commands/init.js";
 import { ConfigError, RouterError } from "./types.js";
 
 /**
@@ -25,10 +27,16 @@ import { ConfigError, RouterError } from "./types.js";
  *
  *   router                → interactive TUI
  *   router run "prompt"   → one-shot TUI seeded with a prompt
+ *   router init           → scaffold a router.config.ts at cwd
  *   router auth login     → device/api-key auth for a provider
  *   router auth status    → show stored credentials
  *   router auth logout    → delete stored credential
  *   router auth doctor    → probe every configured tier
+ *
+ * Environment:
+ *   ROUTER_NO_KEYRING=1  → in-memory credential store (tests, CI)
+ *   ROUTER_NO_PROMPT=1   → fail fast on interactive prompts (CI mode)
+ *   ROUTER_DEBUG=1       → print stack traces on errors
  */
 
 async function buildDeps(): Promise<{
@@ -70,6 +78,47 @@ function handleError(err: unknown): never {
   process.exit(1);
 }
 
+function isCiMode(): boolean {
+  return process.env.ROUTER_NO_PROMPT === "1";
+}
+
+interface RunOptions {
+  tier?: string;
+  requireTier?: string;
+  allowDowngrade?: boolean;
+  noDowngrade?: boolean;
+}
+
+function renderApp(
+  deps: AuthCommandDeps,
+  logger: JsonlLogger,
+  initialPrompt: string | undefined,
+  opts: RunOptions,
+): ReturnType<typeof render> {
+  const downgradePolicy = opts.noDowngrade
+    ? "never"
+    : opts.allowDowngrade
+      ? "auto"
+      : isCiMode()
+        ? "never"
+        : "ask";
+  return render(
+    React.createElement(App, {
+      config: deps.config,
+      providers: deps.providers,
+      store: deps.store,
+      cache: deps.cache,
+      logger,
+      tools: createDefaultRegistry(),
+      initialPrompt,
+      forcedTier: opts.tier,
+      requireTier: opts.requireTier,
+      downgradePolicy,
+      ciMode: isCiMode(),
+    }),
+  );
+}
+
 async function main(): Promise<void> {
   const program = new Command();
   program
@@ -79,27 +128,31 @@ async function main(): Promise<void> {
     )
     .version("0.1.0");
 
+  // `router init`
+  program
+    .command("init")
+    .description("Scaffold a router.config.ts in the current directory")
+    .option("--force", "Overwrite an existing router.config.ts")
+    .action((opts: { force?: boolean }) => {
+      runInit({ force: opts.force });
+    });
+
   // Default command: interactive TUI
   program
     .command("tui", { isDefault: true })
     .description("Launch the interactive TUI")
     .argument("[prompt...]", "Optional initial prompt")
-    .action(async (promptWords: string[]) => {
+    .option("--tier <name>", "Force a specific tier")
+    .option("--require-tier <name>", "Fail if the given tier is unauthorized")
+    .option("--allow-downgrade", "Silently downgrade on auth failures")
+    .option("--no-downgrade", "Never downgrade; hard-fail on auth failures")
+    .action(async (promptWords: string[], opts: RunOptions) => {
       try {
         const { deps, logger } = await buildDeps();
         const initialPrompt = promptWords.length
           ? promptWords.join(" ")
           : undefined;
-        const { waitUntilExit } = render(
-          React.createElement(App, {
-            config: deps.config,
-            providers: deps.providers,
-            store: deps.store,
-            cache: deps.cache,
-            logger,
-            initialPrompt,
-          }),
-        );
+        const { waitUntilExit } = renderApp(deps, logger, initialPrompt, opts);
         await waitUntilExit();
       } catch (err) {
         handleError(err);
@@ -109,22 +162,20 @@ async function main(): Promise<void> {
   // `router run "..."`
   program
     .command("run")
-    .description("Run a one-shot prompt (opens the TUI)")
+    .description("Run a one-shot prompt")
     .argument("<prompt...>", "Prompt to dispatch")
     .option("--tier <name>", "Force a specific tier")
     .option("--require-tier <name>", "Fail if the given tier is unauthorized")
-    .action(async (promptWords: string[]) => {
+    .option("--allow-downgrade", "Silently downgrade on auth failures")
+    .option("--no-downgrade", "Never downgrade; hard-fail on auth failures")
+    .action(async (promptWords: string[], opts: RunOptions) => {
       try {
         const { deps, logger } = await buildDeps();
-        const { waitUntilExit } = render(
-          React.createElement(App, {
-            config: deps.config,
-            providers: deps.providers,
-            store: deps.store,
-            cache: deps.cache,
-            logger,
-            initialPrompt: promptWords.join(" "),
-          }),
+        const { waitUntilExit } = renderApp(
+          deps,
+          logger,
+          promptWords.join(" "),
+          opts,
         );
         await waitUntilExit();
       } catch (err) {
@@ -142,6 +193,11 @@ async function main(): Promise<void> {
     .action(async (opts: { provider?: string }) => {
       try {
         const { deps } = await buildDeps();
+        if (isCiMode() && !opts.provider) {
+          throw new Error(
+            "ROUTER_NO_PROMPT is set; --provider is required in CI mode.",
+          );
+        }
         const providerId =
           opts.provider ??
           (await pickProviderInteractively([...deps.providers.keys()]));
@@ -194,7 +250,6 @@ async function main(): Promise<void> {
 async function pickProviderInteractively(ids: string[]): Promise<string> {
   if (ids.length === 0) throw new Error("No providers configured.");
   if (ids.length === 1) return ids[0]!;
-  // Minimal non-TTY-safe picker: read from stdin.
   console.log("Configured providers:");
   ids.forEach((id, i) => console.log(`  [${i + 1}] ${id}`));
   process.stdout.write("Pick a number: ");

--- a/tools/router/src/providers/anthropic-api.ts
+++ b/tools/router/src/providers/anthropic-api.ts
@@ -1,0 +1,295 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  AuthError,
+  type AuthContext,
+  type AuthEvent,
+  type Credential,
+  type DispatchRequest,
+  type ModelInfo,
+  type ProbeFailureReason,
+  type ProbeResult,
+  type Provider,
+} from "../types.js";
+import { registerProvider } from "./registry.js";
+
+interface AnthropicProviderOptions {
+  id: string;
+  baseURL?: string;
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Direct Anthropic API provider. Auth is API key (paste-in), validated
+ * immediately against the /v1/models endpoint so we catch invalid keys
+ * before any real work happens.
+ *
+ * Dispatch uses the Messages API directly in a tool-calling loop. We avoid
+ * pulling in the Claude Agent SDK here so the provider surface stays minimal
+ * and the same pattern can be copied for other API-key-based providers.
+ */
+export class AnthropicApiProvider implements Provider {
+  readonly id: string;
+  readonly displayName = "Anthropic API";
+  readonly authStrategy = "api-key" as const;
+  private readonly baseURL?: string;
+
+  constructor(opts: AnthropicProviderOptions) {
+    this.id = opts.id;
+    this.baseURL = opts.baseURL;
+  }
+
+  async *login(ctx: AuthContext): AsyncIterable<AuthEvent> {
+    yield {
+      type: "instruction",
+      message:
+        "Paste your Anthropic API key (starts with sk-ant-). Get one at https://console.anthropic.com/settings/keys",
+    };
+
+    let apiKey: string;
+    try {
+      apiKey = await ctx.requestInput({
+        label: "Anthropic API key",
+        mask: true,
+      });
+    } catch (err) {
+      yield {
+        type: "error",
+        message: err instanceof Error ? err.message : "Input cancelled",
+        recoverable: false,
+      };
+      return;
+    }
+
+    apiKey = apiKey.trim();
+    if (!apiKey) {
+      yield {
+        type: "error",
+        message: "No API key provided.",
+        recoverable: true,
+      };
+      return;
+    }
+    if (!apiKey.startsWith("sk-ant-")) {
+      yield {
+        type: "error",
+        message:
+          'API key should start with "sk-ant-". Double-check you copied the full value.',
+        recoverable: true,
+      };
+      return;
+    }
+
+    // Validate the key before persisting it.
+    const client = new Anthropic({ apiKey, baseURL: this.baseURL });
+    try {
+      await client.models.list({ limit: 1 });
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      yield {
+        type: "error",
+        message: `API key rejected: ${message}`,
+        recoverable: reason !== "entitlement_denied",
+      };
+      return;
+    }
+
+    const credential: Credential = {
+      providerId: this.id,
+      kind: "api-key",
+      secret: apiKey,
+    };
+    yield { type: "success", credential };
+  }
+
+  async probe(model: string, credential: Credential): Promise<ProbeResult> {
+    const client = new Anthropic({
+      apiKey: credential.secret,
+      baseURL: this.baseURL,
+    });
+    try {
+      // Cheapest probe: single-token completion. Preferred over models.list()
+      // because it verifies the caller has entitlement for *this specific*
+      // model, not just that the key is valid.
+      await client.messages.create({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+      return { ok: true, checkedAt: Date.now() };
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      return { ok: false, reason, message, checkedAt: Date.now() };
+    }
+  }
+
+  async listModels(credential: Credential): Promise<ModelInfo[]> {
+    const client = new Anthropic({
+      apiKey: credential.secret,
+      baseURL: this.baseURL,
+    });
+    const out: ModelInfo[] = [];
+    for await (const m of client.models.list()) {
+      out.push({ id: m.id, displayName: m.display_name });
+    }
+    return out;
+  }
+
+  async dispatch(
+    request: DispatchRequest,
+    credential: Credential,
+  ): Promise<void> {
+    const { envelope, signal, onEvent } = request;
+    const client = new Anthropic({
+      apiKey: credential.secret,
+      baseURL: this.baseURL,
+    });
+
+    onEvent({ type: "worker_start", model: envelope.triage.model });
+
+    const systemPrompt = buildSystemPrompt(envelope);
+    const userMessage = buildUserMessage(envelope);
+
+    try {
+      const stream = client.messages.stream({
+        model: envelope.triage.model,
+        max_tokens: envelope.budget.maxTokens ?? 4096,
+        system: systemPrompt,
+        messages: [{ role: "user", content: userMessage }],
+      });
+
+      for await (const event of stream) {
+        if (signal.aborted) {
+          stream.controller.abort();
+          break;
+        }
+        if (
+          event.type === "content_block_delta" &&
+          event.delta.type === "text_delta"
+        ) {
+          onEvent({ type: "assistant_text", text: event.delta.text });
+        }
+      }
+
+      const final = await stream.finalMessage();
+      if (final.usage) {
+        onEvent({
+          type: "token_usage",
+          inputTokens: final.usage.input_tokens,
+          outputTokens: final.usage.output_tokens,
+        });
+      }
+
+      const digest = summarizeFinalMessage(final);
+      onEvent({ type: "worker_done", digest, status: "success" });
+    } catch (err) {
+      if (signal.aborted) {
+        onEvent({
+          type: "worker_done",
+          digest: "aborted",
+          status: "failure",
+        });
+        return;
+      }
+      const { reason, message } = classifyAnthropicError(err);
+      throw new AuthError(message, reason);
+    }
+  }
+}
+
+function buildSystemPrompt(
+  envelope: DispatchRequest["envelope"],
+): string {
+  const parts = [
+    "You are a router-dispatched worker agent.",
+    `Tier: ${envelope.triage.tier} (${envelope.triage.model})`,
+    `Goal: ${envelope.goal}`,
+  ];
+  if (envelope.context.constraints.length > 0) {
+    parts.push(`Constraints: ${envelope.context.constraints.join(", ")}`);
+  }
+  if (envelope.budget.escalationAllowed) {
+    parts.push(
+      "If this task is larger or more ambiguous than it appears, respond with the literal token [ESCALATE: <reason>] followed by a one-paragraph digest of what you tried and where you got stuck. Do not retry blindly.",
+    );
+  }
+  if (envelope.escalation) {
+    parts.push(
+      `This is an escalated attempt (bump ${envelope.escalation.bumpCount}). Previous attempt at ${envelope.escalation.fromTier} failed with reason "${envelope.escalation.reason}". Prior digest:\n${envelope.escalation.priorAttemptDigest}`,
+    );
+  }
+  return parts.join("\n\n");
+}
+
+function buildUserMessage(envelope: DispatchRequest["envelope"]): string {
+  const parts = [envelope.originalPrompt];
+  if (envelope.context.files.length > 0) {
+    parts.push(
+      `\nRelevant files identified by triage:\n${envelope.context.files.map((f) => `- ${f}`).join("\n")}`,
+    );
+  }
+  if (envelope.context.priorFindings) {
+    parts.push(`\nPrior findings:\n${envelope.context.priorFindings}`);
+  }
+  return parts.join("\n");
+}
+
+function summarizeFinalMessage(final: Anthropic.Message): string {
+  const text = final.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+  // Keep digests short — they feed into escalation envelopes.
+  return text.length > 2000 ? text.slice(0, 2000) + "…" : text;
+}
+
+/**
+ * Map Anthropic SDK errors to router ProbeFailureReason enum. This is where
+ * we convert opaque HTTP errors into the categories the TUI error panels
+ * know how to render.
+ */
+export function classifyAnthropicError(err: unknown): {
+  reason: ProbeFailureReason;
+  message: string;
+} {
+  if (err instanceof Anthropic.APIError) {
+    const status = err.status;
+    const raw = err.message ?? "";
+    if (status === 401) {
+      return {
+        reason: /expired/i.test(raw)
+          ? "expired_credential"
+          : "invalid_credential",
+        message: raw || "Authentication failed.",
+      };
+    }
+    if (status === 403) {
+      if (/model|plan|subscription|entitlement/i.test(raw)) {
+        return { reason: "entitlement_denied", message: raw };
+      }
+      return { reason: "invalid_credential", message: raw };
+    }
+    if (status === 404) {
+      return {
+        reason: "model_not_found",
+        message: raw || "Model not found.",
+      };
+    }
+    if (status === 429) {
+      return { reason: "rate_limited", message: raw || "Rate limited." };
+    }
+    return { reason: "unknown", message: raw || "API error." };
+  }
+  if (
+    err instanceof Error &&
+    /ENOTFOUND|ECONNREFUSED|ETIMEDOUT|network/i.test(err.message)
+  ) {
+    return { reason: "network_error", message: err.message };
+  }
+  return {
+    reason: "unknown",
+    message: err instanceof Error ? err.message : String(err),
+  };
+}
+
+// Self-register.
+registerProvider("anthropic-api", (opts) => new AnthropicApiProvider(opts));

--- a/tools/router/src/providers/anthropic-api.ts
+++ b/tools/router/src/providers/anthropic-api.ts
@@ -138,7 +138,7 @@ export class AnthropicApiProvider implements Provider {
     request: DispatchRequest,
     credential: Credential,
   ): Promise<void> {
-    const { envelope, signal, onEvent } = request;
+    const { envelope, signal, onEvent, tools, executeTool } = request;
     const client = new Anthropic({
       apiKey: credential.secret,
       baseURL: this.baseURL,
@@ -146,58 +146,155 @@ export class AnthropicApiProvider implements Provider {
 
     onEvent({ type: "worker_start", model: envelope.triage.model });
 
-    const systemPrompt = buildSystemPrompt(envelope);
-    const userMessage = buildUserMessage(envelope);
+    const systemPrompt = buildSystemPrompt(envelope, Boolean(tools?.length));
+    const anthropicTools: Anthropic.Tool[] | undefined = tools?.length
+      ? tools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+        }))
+      : undefined;
+
+    const messages: Anthropic.MessageParam[] = [
+      { role: "user", content: buildUserMessage(envelope) },
+    ];
+
+    const maxIterations = 20; // hard cap on tool-use rounds per worker
+    let finalText = "";
 
     try {
-      const stream = client.messages.stream({
-        model: envelope.triage.model,
-        max_tokens: envelope.budget.maxTokens ?? 4096,
-        system: systemPrompt,
-        messages: [{ role: "user", content: userMessage }],
-      });
-
-      for await (const event of stream) {
+      for (let iter = 0; iter < maxIterations; iter++) {
         if (signal.aborted) {
-          stream.controller.abort();
-          break;
+          onEvent({
+            type: "worker_done",
+            digest: finalText || "aborted",
+            status: "failure",
+          });
+          return;
         }
-        if (
-          event.type === "content_block_delta" &&
-          event.delta.type === "text_delta"
-        ) {
-          onEvent({ type: "assistant_text", text: event.delta.text });
-        }
-      }
 
-      const final = await stream.finalMessage();
-      if (final.usage) {
-        onEvent({
-          type: "token_usage",
-          inputTokens: final.usage.input_tokens,
-          outputTokens: final.usage.output_tokens,
+        const stream = client.messages.stream({
+          model: envelope.triage.model,
+          max_tokens: envelope.budget.maxTokens ?? 4096,
+          system: systemPrompt,
+          messages,
+          ...(anthropicTools ? { tools: anthropicTools } : {}),
         });
+
+        // Stream assistant text to the TUI as it arrives.
+        for await (const event of stream) {
+          if (signal.aborted) {
+            stream.controller.abort();
+            break;
+          }
+          if (
+            event.type === "content_block_delta" &&
+            event.delta.type === "text_delta"
+          ) {
+            onEvent({ type: "assistant_text", text: event.delta.text });
+          }
+        }
+
+        const final = await stream.finalMessage();
+        if (final.usage) {
+          onEvent({
+            type: "token_usage",
+            inputTokens: final.usage.input_tokens,
+            outputTokens: final.usage.output_tokens,
+          });
+        }
+
+        // Accumulate text output for the final digest.
+        finalText += final.content
+          .filter((b): b is Anthropic.TextBlock => b.type === "text")
+          .map((b) => b.text)
+          .join("\n");
+
+        // Append the assistant turn to the running conversation.
+        messages.push({ role: "assistant", content: final.content });
+
+        const toolUses = final.content.filter(
+          (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+        );
+
+        if (final.stop_reason !== "tool_use" || toolUses.length === 0) {
+          // Natural stop — the worker is done.
+          onEvent({
+            type: "worker_done",
+            digest: finalText.slice(0, 2000),
+            status: "success",
+          });
+          return;
+        }
+
+        if (!executeTool) {
+          // Model asked for tools but the dispatcher didn't provide a handler.
+          onEvent({
+            type: "worker_done",
+            digest: "Model requested tools but no executor was provided.",
+            status: "failure",
+          });
+          return;
+        }
+
+        // Execute every tool_use block in this turn and feed the results
+        // back as a single user message.
+        const toolResults: Anthropic.ToolResultBlockParam[] = [];
+        for (const use of toolUses) {
+          onEvent({ type: "tool_call", name: use.name, input: use.input });
+          let result;
+          try {
+            result = await executeTool(use.name, use.input);
+          } catch (err) {
+            result = {
+              isError: true,
+              content:
+                err instanceof Error ? err.message : String(err),
+            };
+          }
+          onEvent({
+            type: "tool_result",
+            name: use.name,
+            ok: !result.isError,
+          });
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: use.id,
+            content: result.content,
+            is_error: result.isError,
+          });
+        }
+        messages.push({ role: "user", content: toolResults });
       }
 
-      const digest = summarizeFinalMessage(final);
-      onEvent({ type: "worker_done", digest, status: "success" });
+      // Fell off the iteration cap without a natural stop.
+      onEvent({
+        type: "worker_done",
+        digest:
+          finalText.slice(0, 2000) + "\n\n[stopped: max tool iterations]",
+        status: "failure",
+      });
     } catch (err) {
       if (signal.aborted) {
         onEvent({
           type: "worker_done",
-          digest: "aborted",
+          digest: finalText || "aborted",
           status: "failure",
         });
         return;
       }
       const { reason, message } = classifyAnthropicError(err);
-      throw new AuthError(message, reason);
+      throw new AuthError(message, reason, {
+        provider: this.id,
+        model: envelope.triage.model,
+      });
     }
   }
 }
 
 function buildSystemPrompt(
   envelope: DispatchRequest["envelope"],
+  hasTools: boolean,
 ): string {
   const parts = [
     "You are a router-dispatched worker agent.",
@@ -207,9 +304,14 @@ function buildSystemPrompt(
   if (envelope.context.constraints.length > 0) {
     parts.push(`Constraints: ${envelope.context.constraints.join(", ")}`);
   }
+  if (hasTools) {
+    parts.push(
+      "You have access to tools for reading files, writing files, listing directories, and running shell commands. Use them to explore the workspace and make changes as needed.",
+    );
+  }
   if (envelope.budget.escalationAllowed) {
     parts.push(
-      "If this task is larger or more ambiguous than it appears, respond with the literal token [ESCALATE: <reason>] followed by a one-paragraph digest of what you tried and where you got stuck. Do not retry blindly.",
+      "If this task is larger or more ambiguous than it appears, call the request_escalation tool with a reason and a one-paragraph digest of what you tried and where you got stuck. Do not retry blindly.",
     );
   }
   if (envelope.escalation) {
@@ -231,15 +333,6 @@ function buildUserMessage(envelope: DispatchRequest["envelope"]): string {
     parts.push(`\nPrior findings:\n${envelope.context.priorFindings}`);
   }
   return parts.join("\n");
-}
-
-function summarizeFinalMessage(final: Anthropic.Message): string {
-  const text = final.content
-    .filter((b): b is Anthropic.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("\n");
-  // Keep digests short — they feed into escalation envelopes.
-  return text.length > 2000 ? text.slice(0, 2000) + "…" : text;
 }
 
 /**

--- a/tools/router/src/providers/bedrock.ts
+++ b/tools/router/src/providers/bedrock.ts
@@ -1,0 +1,234 @@
+import { AnthropicBedrock } from "@anthropic-ai/bedrock-sdk";
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+  AuthError,
+  type AuthContext,
+  type AuthEvent,
+  type Credential,
+  type DispatchRequest,
+  type ProbeResult,
+  type Provider,
+} from "../types.js";
+import { classifyAnthropicError } from "./anthropic-api.js";
+import { registerProvider } from "./registry.js";
+
+interface BedrockOptions {
+  id: string;
+  region?: string;
+  options?: Record<string, unknown>;
+}
+
+/**
+ * AWS Bedrock provider. Uses the AWS default credential chain (env vars,
+ * shared config, SSO, EC2/ECS role) via the official bedrock SDK, so there's
+ * no explicit router-owned credential to store. We still produce a sentinel
+ * Credential so the CredentialStore round-trip works uniformly.
+ *
+ * "Authentication" for this provider is effectively delegated to `aws`
+ * tooling — `aws sso login` or `aws configure` before using router. The
+ * login() flow just verifies the chain resolves.
+ */
+export class BedrockProvider implements Provider {
+  readonly id: string;
+  readonly displayName = "AWS Bedrock";
+  readonly authStrategy = "cloud-sdk" as const;
+  private readonly region: string;
+
+  constructor(opts: BedrockOptions) {
+    this.id = opts.id;
+    this.region = opts.region ?? process.env.AWS_REGION ?? "us-east-1";
+  }
+
+  async *login(_ctx: AuthContext): AsyncIterable<AuthEvent> {
+    yield {
+      type: "instruction",
+      message:
+        "Bedrock uses the AWS credential chain. Run `aws sso login` or `aws configure` in your shell first, then press enter to verify.",
+    };
+
+    // Probe with a minimal request to confirm credentials + region work.
+    try {
+      const client = new AnthropicBedrock({ awsRegion: this.region });
+      await client.messages.create({
+        model: "anthropic.claude-haiku-4-5-v1:0",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+    } catch (err) {
+      yield {
+        type: "error",
+        message: `Bedrock credential chain did not resolve: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        recoverable: true,
+      };
+      return;
+    }
+
+    yield {
+      type: "success",
+      credential: {
+        providerId: this.id,
+        kind: "cloud-sdk",
+        secret: "<bedrock-delegated>",
+        metadata: { region: this.region },
+      },
+    };
+  }
+
+  async probe(model: string, _credential: Credential): Promise<ProbeResult> {
+    try {
+      const client = new AnthropicBedrock({ awsRegion: this.region });
+      await client.messages.create({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+      return { ok: true, checkedAt: Date.now() };
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      return { ok: false, reason, message, checkedAt: Date.now() };
+    }
+  }
+
+  async dispatch(
+    request: DispatchRequest,
+    _credential: Credential,
+  ): Promise<void> {
+    const { envelope, signal, onEvent, tools, executeTool } = request;
+    const client = new AnthropicBedrock({ awsRegion: this.region });
+    await runMessagesLoop(
+      client as unknown as Anthropic,
+      envelope,
+      signal,
+      onEvent,
+      tools,
+      executeTool,
+      this.id,
+    );
+  }
+}
+
+/**
+ * Shared messages-API tool loop used by the bedrock and vertex providers.
+ * Factored out so both SDKs share the same control flow as anthropic-api.ts
+ * without depending on that file's internals.
+ */
+export async function runMessagesLoop(
+  client: Anthropic,
+  envelope: DispatchRequest["envelope"],
+  signal: AbortSignal,
+  onEvent: DispatchRequest["onEvent"],
+  tools: DispatchRequest["tools"],
+  executeTool: DispatchRequest["executeTool"],
+  providerId: string,
+): Promise<void> {
+  onEvent({ type: "worker_start", model: envelope.triage.model });
+
+  const anthropicTools: Anthropic.Tool[] | undefined = tools?.length
+    ? tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+      }))
+    : undefined;
+
+  const messages: Anthropic.MessageParam[] = [
+    { role: "user", content: envelope.originalPrompt },
+  ];
+  const maxIterations = 20;
+  let finalText = "";
+
+  try {
+    for (let iter = 0; iter < maxIterations; iter++) {
+      if (signal.aborted) {
+        onEvent({
+          type: "worker_done",
+          digest: finalText || "aborted",
+          status: "failure",
+        });
+        return;
+      }
+      const final = await client.messages.create({
+        model: envelope.triage.model,
+        max_tokens: envelope.budget.maxTokens ?? 4096,
+        messages,
+        ...(anthropicTools ? { tools: anthropicTools } : {}),
+      });
+      if (final.usage) {
+        onEvent({
+          type: "token_usage",
+          inputTokens: final.usage.input_tokens,
+          outputTokens: final.usage.output_tokens,
+        });
+      }
+      const textChunk = final.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      if (textChunk) {
+        onEvent({ type: "assistant_text", text: textChunk });
+      }
+      finalText += textChunk;
+      messages.push({ role: "assistant", content: final.content });
+
+      const toolUses = final.content.filter(
+        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+      );
+      if (final.stop_reason !== "tool_use" || toolUses.length === 0) {
+        onEvent({
+          type: "worker_done",
+          digest: finalText.slice(0, 2000),
+          status: "success",
+        });
+        return;
+      }
+      if (!executeTool) {
+        onEvent({
+          type: "worker_done",
+          digest: "No tool executor available.",
+          status: "failure",
+        });
+        return;
+      }
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      for (const use of toolUses) {
+        onEvent({ type: "tool_call", name: use.name, input: use.input });
+        let result;
+        try {
+          result = await executeTool(use.name, use.input);
+        } catch (err) {
+          result = {
+            isError: true,
+            content: err instanceof Error ? err.message : String(err),
+          };
+        }
+        onEvent({ type: "tool_result", name: use.name, ok: !result.isError });
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: use.id,
+          content: result.content,
+          is_error: result.isError,
+        });
+      }
+      messages.push({ role: "user", content: toolResults });
+    }
+    onEvent({
+      type: "worker_done",
+      digest: finalText.slice(0, 2000) + "\n\n[stopped: max tool iterations]",
+      status: "failure",
+    });
+  } catch (err) {
+    if (signal.aborted) {
+      onEvent({ type: "worker_done", digest: finalText || "aborted", status: "failure" });
+      return;
+    }
+    const { reason, message } = classifyAnthropicError(err);
+    throw new AuthError(message, reason, {
+      provider: providerId,
+      model: envelope.triage.model,
+    });
+  }
+}
+
+registerProvider("bedrock", (opts) => new BedrockProvider(opts));

--- a/tools/router/src/providers/index.ts
+++ b/tools/router/src/providers/index.ts
@@ -9,5 +9,7 @@
  */
 import "./anthropic-api.js";
 import "./oauth-device.js";
+import "./bedrock.js";
+import "./vertex.js";
 
 export { getProviderFactory, listProviderKinds } from "./registry.js";

--- a/tools/router/src/providers/index.ts
+++ b/tools/router/src/providers/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Barrel file that imports every built-in provider for their side effects
+ * (self-registration). Import this once from the CLI entrypoint to populate
+ * the plugin registry before config is loaded.
+ *
+ * To add a new built-in, create a file under src/providers/ that calls
+ * `registerProvider(kind, factory)` at module top level, then add the import
+ * here.
+ */
+import "./anthropic-api.js";
+import "./oauth-device.js";
+
+export { getProviderFactory, listProviderKinds } from "./registry.js";

--- a/tools/router/src/providers/oauth-device-flow.ts
+++ b/tools/router/src/providers/oauth-device-flow.ts
@@ -1,0 +1,211 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import type { AuthEvent } from "../types.js";
+
+/**
+ * Reusable RFC 8628 OAuth 2.0 Device Authorization Grant implementation.
+ *
+ * Any provider that speaks device flow (GitHub, Google, Auth0, custom) can
+ * invoke `runDeviceFlow()` with its endpoint URLs + client id and get back
+ * an async iterator of AuthEvents that the TUI knows how to render.
+ *
+ * This file has no provider-specific logic — it's pure protocol. The calling
+ * provider is responsible for translating the final access token into a
+ * Credential object with the right providerId and metadata.
+ */
+
+export interface DeviceFlowConfig {
+  /** Device authorization endpoint (where we request a device_code). */
+  deviceAuthorizationUrl: string;
+  /** Token endpoint (where we poll for the access token). */
+  tokenUrl: string;
+  /** OAuth client id registered with the identity provider. */
+  clientId: string;
+  /** Space-separated OAuth scopes. */
+  scope?: string;
+  /** Audience parameter (Auth0-style). */
+  audience?: string;
+  /** Abort signal from the TUI (user pressed Esc). */
+  signal: AbortSignal;
+}
+
+export interface DeviceFlowResult {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  tokenType?: string;
+  scope?: string;
+}
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * Stream AuthEvents through a complete device flow. Terminal events are
+ * `success` (with the final token inside the emitted event payload) or
+ * `error`. The caller is expected to consume the stream with for-await.
+ */
+export async function* runDeviceFlow(
+  config: DeviceFlowConfig,
+): AsyncGenerator<
+  AuthEvent | { type: "device_flow_result"; result: DeviceFlowResult }
+> {
+  // Step 1: request device code
+  let deviceCode: DeviceCodeResponse;
+  try {
+    const res = await fetch(config.deviceAuthorizationUrl, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: config.clientId,
+        ...(config.scope ? { scope: config.scope } : {}),
+        ...(config.audience ? { audience: config.audience } : {}),
+      }).toString(),
+      signal: config.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      yield {
+        type: "error",
+        message: `Device authorization request failed (${res.status}): ${body.slice(0, 200)}`,
+        recoverable: false,
+      };
+      return;
+    }
+    deviceCode = (await res.json()) as DeviceCodeResponse;
+  } catch (err) {
+    yield {
+      type: "error",
+      message: `Could not reach device authorization endpoint: ${(err as Error).message}`,
+      recoverable: true,
+    };
+    return;
+  }
+
+  const expiresAt = Date.now() + deviceCode.expires_in * 1000;
+
+  yield {
+    type: "device_code",
+    userCode: deviceCode.user_code,
+    verificationUri: deviceCode.verification_uri,
+    verificationUriComplete: deviceCode.verification_uri_complete,
+    expiresAt,
+  };
+
+  // Step 2: poll token endpoint at the server-suggested interval.
+  let intervalMs = (deviceCode.interval ?? 5) * 1000;
+  while (Date.now() < expiresAt) {
+    if (config.signal.aborted) {
+      yield {
+        type: "error",
+        message: "Cancelled by user.",
+        recoverable: true,
+      };
+      return;
+    }
+
+    yield { type: "polling", waitMs: intervalMs };
+    try {
+      await sleep(intervalMs, undefined, { signal: config.signal });
+    } catch {
+      yield {
+        type: "error",
+        message: "Cancelled by user.",
+        recoverable: true,
+      };
+      return;
+    }
+
+    let token: TokenResponse;
+    try {
+      const res = await fetch(config.tokenUrl, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code: deviceCode.device_code,
+          client_id: config.clientId,
+        }).toString(),
+        signal: config.signal,
+      });
+      token = (await res.json()) as TokenResponse;
+    } catch (err) {
+      yield {
+        type: "error",
+        message: `Token polling failed: ${(err as Error).message}`,
+        recoverable: true,
+      };
+      return;
+    }
+
+    if (token.access_token) {
+      const result: DeviceFlowResult = {
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token,
+        expiresAt: token.expires_in
+          ? Date.now() + token.expires_in * 1000
+          : undefined,
+        tokenType: token.token_type,
+        scope: token.scope,
+      };
+      yield { type: "device_flow_result", result };
+      return;
+    }
+
+    // RFC 8628 standard polling error codes
+    switch (token.error) {
+      case "authorization_pending":
+        // Keep polling silently.
+        break;
+      case "slow_down":
+        intervalMs += 5000;
+        break;
+      case "expired_token":
+        yield {
+          type: "error",
+          message: "Device code expired before approval.",
+          recoverable: true,
+        };
+        return;
+      case "access_denied":
+        yield {
+          type: "error",
+          message: "Authorization was denied.",
+          recoverable: false,
+        };
+        return;
+      default:
+        if (token.error) {
+          yield {
+            type: "error",
+            message: `OAuth error: ${token.error}${
+              token.error_description ? ` — ${token.error_description}` : ""
+            }`,
+            recoverable: false,
+          };
+          return;
+        }
+    }
+  }
+
+  yield {
+    type: "error",
+    message: "Device code expired before approval.",
+    recoverable: true,
+  };
+}

--- a/tools/router/src/providers/oauth-device.ts
+++ b/tools/router/src/providers/oauth-device.ts
@@ -1,0 +1,234 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  type AuthContext,
+  type AuthEvent,
+  type Credential,
+  type DispatchRequest,
+  type ProbeResult,
+  type Provider,
+  AuthError,
+} from "../types.js";
+import { runDeviceFlow } from "./oauth-device-flow.js";
+import { classifyAnthropicError } from "./anthropic-api.js";
+import { registerProvider } from "./registry.js";
+
+interface OAuthDeviceProviderOptions {
+  id: string;
+  baseURL?: string;
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Generic OAuth 2.0 device-flow provider. Configured via `options` in
+ * router.config.ts:
+ *
+ *   providers: {
+ *     claude: {
+ *       kind: "oauth-device",
+ *       options: {
+ *         deviceAuthorizationUrl: "https://...",
+ *         tokenUrl: "https://...",
+ *         clientId: "...",
+ *         scope: "messages:read messages:write",
+ *         apiBaseURL: "https://api.anthropic.com",
+ *       },
+ *     },
+ *   }
+ *
+ * The resulting credential is a bearer token. Dispatch/probe calls use it
+ * as an Authorization header against the provider's API. This is deliberately
+ * a thin wrapper — the device flow itself lives in oauth-device-flow.ts so
+ * any future OAuth provider can reuse it.
+ */
+export class OAuthDeviceProvider implements Provider {
+  readonly id: string;
+  readonly displayName: string;
+  readonly authStrategy = "oauth-device" as const;
+
+  private readonly deviceAuthorizationUrl: string;
+  private readonly tokenUrl: string;
+  private readonly clientId: string;
+  private readonly scope?: string;
+  private readonly audience?: string;
+  private readonly apiBaseURL: string;
+
+  constructor(opts: OAuthDeviceProviderOptions) {
+    this.id = opts.id;
+    const options = opts.options ?? {};
+    this.deviceAuthorizationUrl = required(
+      options.deviceAuthorizationUrl,
+      "deviceAuthorizationUrl",
+    );
+    this.tokenUrl = required(options.tokenUrl, "tokenUrl");
+    this.clientId = required(options.clientId, "clientId");
+    this.scope = options.scope as string | undefined;
+    this.audience = options.audience as string | undefined;
+    this.apiBaseURL =
+      (options.apiBaseURL as string | undefined) ??
+      opts.baseURL ??
+      "https://api.anthropic.com";
+    this.displayName =
+      (options.displayName as string | undefined) ?? `${opts.id} (OAuth)`;
+  }
+
+  async *login(ctx: AuthContext): AsyncIterable<AuthEvent> {
+    yield {
+      type: "instruction",
+      message: `Starting device authorization for ${this.displayName}. Follow the instructions below.`,
+    };
+
+    const flow = runDeviceFlow({
+      deviceAuthorizationUrl: this.deviceAuthorizationUrl,
+      tokenUrl: this.tokenUrl,
+      clientId: this.clientId,
+      scope: this.scope,
+      audience: this.audience,
+      signal: ctx.signal,
+    });
+
+    for await (const event of flow) {
+      if (event.type === "device_flow_result") {
+        const credential: Credential = {
+          providerId: this.id,
+          kind: "oauth-device",
+          secret: event.result.accessToken,
+          refreshToken: event.result.refreshToken,
+          expiresAt: event.result.expiresAt,
+          metadata: {
+            tokenType: event.result.tokenType ?? "Bearer",
+            scope: event.result.scope,
+          },
+        };
+        yield { type: "success", credential };
+        return;
+      }
+      yield event;
+    }
+  }
+
+  async refresh(credential: Credential): Promise<Credential> {
+    if (!credential.refreshToken) {
+      throw new AuthError(
+        "No refresh token available; re-login required.",
+        "expired_credential",
+      );
+    }
+    const res = await fetch(this.tokenUrl, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: credential.refreshToken,
+        client_id: this.clientId,
+      }).toString(),
+    });
+    if (!res.ok) {
+      throw new AuthError(
+        `Refresh failed (${res.status}): ${await res.text()}`,
+        "expired_credential",
+      );
+    }
+    const body = (await res.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+      token_type?: string;
+    };
+    return {
+      ...credential,
+      secret: body.access_token,
+      refreshToken: body.refresh_token ?? credential.refreshToken,
+      expiresAt: body.expires_in
+        ? Date.now() + body.expires_in * 1000
+        : undefined,
+    };
+  }
+
+  async probe(model: string, credential: Credential): Promise<ProbeResult> {
+    // Treat the bearer token as a drop-in for an API key against the
+    // Anthropic-compatible endpoint. Providers that speak a different API
+    // shape should subclass and override probe/dispatch.
+    const client = new Anthropic({
+      apiKey: credential.secret,
+      baseURL: this.apiBaseURL,
+      authToken: credential.secret,
+    });
+    try {
+      await client.messages.create({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+      return { ok: true, checkedAt: Date.now() };
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      return { ok: false, reason, message, checkedAt: Date.now() };
+    }
+  }
+
+  async dispatch(
+    request: DispatchRequest,
+    credential: Credential,
+  ): Promise<void> {
+    // Same messages-API pattern as anthropic-api; the only difference is
+    // how we authenticate. Reuse the anthropic client with the bearer token.
+    const { envelope, signal, onEvent } = request;
+    const client = new Anthropic({
+      apiKey: credential.secret,
+      baseURL: this.apiBaseURL,
+      authToken: credential.secret,
+    });
+
+    onEvent({ type: "worker_start", model: envelope.triage.model });
+    try {
+      const stream = client.messages.stream({
+        model: envelope.triage.model,
+        max_tokens: envelope.budget.maxTokens ?? 4096,
+        messages: [{ role: "user", content: envelope.originalPrompt }],
+      });
+      for await (const event of stream) {
+        if (signal.aborted) {
+          stream.controller.abort();
+          break;
+        }
+        if (
+          event.type === "content_block_delta" &&
+          event.delta.type === "text_delta"
+        ) {
+          onEvent({ type: "assistant_text", text: event.delta.text });
+        }
+      }
+      const final = await stream.finalMessage();
+      if (final.usage) {
+        onEvent({
+          type: "token_usage",
+          inputTokens: final.usage.input_tokens,
+          outputTokens: final.usage.output_tokens,
+        });
+      }
+      const text = final.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      onEvent({
+        type: "worker_done",
+        digest: text.slice(0, 2000),
+        status: "success",
+      });
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      throw new AuthError(message, reason);
+    }
+  }
+}
+
+function required(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `oauth-device provider requires options.${name} to be a non-empty string.`,
+    );
+  }
+  return value;
+}
+
+registerProvider("oauth-device", (opts) => new OAuthDeviceProvider(opts));

--- a/tools/router/src/providers/registry.ts
+++ b/tools/router/src/providers/registry.ts
@@ -1,0 +1,54 @@
+import type { Provider } from "../types.js";
+import { RouterError } from "../types.js";
+
+/**
+ * Plugin registry for providers. Built-in providers register themselves at
+ * module load; third-party providers can register via `registerProvider()`
+ * from a config hook (or a dedicated `plugins: [...]` entry once we add it).
+ *
+ * Kind vs id
+ * ----------
+ * `kind` identifies the plugin implementation ("anthropic-api", "bedrock").
+ * `id` is the user-facing name in config.providers (e.g. "work", "claude").
+ * A config may have multiple providers with the same kind but different ids
+ * (e.g. two anthropic-api providers pointing at different gateways).
+ */
+export type ProviderFactory = (options: {
+  id: string;
+  baseURL?: string;
+  region?: string;
+  options?: Record<string, unknown>;
+}) => Provider;
+
+const factories = new Map<string, ProviderFactory>();
+
+export function registerProvider(kind: string, factory: ProviderFactory): void {
+  if (factories.has(kind)) {
+    throw new RouterError(
+      `Provider kind "${kind}" is already registered.`,
+      "PROVIDER_DUPLICATE",
+    );
+  }
+  factories.set(kind, factory);
+}
+
+export function getProviderFactory(kind: string): ProviderFactory {
+  const factory = factories.get(kind);
+  if (!factory) {
+    throw new RouterError(
+      `Unknown provider kind "${kind}". Registered kinds: ${[...factories.keys()].join(", ") || "(none)"}`,
+      "PROVIDER_UNKNOWN",
+      { kind },
+    );
+  }
+  return factory;
+}
+
+export function listProviderKinds(): string[] {
+  return [...factories.keys()].sort();
+}
+
+/** Test-only: clear the registry. Not exported from the package index. */
+export function _resetRegistryForTests(): void {
+  factories.clear();
+}

--- a/tools/router/src/providers/resolve.ts
+++ b/tools/router/src/providers/resolve.ts
@@ -1,0 +1,34 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { Provider } from "../types.js";
+import { ConfigError } from "../types.js";
+import { getProviderFactory } from "./registry.js";
+
+/**
+ * Instantiate Provider objects from a validated RouterConfig. Called once at
+ * startup and memoized — provider instances are long-lived for the session.
+ */
+export function resolveProviders(
+  config: RouterConfig,
+): Map<string, Provider> {
+  const providers = new Map<string, Provider>();
+  for (const [id, providerConfig] of Object.entries(config.providers)) {
+    try {
+      const factory = getProviderFactory(providerConfig.kind);
+      const provider = factory({
+        id,
+        baseURL: providerConfig.baseURL,
+        region: providerConfig.region,
+        options: providerConfig.options,
+      });
+      providers.set(id, provider);
+    } catch (err) {
+      throw new ConfigError(
+        `Failed to instantiate provider "${id}" (kind=${providerConfig.kind}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { id, kind: providerConfig.kind },
+      );
+    }
+  }
+  return providers;
+}

--- a/tools/router/src/providers/vertex.ts
+++ b/tools/router/src/providers/vertex.ts
@@ -1,0 +1,129 @@
+import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+  type AuthContext,
+  type AuthEvent,
+  type Credential,
+  type DispatchRequest,
+  type ProbeResult,
+  type Provider,
+} from "../types.js";
+import { classifyAnthropicError } from "./anthropic-api.js";
+import { runMessagesLoop } from "./bedrock.js";
+import { registerProvider } from "./registry.js";
+
+interface VertexOptions {
+  id: string;
+  region?: string;
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Google Cloud Vertex AI provider. Uses Google Application Default
+ * Credentials (ADC) via the vertex SDK. The `projectId` can come from
+ * `GOOGLE_CLOUD_PROJECT` or config options; the `region` defaults to
+ * us-east5 which is where Anthropic models are most broadly available.
+ *
+ * Like the Bedrock provider, there's no stored secret — the SDK picks up
+ * whatever ADC resolves to. The router stores a sentinel credential so the
+ * auth status surface stays uniform.
+ */
+export class VertexProvider implements Provider {
+  readonly id: string;
+  readonly displayName = "Google Vertex AI";
+  readonly authStrategy = "cloud-sdk" as const;
+  private readonly region: string;
+  private readonly projectId?: string;
+
+  constructor(opts: VertexOptions) {
+    this.id = opts.id;
+    this.region = opts.region ?? "us-east5";
+    this.projectId =
+      (opts.options?.projectId as string | undefined) ??
+      process.env.GOOGLE_CLOUD_PROJECT;
+  }
+
+  private createClient(): AnthropicVertex {
+    return new AnthropicVertex({
+      region: this.region,
+      projectId: this.projectId,
+    });
+  }
+
+  async *login(_ctx: AuthContext): AsyncIterable<AuthEvent> {
+    yield {
+      type: "instruction",
+      message:
+        "Vertex uses Google Application Default Credentials. Run `gcloud auth application-default login` and `gcloud config set project <project-id>` before continuing.",
+    };
+    if (!this.projectId) {
+      yield {
+        type: "error",
+        message:
+          "No Google Cloud project id configured. Set GOOGLE_CLOUD_PROJECT or pass options.projectId.",
+        recoverable: true,
+      };
+      return;
+    }
+    try {
+      const client = this.createClient();
+      await client.messages.create({
+        model: "claude-haiku-4-5@20250101",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+    } catch (err) {
+      yield {
+        type: "error",
+        message: `Vertex ADC did not resolve: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        recoverable: true,
+      };
+      return;
+    }
+    yield {
+      type: "success",
+      credential: {
+        providerId: this.id,
+        kind: "cloud-sdk",
+        secret: "<vertex-delegated>",
+        metadata: { region: this.region, projectId: this.projectId },
+      },
+    };
+  }
+
+  async probe(model: string, _credential: Credential): Promise<ProbeResult> {
+    try {
+      const client = this.createClient();
+      await client.messages.create({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "." }],
+      });
+      return { ok: true, checkedAt: Date.now() };
+    } catch (err) {
+      const { reason, message } = classifyAnthropicError(err);
+      return { ok: false, reason, message, checkedAt: Date.now() };
+    }
+  }
+
+  async dispatch(
+    request: DispatchRequest,
+    _credential: Credential,
+  ): Promise<void> {
+    const { envelope, signal, onEvent, tools, executeTool } = request;
+    const client = this.createClient();
+    await runMessagesLoop(
+      client as unknown as Anthropic,
+      envelope,
+      signal,
+      onEvent,
+      tools,
+      executeTool,
+      this.id,
+    );
+  }
+}
+
+registerProvider("vertex", (opts) => new VertexProvider(opts));

--- a/tools/router/src/telemetry/jsonl-logger.ts
+++ b/tools/router/src/telemetry/jsonl-logger.ts
@@ -1,14 +1,36 @@
-import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
+import pino, { type Logger as PinoLogger } from "pino";
 
 /**
- * Simple JSONL logger. One record per line, append-only. Used to capture
- * envelopes, preflight results, escalations, and final outcomes so the
- * rubric can be tuned against historical data later.
+ * JSONL telemetry logger backed by pino. Pino writes structured JSON records
+ * one per line by default, which is exactly what we want for rubric tuning:
+ * append-only, grep-friendly, and easy to ingest later for analysis.
+ *
+ * We wrap pino behind a `.log(record)` method that matches the original
+ * append-file API, so the dispatcher and auth commands don't care which
+ * backend is in use. If pino ever becomes too heavy, swapping back to plain
+ * fs.appendFile is a one-line change inside this file.
  */
 export class JsonlLogger {
-  constructor(private readonly path: string) {
-    mkdirSync(dirname(path), { recursive: true });
+  private readonly logger: PinoLogger;
+  readonly filepath: string;
+
+  constructor(filepath: string) {
+    this.filepath = filepath;
+    mkdirSync(dirname(filepath), { recursive: true });
+    this.logger = pino(
+      {
+        base: null, // don't include pid/hostname fields in every record
+        timestamp: pino.stdTimeFunctions.isoTime,
+      },
+      pino.destination({
+        dest: filepath,
+        sync: false,
+        append: true,
+        mkdir: true,
+      }),
+    );
   }
 
   static default(cwd: string = process.cwd()): JsonlLogger {
@@ -17,20 +39,24 @@ export class JsonlLogger {
   }
 
   log(record: Record<string, unknown>): void {
-    const line =
-      JSON.stringify({ ts: new Date().toISOString(), ...record }) + "\n";
     try {
-      appendFileSync(this.path, line);
+      // Pino requires a message string when called as logger.info(obj, msg),
+      // but logger.info(obj) also works. Use `kind` (if present) as the msg
+      // so the records stay human-scannable when you tail the file.
+      const msg = typeof record.kind === "string" ? record.kind : "event";
+      this.logger.info(record, msg);
     } catch {
-      // Logging is best-effort; never crash the dispatcher on a write failure.
+      // Logging must never crash the dispatcher.
     }
   }
 
-  get filepath(): string {
-    return this.path;
-  }
-
-  exists(): boolean {
-    return existsSync(this.path);
+  /**
+   * Flush pending writes. Call during shutdown to avoid losing the tail of
+   * a busy session. Idempotent and safe to call multiple times.
+   */
+  async flush(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.logger.flush(() => resolve());
+    });
   }
 }

--- a/tools/router/src/telemetry/jsonl-logger.ts
+++ b/tools/router/src/telemetry/jsonl-logger.ts
@@ -1,0 +1,36 @@
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Simple JSONL logger. One record per line, append-only. Used to capture
+ * envelopes, preflight results, escalations, and final outcomes so the
+ * rubric can be tuned against historical data later.
+ */
+export class JsonlLogger {
+  constructor(private readonly path: string) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+
+  static default(cwd: string = process.cwd()): JsonlLogger {
+    const ts = new Date().toISOString().slice(0, 10);
+    return new JsonlLogger(join(cwd, ".router", "logs", `${ts}.jsonl`));
+  }
+
+  log(record: Record<string, unknown>): void {
+    const line =
+      JSON.stringify({ ts: new Date().toISOString(), ...record }) + "\n";
+    try {
+      appendFileSync(this.path, line);
+    } catch {
+      // Logging is best-effort; never crash the dispatcher on a write failure.
+    }
+  }
+
+  get filepath(): string {
+    return this.path;
+  }
+
+  exists(): boolean {
+    return existsSync(this.path);
+  }
+}

--- a/tools/router/src/tools/builtin.ts
+++ b/tools/router/src/tools/builtin.ts
@@ -1,0 +1,278 @@
+import { spawn } from "node:child_process";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { z } from "zod";
+import type { Tool, ToolContext, ToolResult } from "./types.js";
+
+/**
+ * Built-in tools: read_file, write_file, list_files, run_bash, and
+ * request_escalation. These are deliberately minimal — more advanced tools
+ * (Grep, Glob, Edit) can be registered by consumers but aren't the router's
+ * concern.
+ *
+ * All filesystem tools are sandboxed to the dispatcher's cwd: absolute paths
+ * that escape the cwd are rejected, as are traversal attempts (`../`) that
+ * land outside the tree. This is defense-in-depth; the real auth boundary is
+ * still the OS user the router runs as.
+ */
+
+function ensureInside(cwd: string, input: string): string {
+  const resolved = isAbsolute(input) ? resolve(input) : resolve(cwd, input);
+  const rel = relative(cwd, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(
+      `Path "${input}" is outside the router working directory.`,
+    );
+  }
+  return resolved;
+}
+
+const ReadFileInput = z.object({
+  path: z.string().describe("Path to read, relative to the working directory."),
+  maxBytes: z.number().int().positive().optional(),
+});
+
+export const readFileTool: Tool = {
+  name: "read_file",
+  description:
+    "Read a file from the workspace. Returns the file contents as text.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Relative or absolute path." },
+      maxBytes: {
+        type: "number",
+        description:
+          "Optional cap on bytes read; the read is truncated if larger.",
+      },
+    },
+    required: ["path"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = ReadFileInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    try {
+      const abs = ensureInside(ctx.cwd, parsed.data.path);
+      const buf = await readFile(abs);
+      const limit = parsed.data.maxBytes ?? 64 * 1024;
+      const truncated = buf.length > limit;
+      const content = buf.subarray(0, limit).toString("utf8");
+      return {
+        content: truncated
+          ? `${content}\n\n[... truncated ${buf.length - limit} bytes ...]`
+          : content,
+      };
+    } catch (err) {
+      return {
+        isError: true,
+        content: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};
+
+const WriteFileInput = z.object({
+  path: z.string(),
+  content: z.string(),
+});
+
+export const writeFileTool: Tool = {
+  name: "write_file",
+  description:
+    "Write text content to a file in the workspace. Overwrites existing files.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      content: { type: "string" },
+    },
+    required: ["path", "content"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = WriteFileInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    try {
+      const abs = ensureInside(ctx.cwd, parsed.data.path);
+      await writeFile(abs, parsed.data.content, "utf8");
+      return { content: `Wrote ${parsed.data.content.length} bytes to ${parsed.data.path}` };
+    } catch (err) {
+      return {
+        isError: true,
+        content: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};
+
+const ListFilesInput = z.object({
+  path: z.string().optional(),
+  depth: z.number().int().min(1).max(5).optional(),
+});
+
+export const listFilesTool: Tool = {
+  name: "list_files",
+  description:
+    "List files and directories under a path in the workspace, up to a limited depth.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Directory to list (default: cwd)." },
+      depth: { type: "number", description: "Traversal depth (default 1, max 5)." },
+    },
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = ListFilesInput.safeParse(input ?? {});
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    const start = ensureInside(ctx.cwd, parsed.data.path ?? ".");
+    const depth = parsed.data.depth ?? 1;
+    const lines: string[] = [];
+    const walk = async (dir: string, level: number): Promise<void> => {
+      if (level > depth) return;
+      if (ctx.signal.aborted) return;
+      let entries;
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch (err) {
+        lines.push(`[error] ${dir}: ${(err as Error).message}`);
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.name.startsWith(".")) continue;
+        if (entry.name === "node_modules") continue;
+        const full = join(dir, entry.name);
+        const rel = relative(ctx.cwd, full) || ".";
+        lines.push(entry.isDirectory() ? `${rel}/` : rel);
+        if (entry.isDirectory()) await walk(full, level + 1);
+      }
+    };
+    try {
+      const s = await stat(start);
+      if (!s.isDirectory()) {
+        return { isError: true, content: `${parsed.data.path ?? "."} is not a directory` };
+      }
+      await walk(start, 1);
+      return { content: lines.join("\n") || "(empty)" };
+    } catch (err) {
+      return {
+        isError: true,
+        content: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};
+
+const RunBashInput = z.object({
+  command: z.string(),
+  timeoutMs: z.number().int().positive().max(120_000).optional(),
+});
+
+export const runBashTool: Tool = {
+  name: "run_bash",
+  description:
+    "Run a shell command in the workspace. Returns combined stdout+stderr. Capped at 120s.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      command: { type: "string" },
+      timeoutMs: { type: "number" },
+    },
+    required: ["command"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = RunBashInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    const timeout = parsed.data.timeoutMs ?? 30_000;
+
+    return await new Promise<ToolResult>((resolve) => {
+      const child = spawn("bash", ["-lc", parsed.data.command], {
+        cwd: ctx.cwd,
+        signal: ctx.signal,
+      });
+      let out = "";
+      let err = "";
+      const timer = setTimeout(() => child.kill("SIGKILL"), timeout);
+      child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
+      child.stderr?.on("data", (d: Buffer) => (err += d.toString()));
+      child.on("error", (e) => {
+        clearTimeout(timer);
+        resolve({ isError: true, content: e.message });
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        const combined =
+          (out ? out : "") + (err ? (out ? "\n" : "") + err : "");
+        resolve({
+          isError: code !== 0,
+          content:
+            combined.length > 32_768
+              ? combined.slice(0, 32_768) + "\n[... truncated ...]"
+              : combined || `(exit ${code})`,
+        });
+      });
+    });
+  },
+};
+
+const RequestEscalationInput = z.object({
+  reason: z.enum([
+    "self_doubt",
+    "ambiguity",
+    "validation_failed",
+    "user_requested",
+  ]),
+  digest: z.string().min(1),
+});
+
+export const requestEscalationTool: Tool = {
+  name: "request_escalation",
+  description:
+    "Signal that this task is larger or more ambiguous than triage realized. Provide a one-paragraph digest of what you tried so the next-tier worker can continue from where you stopped. Do not retry the task after calling this.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      reason: {
+        type: "string",
+        enum: ["self_doubt", "ambiguity", "validation_failed", "user_requested"],
+      },
+      digest: {
+        type: "string",
+        description: "Summary of prior attempt for the next-tier worker.",
+      },
+    },
+    required: ["reason", "digest"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = RequestEscalationInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    if (ctx.requestEscalation) {
+      ctx.requestEscalation(parsed.data.reason, parsed.data.digest);
+    }
+    return {
+      content:
+        "Escalation requested. Stop working on this task and wait for the next-tier worker to take over.",
+    };
+  },
+};
+
+export const BUILTIN_TOOLS: Tool[] = [
+  readFileTool,
+  writeFileTool,
+  listFilesTool,
+  runBashTool,
+  requestEscalationTool,
+];

--- a/tools/router/src/tools/builtin.ts
+++ b/tools/router/src/tools/builtin.ts
@@ -269,10 +269,141 @@ export const requestEscalationTool: Tool = {
   },
 };
 
+const ConsultExpertInput = z.object({
+  question: z
+    .string()
+    .min(1)
+    .describe(
+      "A self-contained question for the expert. Include all context the expert needs since it has no access to your conversation history.",
+    ),
+  tier: z
+    .string()
+    .optional()
+    .describe(
+      "Optional tier name. Defaults to one tier above the current worker.",
+    ),
+});
+
+export const consultExpertTool: Tool = {
+  name: "consult_expert",
+  description:
+    "Borrow expertise from a higher-tier model for one focused question. Use this BEFORE making any architectural, naming, or refactoring decision you're not confident about. The expert has NO access to your conversation history, your tools, or the workspace — your question must be entirely self-contained, including code snippets and constraints. Returns a one-paragraph answer. Cheap to call sparingly, expensive to call constantly.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        description:
+          "Self-contained question. Include code snippets, constraints, and what you've already considered.",
+      },
+      tier: {
+        type: "string",
+        description:
+          "Optional tier name. Defaults to one tier above current.",
+      },
+    },
+    required: ["question"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = ConsultExpertInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    if (!ctx.consultExpert) {
+      return {
+        isError: true,
+        content:
+          "Expert consultation is not available in this dispatcher (no consultExpert callback wired).",
+      };
+    }
+    try {
+      const { digest, cost } = await ctx.consultExpert(
+        parsed.data.question,
+        parsed.data.tier,
+      );
+      return {
+        content: `[expert response, $${cost.toFixed(4)}]:\n${digest}`,
+      };
+    } catch (err) {
+      return {
+        isError: true,
+        content: `Consultation failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+};
+
+const DelegateSubtaskInput = z.object({
+  prompt: z
+    .string()
+    .min(1)
+    .describe("Self-contained sub-task prompt for an autonomous worker."),
+  tier: z
+    .string()
+    .optional()
+    .describe(
+      "Optional tier name. Defaults to one tier below the current worker.",
+    ),
+});
+
+export const delegateSubtaskTool: Tool = {
+  name: "delegate_subtask",
+  description:
+    "Spawn an autonomous sub-worker to handle a focused sub-task. Use this from a planner role: split your work into independent steps and delegate each to a cheaper executor. The sub-worker has its own tool loop and can read/write files independently. Your prompt must be entirely self-contained (filenames, constraints, expected output). Returns the sub-worker's final digest.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      prompt: {
+        type: "string",
+        description:
+          "Self-contained sub-task. Specify filenames, constraints, and expected output format.",
+      },
+      tier: {
+        type: "string",
+        description:
+          "Optional tier name. Defaults to one tier below current.",
+      },
+    },
+    required: ["prompt"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx): Promise<ToolResult> {
+    const parsed = DelegateSubtaskInput.safeParse(input);
+    if (!parsed.success) {
+      return { isError: true, content: `Invalid input: ${parsed.error.message}` };
+    }
+    if (!ctx.delegateSubtask) {
+      return {
+        isError: true,
+        content:
+          "Subtask delegation is not available in this dispatcher (no delegateSubtask callback wired).",
+      };
+    }
+    try {
+      const { digest, status, cost } = await ctx.delegateSubtask(
+        parsed.data.prompt,
+        parsed.data.tier,
+      );
+      return {
+        content: `[subtask ${status}, $${cost.toFixed(4)}]:\n${digest}`,
+        isError: status === "failure",
+      };
+    } catch (err) {
+      return {
+        isError: true,
+        content: `Delegation failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  },
+};
+
 export const BUILTIN_TOOLS: Tool[] = [
   readFileTool,
   writeFileTool,
   listFilesTool,
   runBashTool,
   requestEscalationTool,
+  consultExpertTool,
+  delegateSubtaskTool,
 ];

--- a/tools/router/src/tools/index.ts
+++ b/tools/router/src/tools/index.ts
@@ -1,0 +1,17 @@
+import { BUILTIN_TOOLS } from "./builtin.js";
+import { ToolRegistry } from "./types.js";
+
+/**
+ * Construct a default tool registry with all built-in tools registered.
+ * Consumers can clone via `.snapshot()` and add their own tools on top
+ * without mutating the default.
+ */
+export function createDefaultRegistry(): ToolRegistry {
+  const registry = new ToolRegistry();
+  for (const tool of BUILTIN_TOOLS) registry.register(tool);
+  return registry;
+}
+
+export { ToolRegistry } from "./types.js";
+export type { Tool, ToolContext, ToolResult, JsonSchema } from "./types.js";
+export { BUILTIN_TOOLS } from "./builtin.js";

--- a/tools/router/src/tools/types.ts
+++ b/tools/router/src/tools/types.ts
@@ -29,6 +29,27 @@ export interface ToolContext {
   config: RouterConfig;
   /** Called by tools that want to signal escalation to the controller. */
   requestEscalation?: (reason: EscalationReason, digest: string) => void;
+  /**
+   * Synchronous expert consultation. Spawns a one-shot child envelope at the
+   * requested tier (or the next tier up if unspecified), runs it as a pure
+   * Q&A worker with NO tools, and returns the digest. The cost rolls into
+   * the parent task's budget. This is the "expensive consultant" pattern:
+   * cheap shell stays in control, expensive model is borrowed surgically.
+   */
+  consultExpert?: (
+    question: string,
+    tier?: string,
+  ) => Promise<{ digest: string; cost: number }>;
+  /**
+   * Spawn a child sub-task envelope. The child runs as a full worker with
+   * its own tool loop and can escalate independently. Used by planners that
+   * want to parcel out independent sub-tasks to cheaper executors. The cost
+   * rolls into the parent task's budget.
+   */
+  delegateSubtask?: (
+    prompt: string,
+    tier?: string,
+  ) => Promise<{ digest: string; status: "success" | "failure"; cost: number }>;
 }
 
 export interface ToolResult {

--- a/tools/router/src/tools/types.ts
+++ b/tools/router/src/tools/types.ts
@@ -1,0 +1,77 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { EscalationReason } from "../types.js";
+
+/**
+ * Tool system used by worker dispatchers. A Tool is a self-describing unit
+ * of work the model can invoke mid-dispatch. The Provider is responsible for
+ * converting between its wire format (Anthropic tool_use blocks, OpenAI
+ * function calls, etc.) and this internal representation, so tools themselves
+ * stay provider-agnostic.
+ *
+ * Every tool receives a ToolContext that carries the router config, the
+ * current working directory, and an abort signal tied to the dispatcher's
+ * lifetime. Tools must honor the signal for long-running operations.
+ */
+
+export interface JsonSchema {
+  type: string;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  description?: string;
+  additionalProperties?: boolean;
+  items?: unknown;
+  enum?: unknown[];
+}
+
+export interface ToolContext {
+  cwd: string;
+  signal: AbortSignal;
+  config: RouterConfig;
+  /** Called by tools that want to signal escalation to the controller. */
+  requestEscalation?: (reason: EscalationReason, digest: string) => void;
+}
+
+export interface ToolResult {
+  /** Plain-text content fed back to the model. */
+  content: string;
+  /** Tag the result as an error so the model can react to failures. */
+  isError?: boolean;
+}
+
+export interface Tool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonSchema;
+  execute(input: unknown, ctx: ToolContext): Promise<ToolResult>;
+}
+
+/**
+ * Registry of tools available to workers. Tools are registered once at
+ * module load; the dispatcher pulls a snapshot of the registry at the start
+ * of each worker so tools can be added or swapped per-invocation if needed.
+ */
+export class ToolRegistry {
+  private readonly tools = new Map<string, Tool>();
+
+  register(tool: Tool): void {
+    this.tools.set(tool.name, tool);
+  }
+
+  get(name: string): Tool | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): Tool[] {
+    return [...this.tools.values()];
+  }
+
+  /**
+   * Return a shallow copy. Used by the dispatcher to snapshot the tool set
+   * for a single worker, so later mutations don't affect in-flight runs.
+   */
+  snapshot(): ToolRegistry {
+    const copy = new ToolRegistry();
+    for (const tool of this.tools.values()) copy.register(tool);
+    return copy;
+  }
+}

--- a/tools/router/src/triage/envelope.ts
+++ b/tools/router/src/triage/envelope.ts
@@ -1,0 +1,154 @@
+import { ulid } from "ulid";
+import type { RouterConfig } from "../config/schema.js";
+import {
+  RouterError,
+  type EscalationReason,
+  type TaskEnvelope,
+  type TierName,
+  type TriageVerdict,
+} from "../types.js";
+
+/**
+ * Materialize a TaskEnvelope from a triage verdict. This is the single point
+ * where we resolve tier → (provider, model) and bake in budget guardrails.
+ */
+export interface BuildEnvelopeInput {
+  prompt: string;
+  goal?: string;
+  config: RouterConfig;
+  verdict: TriageVerdict;
+  contextFiles?: string[];
+  parentSessionId?: string;
+}
+
+export function buildEnvelope(input: BuildEnvelopeInput): TaskEnvelope {
+  const { prompt, config, verdict } = input;
+
+  const tierName = resolveTierName(verdict.recommendedTier, config);
+  const tier = config.tiers[tierName];
+  if (!tier) {
+    throw new RouterError(
+      `Resolved tier "${tierName}" is not defined in config.`,
+      "TIER_UNKNOWN",
+    );
+  }
+
+  return {
+    id: ulid(),
+    createdAt: new Date().toISOString(),
+    parentSessionId: input.parentSessionId,
+    goal: input.goal ?? deriveGoal(prompt),
+    originalPrompt: prompt,
+    triage: {
+      ...verdict,
+      tier: tierName,
+      provider: tier.provider,
+      model: tier.model,
+      rubricVersion: config.rubricVersion,
+    },
+    context: {
+      files: input.contextFiles ?? [],
+      constraints: [],
+    },
+    budget: {
+      maxTokens: tier.maxTokens ?? config.budgets.perTask?.tokens,
+      maxToolCalls: config.budgets.perTask?.toolCalls,
+      maxUsd: config.budgets.perTask?.usd,
+      escalationAllowed: config.escalation.enabled,
+    },
+  };
+}
+
+/**
+ * Mint a new envelope at an escalated tier, carrying the prior attempt's
+ * digest forward. This is the method that makes the handoff actually work
+ * across model boundaries — the old worker session is discarded and the new
+ * one cold-starts with a structured summary.
+ */
+export function escalateEnvelope(
+  prior: TaskEnvelope,
+  config: RouterConfig,
+  reason: EscalationReason,
+  priorDigest: string,
+): TaskEnvelope {
+  const nextTier = bumpTier(prior.triage.tier, config);
+  if (!nextTier) {
+    throw new RouterError(
+      `No higher tier available to escalate from "${prior.triage.tier}".`,
+      "ESCALATION_CEILING",
+    );
+  }
+  const tier = config.tiers[nextTier]!;
+  const bumpCount = (prior.escalation?.bumpCount ?? 0) + 1;
+
+  if (bumpCount > config.escalation.maxBumps) {
+    throw new RouterError(
+      `Escalation cap reached (maxBumps=${config.escalation.maxBumps}).`,
+      "ESCALATION_CAP",
+    );
+  }
+
+  return {
+    ...prior,
+    id: ulid(),
+    createdAt: new Date().toISOString(),
+    triage: {
+      ...prior.triage,
+      tier: nextTier,
+      provider: tier.provider,
+      model: tier.model,
+      source: "user-override",
+      rationale: `Escalated from ${prior.triage.tier} due to ${reason}.`,
+    },
+    budget: {
+      ...prior.budget,
+      maxTokens: tier.maxTokens ?? prior.budget.maxTokens,
+    },
+    escalation: {
+      fromTier: prior.triage.tier,
+      fromModel: prior.triage.model,
+      reason,
+      priorAttemptDigest: priorDigest,
+      bumpCount,
+    },
+  };
+}
+
+function resolveTierName(
+  recommended: TierName,
+  config: RouterConfig,
+): TierName {
+  if (config.tiers[recommended]) return recommended;
+  // Fall back to defaultTier if the LLM picked an unknown tier.
+  return config.defaultTier;
+}
+
+function deriveGoal(prompt: string): string {
+  const firstLine = prompt.trim().split("\n")[0] ?? prompt;
+  return firstLine.length > 120 ? firstLine.slice(0, 117) + "..." : firstLine;
+}
+
+/** Return the next higher tier in config order, or null if at the top. */
+export function bumpTier(
+  current: TierName,
+  config: RouterConfig,
+): TierName | null {
+  const order = tierOrder(config);
+  const idx = order.indexOf(current);
+  if (idx === -1 || idx === order.length - 1) return null;
+  return order[idx + 1]!;
+}
+
+/**
+ * Tier ordering heuristic: sort by maxTokens ascending, using the order in
+ * which tiers were declared as a tiebreaker. Users who want an explicit
+ * ordering can rely on insertion order of the tiers record.
+ */
+function tierOrder(config: RouterConfig): TierName[] {
+  return Object.keys(config.tiers).sort((a, b) => {
+    const ta = config.tiers[a]!.maxTokens ?? Number.POSITIVE_INFINITY;
+    const tb = config.tiers[b]!.maxTokens ?? Number.POSITIVE_INFINITY;
+    if (ta !== tb) return ta - tb;
+    return 0;
+  });
+}

--- a/tools/router/src/triage/heuristics.ts
+++ b/tools/router/src/triage/heuristics.ts
@@ -1,0 +1,227 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { HeuristicRuleType } from "../config/schema.js";
+import type { TierName, TriageSignals, TriageVerdict } from "../types.js";
+
+/**
+ * Fast, deterministic triage that runs before any LLM call.
+ *
+ * Input: the raw prompt + minimal static analysis.
+ * Output: a TriageSignals object and (if any rule matched) a TriageVerdict.
+ *
+ * Design goals:
+ *   1. Zero network calls. Everything here is pure.
+ *   2. Explainable — every verdict records which rule fired.
+ *   3. Config-driven — rules live in router.config.ts, not in code.
+ */
+
+const DESIGN_KEYWORDS = [
+  "architect",
+  "architecture",
+  "refactor",
+  "redesign",
+  "migrate",
+  "migration",
+  "rewrite",
+  "design",
+];
+const WRITE_VERBS = [
+  "add",
+  "create",
+  "implement",
+  "build",
+  "write",
+  "fix",
+  "update",
+  "change",
+  "modify",
+  "remove",
+  "delete",
+  "rename",
+];
+const READ_VERBS = [
+  "show",
+  "list",
+  "explain",
+  "describe",
+  "what",
+  "where",
+  "how",
+  "why",
+  "find",
+  "search",
+  "read",
+  "look",
+];
+const MULTI_STEP_MARKERS = [
+  "then",
+  "and then",
+  "after that",
+  "finally",
+  "first",
+  "second",
+  "step 1",
+  "step 2",
+  "1.",
+  "2.",
+];
+const GLOB_PATTERN = /\*\*?|\{[^}]+\}|\[[^\]]+\]/g;
+
+export function extractSignals(prompt: string): TriageSignals {
+  const lower = prompt.toLowerCase();
+  const promptTokens = estimateTokens(prompt);
+  const fileGlobBreadth = countGlobBreadth(prompt);
+  const verbClass = classifyVerb(lower);
+  const keywords = extractKeywords(lower);
+  const hasMultiStepMarkers = MULTI_STEP_MARKERS.some((m) =>
+    lower.includes(m),
+  );
+
+  return {
+    promptTokens,
+    fileGlobBreadth,
+    verbClass,
+    keywords,
+    hasMultiStepMarkers,
+  };
+}
+
+export interface HeuristicMatch {
+  ruleIndex: number;
+  ruleName: string;
+  tier: TierName;
+}
+
+/**
+ * Walk rules in order. Return the first match, if any. Rule authors put
+ * most-specific rules first in config.
+ */
+export function matchHeuristics(
+  signals: TriageSignals,
+  config: RouterConfig,
+): HeuristicMatch | null {
+  for (let i = 0; i < config.heuristics.length; i++) {
+    const rule = config.heuristics[i]!;
+    if (ruleMatches(rule, signals)) {
+      return {
+        ruleIndex: i,
+        ruleName: rule.name ?? `rule[${i}]`,
+        tier: rule.tier,
+      };
+    }
+  }
+  return null;
+}
+
+export function buildHeuristicVerdict(
+  match: HeuristicMatch,
+  signals: TriageSignals,
+): TriageVerdict {
+  return {
+    complexity: inferComplexityFromTier(match.tier),
+    confidence: 0.9,
+    reasoningDepth: match.tier === "fast" ? 1 : match.tier === "deep" ? 5 : 3,
+    ambiguity: signals.hasMultiStepMarkers ? 3 : 2,
+    requiresCodebaseExploration: signals.fileGlobBreadth > 3,
+    requiresMultiFileEdits:
+      signals.verbClass === "write" && signals.fileGlobBreadth > 1,
+    rationale: `Matched heuristic rule "${match.ruleName}".`,
+    recommendedTier: match.tier,
+    source: "heuristic",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function ruleMatches(
+  rule: HeuristicRuleType,
+  signals: TriageSignals,
+): boolean {
+  const when = rule.when;
+
+  if (when.promptTokens) {
+    if (
+      when.promptTokens.lt !== undefined &&
+      !(signals.promptTokens < when.promptTokens.lt)
+    )
+      return false;
+    if (
+      when.promptTokens.gt !== undefined &&
+      !(signals.promptTokens > when.promptTokens.gt)
+    )
+      return false;
+  }
+
+  if (when.fileGlobBreadth) {
+    if (
+      when.fileGlobBreadth.lt !== undefined &&
+      !(signals.fileGlobBreadth < when.fileGlobBreadth.lt)
+    )
+      return false;
+    if (
+      when.fileGlobBreadth.gt !== undefined &&
+      !(signals.fileGlobBreadth > when.fileGlobBreadth.gt)
+    )
+      return false;
+  }
+
+  if (when.verbClass && when.verbClass !== signals.verbClass) return false;
+
+  if (when.hasMultiStepMarkers !== undefined) {
+    if (when.hasMultiStepMarkers !== signals.hasMultiStepMarkers) return false;
+  }
+
+  if (when.keywords && when.keywords.length > 0) {
+    const hit = when.keywords.some((kw) =>
+      signals.keywords.includes(kw.toLowerCase()),
+    );
+    if (!hit) return false;
+  }
+
+  return true;
+}
+
+function estimateTokens(prompt: string): number {
+  // Rough approximation: 4 chars per token. Good enough for heuristic gates.
+  return Math.ceil(prompt.length / 4);
+}
+
+function countGlobBreadth(prompt: string): number {
+  const matches = prompt.match(GLOB_PATTERN);
+  if (matches) return matches.length * 5;
+  // Count bare file references as breadth 1 each.
+  const fileRefs = prompt.match(/[\w/.-]+\.(ts|tsx|js|jsx|py|go|rs|md)\b/g);
+  return fileRefs?.length ?? 0;
+}
+
+function classifyVerb(lower: string): TriageSignals["verbClass"] {
+  // Check design first — "refactor the architecture" should win over "change".
+  if (DESIGN_KEYWORDS.some((kw) => lower.includes(kw))) return "design";
+  // First-word wins for read vs write.
+  const firstWord = lower.trim().split(/\s+/)[0] ?? "";
+  if (WRITE_VERBS.includes(firstWord)) return "write";
+  if (READ_VERBS.includes(firstWord)) return "read";
+  if (WRITE_VERBS.some((v) => lower.includes(` ${v} `))) return "write";
+  if (READ_VERBS.some((v) => lower.includes(` ${v} `))) return "read";
+  return "unknown";
+}
+
+function extractKeywords(lower: string): string[] {
+  const words = lower.match(/[a-z][a-z0-9-]{2,}/g) ?? [];
+  // Dedupe while preserving order for stable rule matching.
+  return [...new Set(words)];
+}
+
+function inferComplexityFromTier(
+  tier: TierName,
+): TriageVerdict["complexity"] {
+  switch (tier) {
+    case "fast":
+      return "simple";
+    case "deep":
+      return "complex";
+    default:
+      return "moderate";
+  }
+}

--- a/tools/router/src/triage/llm-triage.ts
+++ b/tools/router/src/triage/llm-triage.ts
@@ -1,0 +1,147 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+import type { RouterConfig } from "../config/schema.js";
+import { RouterError, type Credential, type TriageVerdict } from "../types.js";
+import { DEFAULT_RUBRIC } from "./rubric.js";
+
+/**
+ * LLM-backed triage. Called only if no heuristic rule matched. Uses the
+ * cheap triage model (Haiku by default) and expects strict JSON back.
+ *
+ * This deliberately does NOT use the provider plugin interface — triage is
+ * always an Anthropic Messages API call against whichever provider+credential
+ * the config points at. Keeping it direct lets us control the exact shape of
+ * the request and the parsing of the response without adding a second abstract
+ * layer.
+ */
+
+const LlmVerdictSchema = z.object({
+  complexity: z.enum(["trivial", "simple", "moderate", "complex", "research"]),
+  reasoningDepth: z.number().int().min(1).max(5),
+  ambiguity: z.number().int().min(1).max(5),
+  requiresCodebaseExploration: z.boolean(),
+  requiresMultiFileEdits: z.boolean(),
+  recommendedTier: z.string(),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string(),
+});
+
+export interface LlmTriageInput {
+  prompt: string;
+  config: RouterConfig;
+  credential: Credential;
+  signal?: AbortSignal;
+}
+
+export async function runLlmTriage(
+  input: LlmTriageInput,
+): Promise<TriageVerdict> {
+  const { prompt, config, credential, signal } = input;
+
+  const rubric = await loadRubric(config.triage.rubricPath);
+  const client = new Anthropic({ apiKey: credential.secret });
+
+  let response;
+  try {
+    response = await client.messages.create(
+      {
+        model: config.triage.model,
+        max_tokens: 512,
+        system: rubric,
+        messages: [
+          {
+            role: "user",
+            content: `Classify this task:\n\n<prompt>\n${prompt}\n</prompt>\n\nRespond with JSON only.`,
+          },
+        ],
+      },
+      { signal },
+    );
+  } catch (err) {
+    throw new RouterError(
+      `Triage LLM call failed: ${err instanceof Error ? err.message : String(err)}`,
+      "TRIAGE_FAILED",
+    );
+  }
+
+  const textBlock = response.content.find(
+    (b): b is Anthropic.TextBlock => b.type === "text",
+  );
+  if (!textBlock) {
+    throw new RouterError(
+      "Triage response contained no text.",
+      "TRIAGE_EMPTY",
+    );
+  }
+
+  const json = extractJson(textBlock.text);
+  const parsed = LlmVerdictSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new RouterError(
+      `Triage response was not valid JSON: ${parsed.error.message}`,
+      "TRIAGE_INVALID",
+      { raw: textBlock.text },
+    );
+  }
+
+  return {
+    complexity: parsed.data.complexity,
+    confidence: parsed.data.confidence,
+    reasoningDepth:
+      parsed.data.reasoningDepth as TriageVerdict["reasoningDepth"],
+    ambiguity: parsed.data.ambiguity as TriageVerdict["ambiguity"],
+    requiresCodebaseExploration: parsed.data.requiresCodebaseExploration,
+    requiresMultiFileEdits: parsed.data.requiresMultiFileEdits,
+    rationale: parsed.data.rationale,
+    recommendedTier: parsed.data.recommendedTier,
+    source: "llm",
+  };
+}
+
+async function loadRubric(path: string | undefined): Promise<string> {
+  if (!path) return DEFAULT_RUBRIC;
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return DEFAULT_RUBRIC;
+  }
+}
+
+/**
+ * Robust JSON extractor: handles models that stubbornly wrap output in code
+ * fences despite instructions, or prepend a sentence.
+ */
+function extractJson(text: string): unknown {
+  const trimmed = text.trim();
+
+  // Try plain parse first.
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // fall through
+  }
+
+  // Strip markdown fences.
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+  if (fenceMatch?.[1]) {
+    try {
+      return JSON.parse(fenceMatch[1]);
+    } catch {
+      // fall through
+    }
+  }
+
+  // Grab the first {...} block.
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    } catch {
+      // fall through
+    }
+  }
+
+  throw new Error("No parseable JSON found in triage response.");
+}

--- a/tools/router/src/triage/rubric.ts
+++ b/tools/router/src/triage/rubric.ts
@@ -1,0 +1,29 @@
+/**
+ * Default rubric prompt for the LLM triage call. Users can override by
+ * pointing `triage.rubricPath` at their own file in router.config.ts.
+ */
+export const DEFAULT_RUBRIC = `You are a task triage classifier for a coding agent router.
+
+You will receive a user prompt. Your only job is to classify it and emit a
+strict JSON object. Do not attempt to solve the task. Do not add commentary.
+
+Classify along these axes:
+
+- complexity: one of "trivial" | "simple" | "moderate" | "complex" | "research"
+- reasoningDepth: integer 1-5 (1 = none, 5 = deep multi-step planning)
+- ambiguity: integer 1-5 (1 = crystal clear, 5 = needs clarification)
+- requiresCodebaseExploration: boolean
+- requiresMultiFileEdits: boolean
+- recommendedTier: "fast" | "default" | "deep"
+- confidence: number 0-1
+- rationale: one sentence explaining your choice
+
+Rubric:
+- "fast" (haiku-class): lookups, single-file reads, trivial renames, formatting,
+  syntax questions.
+- "default" (sonnet-class): normal coding work, single-feature implementation,
+  bug fixes with known root cause, multi-file reads with small edits.
+- "deep" (opus-class): architecture decisions, refactors spanning many files,
+  ambiguous bugs with unknown root cause, research, migrations, design.
+
+Output ONLY valid JSON. No markdown fences, no prose.`;

--- a/tools/router/src/triage/triage.ts
+++ b/tools/router/src/triage/triage.ts
@@ -1,4 +1,5 @@
 import type { RouterConfig } from "../config/schema.js";
+import { runHook } from "../dispatch/hooks.js";
 import type { Credential, TriageVerdict } from "../types.js";
 import {
   buildHeuristicVerdict,
@@ -6,6 +7,7 @@ import {
   matchHeuristics,
 } from "./heuristics.js";
 import { runLlmTriage } from "./llm-triage.js";
+import { applyWeights } from "./weights.js";
 
 /**
  * Top-level triage entrypoint. Runs heuristics first, then falls back to the
@@ -21,6 +23,18 @@ export interface TriageInput {
 }
 
 export async function triage(input: TriageInput): Promise<TriageVerdict> {
+  // beforeTriage hook — lets callers mutate signals or short-circuit triage.
+  if (input.config.hooks.beforeTriage) {
+    try {
+      await runHook(input.config.hooks.beforeTriage, {
+        event: "beforeTriage",
+        prompt: input.prompt,
+      });
+    } catch {
+      // Non-fatal: triage proceeds even if the hook crashes.
+    }
+  }
+
   const signals = extractSignals(input.prompt);
   const match = matchHeuristics(signals, input.config);
   if (match) {
@@ -44,12 +58,16 @@ export async function triage(input: TriageInput): Promise<TriageVerdict> {
     };
   }
 
-  const verdict = await runLlmTriage({
+  const rawVerdict = await runLlmTriage({
     prompt: input.prompt,
     config: input.config,
     credential: input.triageCredential,
     signal: input.signal,
   });
+
+  // Apply weights-based scoring. This may nudge the tier up or down based
+  // on user preferences expressed in config.weights.
+  const { verdict } = applyWeights(rawVerdict, input.config);
 
   if (verdict.confidence < input.config.triage.minConfidence) {
     // Low confidence → bump one tier up (toward more capability).

--- a/tools/router/src/triage/triage.ts
+++ b/tools/router/src/triage/triage.ts
@@ -1,0 +1,74 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { Credential, TriageVerdict } from "../types.js";
+import {
+  buildHeuristicVerdict,
+  extractSignals,
+  matchHeuristics,
+} from "./heuristics.js";
+import { runLlmTriage } from "./llm-triage.js";
+
+/**
+ * Top-level triage entrypoint. Runs heuristics first, then falls back to the
+ * LLM triage model if no rule matched. Enforces the minConfidence threshold
+ * from config by bumping low-confidence verdicts to the default tier.
+ */
+export interface TriageInput {
+  prompt: string;
+  config: RouterConfig;
+  /** Credential for the triage provider. Required only for LLM fallback. */
+  triageCredential?: Credential | null;
+  signal?: AbortSignal;
+}
+
+export async function triage(input: TriageInput): Promise<TriageVerdict> {
+  const signals = extractSignals(input.prompt);
+  const match = matchHeuristics(signals, input.config);
+  if (match) {
+    return buildHeuristicVerdict(match, signals);
+  }
+
+  if (!input.triageCredential) {
+    // No credential and no heuristic match → safe fallback: default tier
+    // with low confidence so the TUI can warn the user.
+    return {
+      complexity: "moderate",
+      confidence: 0.3,
+      reasoningDepth: 3,
+      ambiguity: 3,
+      requiresCodebaseExploration: false,
+      requiresMultiFileEdits: false,
+      rationale:
+        "No heuristic matched and no triage credential available; defaulting.",
+      recommendedTier: input.config.defaultTier,
+      source: "heuristic",
+    };
+  }
+
+  const verdict = await runLlmTriage({
+    prompt: input.prompt,
+    config: input.config,
+    credential: input.triageCredential,
+    signal: input.signal,
+  });
+
+  if (verdict.confidence < input.config.triage.minConfidence) {
+    // Low confidence → bump one tier up (toward more capability).
+    return {
+      ...verdict,
+      recommendedTier: bumpTierName(
+        verdict.recommendedTier,
+        input.config,
+      ),
+      rationale: `${verdict.rationale} (Confidence ${verdict.confidence.toFixed(2)} below threshold; bumping up.)`,
+    };
+  }
+
+  return verdict;
+}
+
+function bumpTierName(current: string, config: RouterConfig): string {
+  const tiers = Object.keys(config.tiers);
+  const idx = tiers.indexOf(current);
+  if (idx === -1 || idx === tiers.length - 1) return current;
+  return tiers[idx + 1] ?? current;
+}

--- a/tools/router/src/triage/weights.ts
+++ b/tools/router/src/triage/weights.ts
@@ -1,0 +1,120 @@
+import type { RouterConfig } from "../config/schema.js";
+import type { TierName, TriageVerdict } from "../types.js";
+
+/**
+ * Apply user-configured weights to an LLM triage verdict to compute a final
+ * composite complexity score, and map that score to a tier.
+ *
+ * The LLM already emits a `recommendedTier`, but users want to influence how
+ * much each signal contributes — e.g. "ambiguity should dominate" or
+ * "multi-file edits always mean deep". The weights block in router.config.ts
+ * expresses those preferences as a weighted sum. Components are each
+ * normalized to 0-1, multiplied by their weight, and summed; the final
+ * composite is compared against thresholds.
+ *
+ * If the composite score disagrees with the LLM's recommended tier by more
+ * than one step, we bump toward the weighted choice and record that the
+ * verdict was re-weighted (so the TUI can show it).
+ */
+
+export interface WeightedScoring {
+  verdict: TriageVerdict;
+  /** Composite score in [0, 1]. */
+  score: number;
+  /** Tier derived from the composite, independent of the LLM recommendation. */
+  weightedTier: TierName;
+  /** True if weights changed the chosen tier from the LLM recommendation. */
+  adjusted: boolean;
+}
+
+export function applyWeights(
+  verdict: TriageVerdict,
+  config: RouterConfig,
+): WeightedScoring {
+  const w = config.weights;
+
+  // Normalize each signal to [0, 1]. Higher = more complex.
+  const ambiguity = (verdict.ambiguity - 1) / 4;
+  const multiFileEdits = verdict.requiresMultiFileEdits ? 1 : 0;
+  const reasoningDepth = (verdict.reasoningDepth - 1) / 4;
+  const codebaseExplore = verdict.requiresCodebaseExploration ? 1 : 0;
+  // Prompt length is not in the verdict; we approximate it via the rationale
+  // length as a stand-in. It's a minor signal anyway.
+  const promptLength = Math.min(1, verdict.rationale.length / 500);
+
+  const total =
+    w.ambiguity +
+    w.multiFileEdits +
+    w.reasoningDepth +
+    w.codebaseExplore +
+    w.promptLength;
+
+  // Guard against a zero-weight config. Fall back to the LLM pick untouched.
+  if (total === 0) {
+    return {
+      verdict,
+      score: 0,
+      weightedTier: verdict.recommendedTier,
+      adjusted: false,
+    };
+  }
+
+  const score =
+    (w.ambiguity * ambiguity +
+      w.multiFileEdits * multiFileEdits +
+      w.reasoningDepth * reasoningDepth +
+      w.codebaseExplore * codebaseExplore +
+      w.promptLength * promptLength) /
+    total;
+
+  const weightedTier = scoreToTier(score, config);
+  const adjusted = weightedTier !== verdict.recommendedTier;
+
+  if (!adjusted) {
+    return { verdict, score, weightedTier, adjusted };
+  }
+
+  // Only override if the weighted tier differs by more than one step from
+  // the LLM pick — this preserves the LLM's judgment for borderline cases.
+  if (!isBigDivergence(verdict.recommendedTier, weightedTier, config)) {
+    return { verdict, score, weightedTier: verdict.recommendedTier, adjusted: false };
+  }
+
+  return {
+    verdict: {
+      ...verdict,
+      recommendedTier: weightedTier,
+      rationale: `${verdict.rationale} (reweighted from ${verdict.recommendedTier} → ${weightedTier}, score ${score.toFixed(2)})`,
+    },
+    score,
+    weightedTier,
+    adjusted: true,
+  };
+}
+
+/**
+ * Partition the [0, 1] composite score across the tiers in config, in
+ * insertion order. With 3 tiers the cutoffs are 1/3 and 2/3; with 4 tiers
+ * they're 1/4, 2/4, 3/4, etc. This keeps the math config-agnostic.
+ */
+function scoreToTier(score: number, config: RouterConfig): TierName {
+  const tiers = Object.keys(config.tiers);
+  if (tiers.length === 0) return config.defaultTier;
+  const idx = Math.min(
+    tiers.length - 1,
+    Math.floor(score * tiers.length),
+  );
+  return tiers[idx]!;
+}
+
+function isBigDivergence(
+  a: TierName,
+  b: TierName,
+  config: RouterConfig,
+): boolean {
+  const tiers = Object.keys(config.tiers);
+  const ai = tiers.indexOf(a);
+  const bi = tiers.indexOf(b);
+  if (ai === -1 || bi === -1) return true;
+  return Math.abs(ai - bi) > 1;
+}

--- a/tools/router/src/tui/App.tsx
+++ b/tools/router/src/tui/App.tsx
@@ -1,12 +1,13 @@
 import { Box, Text, useApp, useInput } from "ink";
 import TextInput from "ink-text-input";
 import React, { useCallback, useEffect, useState } from "react";
-import { spawn } from "node:child_process";
+import { spawnSync, spawn } from "node:child_process";
 import type { RouterConfig } from "../config/schema.js";
 import type { CredentialStore } from "../credentials/store.js";
 import type { PreflightCache } from "../dispatch/preflight.js";
 import { Dispatcher, type DispatcherEvent } from "../dispatch/dispatcher.js";
 import type { JsonlLogger } from "../telemetry/jsonl-logger.js";
+import type { ToolRegistry } from "../tools/index.js";
 import { buildEnvelope } from "../triage/envelope.js";
 import { triage } from "../triage/triage.js";
 import type {
@@ -32,7 +33,12 @@ interface Props {
   store: CredentialStore;
   cache: PreflightCache;
   logger: JsonlLogger;
+  tools?: ToolRegistry;
   initialPrompt?: string;
+  forcedTier?: string;
+  requireTier?: string;
+  downgradePolicy?: "auto" | "never" | "ask";
+  ciMode?: boolean;
 }
 
 type Screen =
@@ -55,7 +61,12 @@ export function App({
   store,
   cache,
   logger,
+  tools,
   initialPrompt,
+  forcedTier,
+  requireTier,
+  downgradePolicy = "ask",
+  ciMode = false,
 }: Props): React.ReactElement {
   const { exit } = useApp();
   const [screen, setScreen] = useState<Screen>({ kind: "prompt" });
@@ -71,7 +82,16 @@ export function App({
     startedAt: Date.now(),
   });
   const [dispatcher] = useState(
-    () => new Dispatcher({ config, providers, store, cache, logger }),
+    () =>
+      new Dispatcher({
+        config,
+        providers,
+        store,
+        cache,
+        logger,
+        tools,
+        downgradePolicy,
+      }),
   );
 
   // Global hotkeys
@@ -79,7 +99,31 @@ export function App({
     if (key.ctrl && input === "c") {
       exit();
     }
+    // [e] from the prompt screen → spawn $EDITOR on the config file.
+    if (input === "e" && screen.kind === "prompt") {
+      openEditor();
+    }
   });
+
+  const openEditor = useCallback(() => {
+    const editor = process.env.EDITOR ?? process.env.VISUAL ?? "vi";
+    try {
+      spawnSync(editor, ["router.config.ts"], {
+        stdio: "inherit",
+        cwd: process.cwd(),
+      });
+      appendLine({
+        kind: "status",
+        content: "Config reload: restart the TUI for changes to take effect.",
+      });
+    } catch (err) {
+      appendLine({
+        kind: "error",
+        content: `Could not launch ${editor}: ${(err as Error).message}`,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const appendLine = useCallback((line: StreamLine) => {
     setStreamLines((prev) => [...prev, line]);
@@ -98,7 +142,42 @@ export function App({
           config,
           triageCredential: triageCred,
         });
-        const env = buildEnvelope({ prompt: text, config, verdict });
+
+        // Apply --tier override: replace the triaged tier.
+        const effectiveVerdict = forcedTier
+          ? {
+              ...verdict,
+              recommendedTier: forcedTier,
+              source: "user-override" as const,
+              rationale: `${verdict.rationale} [forced: ${forcedTier}]`,
+            }
+          : verdict;
+
+        const env = buildEnvelope({
+          prompt: text,
+          config,
+          verdict: effectiveVerdict,
+        });
+
+        // Apply --require-tier: fail loudly if the chosen tier isn't the
+        // required one (e.g. heuristic picked "default" but CI demanded "deep").
+        if (requireTier && env.triage.tier !== requireTier) {
+          appendLine({
+            kind: "error",
+            content: `--require-tier ${requireTier} but triage chose ${env.triage.tier}.`,
+          });
+          setScreen({
+            kind: "done",
+            envelope: env,
+            status: "failure",
+          });
+          if (ciMode) {
+            process.exitCode = 4;
+            exit();
+          }
+          return;
+        }
+
         setEnvelope(env);
         setScreen({ kind: "running", envelope: env });
 

--- a/tools/router/src/tui/App.tsx
+++ b/tools/router/src/tui/App.tsx
@@ -1,0 +1,384 @@
+import { Box, Text, useApp, useInput } from "ink";
+import TextInput from "ink-text-input";
+import React, { useCallback, useEffect, useState } from "react";
+import { spawn } from "node:child_process";
+import type { RouterConfig } from "../config/schema.js";
+import type { CredentialStore } from "../credentials/store.js";
+import type { PreflightCache } from "../dispatch/preflight.js";
+import { Dispatcher, type DispatcherEvent } from "../dispatch/dispatcher.js";
+import type { JsonlLogger } from "../telemetry/jsonl-logger.js";
+import { buildEnvelope } from "../triage/envelope.js";
+import { triage } from "../triage/triage.js";
+import type {
+  BudgetState,
+  Credential,
+  Provider,
+  TaskEnvelope,
+} from "../types.js";
+import {
+  renderPreflightError,
+  type ErrorAction,
+  type ErrorPanelContent,
+} from "../auth/preflight-error.js";
+import { AuthFlow } from "./components/AuthFlow.js";
+import { BudgetMeter } from "./components/BudgetMeter.js";
+import { ErrorPanel } from "./components/ErrorPanel.js";
+import { TriagePanel } from "./components/TriagePanel.js";
+import { WorkerStream, type StreamLine } from "./components/WorkerStream.js";
+
+interface Props {
+  config: RouterConfig;
+  providers: Map<string, Provider>;
+  store: CredentialStore;
+  cache: PreflightCache;
+  logger: JsonlLogger;
+  initialPrompt?: string;
+}
+
+type Screen =
+  | { kind: "prompt" }
+  | { kind: "triaging" }
+  | { kind: "running"; envelope: TaskEnvelope }
+  | { kind: "auth"; providerId: string; resume: () => void }
+  | { kind: "error"; content: ErrorPanelContent }
+  | { kind: "done"; envelope: TaskEnvelope; status: string };
+
+/**
+ * Main Ink TUI. Wires together the dispatcher, triage, and auth flows into
+ * a single screen-router. State transitions are explicit — every change to
+ * the current screen goes through setScreen() so the render logic stays
+ * flat and debuggable.
+ */
+export function App({
+  config,
+  providers,
+  store,
+  cache,
+  logger,
+  initialPrompt,
+}: Props): React.ReactElement {
+  const { exit } = useApp();
+  const [screen, setScreen] = useState<Screen>({ kind: "prompt" });
+  const [promptText, setPromptText] = useState(initialPrompt ?? "");
+  const [envelope, setEnvelope] = useState<TaskEnvelope | null>(null);
+  const [streamLines, setStreamLines] = useState<StreamLine[]>([]);
+  const [budget, setBudget] = useState<BudgetState>({
+    inputTokens: 0,
+    outputTokens: 0,
+    toolCalls: 0,
+    usd: 0,
+    escalations: 0,
+    startedAt: Date.now(),
+  });
+  const [dispatcher] = useState(
+    () => new Dispatcher({ config, providers, store, cache, logger }),
+  );
+
+  // Global hotkeys
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") {
+      exit();
+    }
+  });
+
+  const appendLine = useCallback((line: StreamLine) => {
+    setStreamLines((prev) => [...prev, line]);
+  }, []);
+
+  const runPrompt = useCallback(
+    async (text: string) => {
+      setScreen({ kind: "triaging" });
+      setStreamLines([]);
+      setEnvelope(null);
+
+      try {
+        const triageCred = await store.get(config.triage.provider);
+        const verdict = await triage({
+          prompt: text,
+          config,
+          triageCredential: triageCred,
+        });
+        const env = buildEnvelope({ prompt: text, config, verdict });
+        setEnvelope(env);
+        setScreen({ kind: "running", envelope: env });
+
+        const abort = new AbortController();
+        await dispatcher.run({
+          envelope: env,
+          signal: abort.signal,
+          onEvent: (event) => handleDispatcherEvent(event),
+        });
+      } catch (err) {
+        if (isAuthLikeError(err)) {
+          const { providerId, model, reason, message } = extractErrorDetails(err);
+          const content = renderPreflightError(
+            reason,
+            providerId ?? "unknown",
+            model ?? "unknown",
+            message,
+          );
+          setScreen({ kind: "error", content });
+          return;
+        }
+        appendLine({
+          kind: "error",
+          content: err instanceof Error ? err.message : String(err),
+        });
+        setScreen({
+          kind: "done",
+          envelope: envelope ?? ({} as TaskEnvelope),
+          status: "failure",
+        });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config, store, dispatcher],
+  );
+
+  const handleDispatcherEvent = useCallback(
+    (event: DispatcherEvent) => {
+      switch (event.type) {
+        case "envelope":
+          setEnvelope(event.envelope);
+          break;
+        case "dispatch_event": {
+          const e = event.event;
+          if (e.type === "worker_start") {
+            appendLine({ kind: "status", content: `worker started (${e.model})` });
+          } else if (e.type === "tool_call") {
+            appendLine({
+              kind: "tool",
+              content: `${e.name}(${previewInput(e.input)})`,
+            });
+          } else if (e.type === "assistant_text") {
+            // Append to last text line if present, else start a new one.
+            setStreamLines((prev) => {
+              const last = prev[prev.length - 1];
+              if (last && last.kind === "text") {
+                const next = [...prev];
+                next[next.length - 1] = { ...last, content: last.content + e.text };
+                return next;
+              }
+              return [...prev, { kind: "text", content: e.text }];
+            });
+          } else if (e.type === "worker_done") {
+            appendLine({
+              kind: "status",
+              content: `worker done (${e.status})`,
+            });
+          }
+          break;
+        }
+        case "budget_update":
+          setBudget({ ...event.tracker.state });
+          break;
+        case "escalating":
+          appendLine({
+            kind: "status",
+            content: `escalating: ${event.reason}`,
+          });
+          setStreamLines((prev) => [
+            ...prev,
+            { kind: "status", content: "— new envelope at higher tier —" },
+          ]);
+          break;
+        case "done":
+          setScreen({
+            kind: "done",
+            envelope: event.envelope,
+            status: event.status,
+          });
+          break;
+        case "preflight_failed":
+          // Handled via thrown AuthError in runPrompt; no-op here.
+          break;
+      }
+    },
+    [appendLine],
+  );
+
+  // Handle error panel actions
+  const handleErrorAction = useCallback(
+    (action: ErrorAction) => {
+      switch (action.type) {
+        case "cancel":
+          setScreen({ kind: "prompt" });
+          break;
+        case "auth_login":
+        case "auth_refresh":
+          setScreen({
+            kind: "auth",
+            providerId: action.providerId,
+            resume: () => runPrompt(promptText),
+          });
+          break;
+        case "downgrade":
+          appendLine({ kind: "status", content: "Downgrading to default tier..." });
+          setScreen({ kind: "prompt" });
+          // User can re-submit; we could also auto-rerun with forced tier here.
+          break;
+        case "retry":
+          runPrompt(promptText);
+          break;
+        case "open_url":
+          try {
+            openUrl(action.url);
+          } catch {
+            // non-fatal
+          }
+          break;
+      }
+    },
+    [runPrompt, promptText, appendLine],
+  );
+
+  // Initial prompt on startup
+  useEffect(() => {
+    if (initialPrompt) {
+      runPrompt(initialPrompt);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Render -------------------------------------------------------------
+  const budgetCap = config.budgets.perSession?.usd;
+  const toolCap = config.budgets.perTask?.toolCalls;
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Box borderStyle="round" borderColor="blue" paddingX={1}>
+        <Text bold color="blue">
+          router{" "}
+        </Text>
+        <Text color="gray">· </Text>
+        <BudgetMeter budget={budget} capUsd={budgetCap} capToolCalls={toolCap} />
+      </Box>
+
+      {/* Screen body */}
+      {screen.kind === "prompt" && (
+        <Box borderStyle="round" borderColor="gray" paddingX={1}>
+          <Text>{">"} </Text>
+          <TextInput
+            value={promptText}
+            onChange={setPromptText}
+            onSubmit={(v) => v.trim() && runPrompt(v)}
+            placeholder="describe a task and press enter..."
+          />
+        </Box>
+      )}
+
+      {screen.kind === "triaging" && (
+        <Box paddingX={1}>
+          <Text color="gray">triaging...</Text>
+        </Box>
+      )}
+
+      {(screen.kind === "running" || screen.kind === "done") && (
+        <>
+          <TriagePanel envelope={envelope} />
+          <WorkerStream
+            lines={streamLines}
+            active={screen.kind === "running"}
+            model={envelope?.triage.model ?? ""}
+          />
+        </>
+      )}
+
+      {screen.kind === "done" && (
+        <Box paddingX={1}>
+          <Text color={screen.status === "success" ? "green" : "red"}>
+            ● {screen.status}
+          </Text>
+          <Text color="gray"> — press enter for new prompt</Text>
+          <TextInput
+            value=""
+            onChange={() => undefined}
+            onSubmit={() => {
+              setPromptText("");
+              setScreen({ kind: "prompt" });
+            }}
+          />
+        </Box>
+      )}
+
+      {screen.kind === "error" && (
+        <ErrorPanel content={screen.content} onAction={handleErrorAction} />
+      )}
+
+      {screen.kind === "auth" && (
+        <AuthFlow
+          provider={providers.get(screen.providerId)!}
+          onComplete={async (event) => {
+            await store.set(screen.providerId, (event as any).credential as Credential);
+            cache.invalidate(screen.providerId);
+            screen.resume();
+          }}
+          onCancel={() => setScreen({ kind: "prompt" })}
+          onError={(message) => {
+            setScreen({
+              kind: "error",
+              content: {
+                title: "Authentication failed",
+                body: [message],
+                actions: [
+                  { key: "r", label: "Retry", action: { type: "retry" } },
+                  { key: "esc", label: "Cancel", action: { type: "cancel" } },
+                ],
+              },
+            });
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+function previewInput(input: unknown): string {
+  const s = JSON.stringify(input);
+  if (!s) return "";
+  return s.length > 60 ? s.slice(0, 57) + "..." : s;
+}
+
+function isAuthLikeError(err: unknown): err is {
+  name: string;
+  reason: string;
+  details?: Record<string, unknown>;
+  message: string;
+} {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "name" in err &&
+    (err as { name: string }).name === "AuthError"
+  );
+}
+
+function extractErrorDetails(err: unknown): {
+  providerId?: string;
+  model?: string;
+  reason: import("../types.js").ProbeFailureReason;
+  message: string;
+} {
+  const e = err as {
+    reason?: import("../types.js").ProbeFailureReason;
+    details?: { provider?: string; model?: string };
+    message?: string;
+  };
+  return {
+    providerId: e.details?.provider,
+    model: e.details?.model,
+    reason: e.reason ?? "unknown",
+    message: e.message ?? "Unknown error",
+  };
+}
+
+function openUrl(url: string): void {
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  spawn(cmd, [url], { stdio: "ignore", detached: true }).unref();
+}

--- a/tools/router/src/tui/components/AuthFlow.tsx
+++ b/tools/router/src/tui/components/AuthFlow.tsx
@@ -1,0 +1,201 @@
+import { Box, Text, useInput } from "ink";
+import Spinner from "ink-spinner";
+import TextInput from "ink-text-input";
+import React, { useEffect, useState } from "react";
+import type { AuthEvent, Provider } from "../../types.js";
+
+interface Props {
+  provider: Provider;
+  onComplete: (credential: AuthEvent & { type: "success" }) => void;
+  onCancel: () => void;
+  onError: (message: string) => void;
+}
+
+type FlowState =
+  | { kind: "idle" }
+  | { kind: "instruction"; message: string }
+  | { kind: "prompt_secret"; label: string; mask: boolean; value: string }
+  | {
+      kind: "device_code";
+      userCode: string;
+      verificationUri: string;
+      verificationUriComplete?: string;
+      expiresAt: number;
+    }
+  | { kind: "polling"; message: string }
+  | { kind: "done" };
+
+/**
+ * Renders a provider's login() event stream. This component is strategy-
+ * agnostic: API-key paste flows and OAuth device flows both produce the same
+ * AuthEvent stream, so the UI adapts automatically to whichever the provider
+ * happens to emit.
+ */
+export function AuthFlow({ provider, onComplete, onCancel, onError }: Props): React.ReactElement {
+  const [state, setState] = useState<FlowState>({ kind: "idle" });
+  const [secretResolver, setSecretResolver] = useState<
+    ((value: string) => void) | null
+  >(null);
+  const [abortController] = useState(() => new AbortController());
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      abortController.abort();
+      onCancel();
+    }
+  });
+
+  useEffect(() => {
+    const ctx = {
+      requestInput: (opts: { label: string; mask: boolean }) =>
+        new Promise<string>((resolve) => {
+          setState({
+            kind: "prompt_secret",
+            label: opts.label,
+            mask: opts.mask,
+            value: "",
+          });
+          setSecretResolver(() => resolve);
+        }),
+      signal: abortController.signal,
+    };
+
+    (async () => {
+      try {
+        for await (const event of provider.login(ctx)) {
+          if (abortController.signal.aborted) return;
+          switch (event.type) {
+            case "instruction":
+              setState({ kind: "instruction", message: event.message });
+              break;
+            case "device_code":
+              setState({
+                kind: "device_code",
+                userCode: event.userCode,
+                verificationUri: event.verificationUri,
+                verificationUriComplete: event.verificationUriComplete,
+                expiresAt: event.expiresAt,
+              });
+              break;
+            case "polling":
+              setState({
+                kind: "polling",
+                message: `Waiting for approval (polling every ${Math.round(
+                  event.waitMs / 1000,
+                )}s)...`,
+              });
+              break;
+            case "success":
+              setState({ kind: "done" });
+              onComplete(event);
+              return;
+            case "error":
+              onError(event.message);
+              return;
+          }
+        }
+      } catch (err) {
+        onError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    return () => {
+      abortController.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider]);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text bold color="cyan">
+        Authenticating with {provider.displayName}
+      </Text>
+      <Box marginY={1}>
+        <FlowBody
+          state={state}
+          onSecretSubmit={(value) => {
+            if (secretResolver) {
+              secretResolver(value);
+              setSecretResolver(null);
+            }
+          }}
+          onSecretChange={(value) => {
+            setState((prev) =>
+              prev.kind === "prompt_secret" ? { ...prev, value } : prev,
+            );
+          }}
+        />
+      </Box>
+      <Text color="gray">[esc] cancel</Text>
+    </Box>
+  );
+}
+
+function FlowBody({
+  state,
+  onSecretSubmit,
+  onSecretChange,
+}: {
+  state: FlowState;
+  onSecretSubmit: (value: string) => void;
+  onSecretChange: (value: string) => void;
+}): React.ReactElement {
+  switch (state.kind) {
+    case "idle":
+      return (
+        <Text color="gray">
+          <Spinner type="dots" /> Starting...
+        </Text>
+      );
+    case "instruction":
+      return <Text wrap="wrap">{state.message}</Text>;
+    case "prompt_secret":
+      return (
+        <Box flexDirection="column">
+          <Text>{state.label}:</Text>
+          <TextInput
+            value={state.value}
+            onChange={onSecretChange}
+            onSubmit={onSecretSubmit}
+            mask={state.mask ? "*" : undefined}
+          />
+        </Box>
+      );
+    case "device_code": {
+      const remaining = Math.max(0, state.expiresAt - Date.now());
+      const mins = Math.floor(remaining / 60_000);
+      const secs = Math.floor((remaining % 60_000) / 1000);
+      return (
+        <Box flexDirection="column">
+          <Text>1. Open in your browser:</Text>
+          <Text color="cyan">   {state.verificationUri}</Text>
+          <Box marginTop={1}>
+            <Text>2. Enter this code: </Text>
+            <Text bold color="yellow">
+              {state.userCode}
+            </Text>
+          </Box>
+          {state.verificationUriComplete && (
+            <Text color="gray">
+              Or open direct: {state.verificationUriComplete}
+            </Text>
+          )}
+          <Box marginTop={1}>
+            <Text color="gray">
+              <Spinner type="dots" /> Waiting for approval... (expires in{" "}
+              {mins}:{String(secs).padStart(2, "0")})
+            </Text>
+          </Box>
+        </Box>
+      );
+    }
+    case "polling":
+      return (
+        <Text color="gray">
+          <Spinner type="dots" /> {state.message}
+        </Text>
+      );
+    case "done":
+      return <Text color="green">✓ Authenticated successfully.</Text>;
+  }
+}

--- a/tools/router/src/tui/components/BudgetMeter.tsx
+++ b/tools/router/src/tui/components/BudgetMeter.tsx
@@ -1,0 +1,48 @@
+import { Box, Text } from "ink";
+import React from "react";
+import type { BudgetState } from "../../types.js";
+
+interface Props {
+  budget: BudgetState;
+  capUsd?: number;
+  capToolCalls?: number;
+}
+
+/**
+ * Compact single-line budget meter for the header bar. Displays running
+ * totals and warning colors as caps are approached.
+ */
+export function BudgetMeter({ budget, capUsd, capToolCalls }: Props): React.ReactElement {
+  const usdColor = capUsd && budget.usd > capUsd * 0.8 ? "yellow" : "gray";
+  const toolColor =
+    capToolCalls && budget.toolCalls > capToolCalls * 0.8 ? "yellow" : "gray";
+  const totalTokens = budget.inputTokens + budget.outputTokens;
+
+  return (
+    <Box>
+      <Text color={usdColor}>
+        ${budget.usd.toFixed(4)}
+        {capUsd ? ` / $${capUsd.toFixed(2)}` : ""}
+      </Text>
+      <Text color="gray"> · </Text>
+      <Text color={toolColor}>
+        {budget.toolCalls}
+        {capToolCalls ? `/${capToolCalls}` : ""} tool calls
+      </Text>
+      <Text color="gray"> · </Text>
+      <Text color="gray">{formatTokens(totalTokens)} tokens</Text>
+      {budget.escalations > 0 && (
+        <>
+          <Text color="gray"> · </Text>
+          <Text color="yellow">↑{budget.escalations} escalations</Text>
+        </>
+      )}
+    </Box>
+  );
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}

--- a/tools/router/src/tui/components/ErrorPanel.tsx
+++ b/tools/router/src/tui/components/ErrorPanel.tsx
@@ -1,0 +1,49 @@
+import { Box, Text, useInput } from "ink";
+import React from "react";
+import type {
+  ErrorAction,
+  ErrorPanelContent,
+} from "../../auth/preflight-error.js";
+
+interface Props {
+  content: ErrorPanelContent;
+  onAction: (action: ErrorAction) => void;
+}
+
+/**
+ * Full-width error panel with keyboard-driven action list. Every error has
+ * at least one forward action, so the user never gets stuck.
+ */
+export function ErrorPanel({ content, onAction }: Props): React.ReactElement {
+  useInput((input, key) => {
+    if (key.escape) {
+      const cancel = content.actions.find((a) => a.action.type === "cancel");
+      if (cancel) onAction(cancel.action);
+      return;
+    }
+    const match = content.actions.find((a) => a.key.toLowerCase() === input.toLowerCase());
+    if (match) onAction(match.action);
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="double" borderColor="red" paddingX={1}>
+      <Text bold color="red">
+        {content.title}
+      </Text>
+      <Box flexDirection="column" marginY={1}>
+        {content.body.map((line, i) => (
+          <Text key={i} wrap="wrap">
+            {line}
+          </Text>
+        ))}
+      </Box>
+      <Box flexDirection="column">
+        {content.actions.map((a) => (
+          <Text key={a.key}>
+            <Text color="cyan">[{a.key}]</Text> <Text>{a.label}</Text>
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/tools/router/src/tui/components/TriagePanel.tsx
+++ b/tools/router/src/tui/components/TriagePanel.tsx
@@ -1,0 +1,65 @@
+import { Box, Text } from "ink";
+import React from "react";
+import type { TaskEnvelope } from "../../types.js";
+
+interface Props {
+  envelope: TaskEnvelope | null;
+}
+
+/**
+ * Shows the current triage verdict: complexity, confidence, chosen tier,
+ * and a one-line rationale. Updates in place when escalation mints a new
+ * envelope.
+ */
+export function TriagePanel({ envelope }: Props): React.ReactElement {
+  if (!envelope) {
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1}>
+        <Text color="gray">Triage: waiting for prompt…</Text>
+      </Box>
+    );
+  }
+
+  const { triage } = envelope;
+  const tierColor =
+    triage.tier === "fast" ? "green" : triage.tier === "deep" ? "magenta" : "cyan";
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1}>
+      <Box>
+        <Text bold>Triage </Text>
+        <Text color="gray">({triage.source})</Text>
+      </Box>
+      <Box>
+        <Text>  complexity: </Text>
+        <Text bold>{triage.complexity}</Text>
+        <Text>   confidence: </Text>
+        <Text>{triage.confidence.toFixed(2)}</Text>
+      </Box>
+      <Box>
+        <Text>  tier:       </Text>
+        <Text color={tierColor} bold>
+          {triage.tier}
+        </Text>
+        <Text>   model: </Text>
+        <Text>{triage.model}</Text>
+      </Box>
+      <Box>
+        <Text>  provider:   </Text>
+        <Text>{triage.provider}</Text>
+      </Box>
+      {envelope.escalation && (
+        <Box>
+          <Text color="yellow">
+            ⚠ escalated from {envelope.escalation.fromTier} ({envelope.escalation.reason})
+          </Text>
+        </Box>
+      )}
+      <Box>
+        <Text color="gray" wrap="wrap">
+          {triage.rationale}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/tools/router/src/tui/components/WorkerStream.tsx
+++ b/tools/router/src/tui/components/WorkerStream.tsx
@@ -1,0 +1,82 @@
+import { Box, Text } from "ink";
+import Spinner from "ink-spinner";
+import React from "react";
+
+export interface StreamLine {
+  kind: "text" | "tool" | "status" | "error";
+  content: string;
+}
+
+interface Props {
+  lines: StreamLine[];
+  active: boolean;
+  model: string;
+  maxLines?: number;
+}
+
+/**
+ * Streaming worker output. Keeps the last N lines (default 20) so the panel
+ * never grows unbounded. Tool calls are rendered with an arrow marker; plain
+ * assistant text is rendered as-is.
+ */
+export function WorkerStream({
+  lines,
+  active,
+  model,
+  maxLines = 20,
+}: Props): React.ReactElement {
+  const visible = lines.slice(-maxLines);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} flexGrow={1}>
+      <Box>
+        <Text bold>Worker </Text>
+        <Text color="gray">({model})</Text>
+        <Text> </Text>
+        {active ? (
+          <Text color="green">
+            <Spinner type="dots" /> live
+          </Text>
+        ) : (
+          <Text color="gray">idle</Text>
+        )}
+      </Box>
+      {visible.length === 0 ? (
+        <Text color="gray">  (no output yet)</Text>
+      ) : (
+        visible.map((line, i) => (
+          <Box key={i}>
+            <Text color={colorFor(line.kind)}>{prefixFor(line.kind)}</Text>
+            <Text wrap="wrap">{line.content}</Text>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}
+
+function prefixFor(kind: StreamLine["kind"]): string {
+  switch (kind) {
+    case "tool":
+      return "▸ ";
+    case "status":
+      return "· ";
+    case "error":
+      return "✗ ";
+    default:
+      return "  ";
+  }
+}
+
+function colorFor(kind: StreamLine["kind"]): string {
+  switch (kind) {
+    case "tool":
+      return "cyan";
+    case "status":
+      return "gray";
+    case "error":
+      return "red";
+    default:
+      return "white";
+  }
+}

--- a/tools/router/src/types.ts
+++ b/tools/router/src/types.ts
@@ -1,0 +1,276 @@
+/**
+ * Core type definitions shared across the router.
+ *
+ * All cross-module contracts live here so that config, providers, triage,
+ * dispatch, and the TUI can agree on a single vocabulary.
+ */
+
+// ---------------------------------------------------------------------------
+// Tiers
+// ---------------------------------------------------------------------------
+
+export type TierName = "fast" | "default" | "deep" | (string & {});
+
+export interface TierConfig {
+  /** Provider id (must exist in config.providers). */
+  provider: string;
+  /** Model id to request from the provider. */
+  model: string;
+  /** Soft cap on response tokens for workers at this tier. */
+  maxTokens?: number;
+  /** Human-readable description, shown in the TUI. */
+  description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Triage
+// ---------------------------------------------------------------------------
+
+export type ComplexityLabel =
+  | "trivial"
+  | "simple"
+  | "moderate"
+  | "complex"
+  | "research";
+
+export interface TriageSignals {
+  promptTokens: number;
+  fileGlobBreadth: number;
+  verbClass: "read" | "write" | "design" | "unknown";
+  keywords: string[];
+  hasMultiStepMarkers: boolean;
+}
+
+export interface TriageVerdict {
+  complexity: ComplexityLabel;
+  confidence: number;
+  reasoningDepth: 1 | 2 | 3 | 4 | 5;
+  ambiguity: 1 | 2 | 3 | 4 | 5;
+  requiresCodebaseExploration: boolean;
+  requiresMultiFileEdits: boolean;
+  rationale: string;
+  recommendedTier: TierName;
+  source: "heuristic" | "llm" | "user-override";
+}
+
+// ---------------------------------------------------------------------------
+// Envelope (the handoff contract)
+// ---------------------------------------------------------------------------
+
+export interface TaskEnvelope {
+  id: string;
+  createdAt: string;
+  parentSessionId?: string;
+  goal: string;
+  originalPrompt: string;
+  triage: TriageVerdict & {
+    tier: TierName;
+    provider: string;
+    model: string;
+    rubricVersion: string;
+  };
+  context: {
+    files: string[];
+    constraints: string[];
+    priorFindings?: string;
+  };
+  budget: {
+    maxToolCalls?: number;
+    maxTokens?: number;
+    maxUsd?: number;
+    escalationAllowed: boolean;
+  };
+  escalation?: {
+    fromTier: TierName;
+    fromModel: string;
+    reason: EscalationReason;
+    priorAttemptDigest: string;
+    bumpCount: number;
+  };
+}
+
+export type EscalationReason =
+  | "self_doubt"
+  | "loop_detected"
+  | "validation_failed"
+  | "ambiguity"
+  | "budget_exceeded"
+  | "user_requested";
+
+// ---------------------------------------------------------------------------
+// Credentials & Providers
+// ---------------------------------------------------------------------------
+
+export type AuthStrategy =
+  | "api-key"
+  | "oauth-device"
+  | "oauth-browser"
+  | "cloud-sdk"
+  | "none";
+
+export interface Credential {
+  providerId: string;
+  kind: AuthStrategy;
+  /** Opaque secret material (token, api key, etc.). Never logged. */
+  secret: string;
+  /** Optional refresh token for OAuth strategies. */
+  refreshToken?: string;
+  /** Unix ms. Undefined for non-expiring credentials like API keys. */
+  expiresAt?: number;
+  /** Provider-specific metadata (e.g. scopes, account id). */
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProbeResult {
+  ok: boolean;
+  /** Machine-readable failure kind, if not ok. */
+  reason?: ProbeFailureReason;
+  /** Human-readable detail for TUI display. */
+  message?: string;
+  /** Unix ms when this probe was performed. */
+  checkedAt: number;
+}
+
+export type ProbeFailureReason =
+  | "missing_credential"
+  | "expired_credential"
+  | "invalid_credential"
+  | "model_not_found"
+  | "entitlement_denied"
+  | "region_unavailable"
+  | "rate_limited"
+  | "network_error"
+  | "unknown";
+
+// Streaming auth events — providers emit these during login flows so the
+// TUI can render device codes, polling spinners, etc.
+export type AuthEvent =
+  | { type: "instruction"; message: string }
+  | {
+      type: "device_code";
+      userCode: string;
+      verificationUri: string;
+      verificationUriComplete?: string;
+      expiresAt: number;
+    }
+  | { type: "polling"; waitMs: number }
+  | { type: "prompt_secret"; label: string; mask: boolean }
+  | { type: "success"; credential: Credential }
+  | { type: "error"; message: string; recoverable: boolean };
+
+export interface AuthContext {
+  /**
+   * Invoked by a provider when it needs a value from the user (API key paste,
+   * passphrase, etc.). The TUI wires this up to an interactive prompt.
+   */
+  requestInput(opts: { label: string; mask: boolean }): Promise<string>;
+  /** Abort signal — TUI cancels auth flows when user presses Esc. */
+  signal: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// Provider plugin interface
+// ---------------------------------------------------------------------------
+
+export interface ModelInfo {
+  id: string;
+  displayName?: string;
+  contextWindow?: number;
+  tierHint?: TierName;
+}
+
+export interface DispatchRequest {
+  envelope: TaskEnvelope;
+  signal: AbortSignal;
+  onEvent: (event: DispatchEvent) => void;
+}
+
+export type DispatchEvent =
+  | { type: "worker_start"; model: string }
+  | { type: "tool_call"; name: string; input: unknown }
+  | { type: "tool_result"; name: string; ok: boolean }
+  | { type: "assistant_text"; text: string }
+  | { type: "token_usage"; inputTokens: number; outputTokens: number }
+  | {
+      type: "escalation_requested";
+      reason: EscalationReason;
+      digest: string;
+    }
+  | { type: "worker_done"; digest: string; status: "success" | "failure" };
+
+export interface Provider {
+  /** Stable identifier used in config (e.g. "anthropic", "claude"). */
+  readonly id: string;
+  readonly displayName: string;
+  readonly authStrategy: AuthStrategy;
+
+  /**
+   * Stream an auth flow. Yields AuthEvent until a credential is obtained
+   * or an error is thrown. The final event must be `success` or `error`.
+   */
+  login(ctx: AuthContext): AsyncIterable<AuthEvent>;
+
+  /** Refresh an expired credential, if the strategy supports it. */
+  refresh?(credential: Credential): Promise<Credential>;
+
+  /** Revoke server-side if applicable. */
+  logout?(credential: Credential): Promise<void>;
+
+  /** Cheap check: can this credential actually call this model? */
+  probe(model: string, credential: Credential): Promise<ProbeResult>;
+
+  /**
+   * Run a task envelope against this provider. Yields DispatchEvent via
+   * the onEvent callback and resolves when the worker is done.
+   */
+  dispatch(request: DispatchRequest, credential: Credential): Promise<void>;
+
+  /** Optional: discover available models for an authenticated account. */
+  listModels?(credential: Credential): Promise<ModelInfo[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+export interface BudgetState {
+  inputTokens: number;
+  outputTokens: number;
+  toolCalls: number;
+  usd: number;
+  escalations: number;
+  startedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class RouterError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "RouterError";
+  }
+}
+
+export class AuthError extends RouterError {
+  constructor(
+    message: string,
+    public reason: ProbeFailureReason,
+    details?: Record<string, unknown>,
+  ) {
+    super(message, "AUTH_ERROR", details);
+    this.name = "AuthError";
+  }
+}
+
+export class ConfigError extends RouterError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, "CONFIG_ERROR", details);
+    this.name = "ConfigError";
+  }
+}

--- a/tools/router/src/types.ts
+++ b/tools/router/src/types.ts
@@ -183,6 +183,24 @@ export interface DispatchRequest {
   envelope: TaskEnvelope;
   signal: AbortSignal;
   onEvent: (event: DispatchEvent) => void;
+  /** Tools the worker can invoke. Passed in by the dispatcher. */
+  tools?: ToolSpec[];
+  /** Callback for executing a tool the provider surfaced from the model. */
+  executeTool?: (
+    name: string,
+    input: unknown,
+  ) => Promise<{ content: string; isError?: boolean }>;
+}
+
+/**
+ * Provider-agnostic tool specification. The dispatcher converts its internal
+ * ToolRegistry to this shape before handing off to a Provider, so providers
+ * don't need to know about the ToolRegistry class.
+ */
+export interface ToolSpec {
+  name: string;
+  description: string;
+  inputSchema: unknown;
 }
 
 export type DispatchEvent =

--- a/tools/router/src/types.ts
+++ b/tools/router/src/types.ts
@@ -61,6 +61,19 @@ export interface TaskEnvelope {
   id: string;
   createdAt: string;
   parentSessionId?: string;
+  /**
+   * If this envelope was spawned by a parent worker via consult_expert or
+   * delegate_subtask, this points back to the parent envelope. Used by the
+   * cost analyzer and the TUI to attribute child cost to its parent task.
+   */
+  parentEnvelopeId?: string;
+  /**
+   * Mode of decomposition. "consultation" envelopes are one-shot Q&A workers
+   * with no tools and no further escalation; "delegation" envelopes are full
+   * sub-tasks that can use tools and escalate. The dispatcher uses this to
+   * pick the right code path.
+   */
+  decompositionMode?: "consultation" | "delegation";
   goal: string;
   originalPrompt: string;
   triage: TriageVerdict & {

--- a/tools/router/test/budget.test.ts
+++ b/tools/router/test/budget.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import { BudgetTracker } from "../src/dispatch/budget.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: { default: { provider: "p", model: "claude-sonnet-4-6" } },
+  providers: { p: { kind: "anthropic-api" } },
+  budgets: {
+    perTask: { usd: 0.01, toolCalls: 2 },
+  },
+});
+
+describe("BudgetTracker", () => {
+  it("accumulates tokens and computes cost", () => {
+    const t = new BudgetTracker(config);
+    t.observe(
+      { type: "token_usage", inputTokens: 1000, outputTokens: 1000 },
+      "claude-sonnet-4-6",
+    );
+    assert.equal(t.state.inputTokens, 1000);
+    assert.equal(t.state.outputTokens, 1000);
+    assert.ok(t.state.usd > 0);
+  });
+
+  it("counts tool calls", () => {
+    const t = new BudgetTracker(config);
+    t.observe({ type: "tool_call", name: "read", input: {} }, "m");
+    t.observe({ type: "tool_call", name: "read", input: {} }, "m");
+    assert.equal(t.state.toolCalls, 2);
+  });
+
+  it("reports exceedance when caps are blown", () => {
+    const t = new BudgetTracker(config);
+    t.observe({ type: "tool_call", name: "x", input: {} }, "m");
+    t.observe({ type: "tool_call", name: "x", input: {} }, "m");
+    t.observe({ type: "tool_call", name: "x", input: {} }, "m");
+    assert.match(t.exceeded() ?? "", /tool call cap/);
+  });
+
+  it("returns null when within caps", () => {
+    const t = new BudgetTracker(config);
+    t.observe({ type: "tool_call", name: "x", input: {} }, "m");
+    assert.equal(t.exceeded(), null);
+  });
+});

--- a/tools/router/test/config.test.ts
+++ b/tools/router/test/config.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+
+describe("RouterConfigSchema", () => {
+  it("accepts a minimal config and fills defaults", () => {
+    const parsed = RouterConfigSchema.parse({
+      tiers: {
+        fast: { provider: "p", model: "m" },
+        default: { provider: "p", model: "m" },
+      },
+      providers: { p: { kind: "anthropic-api" } },
+    });
+    assert.equal(parsed.defaultTier, "default");
+    assert.equal(parsed.escalation.enabled, true);
+    assert.equal(parsed.triage.minConfidence, 0.6);
+    assert.deepEqual(parsed.heuristics, []);
+  });
+
+  it("rejects heuristic rules without a tier", () => {
+    assert.throws(() =>
+      RouterConfigSchema.parse({
+        tiers: { default: { provider: "p", model: "m" } },
+        providers: { p: { kind: "anthropic-api" } },
+        heuristics: [{ when: {} }],
+      }),
+    );
+  });
+
+  it("preserves weights when fully specified", () => {
+    const parsed = RouterConfigSchema.parse({
+      tiers: { default: { provider: "p", model: "m" } },
+      providers: { p: { kind: "anthropic-api" } },
+      weights: {
+        ambiguity: 0.5,
+        multiFileEdits: 0.1,
+        reasoningDepth: 0.1,
+        codebaseExplore: 0.2,
+        promptLength: 0.1,
+      },
+    });
+    assert.equal(parsed.weights.ambiguity, 0.5);
+  });
+});

--- a/tools/router/test/consultation.test.ts
+++ b/tools/router/test/consultation.test.ts
@@ -1,0 +1,214 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import { MemoryCredentialStore } from "../src/credentials/memory-store.js";
+import { Dispatcher } from "../src/dispatch/dispatcher.js";
+import { PreflightCache } from "../src/dispatch/preflight.js";
+import { JsonlLogger } from "../src/telemetry/jsonl-logger.js";
+import { buildEnvelope } from "../src/triage/envelope.js";
+import type {
+  Credential,
+  DispatchRequest,
+  ProbeResult,
+  Provider,
+  TriageVerdict,
+} from "../src/types.js";
+
+/**
+ * Scriptable provider that returns a fixed digest and reports a fixed token
+ * usage. Used to verify the consult/delegate cost accounting without making
+ * real API calls.
+ */
+class ScriptedProvider implements Provider {
+  readonly authStrategy = "api-key" as const;
+  digestForModel: Record<string, string> = {};
+  inputTokensForModel: Record<string, number> = {};
+  outputTokensForModel: Record<string, number> = {};
+  consultsObserved = 0;
+
+  constructor(
+    readonly id: string,
+    readonly displayName: string = id,
+  ) {}
+
+  async *login(): AsyncIterable<never> {}
+
+  async probe(): Promise<ProbeResult> {
+    return { ok: true, checkedAt: Date.now() };
+  }
+
+  async dispatch(req: DispatchRequest, _credential: Credential): Promise<void> {
+    if (req.envelope.decompositionMode === "consultation") {
+      this.consultsObserved += 1;
+    }
+    req.onEvent({ type: "worker_start", model: req.envelope.triage.model });
+    req.onEvent({
+      type: "token_usage",
+      inputTokens: this.inputTokensForModel[req.envelope.triage.model] ?? 100,
+      outputTokens: this.outputTokensForModel[req.envelope.triage.model] ?? 200,
+    });
+    req.onEvent({
+      type: "worker_done",
+      digest:
+        this.digestForModel[req.envelope.triage.model] ??
+        `default digest from ${req.envelope.triage.model}`,
+      status: "success",
+    });
+  }
+}
+
+const baseConfig = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "claude-haiku-4-5", maxTokens: 1000 },
+    default: { provider: "p", model: "claude-sonnet-4-6", maxTokens: 10000 },
+    deep: { provider: "p", model: "claude-opus-4-6", maxTokens: 100000 },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+});
+
+const verdict: TriageVerdict = {
+  complexity: "simple",
+  confidence: 0.9,
+  reasoningDepth: 1,
+  ambiguity: 1,
+  requiresCodebaseExploration: false,
+  requiresMultiFileEdits: false,
+  rationale: "t",
+  recommendedTier: "fast",
+  source: "heuristic",
+};
+
+async function tempLogger(): Promise<JsonlLogger> {
+  const dir = await mkdtemp(join(tmpdir(), "router-consult-"));
+  return new JsonlLogger(join(dir, "log.jsonl"));
+}
+
+async function makeDispatcher(
+  provider: ScriptedProvider,
+  overrides: { maxConsultationsPerTask?: number } = {},
+): Promise<Dispatcher> {
+  const store = new MemoryCredentialStore();
+  await store.set("p", { providerId: "p", kind: "api-key", secret: "sk" });
+  return new Dispatcher({
+    config: baseConfig,
+    providers: new Map([["p", provider]]),
+    store,
+    cache: new PreflightCache(join(tmpdir(), `consult-cache-${Date.now()}.json`)),
+    logger: await tempLogger(),
+    ...overrides,
+  });
+}
+
+describe("Dispatcher.consult", () => {
+  it("returns a digest from a higher-tier model", async () => {
+    const provider = new ScriptedProvider("p");
+    provider.digestForModel["claude-sonnet-4-6"] = "expert says: do this";
+    const dispatcher = await makeDispatcher(provider);
+
+    const env = buildEnvelope({ prompt: "tiny task", config: baseConfig, verdict });
+    const result = await dispatcher.consult(env, "should I refactor X?");
+    assert.equal(result.digest, "expert says: do this");
+    assert.ok(result.cost > 0, "consultation should incur a cost");
+    assert.equal(provider.consultsObserved, 1);
+  });
+
+  it("respects the maxConsultationsPerTask cap", async () => {
+    const provider = new ScriptedProvider("p");
+    const dispatcher = await makeDispatcher(provider, {
+      maxConsultationsPerTask: 2,
+    });
+    const env = buildEnvelope({ prompt: "x", config: baseConfig, verdict });
+    await dispatcher.consult(env, "q1");
+    await dispatcher.consult(env, "q2");
+    await assert.rejects(
+      () => dispatcher.consult(env, "q3"),
+      /Consultation cap reached/,
+    );
+  });
+
+  it("counts consultations against the root task across child envelopes", async () => {
+    const provider = new ScriptedProvider("p");
+    const dispatcher = await makeDispatcher(provider, {
+      maxConsultationsPerTask: 1,
+    });
+    const env = buildEnvelope({ prompt: "x", config: baseConfig, verdict });
+    await dispatcher.consult(env, "q1");
+
+    // A child envelope sharing the same root id is still capped.
+    const childEnv = {
+      ...env,
+      id: `${env.id}-child`,
+      parentEnvelopeId: env.id,
+    };
+    await assert.rejects(
+      () => dispatcher.consult(childEnv, "q2"),
+      /Consultation cap reached/,
+    );
+  });
+
+  it("uses the next-higher tier when no tier is specified", async () => {
+    const provider = new ScriptedProvider("p");
+    provider.digestForModel["claude-sonnet-4-6"] = "from sonnet";
+    provider.digestForModel["claude-opus-4-6"] = "from opus";
+    const dispatcher = await makeDispatcher(provider);
+
+    const env = buildEnvelope({
+      prompt: "x",
+      config: baseConfig,
+      verdict: { ...verdict, recommendedTier: "fast" },
+    });
+    const result = await dispatcher.consult(env, "q");
+    // fast → default = sonnet
+    assert.equal(result.digest, "from sonnet");
+  });
+
+  it("respects an explicit tier override", async () => {
+    const provider = new ScriptedProvider("p");
+    provider.digestForModel["claude-opus-4-6"] = "from opus directly";
+    const dispatcher = await makeDispatcher(provider);
+
+    const env = buildEnvelope({
+      prompt: "x",
+      config: baseConfig,
+      verdict: { ...verdict, recommendedTier: "fast" },
+    });
+    const result = await dispatcher.consult(env, "q", "deep");
+    assert.equal(result.digest, "from opus directly");
+  });
+});
+
+describe("Dispatcher.delegate", () => {
+  it("returns the sub-worker's digest and a cost", async () => {
+    const provider = new ScriptedProvider("p");
+    provider.digestForModel["claude-haiku-4-5"] = "subtask done";
+    const dispatcher = await makeDispatcher(provider);
+
+    const env = buildEnvelope({
+      prompt: "plan",
+      config: baseConfig,
+      verdict: { ...verdict, recommendedTier: "deep" },
+    });
+    const result = await dispatcher.delegate(env, "execute step 1", "fast");
+    assert.equal(result.status, "success");
+    assert.equal(result.digest, "subtask done");
+    assert.ok(result.cost > 0);
+  });
+
+  it("uses the next-lower tier when no tier is specified", async () => {
+    const provider = new ScriptedProvider("p");
+    provider.digestForModel["claude-sonnet-4-6"] = "from sonnet exec";
+    const dispatcher = await makeDispatcher(provider);
+
+    const env = buildEnvelope({
+      prompt: "plan",
+      config: baseConfig,
+      verdict: { ...verdict, recommendedTier: "deep" },
+    });
+    const result = await dispatcher.delegate(env, "execute");
+    // deep → default = sonnet
+    assert.equal(result.digest, "from sonnet exec");
+  });
+});

--- a/tools/router/test/cost.test.ts
+++ b/tools/router/test/cost.test.ts
@@ -1,0 +1,241 @@
+import { strict as assert } from "node:assert";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { analyzeCost } from "../src/commands/cost.js";
+import { RouterConfigSchema } from "../src/config/schema.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "claude-haiku-4-5" },
+    default: { provider: "p", model: "claude-sonnet-4-6" },
+    deep: { provider: "p", model: "claude-opus-4-6" },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+});
+
+interface FakeRecord {
+  ts: string;
+  kind: string;
+  [key: string]: unknown;
+}
+
+async function withFixture(records: FakeRecord[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "router-cost-"));
+  const logsDir = join(dir, "logs");
+  mkdirSync(logsDir, { recursive: true });
+  // Group records by date prefix into separate JSONL files (the analyzer
+  // uses filename as a fast date filter).
+  const byDay = new Map<string, FakeRecord[]>();
+  for (const r of records) {
+    const day = r.ts.slice(0, 10);
+    const cur = byDay.get(day) ?? [];
+    cur.push(r);
+    byDay.set(day, cur);
+  }
+  for (const [day, group] of byDay) {
+    writeFileSync(
+      join(logsDir, `${day}.jsonl`),
+      group.map((r) => JSON.stringify(r)).join("\n") + "\n",
+    );
+  }
+  return logsDir;
+}
+
+describe("analyzeCost", () => {
+  it("rolls up realized spend across envelopes", async () => {
+    const logsDir = await withFixture([
+      {
+        ts: "2026-04-01T10:00:00Z",
+        kind: "envelope",
+        envelopeId: "e1",
+        tier: "fast",
+        provider: "p",
+        model: "claude-haiku-4-5",
+        complexity: "simple",
+        confidence: 0.9,
+        source: "heuristic",
+        escalated: false,
+      },
+      {
+        ts: "2026-04-01T10:00:01Z",
+        kind: "done",
+        envelopeId: "e1",
+        status: "success",
+        budget: {
+          inputTokens: 1000,
+          outputTokens: 500,
+          toolCalls: 2,
+          usd: 0.0035,
+          escalations: 0,
+          startedAt: 0,
+        },
+      },
+      {
+        ts: "2026-04-01T11:00:00Z",
+        kind: "envelope",
+        envelopeId: "e2",
+        tier: "deep",
+        provider: "p",
+        model: "claude-opus-4-6",
+        complexity: "complex",
+        confidence: 0.9,
+        source: "llm",
+        escalated: false,
+      },
+      {
+        ts: "2026-04-01T11:00:01Z",
+        kind: "done",
+        envelopeId: "e2",
+        status: "success",
+        budget: {
+          inputTokens: 2000,
+          outputTokens: 1000,
+          toolCalls: 5,
+          usd: 0.105,
+          escalations: 0,
+          startedAt: 0,
+        },
+      },
+    ]);
+    const report = analyzeCost({ config, logsDir });
+    assert.equal(report.totalEnvelopes, 2);
+    assert.ok(Math.abs(report.totalUsd - 0.1085) < 1e-9);
+    assert.equal(report.byTier.fast?.count, 1);
+    assert.equal(report.byTier.deep?.count, 1);
+    assert.ok(report.byTier.deep?.usd && report.byTier.deep.usd > 0.1);
+    await rm(logsDir, { recursive: true, force: true });
+  });
+
+  it("computes counterfactual baselines for every tier", async () => {
+    const logsDir = await withFixture([
+      {
+        ts: "2026-04-01T10:00:00Z",
+        kind: "envelope",
+        envelopeId: "e1",
+        tier: "fast",
+        provider: "p",
+        model: "claude-haiku-4-5",
+        complexity: "simple",
+        confidence: 0.9,
+        source: "heuristic",
+        escalated: false,
+      },
+      {
+        ts: "2026-04-01T10:00:01Z",
+        kind: "done",
+        envelopeId: "e1",
+        status: "success",
+        budget: {
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          toolCalls: 0,
+          usd: 6, // (1M*$1 + 1M*$5) / 1M = $6
+          escalations: 0,
+          startedAt: 0,
+        },
+      },
+    ]);
+    const report = analyzeCost({ config, logsDir });
+    // Counterfactual for "deep" (opus): (1M*$15 + 1M*$75) / 1M = $90
+    const deepCf = report.counterfactuals.deep;
+    assert.ok(deepCf, "expected deep counterfactual");
+    assert.ok(Math.abs(deepCf.usd - 90) < 1e-9);
+    // Saving = always-deep - realized = 90 - 6 = 84
+    assert.ok(Math.abs(deepCf.saving - 84) < 1e-9);
+    assert.ok(deepCf.savingPct > 90); // 84/90 ≈ 93%
+    await rm(logsDir, { recursive: true, force: true });
+  });
+
+  it("filters by --since and --until", async () => {
+    const logsDir = await withFixture([
+      {
+        ts: "2026-04-01T10:00:00Z",
+        kind: "envelope",
+        envelopeId: "old",
+        tier: "fast",
+        provider: "p",
+        model: "claude-haiku-4-5",
+        complexity: "simple",
+        confidence: 0.9,
+        source: "heuristic",
+        escalated: false,
+      },
+      {
+        ts: "2026-04-05T10:00:00Z",
+        kind: "envelope",
+        envelopeId: "new",
+        tier: "fast",
+        provider: "p",
+        model: "claude-haiku-4-5",
+        complexity: "simple",
+        confidence: 0.9,
+        source: "heuristic",
+        escalated: false,
+      },
+    ]);
+    const filtered = analyzeCost({ config, logsDir, since: "2026-04-03" });
+    assert.equal(filtered.totalEnvelopes, 1);
+    await rm(logsDir, { recursive: true, force: true });
+  });
+
+  it("attributes consultation overhead from consultation_done records", async () => {
+    const logsDir = await withFixture([
+      {
+        ts: "2026-04-01T10:00:00Z",
+        kind: "envelope",
+        envelopeId: "main",
+        tier: "fast",
+        provider: "p",
+        model: "claude-haiku-4-5",
+        complexity: "simple",
+        confidence: 0.9,
+        source: "heuristic",
+        escalated: false,
+      },
+      {
+        ts: "2026-04-01T10:00:01Z",
+        kind: "done",
+        envelopeId: "main",
+        status: "success",
+        budget: {
+          inputTokens: 100,
+          outputTokens: 100,
+          toolCalls: 1,
+          usd: 0.01,
+          escalations: 0,
+          startedAt: 0,
+        },
+      },
+      {
+        ts: "2026-04-01T10:00:02Z",
+        kind: "consultation",
+        envelopeId: "main-c1",
+        parentEnvelopeId: "main",
+        tier: "deep",
+        model: "claude-opus-4-6",
+      },
+      {
+        ts: "2026-04-01T10:00:03Z",
+        kind: "consultation_done",
+        envelopeId: "main-c1",
+        parentEnvelopeId: "main",
+        cost: 0.005,
+      },
+    ]);
+    const report = analyzeCost({ config, logsDir });
+    assert.equal(report.totalConsultations, 1);
+    assert.ok(Math.abs(report.consultationOverheadUsd - 0.005) < 1e-9);
+    await rm(logsDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty report when no logs exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "router-empty-"));
+    const report = analyzeCost({ config, logsDir: join(dir, "logs") });
+    assert.equal(report.totalEnvelopes, 0);
+    assert.equal(report.totalUsd, 0);
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tools/router/test/credentials.test.ts
+++ b/tools/router/test/credentials.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { MemoryCredentialStore } from "../src/credentials/memory-store.js";
+import type { Credential } from "../src/types.js";
+
+describe("MemoryCredentialStore", () => {
+  const cred: Credential = {
+    providerId: "test",
+    kind: "api-key",
+    secret: "sk-ant-fake",
+  };
+
+  it("round-trips a credential", async () => {
+    const store = new MemoryCredentialStore();
+    await store.set("test", cred);
+    const got = await store.get("test");
+    assert.deepEqual(got, cred);
+  });
+
+  it("returns null for missing providers", async () => {
+    const store = new MemoryCredentialStore();
+    assert.equal(await store.get("nope"), null);
+  });
+
+  it("lists stored providers", async () => {
+    const store = new MemoryCredentialStore();
+    await store.set("a", cred);
+    await store.set("b", cred);
+    const list = await store.list();
+    assert.deepEqual(list.sort(), ["a", "b"]);
+  });
+
+  it("deletes credentials", async () => {
+    const store = new MemoryCredentialStore();
+    await store.set("test", cred);
+    await store.delete("test");
+    assert.equal(await store.get("test"), null);
+  });
+
+  it("delete is idempotent", async () => {
+    const store = new MemoryCredentialStore();
+    await store.delete("never-existed");
+    assert.equal(await store.get("never-existed"), null);
+  });
+});

--- a/tools/router/test/envelope.test.ts
+++ b/tools/router/test/envelope.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import {
+  buildEnvelope,
+  bumpTier,
+  escalateEnvelope,
+} from "../src/triage/envelope.js";
+import type { TriageVerdict } from "../src/types.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "m-fast", maxTokens: 1000 },
+    default: { provider: "p", model: "m-default", maxTokens: 10000 },
+    deep: { provider: "p", model: "m-deep", maxTokens: 100000 },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+  escalation: { maxBumps: 2 },
+});
+
+const verdict: TriageVerdict = {
+  complexity: "moderate",
+  confidence: 0.8,
+  reasoningDepth: 3,
+  ambiguity: 2,
+  requiresCodebaseExploration: false,
+  requiresMultiFileEdits: false,
+  rationale: "test",
+  recommendedTier: "default",
+  source: "heuristic",
+};
+
+describe("buildEnvelope", () => {
+  it("resolves tier to provider and model", () => {
+    const env = buildEnvelope({ prompt: "do a thing", config, verdict });
+    assert.equal(env.triage.tier, "default");
+    assert.equal(env.triage.provider, "p");
+    assert.equal(env.triage.model, "m-default");
+  });
+
+  it("derives a goal from the first line of the prompt", () => {
+    const env = buildEnvelope({
+      prompt: "short goal\nlots of detail below",
+      config,
+      verdict,
+    });
+    assert.equal(env.goal, "short goal");
+  });
+
+  it("falls back to default tier when recommended tier is unknown", () => {
+    const env = buildEnvelope({
+      prompt: "x",
+      config,
+      verdict: { ...verdict, recommendedTier: "turbo" },
+    });
+    assert.equal(env.triage.tier, "default");
+  });
+
+  it("populates budget from tier maxTokens", () => {
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    assert.equal(env.budget.maxTokens, 10000);
+  });
+});
+
+describe("bumpTier", () => {
+  it("moves up one step in maxTokens order", () => {
+    assert.equal(bumpTier("fast", config), "default");
+    assert.equal(bumpTier("default", config), "deep");
+  });
+  it("returns null at the top", () => {
+    assert.equal(bumpTier("deep", config), null);
+  });
+});
+
+describe("escalateEnvelope", () => {
+  it("mints a new envelope with the next tier and the prior digest", () => {
+    const first = buildEnvelope({ prompt: "x", config, verdict });
+    const next = escalateEnvelope(first, config, "self_doubt", "got stuck");
+    assert.notEqual(next.id, first.id);
+    assert.equal(next.triage.tier, "deep");
+    assert.equal(next.escalation?.reason, "self_doubt");
+    assert.equal(next.escalation?.bumpCount, 1);
+    assert.equal(next.escalation?.priorAttemptDigest, "got stuck");
+  });
+
+  it("enforces the bump cap", () => {
+    const first = buildEnvelope({
+      prompt: "x",
+      config,
+      verdict: { ...verdict, recommendedTier: "fast" },
+    });
+    const second = escalateEnvelope(first, config, "self_doubt", "d1");
+    const third = escalateEnvelope(second, config, "self_doubt", "d2");
+    assert.equal(third.escalation?.bumpCount, 2);
+    assert.throws(
+      () => escalateEnvelope(third, config, "self_doubt", "d3"),
+      /No higher tier|Escalation cap reached/,
+    );
+  });
+});

--- a/tools/router/test/escalation.test.ts
+++ b/tools/router/test/escalation.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import { EscalationController } from "../src/dispatch/escalation.js";
+import { buildEnvelope } from "../src/triage/envelope.js";
+import type { TriageVerdict } from "../src/types.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "m1" },
+    default: { provider: "p", model: "m2" },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+  escalation: {
+    enabled: true,
+    triggers: {
+      validationFailures: 2,
+      toolLoopThreshold: 3,
+      selfDoubt: true,
+    },
+    maxBumps: 2,
+  },
+});
+
+const verdict: TriageVerdict = {
+  complexity: "simple",
+  confidence: 0.9,
+  reasoningDepth: 1,
+  ambiguity: 1,
+  requiresCodebaseExploration: false,
+  requiresMultiFileEdits: false,
+  rationale: "t",
+  recommendedTier: "fast",
+  source: "heuristic",
+};
+
+describe("EscalationController", () => {
+  it("fires on self-doubt signal", () => {
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    let fired: { reason: string; digest: string } | null = null;
+    const ctrl = new EscalationController(config, env, (t) => {
+      fired = t;
+    });
+    ctrl.observe({
+      type: "escalation_requested",
+      reason: "self_doubt",
+      digest: "help",
+    });
+    assert.ok(fired);
+    assert.equal((fired as { reason: string }).reason, "self_doubt");
+  });
+
+  it("fires after repeated validation failures", () => {
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    let count = 0;
+    const ctrl = new EscalationController(config, env, () => {
+      count += 1;
+    });
+    ctrl.observe({ type: "tool_result", name: "validate", ok: false });
+    assert.equal(count, 0);
+    ctrl.observe({ type: "tool_result", name: "validate", ok: false });
+    assert.equal(count, 1);
+  });
+
+  it("fires only once even after repeat triggers", () => {
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    let count = 0;
+    const ctrl = new EscalationController(config, env, () => {
+      count += 1;
+    });
+    ctrl.observe({
+      type: "escalation_requested",
+      reason: "self_doubt",
+      digest: "a",
+    });
+    ctrl.observe({
+      type: "escalation_requested",
+      reason: "self_doubt",
+      digest: "b",
+    });
+    assert.equal(count, 1);
+  });
+
+  it("detects tool loops", () => {
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    let fired = false;
+    const ctrl = new EscalationController(config, env, () => {
+      fired = true;
+    });
+    for (let i = 0; i < 3; i++) {
+      ctrl.observe({ type: "tool_call", name: "read", input: { path: "x" } });
+    }
+    assert.equal(fired, true);
+  });
+
+  it("respects disabled escalation", () => {
+    const disabled = RouterConfigSchema.parse({
+      ...config,
+      escalation: { ...config.escalation, enabled: false },
+    });
+    const env = buildEnvelope({ prompt: "x", config: disabled, verdict });
+    let fired = false;
+    const ctrl = new EscalationController(disabled, env, () => {
+      fired = true;
+    });
+    ctrl.observe({
+      type: "escalation_requested",
+      reason: "self_doubt",
+      digest: "a",
+    });
+    assert.equal(fired, false);
+  });
+});

--- a/tools/router/test/fallback.test.ts
+++ b/tools/router/test/fallback.test.ts
@@ -1,0 +1,172 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import { MemoryCredentialStore } from "../src/credentials/memory-store.js";
+import { Dispatcher } from "../src/dispatch/dispatcher.js";
+import { PreflightCache } from "../src/dispatch/preflight.js";
+import { JsonlLogger } from "../src/telemetry/jsonl-logger.js";
+import { buildEnvelope } from "../src/triage/envelope.js";
+import type {
+  Credential,
+  DispatchEvent,
+  DispatchRequest,
+  ProbeResult,
+  Provider,
+  TriageVerdict,
+} from "../src/types.js";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Fake Provider that lets tests script both probe outcomes and dispatch
+ * behavior. Used to verify fallback chain walking without real API calls.
+ */
+class FakeProvider implements Provider {
+  readonly authStrategy = "api-key" as const;
+  probeResults: ProbeResult[] = [];
+  dispatched: string[] = [];
+
+  constructor(
+    readonly id: string,
+    readonly displayName: string = id,
+  ) {}
+
+  async *login(): AsyncIterable<never> {
+    // not used in these tests
+  }
+
+  async probe(): Promise<ProbeResult> {
+    const next = this.probeResults.shift();
+    return next ?? { ok: true, checkedAt: Date.now() };
+  }
+
+  async dispatch(
+    req: DispatchRequest,
+    _credential: Credential,
+  ): Promise<void> {
+    this.dispatched.push(req.envelope.triage.model);
+    req.onEvent({ type: "worker_start", model: req.envelope.triage.model });
+    req.onEvent({
+      type: "worker_done",
+      digest: `ok from ${this.id}`,
+      status: "success",
+    });
+  }
+}
+
+async function tempLogger(): Promise<JsonlLogger> {
+  const dir = await mkdtemp(join(tmpdir(), "router-log-"));
+  return new JsonlLogger(join(dir, "log.jsonl"));
+}
+
+const verdict: TriageVerdict = {
+  complexity: "complex",
+  confidence: 0.9,
+  reasoningDepth: 5,
+  ambiguity: 3,
+  requiresCodebaseExploration: true,
+  requiresMultiFileEdits: true,
+  rationale: "t",
+  recommendedTier: "deep",
+  source: "llm",
+};
+
+describe("fallback chain", () => {
+  it("falls back to the next tier when preflight fails", async () => {
+    const config = RouterConfigSchema.parse({
+      tiers: {
+        default: { provider: "primary", model: "m-default", maxTokens: 10000 },
+        deep: { provider: "primary", model: "m-deep", maxTokens: 100000 },
+      },
+      providers: {
+        primary: { kind: "anthropic-api" },
+      },
+      fallback: { deep: ["default"] },
+    });
+
+    const primary = new FakeProvider("primary");
+    // Fail the first probe (deep), succeed the second (default).
+    primary.probeResults = [
+      { ok: false, reason: "entitlement_denied", checkedAt: Date.now() },
+      { ok: true, checkedAt: Date.now() },
+    ];
+
+    const store = new MemoryCredentialStore();
+    await store.set("primary", {
+      providerId: "primary",
+      kind: "api-key",
+      secret: "sk-test",
+    });
+
+    const cache = new PreflightCache(join(tmpdir(), "rt-cache.json"));
+    const logger = await tempLogger();
+
+    const dispatcher = new Dispatcher({
+      config,
+      providers: new Map([["primary", primary]]),
+      store,
+      cache,
+      logger,
+      downgradePolicy: "auto",
+    });
+
+    const env = buildEnvelope({ prompt: "hard task", config, verdict });
+    const events: DispatchEvent[] = [];
+    await dispatcher.run({
+      envelope: env,
+      signal: new AbortController().signal,
+      onEvent: (e) => {
+        if (e.type === "dispatch_event") events.push(e.event);
+      },
+    });
+
+    // The fallback should have dispatched m-default.
+    assert.ok(primary.dispatched.includes("m-default"));
+  });
+
+  it("surfaces error when downgradePolicy is never", async () => {
+    const config = RouterConfigSchema.parse({
+      tiers: {
+        default: { provider: "p", model: "m-default" },
+        deep: { provider: "p", model: "m-deep" },
+      },
+      providers: { p: { kind: "anthropic-api" } },
+      fallback: { deep: ["default"] },
+    });
+
+    const provider = new FakeProvider("p");
+    provider.probeResults = [
+      { ok: false, reason: "entitlement_denied", checkedAt: Date.now() },
+    ];
+
+    const store = new MemoryCredentialStore();
+    await store.set("p", {
+      providerId: "p",
+      kind: "api-key",
+      secret: "sk",
+    });
+    const cache = new PreflightCache(join(tmpdir(), "rt-cache2.json"));
+    const logger = await tempLogger();
+
+    const dispatcher = new Dispatcher({
+      config,
+      providers: new Map([["p", provider]]),
+      store,
+      cache,
+      logger,
+      downgradePolicy: "never",
+    });
+
+    const env = buildEnvelope({ prompt: "x", config, verdict });
+    await assert.rejects(
+      () =>
+        dispatcher.run({
+          envelope: env,
+          signal: new AbortController().signal,
+          onEvent: () => {},
+        }),
+      /entitlement_denied|Preflight failed/,
+    );
+  });
+});

--- a/tools/router/test/heuristics.test.ts
+++ b/tools/router/test/heuristics.test.ts
@@ -1,0 +1,99 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import {
+  buildHeuristicVerdict,
+  extractSignals,
+  matchHeuristics,
+} from "../src/triage/heuristics.js";
+
+const baseConfig = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "m-fast" },
+    default: { provider: "p", model: "m-default" },
+    deep: { provider: "p", model: "m-deep" },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+  heuristics: [
+    {
+      name: "trivial-reads",
+      when: { promptTokens: { lt: 50 }, verbClass: "read" },
+      tier: "fast",
+    },
+    {
+      name: "design-keywords",
+      when: { keywords: ["refactor", "architecture"] },
+      tier: "deep",
+    },
+  ],
+});
+
+describe("extractSignals", () => {
+  it("classifies verbs from the leading word", () => {
+    assert.equal(extractSignals("explain this function").verbClass, "read");
+    assert.equal(extractSignals("add a new field").verbClass, "write");
+    assert.equal(
+      extractSignals("refactor the worker pool").verbClass,
+      "design",
+    );
+  });
+
+  it("design wins over write when both present", () => {
+    const s = extractSignals("add support and refactor the architecture");
+    assert.equal(s.verbClass, "design");
+  });
+
+  it("detects multi-step markers", () => {
+    assert.equal(
+      extractSignals("first do A, then do B").hasMultiStepMarkers,
+      true,
+    );
+    assert.equal(extractSignals("just fix this bug").hasMultiStepMarkers, false);
+  });
+
+  it("estimates prompt tokens by character count", () => {
+    const s = extractSignals("abcd");
+    assert.equal(s.promptTokens, 1);
+  });
+
+  it("extracts lowercase keywords without duplicates", () => {
+    const s = extractSignals("Refactor the REFACTOR refactor");
+    assert.equal(s.keywords.filter((k) => k === "refactor").length, 1);
+  });
+});
+
+describe("matchHeuristics", () => {
+  it("matches the first applicable rule in order", () => {
+    const signals = extractSignals("explain this");
+    const match = matchHeuristics(signals, baseConfig);
+    assert.ok(match, "expected a match");
+    assert.equal(match.tier, "fast");
+  });
+
+  it("matches design keyword rules", () => {
+    const signals = extractSignals("please refactor the worker pool");
+    const match = matchHeuristics(signals, baseConfig);
+    assert.ok(match);
+    assert.equal(match.tier, "deep");
+  });
+
+  it("returns null when nothing matches", () => {
+    const signals = extractSignals(
+      "do something moderately complicated that does not mention the trigger words " +
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z".repeat(3),
+    );
+    assert.equal(matchHeuristics(signals, baseConfig), null);
+  });
+});
+
+describe("buildHeuristicVerdict", () => {
+  it("preserves the matched tier and cites the rule name", () => {
+    const signals = extractSignals("refactor the architecture");
+    const match = matchHeuristics(signals, baseConfig);
+    assert.ok(match);
+    const verdict = buildHeuristicVerdict(match, signals);
+    assert.equal(verdict.recommendedTier, "deep");
+    assert.equal(verdict.source, "heuristic");
+    assert.match(verdict.rationale, /design-keywords/);
+  });
+});

--- a/tools/router/test/hooks.test.ts
+++ b/tools/router/test/hooks.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { runHook } from "../src/dispatch/hooks.js";
+
+describe("runHook", () => {
+  it("invokes a default-export function", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "router-hook-"));
+    const hookPath = join(dir, "hook.mjs");
+    await writeFile(
+      hookPath,
+      `globalThis.__routerHookCalled = null;
+       export default function hook(payload) {
+         globalThis.__routerHookCalled = payload.event;
+       }`,
+    );
+    try {
+      await runHook(hookPath, { event: "beforeTriage", prompt: "x" });
+      assert.equal(
+        (globalThis as unknown as { __routerHookCalled: string })
+          .__routerHookCalled,
+        "beforeTriage",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("invokes an { onEvent } object export", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "router-hook-"));
+    const hookPath = join(dir, "hook-obj.mjs");
+    await writeFile(
+      hookPath,
+      `globalThis.__routerHookObj = null;
+       export const onEvent = (payload) => {
+         globalThis.__routerHookObj = payload.event;
+       };`,
+    );
+    try {
+      await runHook(hookPath, { event: "afterDispatch" });
+      assert.equal(
+        (globalThis as unknown as { __routerHookObj: string }).__routerHookObj,
+        "afterDispatch",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws on a module with no hook export", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "router-hook-"));
+    const hookPath = join(dir, "hook-bad.mjs");
+    await writeFile(hookPath, `export const unrelated = 1;`);
+    try {
+      await assert.rejects(
+        () => runHook(hookPath, { event: "beforeTriage" }),
+        /does not export/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/router/test/preflight-error.test.ts
+++ b/tools/router/test/preflight-error.test.ts
@@ -1,0 +1,51 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { renderPreflightError } from "../src/auth/preflight-error.js";
+
+describe("renderPreflightError", () => {
+  it("missing_credential offers auth and downgrade", () => {
+    const e = renderPreflightError("missing_credential", "anthropic", "opus");
+    assert.match(e.title, /opus/);
+    const actionTypes = e.actions.map((a) => a.action.type);
+    assert.ok(actionTypes.includes("auth_login"));
+    assert.ok(actionTypes.includes("downgrade"));
+    assert.ok(actionTypes.includes("cancel"));
+  });
+
+  it("entitlement_denied offers upgrade URL and downgrade", () => {
+    const e = renderPreflightError("entitlement_denied", "anthropic", "opus");
+    const actionTypes = e.actions.map((a) => a.action.type);
+    assert.ok(actionTypes.includes("open_url"));
+    assert.ok(actionTypes.includes("downgrade"));
+  });
+
+  it("every error provides at least one non-cancel forward action", () => {
+    const reasons = [
+      "missing_credential",
+      "expired_credential",
+      "invalid_credential",
+      "model_not_found",
+      "entitlement_denied",
+      "region_unavailable",
+      "rate_limited",
+      "network_error",
+      "unknown",
+    ] as const;
+    for (const r of reasons) {
+      const e = renderPreflightError(r, "p", "m");
+      const forward = e.actions.filter((a) => a.action.type !== "cancel");
+      assert.ok(forward.length > 0, `${r} has no forward action`);
+    }
+  });
+
+  it("includes the upstream message when provided", () => {
+    const e = renderPreflightError(
+      "invalid_credential",
+      "anthropic",
+      "opus",
+      "key sk-ant-abc revoked",
+    );
+    const body = e.body.join(" ");
+    assert.match(body, /revoked/);
+  });
+});

--- a/tools/router/test/tools.test.ts
+++ b/tools/router/test/tools.test.ts
@@ -1,0 +1,187 @@
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import {
+  listFilesTool,
+  readFileTool,
+  requestEscalationTool,
+  runBashTool,
+  writeFileTool,
+} from "../src/tools/builtin.js";
+import { createDefaultRegistry } from "../src/tools/index.js";
+import type { ToolContext } from "../src/tools/types.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: { default: { provider: "p", model: "m" } },
+  providers: { p: { kind: "anthropic-api" } },
+});
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "router-test-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function makeCtx(cwd: string): ToolContext {
+  return {
+    cwd,
+    signal: new AbortController().signal,
+    config,
+  };
+}
+
+describe("read_file tool", () => {
+  it("reads a file inside the cwd", async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(join(dir, "hello.txt"), "hi there");
+      const result = await readFileTool.execute({ path: "hello.txt" }, makeCtx(dir));
+      assert.equal(result.isError, undefined);
+      assert.equal(result.content, "hi there");
+    });
+  });
+
+  it("rejects paths that escape the cwd", async () => {
+    await withTempDir(async (dir) => {
+      const result = await readFileTool.execute(
+        { path: "../etc/passwd" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, true);
+      assert.match(result.content, /outside/);
+    });
+  });
+
+  it("rejects invalid input shapes", async () => {
+    await withTempDir(async (dir) => {
+      const result = await readFileTool.execute(
+        { nope: "no path field" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, true);
+    });
+  });
+
+  it("truncates large files at maxBytes", async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(join(dir, "big.txt"), "x".repeat(1000));
+      const result = await readFileTool.execute(
+        { path: "big.txt", maxBytes: 10 },
+        makeCtx(dir),
+      );
+      assert.match(result.content, /truncated/);
+    });
+  });
+});
+
+describe("write_file tool", () => {
+  it("writes a file inside the cwd", async () => {
+    await withTempDir(async (dir) => {
+      const result = await writeFileTool.execute(
+        { path: "out.txt", content: "abc" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, undefined);
+      assert.equal(await readFile(join(dir, "out.txt"), "utf8"), "abc");
+    });
+  });
+
+  it("rejects absolute paths outside the cwd", async () => {
+    await withTempDir(async (dir) => {
+      const result = await writeFileTool.execute(
+        { path: "/tmp/evil.txt", content: "bad" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, true);
+    });
+  });
+});
+
+describe("list_files tool", () => {
+  it("lists entries at depth 1", async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(join(dir, "a.txt"), "");
+      await writeFile(join(dir, "b.txt"), "");
+      const result = await listFilesTool.execute({}, makeCtx(dir));
+      assert.match(result.content, /a\.txt/);
+      assert.match(result.content, /b\.txt/);
+    });
+  });
+
+  it("skips dotfiles and node_modules", async () => {
+    await withTempDir(async (dir) => {
+      await writeFile(join(dir, ".hidden"), "");
+      await writeFile(join(dir, "visible.txt"), "");
+      const result = await listFilesTool.execute({}, makeCtx(dir));
+      assert.doesNotMatch(result.content, /\.hidden/);
+      assert.match(result.content, /visible/);
+    });
+  });
+});
+
+describe("run_bash tool", () => {
+  it("captures stdout on success", async () => {
+    await withTempDir(async (dir) => {
+      const result = await runBashTool.execute(
+        { command: "echo hello" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, false);
+      assert.match(result.content, /hello/);
+    });
+  });
+
+  it("marks non-zero exits as errors", async () => {
+    await withTempDir(async (dir) => {
+      const result = await runBashTool.execute(
+        { command: "exit 7" },
+        makeCtx(dir),
+      );
+      assert.equal(result.isError, true);
+    });
+  });
+});
+
+describe("request_escalation tool", () => {
+  it("invokes the escalation callback", async () => {
+    let called: { reason?: string; digest?: string } = {};
+    const ctx: ToolContext = {
+      cwd: process.cwd(),
+      signal: new AbortController().signal,
+      config,
+      requestEscalation: (reason, digest) => {
+        called = { reason, digest };
+      },
+    };
+    const result = await requestEscalationTool.execute(
+      { reason: "self_doubt", digest: "stuck on auth flow" },
+      ctx,
+    );
+    assert.equal(result.isError, undefined);
+    assert.equal(called.reason, "self_doubt");
+    assert.equal(called.digest, "stuck on auth flow");
+  });
+});
+
+describe("createDefaultRegistry", () => {
+  it("registers all built-in tools", () => {
+    const registry = createDefaultRegistry();
+    const names = registry.list().map((t) => t.name);
+    assert.ok(names.includes("read_file"));
+    assert.ok(names.includes("write_file"));
+    assert.ok(names.includes("list_files"));
+    assert.ok(names.includes("run_bash"));
+    assert.ok(names.includes("request_escalation"));
+  });
+
+  it("snapshot is isolated from the original", () => {
+    const original = createDefaultRegistry();
+    const snap = original.snapshot();
+    assert.equal(original.list().length, snap.list().length);
+  });
+});

--- a/tools/router/test/weights.test.ts
+++ b/tools/router/test/weights.test.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { RouterConfigSchema } from "../src/config/schema.js";
+import { applyWeights } from "../src/triage/weights.js";
+import type { TriageVerdict } from "../src/types.js";
+
+const config = RouterConfigSchema.parse({
+  tiers: {
+    fast: { provider: "p", model: "h" },
+    default: { provider: "p", model: "s" },
+    deep: { provider: "p", model: "o" },
+  },
+  providers: { p: { kind: "anthropic-api" } },
+  weights: {
+    ambiguity: 0.4,
+    multiFileEdits: 0.3,
+    reasoningDepth: 0.2,
+    codebaseExplore: 0.05,
+    promptLength: 0.05,
+  },
+});
+
+function verdict(overrides: Partial<TriageVerdict>): TriageVerdict {
+  return {
+    complexity: "moderate",
+    confidence: 0.9,
+    reasoningDepth: 3,
+    ambiguity: 3,
+    requiresCodebaseExploration: false,
+    requiresMultiFileEdits: false,
+    rationale: "baseline",
+    recommendedTier: "default",
+    source: "llm",
+    ...overrides,
+  };
+}
+
+describe("applyWeights", () => {
+  it("leaves the verdict alone for small divergences", () => {
+    const v = verdict({ recommendedTier: "default" });
+    const result = applyWeights(v, config);
+    assert.equal(result.verdict.recommendedTier, "default");
+  });
+
+  it("bumps to deep when ambiguity and multi-file edits are maxed", () => {
+    const v = verdict({
+      recommendedTier: "fast",
+      ambiguity: 5,
+      requiresMultiFileEdits: true,
+      reasoningDepth: 5,
+      requiresCodebaseExploration: true,
+    });
+    const result = applyWeights(v, config);
+    // Heavy signals + fast recommendation = big divergence → override.
+    assert.equal(result.adjusted, true);
+    assert.notEqual(result.verdict.recommendedTier, "fast");
+  });
+
+  it("does not override single-step divergences", () => {
+    // Score near the boundary but LLM says default → should stay default.
+    const v = verdict({
+      recommendedTier: "default",
+      ambiguity: 3,
+      reasoningDepth: 3,
+    });
+    const result = applyWeights(v, config);
+    assert.equal(result.verdict.recommendedTier, "default");
+  });
+
+  it("records the reweighted rationale when it overrides", () => {
+    const v = verdict({
+      recommendedTier: "fast",
+      ambiguity: 5,
+      requiresMultiFileEdits: true,
+      requiresCodebaseExploration: true,
+      reasoningDepth: 5,
+    });
+    const result = applyWeights(v, config);
+    if (result.adjusted) {
+      assert.match(result.verdict.rationale, /reweighted/);
+    }
+  });
+});

--- a/tools/router/tsconfig.json
+++ b/tools/router/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds `tools/router/` — a standalone CLI/TUI that classifies incoming tasks by complexity, dispatches them to the right model tier, and escalates mid-run when a worker gets stuck. Prioritization is fully driven by `router.config.ts` so behavior is tunable without touching code.

This is exploratory work on `claude/dynamic-agent-model-selection-74UNo` (no Jira ticket yet). Opening as **draft** so maintainers can decide scope: land as-is, scope down, or move to its own repo.

## What's in `tools/router/`

- **Pluggable provider interface** with four built-ins:
  - `anthropic-api` — paste-key auth, validated before storage, full tool-use loop
  - `oauth-device` — reusable RFC 8628 device authorization grant
  - `bedrock` — `@anthropic-ai/bedrock-sdk`, AWS default credential chain
  - `vertex` — `@anthropic-ai/vertex-sdk`, Google ADC
  - Shared `runMessagesLoop` helper so bedrock and vertex reuse the anthropic tool_use control flow
- **Credential storage** via `@napi-rs/keyring` → native OS keychains (macOS Keychain, Windows Credential Manager, Linux Secret Service). Zero plaintext on disk.
- **`TaskEnvelope` contract** as the only thing that crosses model boundaries on escalation — prior attempts survive as digests, not transcripts.
- **Dispatcher** with preflight → dispatch → escalation loop, budget tracker (tokens/tools/USD), tool registry snapshot per worker, and fallback chain walking gated by `downgradePolicy`.
- **Escalation controller** state machine: self-doubt, tool loops, validation failures, budget caps.
- **Triage** with static heuristics → Haiku LLM fallback → weights-based re-scoring. LLM judgment preserved on borderline cases.
- **Ink TUI** with triage panel, worker stream, budget meter, actionable error panels for every auth failure mode, and a device-code renderer shared between API-key paste and OAuth flows.
- **Sandboxed tool registry**: `read_file`, `write_file`, `list_files`, `run_bash`, `request_escalation`. All filesystem tools reject paths that escape the router cwd.
- **Lifecycle hooks**: `beforeTriage`, `afterDispatch`, `onEscalation` via dynamic import.
- **CLI surface**: `router`, `router run`, `router init`, `router auth {login,logout,status,doctor}`, plus `--tier`, `--require-tier`, `--allow-downgrade`, `--no-downgrade`, and `ROUTER_NO_PROMPT` CI mode.
- **Telemetry** via pino with async JSONL destination for rubric tuning.
- **60 tests** covering heuristics, envelope, escalation state machine, budget tracking, config schema, preflight error mapping, credentials, tool sandboxing, fallback chain (success + never-policy), weights boundaries, and hook loader. `tsc --noEmit` clean.

## Architecture

```
CLI (commander)
  ↓
TUI (Ink)                 auth commands (auth login/status/doctor)
  ↓                                 ↓
Dispatcher  ←  Triage  ←  Config loader (cosmiconfig + Zod)
  ↓              ↓
Providers ←  Credential store (@napi-rs/keyring)
  ↓
Tool registry (sandboxed read/write/bash/escalate)
```

All cross-module contracts live in `src/types.ts`. The dispatcher, triage, and TUI are all driven by the same event stream, so the dispatcher is equally usable headless.

## Caveats

1. **`package-lock.json` is not in this branch.** The lockfile was 262KB which exceeded the single-call size budget for the MCP push tool this session used. Run `npm install` in `tools/router/` to regenerate it against the updated `package.json` (which now includes `@anthropic-ai/bedrock-sdk` and `@anthropic-ai/vertex-sdk`).
2. **Cloud SDK providers have no integration tests.** Bedrock and Vertex have unit-testable shapes but weren't verified against real AWS/GCP endpoints in the development environment.
3. **`oauth-device` provider has no public endpoint wired in.** It's a reusable framework — consumers configure their own OAuth endpoints via `router.config.ts` options.
4. **Standalone workspace.** Intentionally not added to the root `package.json` workspaces — `tools/router/` has its own `node_modules` and lives outside the main ESO app's build. Zero risk of breaking `npm run validate` on the app.
5. **Exploratory branch name.** `AGENTS.md` prefers `ESO-<ticket>/...` for work tied to Jira. No ticket exists yet; create one first if this should land on main.
6. **Main-repo validation not run.** `npm run validate` and `npm test -- --watchAll=false` in the repo root weren't executed, since this PR only adds a sibling tool and doesn't touch the ESO app. They should pass untouched but haven't been verified.

## Test plan

- [ ] `cd tools/router && npm install` (regenerates lockfile, installs deps)
- [ ] `cd tools/router && npm test` — expect 60/60 passing
- [ ] `cd tools/router && npx tsc -p tsconfig.json --noEmit` — expect zero errors
- [ ] `cd tools/router && npx tsx src/index.ts --help` — CLI surface sanity
- [ ] `npm run validate` at repo root — confirm main app still passes
- [ ] Optional: `router init`, add an API key via `router auth login`, run `router auth doctor` against a real Anthropic key to verify end-to-end auth + preflight

## Open questions for review

1. Should `tools/router/` be added to root workspaces (idiomatic) or kept fully standalone (zero-risk)?
2. Is `claude/` branch naming acceptable here, or should we mint a Jira ticket first?
3. Scope: is this the right home for this tool, or should it be in a separate `eso-toolkit/router` repo?

https://claude.ai/code/session_01XAN9d7qYb9myM7SKEeuaXK