### PR TITLE
feat(infra): mirror legacy-sports worktree and node_modules infrastructure

### DIFF
--- a/.claude/hooks/check-github-auth.sh
+++ b/.claude/hooks/check-github-auth.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SessionStart hook: warn if GitHub auth is not configured.
+# Non-blocking — prints a warning but never fails the session.
+
+# Skip on Windows local dev — gh auth login handles it
+if [ "$(uname -s)" = "Linux" ] && [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "WARNING: GitHub is not authenticated. PR creation will fail."
+      echo "  Set GH_TOKEN in cloud env settings or run: gh auth login"
+      echo "  See .agents/skills/auth/SKILL.md for auth guidance"
+    fi
+  fi
+fi

--- a/.claude/hooks/cleanup-worktree-junction.sh
+++ b/.claude/hooks/cleanup-worktree-junction.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Stop hook: remove node_modules symlink from ephemeral worktree before session ends.
+# This is a belt-and-suspenders cleanup — the main protection is that directory
+# symlinks (mklink /D) are NOT followed by recursive-delete tools, so even if this
+# hook doesn't fire (e.g. Claude Code archive), the target is safe.
+#
+# Uses `cmd //c rmdir` (non-recursive) which safely removes both symlinks and
+# junctions without touching the target. Real directories are left untouched.
+#
+# Note: on Windows git-bash, `[ -L ]` returns false for NTFS junctions (only true
+# symlinks), so we always attempt the non-recursive rmdir whenever node_modules exists.
+# cmd rmdir succeeds for symlinks/junctions and fails harmlessly on non-empty real dirs.
+
+WORKTREE="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Only act inside Claude Code ephemeral worktrees
+if [[ "$WORKTREE" != *"/.claude/worktrees/"* ]]; then
+  exit 0
+fi
+
+NM="$WORKTREE/node_modules"
+
+if [ ! -e "$NM" ] && [ ! -L "$NM" ]; then
+  exit 0
+fi
+
+# Attempt non-recursive removal whenever node_modules exists in an ephemeral worktree.
+WIN_PATH=$(cygpath -w "$NM" 2>/dev/null || echo "$NM" | sed 's|/d/|D:\\|; s|/|\\|g')
+cmd //c "rmdir \"$WIN_PATH\"" >/dev/null 2>&1
+
+exit 0

--- a/.claude/hooks/guard-bash-mcp-first.sh
+++ b/.claude/hooks/guard-bash-mcp-first.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# PreToolUse hook: warn when Bash commands have direct MCP tool replacements
+# (ls/find/cat/head/tail/grep/rg). Always exits 0 — this is a WARNING hook,
+# not a blocker. Agents are never trapped in a retry loop.
+#
+# Receives JSON on stdin with tool_name and tool_input.command.
+# Exit 0 = allow (command always runs). Warning is written to stdout so
+# Claude sees it in context before the tool executes.
+#
+# Bypass: add `# mcp-ok` anywhere in the command when you have verified
+# that no MCP tool covers this case. This suppresses the warning and marks
+# the command as intentional in the audit log:
+#
+#   find . -name "*.ts" -exec wc -l {} \;  # mcp-ok: no -exec equivalent in MCP
+#   rg --type ts "pattern" /abs/path       # mcp-ok: Grep does not support absolute path on Windows
+#
+# Audit: every command that matches a banned binary AND passes the cat
+# allow-list checks (i.e., would warn or bypass) is appended to
+# .claude/bash-audit.log (WARN = no bypass marker, BYPASS = acknowledged).
+# The file is covered by the **/*.log gitignore rule and is never committed.
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail open silently if input is empty or jq is not available
+if [ -z "$INPUT" ] || ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Strip leading whitespace and capture the first token.
+# Split on whitespace AND shell operators (;, &, |) and redirection operators
+# (<, >) so compound commands like `ls;pwd`, `ls&&echo ok`, `ls>/tmp/out`,
+# and `cat</etc/hosts` are all caught correctly.
+TRIMMED=$(echo "$COMMAND" | sed -E 's/^[[:space:]]+//')
+FIRST_WORD=$(echo "$TRIMMED" | sed -E 's/[[:space:];|&<>].*//')
+
+# Normalize to basename so absolute-path invocations like /bin/head or
+# /usr/bin/rg match the same cases as bare names.
+# Guard empty/"-" values and stop option parsing so option-like input cannot
+# make basename error and accidentally bypass the check.
+if [ -n "$FIRST_WORD" ] && [ "$FIRST_WORD" != "-" ]; then
+  FIRST_WORD=$(basename -- "$FIRST_WORD")
+fi
+
+# Pattern: first word is one of the banned binaries. We match the bare binary
+# name only (after basename normalization) — `aws ls` and friends are not
+# affected because they start with `aws`.
+case "$FIRST_WORD" in
+  ls)
+    REPLACEMENT="Glob (e.g. Glob({ pattern: \"**/*.ts\", path: \"<dir>\" })). If Glob returns empty on a Windows worktree absolute path, fall back to worktree_run({ command: \"dir <dir>\" }) from the eso-logs-worktree MCP server"
+    BAD="ls"
+    ;;
+  find)
+    REPLACEMENT="Glob for file discovery (Glob({ pattern: \"**/*.ts\" })) or Grep for content search (Grep({ pattern: \"foo\", glob: \"**/*.ts\" })). For find ... -exec with no MCP equivalent, add \`# mcp-ok\` (see below)"
+    BAD="find"
+    ;;
+  cat)
+    # Allow:
+    #   - heredocs:        cat <<EOF
+    #   - true pipelines:  cat file | ...   (single |, not ||)
+    #   - no file args:    cat              (stdin passthrough)
+    #   - redirect forms:  cat > file  /  cat >> file  /  cat file > out
+    # Warn: cat <file(s)> with no redirect or pipeline (plain file read),
+    #       including redirection-adjacent forms like cat</etc/hosts.
+    # Derive REST by stripping the leading "cat" command (with optional spaces)
+    # so redirection-adjacent forms like `cat</etc/hosts` yield `</etc/hosts`.
+    REST=$(echo "$TRIMMED" | sed -E 's/^cat[[:space:]]*//')
+    # Heredoc: cat <<EOF
+    if echo "$TRIMMED" | grep -qE '<<'; then
+      exit 0
+    fi
+    # True pipeline: single | not part of ||
+    # Uses portable awk (not grep -P) for cross-platform compatibility.
+    if echo "$TRIMMED" | awk '{
+      for (i=1;i<=length($0);i++) {
+        if (substr($0,i,1)=="|") {
+          prev=(i>1?substr($0,i-1,1):"")
+          nxt=(i<length($0)?substr($0,i+1,1):"")
+          if (prev!="|" && nxt!="|") { exit 0 }
+        }
+      }
+      exit 1
+    }'; then
+      exit 0
+    fi
+    # No arguments at all (stdin passthrough)
+    if [ -z "$REST" ]; then
+      exit 0
+    fi
+    # Output redirect forms: > or >> anywhere in REST (cat > file, cat >> file,
+    # cat file > out). Input redirect (<) without heredoc (<<) is a plain file
+    # read — it is warned, including cat</etc/hosts.
+    if echo "$REST" | grep -qE '>>|[^<]>|^>'; then
+      exit 0
+    fi
+    REPLACEMENT="Read (Read({ file_path: \"<absolute path>\" }))"
+    BAD="cat"
+    ;;
+  head)
+    REPLACEMENT="Read with limit (Read({ file_path: \"...\", limit: N }))"
+    BAD="head"
+    ;;
+  tail)
+    REPLACEMENT="Read with offset (first Read to get total_lines, then Read({ file_path: \"...\", offset: total - N, limit: N }))"
+    BAD="tail"
+    ;;
+  grep|rg)
+    REPLACEMENT="Grep (Grep({ pattern: \"foo\", path: \"<dir>\", glob: \"**/*.ts\", output_mode: \"content\" }))"
+    BAD="$FIRST_WORD"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# Check for bypass marker — suppresses warning when agent has verified no MCP alternative.
+# The `# mcp-ok` comment is stripped by the shell before execution, so it never
+# affects the command itself. It shows up in session logs and audit output.
+#
+# Pattern requires `#` to be preceded by whitespace or at start of the command
+# so that occurrences inside quoted strings (e.g. echo "# mcp-ok") are ignored.
+BYPASSED=0
+if echo "$COMMAND" | grep -qE '(^|[[:space:]])#[[:space:]]*mcp-ok'; then
+  BYPASSED=1
+fi
+
+# Append to audit log (best-effort; errors are silenced).
+# Normalize newlines/tabs to spaces so multi-line scripts produce one log line.
+AUDIT_LOG=".claude/bash-audit.log"
+AUDIT_STATUS="WARN"
+if [ "$BYPASSED" = "1" ]; then
+  AUDIT_STATUS="BYPASS"
+fi
+TRIMMED_ONE_LINE=$(printf '%s' "$TRIMMED" | tr '\n\t\r' ' ' | sed -E 's/  +/ /g')
+printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$AUDIT_STATUS" "$TRIMMED_ONE_LINE" >> "$AUDIT_LOG" 2>/dev/null || true
+
+# If agent acknowledged with # mcp-ok, allow silently.
+if [ "$BYPASSED" = "1" ]; then
+  exit 0
+fi
+
+# Emit warning to stdout — Claude Code injects PreToolUse stdout into the
+# agent's context before the tool executes, so Claude sees this warning.
+# The command still runs (exit 0).
+cat <<EOF
+[MCP-FIRST WARNING] \`$BAD\` has MCP-first alternatives — check for an MCP tool before using Bash.
+
+  Preferred: $REPLACEMENT
+
+  Command running: $TRIMMED
+
+  If you have already verified that no MCP tool covers this case, add \`# mcp-ok\` to suppress this warning and mark it for the gap audit:
+    $TRIMMED  # mcp-ok: <brief reason>
+EOF
+exit 0

--- a/.claude/hooks/guard-main-repo.sh
+++ b/.claude/hooks/guard-main-repo.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# PreToolUse hook: block Edit/Write operations targeting the main repo
+# when worktrees exist. Forces agents to use the worktree path.
+#
+# Receives JSON on stdin with tool_name and tool_input.file_path.
+# Exit 0 = allow, exit 2 = block.
+# Fails open: if jq is missing or input is invalid, allows the operation.
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail open if input is empty or jq is not available
+if [ -z "$INPUT" ] || ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+
+# Nothing to check if no file_path
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Normalise to forward slashes for comparison
+FILE_PATH=$(echo "$FILE_PATH" | sed 's|\\|/|g')
+
+# Main repo path (normalised)
+MAIN_REPO="D:/code/eso-log-aggregator"
+
+# Check if the file is inside the main repo (but NOT in a worktree)
+if [[ "$FILE_PATH" != "$MAIN_REPO"/* ]]; then
+  exit 0  # Not in main repo — allow
+fi
+
+# Allow edits to config/settings files in .claude/
+if [[ "$FILE_PATH" == "$MAIN_REPO/.claude/"* ]]; then
+  exit 0
+fi
+
+# Allow edits to workspace file
+if [[ "$FILE_PATH" == *"eso-log-aggregator.code-workspace" ]]; then
+  exit 0
+fi
+
+# Allow edits to MCP server source files (development tooling)
+if [[ "$FILE_PATH" == "$MAIN_REPO/tools/mcp/"* ]]; then
+  exit 0
+fi
+
+# Check if worktrees exist
+WORKTREE_COUNT=$(git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null | grep -c "^worktree " || true)
+
+# Subtract 1 for the main repo entry itself
+WORKTREE_COUNT=$((WORKTREE_COUNT - 1))
+
+if [ "$WORKTREE_COUNT" -le 0 ]; then
+  exit 0  # No worktrees — allow main repo edits
+fi
+
+# Block: file is in main repo and worktrees exist
+echo "BLOCKED: Editing files in the main repo ($MAIN_REPO) while $WORKTREE_COUNT worktree(s) exist. Edit the file in the worktree path instead (D:/code/eso-log-aggregator-worktrees/... or .claude/worktrees/...)." >&2
+exit 2

--- a/.claude/hooks/setup-worktree-junction.sh
+++ b/.claude/hooks/setup-worktree-junction.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# SessionStart hook: validate and recreate the node_modules symlink for
+# ephemeral worktrees (.claude/worktrees/<name>/).
+#
+# Responsibilities:
+#   1. Validate the symlink: check that .bin is non-empty (empty .bin is the
+#      most common symptom of a stale or broken link on Windows/npm).
+#   2. If missing or invalid, recreate via cmd mklink /D (directory symlink,
+#      preferred) or PowerShell New-Item -ItemType SymbolicLink as fallback.
+#
+# Why symlinks, not junctions:
+#   NTFS junctions are followed by recursive-delete tools (PowerShell
+#   Remove-Item, Node.js fs.rmSync, git worktree remove). When Claude Code's
+#   archive deletes the worktree directory, it follows the junction into the
+#   main repo's node_modules and destroys it. Directory symlinks (mklink /D)
+#   are NOT followed — the recursive delete removes the link itself, leaving
+#   the target intact. Requires Windows Developer Mode (one-time setting).
+#
+# Windows notes:
+#   - Runs in git-bash (ships with Git for Windows); cygpath is available.
+#   - `cmd //c` is required — git-bash interprets a single /c as a path.
+#   - Path conversion: cygpath -w is the primary method; the sed fallback
+#     uses the repo-specific /d/ prefix that matches this machine's layout.
+#   - The Stop hook (cleanup-worktree-junction.sh) removes the symlink
+#     when the session ends cleanly.
+
+# Prefer CLAUDE_PROJECT_DIR over pwd — Claude Code may invoke hooks with the
+# main repo as the process cwd even for worktree sessions, while CLAUDE_PROJECT_DIR
+# is the stable per-session project root (set to the worktree path by the launcher).
+WORKTREE="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Diagnostic: opt-in logging gated on CLAUDE_HOOK_DEBUG=1.
+# Runs before the guard so failures (wrong CLAUDE_PROJECT_DIR) are visible.
+# Log is capped at 200 lines to prevent unbounded growth.
+if [[ "${CLAUDE_HOOK_DEBUG:-}" == "1" ]]; then
+  {
+    echo "--- setup-worktree-junction $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
+    echo "  pwd:                 $(pwd)"
+    echo "  CLAUDE_PROJECT_DIR:  ${CLAUDE_PROJECT_DIR:-unset}"
+    echo "  WORKTREE (resolved): $WORKTREE"
+  } >> /tmp/claude-hook-debug.log 2>&1
+  if [ -f /tmp/claude-hook-debug.log ]; then
+    tail -200 /tmp/claude-hook-debug.log > /tmp/claude-hook-debug.log.tmp 2>/dev/null \
+      && mv /tmp/claude-hook-debug.log.tmp /tmp/claude-hook-debug.log 2>/dev/null || true
+  fi
+fi
+
+# Only act inside Claude Code ephemeral worktrees
+if [[ "$WORKTREE" != *"/.claude/worktrees/"* ]]; then
+  exit 0
+fi
+
+# --- 1. Determine paths ------------------------------------------------------
+NM="$WORKTREE/node_modules"
+BIN="$NM/.bin"
+
+# Strip /.claude/worktrees/<name> to get main repo root
+MAIN_REPO=$(echo "$WORKTREE" | sed 's|/.claude/worktrees/[^/]*$||')
+MAIN_NM="$MAIN_REPO/node_modules"
+
+# If main repo node_modules doesn't exist there's nothing we can do here.
+# The agent will surface the issue when it runs its first npm/make command.
+if [ ! -d "$MAIN_NM" ]; then
+  exit 0
+fi
+
+# --- 2. Decide if symlink needs creation/repair ------------------------------
+needs_recreate=false
+
+if [ ! -e "$NM" ] && [ ! -L "$NM" ]; then
+  # Symlink is entirely absent
+  needs_recreate=true
+elif [ ! -d "$BIN" ] || [ -z "$(ls -A "$BIN" 2>/dev/null | head -c1)" ]; then
+  # .bin is missing or empty — symlink is broken or stale
+  needs_recreate=true
+elif [ -e "$NM" ]; then
+  # node_modules exists and .bin is healthy — check if it's a junction (unsafe)
+  # vs a symlink (safe). Junctions must be migrated to symlinks.
+  # `dir /AL` shows <JUNCTION> vs <SYMLINKD> in its output.
+  WIN_NM_CHECK=$(cygpath -w "$NM" 2>/dev/null || echo "$NM" | sed 's|/d/|D:\\|; s|/|\\|g')
+  if cmd //c "dir /AL \"$(dirname "$WIN_NM_CHECK")\"" 2>/dev/null | grep -q "JUNCTION.*node_modules"; then
+    needs_recreate=true  # migrate junction -> symlink
+  fi
+fi
+
+if [ "$needs_recreate" = "false" ]; then
+  exit 0
+fi
+
+# --- 3. Remove any existing stale/broken link (non-recursive, safe) ----------
+WIN_NM=$(cygpath -w "$NM" 2>/dev/null || echo "$NM" | sed 's|/d/|D:\\|; s|/|\\|g')
+cmd //c "rmdir \"$WIN_NM\"" >/dev/null 2>&1
+
+# --- 4. Recreate as directory symlink via cmd mklink /D ----------------------
+# mklink /D creates a directory symlink (not a junction). Recursive-delete tools
+# remove the symlink without following it into the target — this is the key
+# protection against Claude Code's archive destroying the main repo's node_modules.
+WIN_MAIN_NM=$(cygpath -w "$MAIN_NM" 2>/dev/null || echo "$MAIN_NM" | sed 's|/d/|D:\\|; s|/|\\|g')
+cmd //c "mklink /D \"$WIN_NM\" \"$WIN_MAIN_NM\"" >/dev/null 2>&1
+
+# Verify; fall back to PowerShell if cmd mklink failed
+if [ ! -d "$NM" ]; then
+  powershell -NoProfile -NonInteractive -Command \
+    "New-Item -ItemType SymbolicLink -Path '$WIN_NM' -Target '$WIN_MAIN_NM'" \
+    >/dev/null 2>&1
+fi
+
+# If both methods failed, warn the user — most likely Developer Mode is off
+if [ ! -d "$NM" ]; then
+  echo "WARNING: Failed to create node_modules symlink in worktree." >&2
+  echo "  Directory symlinks require Windows Developer Mode to be enabled." >&2
+  echo "  Enable it: Settings > System > For Developers > Developer Mode" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "ENABLE_TOOL_SEARCH": "true"
+  },
   "permissions": {
     "allow": [
       "Bash(npm run:*)",
@@ -37,24 +40,77 @@
       "mcp__eso-logs-ci__ci_get_logs",
       "mcp__eso-logs-ci__ci_search_logs",
       "mcp__eso-logs-ci__ci_rerun",
-      "mcp__eso-logs-worktree__worktree_list",
+      "mcp__eso-logs-worktree__worktree_checkout_file",
+      "mcp__eso-logs-worktree__worktree_clean",
+      "mcp__eso-logs-worktree__worktree_commit",
+      "mcp__eso-logs-worktree__worktree_conflict_info",
       "mcp__eso-logs-worktree__worktree_create",
-      "mcp__eso-logs-worktree__worktree_run",
+      "mcp__eso-logs-worktree__worktree_diff",
       "mcp__eso-logs-worktree__worktree_guard",
+      "mcp__eso-logs-worktree__worktree_list",
+      "mcp__eso-logs-worktree__worktree_lock",
+      "mcp__eso-logs-worktree__worktree_log",
+      "mcp__eso-logs-worktree__worktree_ls_tree",
       "mcp__eso-logs-worktree__worktree_push",
+      "mcp__eso-logs-worktree__worktree_rebase_continue",
+      "mcp__eso-logs-worktree__worktree_rebase",
+      "mcp__eso-logs-worktree__worktree_rename_branch",
+      "mcp__eso-logs-worktree__worktree_resolve_conflict",
+      "mcp__eso-logs-worktree__worktree_run",
+      "mcp__eso-logs-worktree__worktree_set",
+      "mcp__eso-logs-worktree__worktree_setup_node_modules",
+      "mcp__eso-logs-worktree__worktree_show_file",
+      "mcp__eso-logs-worktree__worktree_show",
+      "mcp__eso-logs-worktree__worktree_stabilize",
       "mcp__eso-logs-worktree__worktree_status",
-      "mcp__eso-logs-worktree__worktree_diff"
-    ],
-    "deny": []
+      "mcp__eso-logs-worktree__worktree_unjunction",
+      "mcp__eso-logs-worktree__worktree_unlock",
+      "mcp__eso-logs-worktree__worktree_unstage"
+    ]
   },
   "hooks": {
-    "PreToolUse": [
+    "Stop": [
       {
-        "matcher": "Bash",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "node $CLAUDE_PROJECT_DIR/scripts/validate-branch-name.mjs"
+            "command": ".claude/hooks/cleanup-worktree-junction.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/setup-worktree-junction.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-github-auth.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^(Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/guard-main-repo.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/guard-bash-mcp-first.sh"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@ npm run codegen                      # Generate GraphQL types (required after sc
 npm run test:smoke:e2e               # Quick E2E check
 ```
 
+**Worktree setup** (after `worktree_create` or creating a new worktree):
+```bash
+make wt-setup WT=D:/code/eso-log-aggregator-worktrees/ESO-XXX/description
+  # Junctions node_modules -> main repo (if package-lock.json matches) or runs npm ci
+  # Copies .env from main repo
+  # Junctions .twig from main repo (if present)
+make kill-stale                      # Kill stale Node.js processes holding port/file locks
+make refresh                         # Pull latest main + npm ci (run from main repo)
+```
+
 > **Before creating any PR**: run `npm run validate` AND `npm test -- --watchAll=false` — both must pass with zero errors/warnings. Do not open a PR or move a ticket to "In Review" until they do.
 
 **E2E Testing**: Use VS Code MCP Playwright tool (structured testing) or Agent Skills (exploratory)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	RM_ESLINT := rm -rf .eslintcache
 endif
 
-.PHONY: help install build test test-all lint lint-fix format fmt clean dev codegen fetch-abilities all os-info clear-cache clean-modules clean-all reinstall pre-commit pc check prod-build setup test-watch typecheck pr clean-test-data test-screen-sizes test-screen-sizes-mobile test-screen-sizes-tablet test-screen-sizes-desktop test-screen-sizes-report test-screen-sizes-update
+.PHONY: help install build test test-all lint lint-fix format fmt clean dev codegen fetch-abilities all os-info clear-cache clean-modules clean-all reinstall pre-commit pc check prod-build setup test-watch typecheck pr clean-test-data test-screen-sizes test-screen-sizes-mobile test-screen-sizes-tablet test-screen-sizes-desktop test-screen-sizes-report test-screen-sizes-update wt-setup kill-stale refresh
 
 # Default target
 help:
@@ -56,6 +56,10 @@ help:
 	@$(COLOR) color brightMagenta "  setup         - Initial project setup for new developers"
 	@$(COLOR) color brightMagenta "  all           - Run clean, install, lint, test, and build"
 	@$(COLOR) color brightMagenta "  pr            - Create a pull request using twig"
+	@$(COLOR) info "Worktree Commands:"
+	@$(COLOR) color brightCyan "  wt-setup WT=<path>  - Set up worktree deps (node_modules junction + .env + .twig)"
+	@$(COLOR) color brightCyan "  kill-stale          - Kill stale Node.js processes"
+	@$(COLOR) color brightCyan "  refresh             - Pull latest main and reinstall shared node_modules"
 	@$(COLOR) info "Screen Size Testing Commands:"
 	@$(COLOR) color brightBlue "  test-screen-sizes         - Run all screen size validation tests"
 	@$(COLOR) color brightBlue "  test-screen-sizes-mobile  - Test mobile device screen sizes"
@@ -258,3 +262,34 @@ test-screen-sizes-update:
 	@$(COLOR) subheader "Updating Screen Size Test Snapshots"
 	@$(COLOR) warning "Updating visual regression baselines..."
 	npm run test:screen-sizes:update-snapshots
+
+# Set up a worktree's dependencies (node_modules junction + .env + .twig)
+# Usage: make wt-setup WT=D:/code/eso-log-aggregator-worktrees/ESO-123/my-feature
+wt-setup:
+	@$(COLOR) subheader "Setting Up Worktree"
+ifndef WT
+	@$(COLOR) error "Usage: make wt-setup WT=<worktree-path>"
+	@exit 1
+endif
+	pwsh -File scripts/setup-worktree.ps1 -WorktreePath "$(WT)"
+
+# Kill stale Node.js processes (useful when ports are stuck or .node file locks block installs)
+kill-stale:
+	@$(COLOR) subheader "Killing Stale Node Processes"
+	@$(COLOR) warning "Terminating node.exe processes..."
+ifeq ($(OS),Windows_NT)
+	-taskkill //F //IM node.exe 2>nul || true
+else
+	-pkill -f "node" 2>/dev/null || true
+endif
+	@$(COLOR) success "Done."
+
+# Pull latest main and reinstall shared node_modules
+refresh:
+	@$(COLOR) subheader "Refreshing Repository"
+	@$(COLOR) info "Fetching and pulling latest main..."
+	git fetch origin
+	git pull --ff-only
+	@$(COLOR) info "Reinstalling dependencies..."
+	npm ci
+	@$(COLOR) success "Refresh complete!"

--- a/scripts/setup-worktree.ps1
+++ b/scripts/setup-worktree.ps1
@@ -1,0 +1,339 @@
+# setup-worktree.ps1 - Smart worktree dependency setup
+#
+# Automates the setup steps every worktree needs:
+#   1. node_modules  - junction to main repo when lockfiles match; full npm ci otherwise
+#   2. .env          - copy from main repo
+#   3. .twig         - junction to main repo (shared branch-dependency state, if present)
+#
+# Usage (from any directory):
+#   .\scripts\setup-worktree.ps1 -WorktreePath <path>
+#   .\scripts\setup-worktree.ps1 -WorktreePath <path> -Force        # always run npm ci
+#   .\scripts\setup-worktree.ps1 -WorktreePath <path> -SkipInstall  # env + twig only
+#
+# Called by: make wt-setup WT=<path>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$WorktreePath,
+
+    [Parameter()]
+    [string]$MainRepoPath,
+
+    [Parameter()]
+    [switch]$Force,
+
+    [Parameter()]
+    [switch]$SkipInstall
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Write-Step  { param([string]$msg) Write-Host "`n> $msg" -ForegroundColor Cyan }
+function Write-Ok    { param([string]$msg) Write-Host "  [ok] $msg" -ForegroundColor Green }
+function Write-Skip  { param([string]$msg) Write-Host "  [--] $msg" -ForegroundColor DarkGray }
+function Write-Warn  { param([string]$msg) Write-Host "  [!!] $msg" -ForegroundColor Yellow }
+
+function Confirm-IndependentInstall {
+    # Prompt the user to confirm a full npm ci in the worktree when the
+    # main repo's node_modules is broken. In non-interactive sessions (e.g.
+    # agents running via make wt-setup) default to 'yes' so work isn't blocked.
+    param([string]$Reason)
+    Write-Host ""
+    Write-Warn "Main repo node_modules is unhealthy: $Reason"
+    Write-Warn "Junctioning would propagate the broken state to this worktree."
+    Write-Host "  Options:" -ForegroundColor Yellow
+    Write-Host "    Y - Run npm ci in this worktree only (independent node_modules)" -ForegroundColor Yellow
+    Write-Host "    N - Abort setup (fix main repo first: cd $MainRepoPath ; make install)" -ForegroundColor Yellow
+    $isInteractive = [Environment]::UserInteractive -and (-not [Console]::IsInputRedirected)
+    if (-not $isInteractive) {
+        Write-Warn "Non-interactive session detected -- defaulting to independent install"
+        return $true
+    }
+    $answer = Read-Host "  Install independently in this worktree? [Y/n]"
+    if ($answer -match '^[Nn]') {
+        return $false
+    }
+    return $true
+}
+
+function Get-LockfileHash {
+    # Content-normalised SHA-256 for lockfile comparison.
+    # Normalises CRLF -> LF and strips a leading BOM so that minor formatting
+    # differences (CRLF checkout on Windows, git config differences) do not
+    # trigger a false-positive "lockfiles differ" and a needless full npm ci.
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    $content = [System.IO.File]::ReadAllText($Path)
+    # Strip UTF-8 BOM (U+FEFF) if present
+    if ($content.Length -gt 0 -and [int][char]$content[0] -eq 0xFEFF) {
+        $content = $content.Substring(1)
+    }
+    # Normalise line endings: CRLF -> LF
+    $content = $content -replace "`r`n", "`n"
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($content)
+    $sha   = [System.Security.Cryptography.SHA256]::Create()
+    $hash  = $sha.ComputeHash($bytes)
+    $sha.Dispose()
+    return ([System.BitConverter]::ToString($hash) -replace '-', '')
+}
+
+function Assert-NodeModulesValid {
+    # Validate that npm ci produced a usable node_modules.
+    # Returns $true when valid, $false when broken.
+    # npm >= 7 writes .package-lock.json; always check .bin as the primary signal.
+    param([string]$NMPath)
+    $binDir = Join-Path $NMPath ".bin"
+    $binItems = @(Get-ChildItem $binDir -ErrorAction SilentlyContinue)
+    if ($binItems.Count -eq 0) {
+        Write-Warn "$NMPath/.bin is empty -- install may have failed"
+        return $false
+    }
+    return $true
+}
+
+function Test-IsJunction {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $false }
+    $item = Get-Item $Path -Force
+    return ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0
+}
+
+function Remove-JunctionSafe {
+    # Remove a junction WITHOUT deleting the target contents.
+    # Remove-Item -Recurse on a junction follows it; cmd rmdir does not.
+    param([string]$Path)
+    if (Test-IsJunction $Path) {
+        cmd /c "rmdir `"$Path`"" 2>$null
+        Write-Ok "Removed stale junction at $Path"
+    }
+}
+
+function Invoke-NpmCiWithRetry {
+    # Run npm ci in $InstallPath, validate, retry once if incomplete.
+    # Throws on failure.
+    param([string]$InstallPath)
+    Push-Location $InstallPath
+    try { npm ci } finally { Pop-Location }
+    $nm = Join-Path $InstallPath "node_modules"
+    if (-not (Assert-NodeModulesValid $nm)) {
+        Write-Warn "Retrying npm ci (first attempt left node_modules incomplete)"
+        Push-Location $InstallPath
+        try { npm ci } finally { Pop-Location }
+        if (-not (Assert-NodeModulesValid $nm)) {
+            Write-Error "npm ci failed to produce a valid node_modules. Run 'make wt-setup WT=`"$InstallPath`"' again."
+        }
+    }
+}
+
+function Get-FileHash256 {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    (Get-FileHash -Path $Path -Algorithm SHA256).Hash
+}
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+
+$WorktreePath = (Resolve-Path $WorktreePath -ErrorAction Stop).Path
+
+if (-not $MainRepoPath) {
+    # Find via git common dir (works from any worktree)
+    $gitCommonDir = $null
+    try { $gitCommonDir = (git -C $WorktreePath rev-parse --git-common-dir 2>$null) } catch {}
+    if ($gitCommonDir) {
+        $MainRepoPath = (Resolve-Path (Split-Path $gitCommonDir -Parent) -ErrorAction SilentlyContinue).Path
+    }
+    if (-not $MainRepoPath) {
+        $MainRepoPath = "D:\code\eso-log-aggregator"
+    }
+}
+
+if (-not (Test-Path (Join-Path $MainRepoPath "package-lock.json"))) {
+    Write-Error "Main repo not found at $MainRepoPath (no package-lock.json). Pass -MainRepoPath explicitly."
+    return
+}
+if (-not (Test-Path (Join-Path $WorktreePath "package-lock.json"))) {
+    Write-Error "Worktree at $WorktreePath has no package-lock.json -- is it a valid checkout?"
+    return
+}
+
+Write-Host ""
+Write-Host "=== Worktree Smart Setup ===" -ForegroundColor Cyan
+Write-Host "  Worktree : $WorktreePath"
+Write-Host "  Main repo: $MainRepoPath"
+
+# ---------------------------------------------------------------------------
+# 1. node_modules
+# ---------------------------------------------------------------------------
+
+if ($SkipInstall) {
+    Write-Step "node_modules -- skipped (-SkipInstall)"
+}
+else {
+    Write-Step "node_modules"
+
+    $wtLockPath   = Join-Path $WorktreePath "package-lock.json"
+    $mainLockPath = Join-Path $MainRepoPath "package-lock.json"
+    # Use content-normalised hashes to avoid false positives from CRLF/LF or
+    # BOM differences that git may introduce on Windows checkout.
+    $wtLock       = Get-LockfileHash $wtLockPath
+    $mainLock     = Get-LockfileHash $mainLockPath
+    $mainNM       = Join-Path $MainRepoPath "node_modules"
+    $wtNM         = Join-Path $WorktreePath "node_modules"
+
+    $currentIsJunction = Test-IsJunction $wtNM
+    $lockfilesMatch    = ($wtLock -eq $mainLock)
+
+    if ($Force) {
+        # Force mode: always full install
+        Write-Warn "Force mode -- running full npm ci"
+        Remove-JunctionSafe $wtNM
+        Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+        Write-Ok "npm ci completed (independent node_modules)"
+    }
+    elseif ($lockfilesMatch -and (Test-Path $mainNM) -and -not $currentIsJunction) {
+        # Lockfiles match + main has node_modules + worktree has no junction yet
+        # Validate main node_modules BEFORE junctioning to avoid propagating broken state
+        if (-not (Assert-NodeModulesValid $mainNM)) {
+            $reason = "main repo node_modules/.bin is missing or empty"
+            if (Confirm-IndependentInstall -Reason $reason) {
+                # If worktree already has a valid independent node_modules, skip reinstall
+                if ((Test-Path $wtNM) -and -not (Test-IsJunction $wtNM) -and (Assert-NodeModulesValid $wtNM)) {
+                    Write-Ok "Worktree already has valid independent node_modules -- skipping reinstall"
+                }
+                else {
+                    Write-Warn "Installing independently in worktree (not junctioning)"
+                    if (Test-Path $wtNM) {
+                        cmd /c "rmdir /s /q `"$wtNM`"" 2>$null
+                        if (Test-Path $wtNM) { Remove-Item $wtNM -Recurse -Force -ErrorAction SilentlyContinue }
+                    }
+                    Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+                    Write-Ok "npm ci completed (independent node_modules, main repo still needs repair)"
+                }
+            }
+            else {
+                Write-Error "Aborting: fix main repo node_modules first (cd $MainRepoPath ; make install), then re-run wt-setup."
+            }
+        }
+        else {
+            if (Test-Path $wtNM) {
+                Write-Warn "Removing existing node_modules to replace with junction (lockfiles match)"
+                # cmd rmdir /s /q is faster than Remove-Item -Recurse on Windows
+                cmd /c "rmdir /s /q `"$wtNM`"" 2>$null
+                if (Test-Path $wtNM) {
+                    Remove-Item $wtNM -Recurse -Force -ErrorAction SilentlyContinue
+                }
+            }
+            cmd /c "mklink /J `"$wtNM`" `"$mainNM`"" | Out-Null
+            Write-Ok "Junctioned node_modules -> main repo (lockfiles match, saved ~400 MB)"
+        }
+    }
+    elseif ($lockfilesMatch -and $currentIsJunction) {
+        # Already junctioned -- verify the target is still healthy
+        if (-not (Assert-NodeModulesValid $wtNM)) {
+            $reason = "junctioned node_modules/.bin is missing or empty"
+            if (Confirm-IndependentInstall -Reason $reason) {
+                Write-Warn "Replacing broken junction with independent install"
+                Remove-JunctionSafe $wtNM
+                Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+                Write-Ok "npm ci completed (independent node_modules, main repo still needs repair)"
+            }
+            else {
+                Write-Error "Aborting: fix main repo node_modules first (cd $MainRepoPath ; make install), then re-run wt-setup."
+            }
+        }
+        else {
+            Write-Ok "node_modules already junctioned to main repo (lockfiles still match)"
+        }
+    }
+    elseif (-not $lockfilesMatch -and $currentIsJunction) {
+        # Lockfiles diverged -- need independent install
+        Write-Warn "Lockfiles diverged -- removing junction, running npm ci"
+        Remove-JunctionSafe $wtNM
+        Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+        Write-Ok "npm ci completed (independent node_modules)"
+    }
+    elseif (-not $lockfilesMatch) {
+        # Lockfiles differ, no junction -- normal install
+        Write-Warn "Lockfiles differ from main -- running npm ci"
+        Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+        Write-Ok "npm ci completed (independent node_modules)"
+    }
+    else {
+        # Lockfiles match but main has no node_modules
+        Write-Warn "Main repo has no node_modules -- running npm ci in worktree"
+        Invoke-NpmCiWithRetry -InstallPath $WorktreePath
+        Write-Ok "npm ci completed"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 2. .env
+# ---------------------------------------------------------------------------
+
+Write-Step ".env"
+
+$mainEnv = Join-Path $MainRepoPath ".env"
+$wtEnv   = Join-Path $WorktreePath ".env"
+
+if (-not (Test-Path $mainEnv)) {
+    Write-Warn "No .env in main repo -- skipping"
+}
+elseif (Test-Path $wtEnv) {
+    $mainHash = Get-FileHash256 $mainEnv
+    $wtHash   = Get-FileHash256 $wtEnv
+    if ($mainHash -eq $wtHash) {
+        Write-Ok ".env already up to date"
+    }
+    else {
+        Copy-Item $mainEnv $wtEnv -Force
+        Write-Ok ".env updated from main repo"
+    }
+}
+else {
+    Copy-Item $mainEnv $wtEnv
+    Write-Ok ".env copied from main repo"
+}
+
+# ---------------------------------------------------------------------------
+# 3. .twig junction (optional — skip if main repo has no .twig)
+# ---------------------------------------------------------------------------
+
+Write-Step ".twig"
+
+$mainTwig = Join-Path $MainRepoPath ".twig"
+$wtTwig   = Join-Path $WorktreePath ".twig"
+
+if (-not (Test-Path $mainTwig)) {
+    Write-Skip "No .twig in main repo -- skipping (twig not installed or not initialised)"
+}
+elseif (Test-IsJunction $wtTwig) {
+    Write-Ok ".twig junction already exists"
+}
+elseif (Test-Path $wtTwig) {
+    Write-Warn ".twig exists but is not a junction -- replacing with junction"
+    Remove-Item $wtTwig -Recurse -Force
+    cmd /c "mklink /J `"$wtTwig`" `"$mainTwig`"" | Out-Null
+    Write-Ok ".twig junctioned -> main repo"
+}
+else {
+    cmd /c "mklink /J `"$wtTwig`" `"$mainTwig`"" | Out-Null
+    Write-Ok ".twig junctioned -> main repo"
+}
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "=== Setup complete! ===" -ForegroundColor Green
+Write-Host "  Next: code $WorktreePath"
+Write-Host "  Start dev: `$env:PORT = `"3002`" ; npm run dev"
+Write-Host ""


### PR DESCRIPTION
## Summary

- **`.claude/hooks/`** — 5 new session lifecycle hooks (SessionStart, Stop, PreToolUse) mirroring legacy-sports patterns
- **`scripts/setup-worktree.ps1`** — smart worktree setup script adapted for npm/`package-lock.json`; junctions `node_modules` when lockfiles match, runs `npm ci` when diverged
- **`.claude/settings.json`** — adds `ENABLE_TOOL_SEARCH` env flag, full worktree MCP tool permission list (24 tools), and hooks wiring
- **`Makefile`** — `wt-setup`, `kill-stale`, `refresh` targets
- **`AGENTS.md`** — documents worktree setup commands

### Key design decisions inherited from legacy-sports

**Symlinks not junctions for ephemeral worktrees**: `setup-worktree-junction.sh` uses `mklink /D` (directory symlink) rather than `mklink /J` (junction). NTFS junctions are followed by recursive-delete tools — when Claude Code archives an ephemeral worktree it would follow the junction and destroy the main repo's `node_modules`. Directory symlinks are not followed. Requires Windows Developer Mode (one-time).

**Lockfile hash comparison**: `setup-worktree.ps1` normalises CRLF→LF and strips BOM before SHA-256 hashing `package-lock.json`, preventing false "lockfiles differ" positives from git's CRLF handling on Windows.

**Guard hooks are non-destructive**: `guard-bash-mcp-first.sh` always exits 0 (warning only, never blocks). `guard-main-repo.sh` exits 2 (blocks) only when both conditions are true: file is in main repo AND worktrees exist.

## Test plan

- [ ] Open a new Claude Code session in a worktree — verify `node_modules` symlink is created by `setup-worktree-junction.sh`
- [ ] End the session — verify symlink is removed by `cleanup-worktree-junction.sh`
- [ ] Run `make wt-setup WT=<path>` on a fresh worktree — verify junction is created when lockfiles match
- [ ] Run `make wt-setup WT=<path>` after modifying `package-lock.json` in the worktree — verify independent `npm ci` runs
- [ ] Attempt to edit a main-repo file while a worktree exists — verify `guard-main-repo.sh` blocks it
- [ ] Run `ls` in a Bash tool call — verify `guard-bash-mcp-first.sh` warning appears in context
- [ ] Add `# mcp-ok` to an `ls` command — verify warning is suppressed and audit log entry is written
- [ ] `make kill-stale` — kills node processes on both Windows and Linux
- [ ] `make refresh` — pulls and reinstalls from main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
