### PR TITLE
Reverse fight stats fill to show damage progress

### DIFF
--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -1111,7 +1111,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                   <Box
                     sx={{
                       height: '100%',
-                      width: `${100 - bossHealthPercent}%`,
+                      width: `${backgroundFillPercent}%`,
                       borderRadius: '1.5px',
                       background: accentBarColor,
                       boxShadow: darkMode ? `0 0 4px ${accentBarColor}66` : 'none',

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -766,8 +766,8 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
           ? Math.round(fight.bossPercentage)
           : 0;
 
-      // If boss was killed, show full green bar, otherwise show health percentage for wipes
-      backgroundFillPercent = bossWasKilled ? 100 : isWipe ? bossHealthPercent : 100;
+      // Fill represents progress (damage dealt): kills = full, wipes = 100 - health remaining
+      backgroundFillPercent = bossWasKilled ? 100 : isWipe ? 100 - bossHealthPercent : 100;
     } else {
       // Trash fight logic - use the kill field to determine success/wipe
       // kill === true means success, kill === false means wipe, kill === null means unknown (treat as successful)
@@ -1096,7 +1096,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                   {fight.friendlyPlayers.filter(Boolean).length}p
                 </Typography>
               )}
-              {/* Progress micro-bar — wipes only, shows health remaining */}
+              {/* Progress micro-bar — wipes only, shows damage progress */}
               {isWipe ? (
                 <Box
                   sx={{
@@ -1111,7 +1111,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                   <Box
                     sx={{
                       height: '100%',
-                      width: `${bossHealthPercent}%`,
+                      width: `${100 - bossHealthPercent}%`,
                       borderRadius: '1.5px',
                       background: accentBarColor,
                       boxShadow: darkMode ? `0 0 4px ${accentBarColor}66` : 'none',


### PR DESCRIPTION
## Summary
- Reverses the background gradient fill and micro-bar on fight cards so they represent **damage dealt** (progress) rather than boss health remaining
- Kills remain full green; wipes now grow from a small sliver (barely damaged) to nearly full (almost killed) — making the visual behave like an intuitive progress bar
- Badge text still shows remaining health percent (e.g. "87%") since that's the ESO convention

## Motivation
The previous fill direction was counterintuitive — a bad pull at 87% health remaining showed an almost-full red bar, visually suggesting "almost there." Reversing the fill makes it consistent with a progress metaphor: more fill = better performance, and a full green bar = kill.

## Test plan
- [ ] Verify kill fights show full green gradient fill (unchanged)
- [ ] Verify wipe at high boss health (e.g. 87%) shows a small red sliver
- [ ] Verify wipe at low boss health (e.g. 5%) shows a nearly-full green fill
- [ ] Verify micro-bar in the bottom-right of fight cards matches the reversed fill
- [ ] Verify badge text still shows remaining health percent
- [ ] Check both dark mode and light mode

https://claude.ai/code/session_01YNTjowYFg7kFiJYVe2HFce