### PR TITLE
fix(ci): pass vars context through input to composite action

### DIFF
--- a/.github/actions/build-and-deploy/action.yml
+++ b/.github/actions/build-and-deploy/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Google Analytics measurement identifier for the build'
     required: false
     default: ''
+  vite_discord_client_id:
+    description: 'Discord OAuth client ID for the build'
+    required: false
+    default: ''
   vite_roster_hub_api_url:
     description: 'Roster Hub API URL for the build'
     required: false
@@ -46,7 +50,7 @@ runs:
       env:
         VITE_BASE_URL: '${{steps.setup.outputs.base_path}}'
         VITE_GA_MEASUREMENT_ID: ${{ inputs.vite_ga_measurement_id }}
-        VITE_DISCORD_CLIENT_ID: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+        VITE_DISCORD_CLIENT_ID: ${{ inputs.vite_discord_client_id }}
         VITE_ROSTER_HUB_API_URL: ${{ inputs.vite_roster_hub_api_url }}
 
     - name: Build Storybook

--- a/.github/actions/build-and-deploy/action.yml
+++ b/.github/actions/build-and-deploy/action.yml
@@ -15,8 +15,7 @@ inputs:
     default: ''
   vite_discord_client_id:
     description: 'Discord OAuth client ID for the build'
-    required: false
-    default: ''
+    required: true
   vite_roster_hub_api_url:
     description: 'Roster Hub API URL for the build'
     required: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,4 @@ jobs:
           enable_sourcemaps: 'true'
           release_version: ${{ github.sha }}
           vite_ga_measurement_id: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+          vite_discord_client_id: ${{ vars.VITE_DISCORD_CLIENT_ID }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -41,3 +41,4 @@ jobs:
         with:
           enable_sourcemaps: 'false'
           vite_ga_measurement_id: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+          vite_discord_client_id: ${{ vars.VITE_DISCORD_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- The `vars` context is **not available** inside composite actions — only in workflows
- This caused the deploy workflow to fail with `Unrecognized named-value: 'vars'` at action.yml line 49
- Added `vite_discord_client_id` as a new input to the composite action
- Workflow now passes `${{ vars.VITE_DISCORD_CLIENT_ID }}` through the input

## Test plan
- [ ] Merge and verify the deploy workflow passes on `main`