### PR TITLE
fix(hub): resolve pack hub 500, MMOUI addon search, and public build hub

### DIFF
--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -1446,6 +1446,12 @@ app.get('/search-addons', async (c) => {
   // Simple in-memory rate limit per IP (resets each minute)
   const ip = c.req.header('CF-Connecting-IP') ?? 'unknown';
   const now = Date.now();
+
+  // Prune expired buckets to prevent unbounded map growth
+  for (const [key, val] of searchRateCounts) {
+    if (val.expires <= now) searchRateCounts.delete(key);
+  }
+
   const bucket = searchRateCounts.get(ip);
   if (bucket && bucket.expires > now) {
     if (bucket.count >= SEARCH_RATE_LIMIT) {

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -67,6 +67,16 @@ import type { Env, RecommendedAddonEntry, RecommendedAddons } from './types';
 
 const app = new Hono<{ Bindings: Env }>();
 
+// ─── Global error handler ───────────────────────────────────────────────────
+// Returns a JSON body with the error message instead of Cloudflare's generic
+// "Internal Server Error" plain-text response.
+
+app.onError((err, c) => {
+  console.error(`[${c.req.method} ${c.req.path}]`, err.message, err.stack);
+  const status = 'status' in err && typeof err.status === 'number' ? err.status : 500;
+  return c.json({ error: err.message || 'Internal server error' }, status as 500);
+});
+
 /** Best-effort delete of an ImgBB-hosted image via its delete URL (fire-and-forget). */
 function tryDeleteImgBBImage(deleteUrl: string | null): void {
   if (deleteUrl && /^https:\/\/ibb\.co\//.test(deleteUrl)) {
@@ -1389,6 +1399,96 @@ app.post('/packs/:id/vote', async (c) => {
 
   const result = await togglePackVote(c.env.DB, c.req.param('id'), user.id);
   return c.json(result);
+});
+
+// ─── GET /search-addons — ESOUI addon search proxy ──────────────────────────
+// Scrapes the ESOUI search page and returns structured results.
+// No auth required — anyone can search.  Rate-limited to prevent abuse.
+
+const ESOUI_SEARCH_URL = 'https://www.esoui.com/downloads/search.php';
+const SEARCH_RATE_LIMIT = 20; // max requests per minute per IP
+const searchRateCounts = new Map<string, { count: number; expires: number }>();
+
+app.get('/search-addons', async (c) => {
+  const q = (c.req.query('q') ?? '').trim();
+  if (!q || q.length < 2) return c.json({ results: [] });
+  if (q.length > 100) return c.json({ error: 'Query too long' }, 400);
+
+  // Simple in-memory rate limit per IP (resets each minute)
+  const ip = c.req.header('CF-Connecting-IP') ?? 'unknown';
+  const now = Date.now();
+  const bucket = searchRateCounts.get(ip);
+  if (bucket && bucket.expires > now) {
+    if (bucket.count >= SEARCH_RATE_LIMIT) {
+      return c.json({ error: 'Rate limit exceeded' }, 429);
+    }
+    bucket.count++;
+  } else {
+    searchRateCounts.set(ip, { count: 1, expires: now + 60_000 });
+  }
+
+  try {
+    const params = new URLSearchParams({ search: q, se_search: 'files' });
+    const res = await fetch(`${ESOUI_SEARCH_URL}?${params.toString()}`, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ESOToolkit/1.0',
+        Accept: 'text/html',
+      },
+    });
+    if (!res.ok) return c.json({ error: 'ESOUI search unavailable' }, 502);
+
+    const html = await res.text();
+
+    interface SearchResult {
+      id: number;
+      title: string;
+      author: string;
+      category: string;
+      downloads: string;
+    }
+
+    const results: SearchResult[] = [];
+    const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+    const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+    const linkRegex = /fileinfo\.php\?id=(\d+)[^"]*"[^>]*>([^<]+)/;
+    const stripTags = (s: string): string => s.replace(/<[^>]+>/g, '').trim();
+
+    let rowMatch: RegExpExecArray | null;
+    while ((rowMatch = rowRegex.exec(html)) !== null) {
+      const rowHtml = rowMatch[1];
+      const cells: string[] = [];
+      let cellMatch: RegExpExecArray | null;
+      while ((cellMatch = cellRegex.exec(rowHtml)) !== null) {
+        cells.push(cellMatch[1]);
+      }
+      if (cells.length < 5) continue;
+
+      let id = 0;
+      let title = '';
+      let titleIdx = -1;
+      for (let i = 0; i < cells.length; i++) {
+        const lm = linkRegex.exec(cells[i]);
+        if (lm) {
+          id = parseInt(lm[1], 10);
+          title = lm[2].trim();
+          titleIdx = i;
+          break;
+        }
+      }
+      if (!id || titleIdx < 0) continue;
+
+      const author = stripTags(cells[titleIdx + 1] ?? '');
+      const category = stripTags(cells[titleIdx + 2] ?? '');
+      const downloads = stripTags(cells[titleIdx + 3] ?? '');
+
+      results.push({ id, title, author, category, downloads });
+    }
+
+    return c.json({ results });
+  } catch (err) {
+    console.error('ESOUI search failed:', err);
+    return c.json({ error: 'Search failed' }, 502);
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -1401,13 +1401,42 @@ app.post('/packs/:id/vote', async (c) => {
   return c.json(result);
 });
 
-// ─── GET /search-addons — ESOUI addon search proxy ──────────────────────────
-// Scrapes the ESOUI search page and returns structured results.
-// No auth required — anyone can search.  Rate-limited to prevent abuse.
+// ─── GET /search-addons — ESOUI addon search via MMOUI API ─────────────────
+// Fetches the full addon catalog from api.mmoui.com and caches it in Worker
+// memory.  Search is a case-insensitive substring match on title + author,
+// ranked: exact title match → title startsWith → title/author includes.
 
-const ESOUI_SEARCH_URL = 'https://www.esoui.com/downloads/search.php';
+const MMOUI_FILELIST_URL = 'https://api.mmoui.com/v4/game/ESO/filelist.json';
+const ADDON_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const SEARCH_RATE_LIMIT = 20; // max requests per minute per IP
 const searchRateCounts = new Map<string, { count: number; expires: number }>();
+
+interface MmoUiAddon {
+  id: number;
+  title: string;
+  author: string;
+  downloads: number;
+  downloadsMonthly: number;
+  favorites: number;
+}
+
+let addonCache: { addons: MmoUiAddon[]; fetchedAt: number } | null = null;
+
+async function getAddonCatalog(): Promise<MmoUiAddon[]> {
+  const now = Date.now();
+  if (addonCache && now - addonCache.fetchedAt < ADDON_CACHE_TTL_MS) {
+    return addonCache.addons;
+  }
+
+  const res = await fetch(MMOUI_FILELIST_URL, {
+    headers: { 'User-Agent': 'ESO-Toolkit/1.0' },
+  });
+  if (!res.ok) throw new Error(`MMOUI API returned ${res.status}`);
+
+  const raw = (await res.json()) as MmoUiAddon[];
+  addonCache = { addons: raw, fetchedAt: now };
+  return raw;
+}
 
 app.get('/search-addons', async (c) => {
   const q = (c.req.query('q') ?? '').trim();
@@ -1428,16 +1457,13 @@ app.get('/search-addons', async (c) => {
   }
 
   try {
-    const params = new URLSearchParams({ search: q, se_search: 'files' });
-    const res = await fetch(`${ESOUI_SEARCH_URL}?${params.toString()}`, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ESOToolkit/1.0',
-        Accept: 'text/html',
-      },
-    });
-    if (!res.ok) return c.json({ error: 'ESOUI search unavailable' }, 502);
+    const addons = await getAddonCatalog();
+    const lower = q.toLowerCase();
 
-    const html = await res.text();
+    // Bucket matches by relevance
+    const exact: typeof results = [];
+    const starts: typeof results = [];
+    const contains: typeof results = [];
 
     interface SearchResult {
       id: number;
@@ -1448,45 +1474,29 @@ app.get('/search-addons', async (c) => {
     }
 
     const results: SearchResult[] = [];
-    const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
-    const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
-    const linkRegex = /fileinfo\.php\?id=(\d+)[^"]*"[^>]*>([^<]+)/;
-    const stripTags = (s: string): string => s.replace(/<[^>]+>/g, '').trim();
 
-    let rowMatch: RegExpExecArray | null;
-    while ((rowMatch = rowRegex.exec(html)) !== null) {
-      const rowHtml = rowMatch[1];
-      const cells: string[] = [];
-      let cellMatch: RegExpExecArray | null;
-      while ((cellMatch = cellRegex.exec(rowHtml)) !== null) {
-        cells.push(cellMatch[1]);
-      }
-      if (cells.length < 5) continue;
+    for (const a of addons) {
+      const tLower = a.title.toLowerCase();
+      const aLower = a.author.toLowerCase();
+      if (tLower !== lower && !tLower.includes(lower) && !aLower.includes(lower)) continue;
 
-      let id = 0;
-      let title = '';
-      let titleIdx = -1;
-      for (let i = 0; i < cells.length; i++) {
-        const lm = linkRegex.exec(cells[i]);
-        if (lm) {
-          id = parseInt(lm[1], 10);
-          title = lm[2].trim();
-          titleIdx = i;
-          break;
-        }
-      }
-      if (!id || titleIdx < 0) continue;
+      const hit: SearchResult = {
+        id: a.id,
+        title: a.title,
+        author: a.author,
+        category: '',
+        downloads: String(a.downloads),
+      };
 
-      const author = stripTags(cells[titleIdx + 1] ?? '');
-      const category = stripTags(cells[titleIdx + 2] ?? '');
-      const downloads = stripTags(cells[titleIdx + 3] ?? '');
-
-      results.push({ id, title, author, category, downloads });
+      if (tLower === lower) exact.push(hit);
+      else if (tLower.startsWith(lower)) starts.push(hit);
+      else contains.push(hit);
     }
 
-    return c.json({ results });
+    results.push(...exact, ...starts, ...contains);
+    return c.json({ results: results.slice(0, 25) });
   } catch (err) {
-    console.error('ESOUI search failed:', err);
+    console.error('Addon search failed:', err);
     return c.json({ error: 'Search failed' }, 502);
   }
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -750,13 +750,11 @@ const AppRoutes: React.FC = () => {
             <Route
               path="/build-hub"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <BuildHubPage />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <BuildHubPage />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -168,6 +168,7 @@ const MobileSheetItem = styled(ButtonBase, {
     padding: '10px 12px',
     borderRadius: 12,
     width: '100%',
+    textAlign: 'left',
     position: 'relative',
     transition: 'background 0.2s ease, transform 0.2s ease',
     background: active ? (isDark ? alpha(accent, 0.1) : alpha(accent, 0.06)) : 'transparent',


### PR DESCRIPTION
Three related hub improvements on this branch:

### 1. Fix pack hub 500 errors
The deployed worker was a stale April 4 rollback where `listPacks` was
not defined in the bundle, causing all /packs routes to crash with a
ReferenceError. Added `app.onError()` global handler so future exceptions
return JSON with the actual error message, and added the /search-addons
route the pack-hub frontend expects.

### 2. Replace ESOUI scraping with MMOUI API
ESOUI's Cloudflare bot protection blocks requests from Workers. Switched
to the MMOUI public JSON API which returns the full addon catalog (~3900
addons) with no auth required. Results are cached in Worker memory with a
1-hour TTL, ranked by match quality, and capped at 25 per query.

### 3. Allow unauthenticated access to build hub
Removed the `AuthenticatedRoute` wrapper from the `/build-hub` route.
The `BuildHubPage` component already handles unauthenticated users —
gating voting/publishing/editing behind login checks and showing a
login nudge alert. This matches how Roster Hub, Pack Hub, and the view
pages (`/rv`, `/bv`) already work.