### PR TITLE
feat(ci): Discord notifications for nightly tests and releases

### DIFF
--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -1,0 +1,226 @@
+name: "Discord Notification"
+description: "Post deployment status or CI failure notifications to a Discord webhook channel"
+
+inputs:
+  webhook-url:
+    description: "Discord webhook URL. If empty, the step is silently skipped."
+    required: false
+    default: ""
+  status:
+    description: "Event status: success, failure, cancelled, or running"
+    required: true
+  title:
+    description: "Embed title (e.g. 'Deploy to GitHub Pages', 'Nightly Playwright Suite')"
+    required: true
+  environment:
+    description: "Target environment (e.g. production, staging). Omit for CI notifications."
+    required: false
+    default: ""
+  commit-sha:
+    description: "Git commit SHA"
+    required: false
+    default: ${{ github.sha }}
+  actor:
+    description: "User who triggered the workflow"
+    required: false
+    default: ${{ github.actor }}
+  run-id:
+    description: "GitHub Actions run ID (used to build the run URL)"
+    required: false
+    default: ${{ github.run_id }}
+  description:
+    description: "Optional extra description text for the embed body"
+    required: false
+    default: ""
+  content:
+    description: "Top-level message content (outside embed). Use for Discord user mentions like <@USER_ID>."
+    required: false
+    default: ""
+  thread-name:
+    description: "Create a new forum thread with this name (forum channels only). Returns thread-id as output."
+    required: false
+    default: ""
+  thread-id:
+    description: "Post into an existing thread instead of the channel root."
+    required: false
+    default: ""
+  commits:
+    description: "Newline-separated commit log (e.g. 'abc1234 feat: thing'). Shown as a 'Changes' field. Truncated to fit Discord embed limits."
+    required: false
+    default: ""
+
+outputs:
+  thread-id:
+    description: "Thread/channel ID from the Discord response (available when thread-name is set and the webhook targets a forum channel)"
+    value: ${{ steps.post.outputs.thread-id }}
+  message-id:
+    description: "Message ID from the Discord response (available when ?wait=true is used)"
+    value: ${{ steps.post.outputs.message-id }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Post to Discord"
+      id: post
+      if: inputs.webhook-url != ''
+      shell: bash
+      env:
+        DISCORD_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        NOTIFY_STATUS: ${{ inputs.status }}
+        NOTIFY_TITLE: ${{ inputs.title }}
+        NOTIFY_ENV: ${{ inputs.environment }}
+        NOTIFY_SHA: ${{ inputs.commit-sha }}
+        NOTIFY_ACTOR: ${{ inputs.actor }}
+        NOTIFY_RUN_ID: ${{ inputs.run-id }}
+        NOTIFY_DESC: ${{ inputs.description }}
+        NOTIFY_CONTENT: ${{ inputs.content }}
+        NOTIFY_THREAD_NAME: ${{ inputs.thread-name }}
+        NOTIFY_THREAD_ID: ${{ inputs.thread-id }}
+        NOTIFY_COMMITS: ${{ inputs.commits }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_SERVER: ${{ github.server_url }}
+      run: |
+        # Ensure required CLI tools are available
+        for cmd in jq curl; do
+          if ! command -v "$cmd" &>/dev/null; then
+            echo "::warning::Discord notification skipped: '$cmd' is not installed on this runner"
+            exit 0
+          fi
+        done
+
+        # Map status to color and emoji
+        case "$NOTIFY_STATUS" in
+          success)
+            COLOR=5763719   # Green (0x57F287)
+            EMOJI="✅"
+            STATUS_TEXT="Succeeded"
+            ;;
+          failure)
+            COLOR=15548997  # Red (0xED4245)
+            EMOJI="❌"
+            STATUS_TEXT="Failed"
+            ;;
+          cancelled)
+            COLOR=16705372  # Yellow (0xFEE75C)
+            EMOJI="⚠️"
+            STATUS_TEXT="Cancelled"
+            ;;
+          *)
+            COLOR=5793266   # Blurple (0x5865F2)
+            EMOJI="ℹ️"
+            STATUS_TEXT="$NOTIFY_STATUS"
+            ;;
+        esac
+
+        SHORT_SHA="${NOTIFY_SHA:0:7}"
+        RUN_URL="${GITHUB_SERVER}/${GITHUB_REPO}/actions/runs/${NOTIFY_RUN_ID}"
+        COMMIT_URL="${GITHUB_SERVER}/${GITHUB_REPO}/commit/${NOTIFY_SHA}"
+        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        # Build fields array
+        FIELDS="[]"
+        FIELDS=$(echo "$FIELDS" | jq \
+          --arg status "${EMOJI} ${STATUS_TEXT}" \
+          '. + [{"name": "Status", "value": $status, "inline": true}]')
+
+        if [ -n "$NOTIFY_ENV" ]; then
+          FIELDS=$(echo "$FIELDS" | jq \
+            --arg env "$NOTIFY_ENV" \
+            '. + [{"name": "Environment", "value": $env, "inline": true}]')
+        fi
+
+        FIELDS=$(echo "$FIELDS" | jq \
+          --arg actor "$NOTIFY_ACTOR" \
+          '. + [{"name": "Triggered by", "value": $actor, "inline": true}]')
+
+        FIELDS=$(echo "$FIELDS" | jq \
+          --arg sha "[${SHORT_SHA}](${COMMIT_URL})" \
+          '. + [{"name": "Commit", "value": $sha, "inline": true}]')
+
+        FIELDS=$(echo "$FIELDS" | jq \
+          --arg url "[View Run](${RUN_URL})" \
+          '. + [{"name": "Workflow", "value": $url, "inline": true}]')
+
+        # Append commits as a non-inline "Changes" field (truncated to 1024 chars — Discord field limit)
+        if [ -n "$NOTIFY_COMMITS" ]; then
+          # Truncate to 1000 chars to leave room for the ellipsis marker
+          COMMIT_TEXT="$NOTIFY_COMMITS"
+          if [ ${#COMMIT_TEXT} -gt 1000 ]; then
+            COMMIT_TEXT="${COMMIT_TEXT:0:1000}…"
+          fi
+          FIELDS=$(echo "$FIELDS" | jq \
+            --arg commits "$COMMIT_TEXT" \
+            '. + [{"name": "Changes", "value": $commits, "inline": false}]')
+        fi
+
+        # Build description
+        DESC=""
+        if [ -n "$NOTIFY_DESC" ]; then
+          DESC="$NOTIFY_DESC"
+        fi
+
+        # Build the embed payload
+        PAYLOAD=$(jq -n \
+          --arg title "$NOTIFY_TITLE" \
+          --arg desc "$DESC" \
+          --arg content "$NOTIFY_CONTENT" \
+          --argjson color "$COLOR" \
+          --argjson fields "$FIELDS" \
+          --arg timestamp "$TIMESTAMP" \
+          '{
+            content: (if $content == "" then null else $content end),
+            embeds: [{
+              title: $title,
+              description: (if $desc == "" then null else $desc end),
+              color: $color,
+              fields: $fields,
+              timestamp: $timestamp,
+              footer: { text: "ESO Log Aggregator CI/CD" }
+            }]
+          }')
+
+        # thread_name must be a top-level JSON body field for forum channels (not a query param).
+        # thread_id goes in the query string to target an existing thread.
+        if [ -n "$NOTIFY_THREAD_NAME" ]; then
+          PAYLOAD=$(echo "$PAYLOAD" | jq --arg tn "$NOTIFY_THREAD_NAME" '. + {thread_name: $tn}')
+        fi
+
+        # Build webhook URL with query params
+        # ?wait=true returns the message object so we can extract IDs
+        WEBHOOK_URL="${DISCORD_WEBHOOK_URL}?wait=true"
+        if [ -n "$NOTIFY_THREAD_ID" ]; then
+          WEBHOOK_URL="${WEBHOOK_URL}&thread_id=${NOTIFY_THREAD_ID}"
+        fi
+
+        # Send to Discord
+        HTTP_CODE=$(curl --connect-timeout 5 --max-time 15 --retry 3 --retry-all-errors \
+          -s -o /tmp/discord-response.txt -w "%{http_code}" \
+          -X POST "$WEBHOOK_URL" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" || echo "000")
+
+        if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+          echo "✅ Discord notification sent (status=$NOTIFY_STATUS, http=$HTTP_CODE)"
+
+          # Extract IDs from response for threading support
+          MESSAGE_ID=$(jq -r '.id // empty' /tmp/discord-response.txt 2>/dev/null || true)
+          # channel_id in the response is the thread ID when thread_name creates a forum thread
+          THREAD_ID=$(jq -r '.channel_id // empty' /tmp/discord-response.txt 2>/dev/null || true)
+
+          echo "message-id=${MESSAGE_ID}" >> "$GITHUB_OUTPUT"
+          # Only set thread-id when a thread was actually created (thread-name was provided);
+          # for non-forum webhooks, channel_id is the root channel, not a thread.
+          if [ -n "$NOTIFY_THREAD_NAME" ] && [ -n "$THREAD_ID" ]; then
+            echo "thread-id=${THREAD_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "thread-id=" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          RESPONSE=$(cat /tmp/discord-response.txt 2>/dev/null || echo "(empty)")
+          echo "::warning::Discord notification failed (http=$HTTP_CODE): $RESPONSE"
+          echo "message-id=" >> "$GITHUB_OUTPUT"
+          echo "thread-id=" >> "$GITHUB_OUTPUT"
+          # Don't fail the workflow for a notification issue
+        fi
+
+        rm -f /tmp/discord-response.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,51 @@ jobs:
           release_version: ${{ github.sha }}
           vite_ga_measurement_id: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
           vite_discord_client_id: ${{ vars.VITE_DISCORD_CLIENT_ID }}
+
+  # Post deploy status to Discord. Runs after `deploy` regardless of outcome.
+  discord-notify:
+    name: "Deploy Notification"
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: always()
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build Changelog
+        id: changelog
+        shell: bash
+        run: |
+          COMMITS=$(git log --pretty=format:'[`%h`](https://github.com/${{ github.repository }}/commit/%H) %s' \
+            --no-merges -10)
+          {
+            echo "commits<<CHANGELOG_EOF"
+            echo "$COMMITS"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Discord Release Announcement
+        if: needs.deploy.result == 'success'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          status: success
+          title: "ESO Log Aggregator — New Release"
+          environment: production
+          commits: ${{ steps.changelog.outputs.commits }}
+          thread-name: "Deploy #${{ github.run_number }}"
+
+      - name: Discord Deploy Failure
+        if: needs.deploy.result == 'failure'
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          status: failure
+          title: "Deploy to GitHub Pages"
+          environment: production
+          commits: ${{ steps.changelog.outputs.commits }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -313,6 +313,56 @@ jobs:
               });
             }
 
+  # Post a "starting" Discord notification and open a forum thread before tests run.
+  # Runs in parallel with nightly-tests (both depend only on setup).
+  notify-nightly-start:
+    name: "Nightly Start"
+    runs-on: ubuntu-latest
+    needs: [setup]
+    if: always()
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    outputs:
+      thread-id: ${{ steps.notify.outputs.thread-id }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Compute notification params
+        id: params
+        shell: bash
+        run: |
+          SHARDS="${{ needs.setup.outputs.total_shards }}"
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "title=Nightly Playwright Suite" >> "$GITHUB_OUTPUT"
+            {
+              echo 'description<<EOF_NOTIFY'
+              echo "**Shards:** ${SHARDS} · **Suite:** all · **Browsers:** chromium, firefox, webkit, mobile"
+              echo 'EOF_NOTIFY'
+            } >> "$GITHUB_OUTPUT"
+            echo "thread_name=Nightly Playwright — ${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            SUITE="${{ github.event.inputs.test_suite || 'all' }}"
+            echo "title=Manual Playwright Suite" >> "$GITHUB_OUTPUT"
+            {
+              echo 'description<<EOF_NOTIFY'
+              echo "**Suite:** ${SUITE} · **Shards:** ${SHARDS}"
+              echo 'EOF_NOTIFY'
+            } >> "$GITHUB_OUTPUT"
+            echo "thread_name=Manual Playwright — ${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Discord Playwright Starting
+        id: notify
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_NIGHTLY_TESTS }}
+          status: running
+          title: ${{ steps.params.outputs.title }}
+          description: ${{ steps.params.outputs.description }}
+          thread-name: ${{ steps.params.outputs.thread_name }}
+
   # Job to consolidate results from all shards
   consolidate-results:
     runs-on: ubuntu-latest
@@ -444,67 +494,58 @@ jobs:
               });
             }
 
-  # Post nightly test results to Discord
+  # Post nightly test results to Discord, replying in the thread opened by notify-nightly-start
   discord-notify:
+    name: "Nightly Results"
     runs-on: ubuntu-latest
-    needs: [setup, nightly-tests, consolidate-results]
+    needs: [setup, nightly-tests, consolidate-results, notify-nightly-start]
     if: always()
-    permissions: {}
+    timeout-minutes: 3
+    permissions:
+      contents: read
 
     steps:
-      - name: Post Discord Notification
-        uses: actions/github-script@v8
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_NIGHTLY_TESTS }}
-          TESTS_RESULT: ${{ needs.nightly-tests.result }}
-          TOTAL_SHARDS: ${{ needs.setup.outputs.total_shards }}
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Resolve Status
+        id: status
+        shell: bash
+        run: |
+          TESTS_RESULT="${{ needs.nightly-tests.result }}"
+          case "$TESTS_RESULT" in
+            success) STATUS="success" ;;
+            failure) STATUS="failure" ;;
+            *) STATUS="failure" ;;
+          esac
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          if [ "$STATUS" != "success" ]; then
+            echo "content=<@205483185893670912> <@266089059028434944>" >> "$GITHUB_OUTPUT"
+          else
+            echo "content=" >> "$GITHUB_OUTPUT"
+          fi
+
+          SHARDS="${{ needs.setup.outputs.total_shards }}"
+          TRIGGER="${{ github.event_name == 'schedule' && 'Scheduled' || 'Manual' }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo 'description<<EOF_NOTIFY'
+            echo "**[View Run](${RUN_URL})**"
+            echo ""
+            echo "**Shards:** ${SHARDS} · **Trigger:** ${TRIGGER}"
+            echo 'EOF_NOTIFY'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Discord Playwright Results
+        uses: ./.github/actions/discord-notify
         with:
-          script: |
-            const webhook = process.env.DISCORD_WEBHOOK;
-            if (!webhook) {
-              console.log('DISCORD_WEBHOOK_NIGHTLY_TESTS secret not set — skipping notification');
-              return;
-            }
-
-            const result = process.env.TESTS_RESULT;       // success | failure | cancelled | skipped
-            const shards = process.env.TOTAL_SHARDS || '3';
-            const runUrl  = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
-            const trigger = '${{ github.event_name }}' === 'schedule' ? 'Scheduled' : 'Manual';
-
-            const passed = result === 'success';
-            const color  = passed ? 0x2ecc71 : 0xe74c3c;   // green / red
-            const status = passed ? 'Passed' : result.charAt(0).toUpperCase() + result.slice(1);
-            const icon   = passed ? '✅' : '❌';
-
-            const payload = {
-              // Ping users on failure (mentions must be in content, not embeds)
-              ...(!passed && { content: '<@205483185893670912> <@266089059028434944>' }),
-              embeds: [{
-                title: `${icon} Nightly Tests ${status}`,
-                color,
-                fields: [
-                  { name: 'Status',  value: status,  inline: true },
-                  { name: 'Shards',  value: shards,  inline: true },
-                  { name: 'Trigger', value: trigger,  inline: true },
-                ],
-                url: runUrl,
-                timestamp: new Date().toISOString(),
-                footer: { text: 'ESO Log Aggregator · Nightly Tests' },
-              }],
-            };
-
-            const res = await fetch(webhook, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(payload),
-            });
-
-            if (!res.ok) {
-              const body = await res.text();
-              core.setFailed(`Discord webhook returned ${res.status}: ${body}`);
-            } else {
-              console.log('Discord notification sent successfully');
-            }
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_NIGHTLY_TESTS }}
+          status: ${{ steps.status.outputs.status }}
+          title: "${{ github.event_name == 'schedule' && 'Nightly Playwright Suite — Results' || 'Manual Playwright Suite — Results' }}"
+          description: ${{ steps.status.outputs.description }}
+          content: ${{ steps.status.outputs.content }}
+          thread-id: ${{ needs.notify-nightly-start.outputs.thread-id }}
 
   notify-on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a reusable `.github/actions/discord-notify` composite action (ported from legacy-sports) — uses `curl`+`jq`, supports forum thread creation/reply, retries, and silently skips when no webhook is configured
- Upgrades `nightly-tests.yml`: a **start** notification fires before tests and opens a forum thread; the **results** notification replies to that thread on completion (pings users on failure)
- Adds a `discord-notify` job to `deploy.yml`: successful deploys create a forum thread in the releases channel (`Deploy #N` + 10-commit changelog); failures post a plain failure embed to the same channel

## Secrets configured

| Secret | Channel type | Used by |
|---|---|---|
| `DISCORD_WEBHOOK_NIGHTLY_TESTS` | Forum (for threading) | nightly-tests.yml |
| `DISCORD_WEBHOOK_RELEASES` | Forum (for threading) | deploy.yml |

Both secrets are already set in the repo.

## Test plan

- [ ] Manually trigger **Nightly Regression Tests** workflow — verify a forum thread is created before tests start and results are posted to that thread
- [ ] Push a commit to `main` (or manually trigger **Build and Deploy**) — verify a `Deploy #N` forum thread appears in the releases channel
- [ ] Simulate a deploy failure — verify a failure embed posts to the releases channel (no thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)