### PR TITLE
feat(api): Cloudflare Worker GQL proxy for ESO Logs API

### DIFF
--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -1,0 +1,95 @@
+/**
+ * Cloudflare Worker proxy for ESO Logs GraphQL API.
+ *
+ * Injects a server-side client-credentials token so the frontend can query
+ * public data on /api/v2/client without requiring the user to log in.
+ *
+ * Token is cached in module scope (within a V8 isolate) and refreshed 60 s
+ * before expiry to avoid stale-token errors at the edge.
+ */
+
+import type { Context } from 'hono';
+
+import type { Env } from './types';
+
+const ESOLOGS_TOKEN_URL = 'https://www.esologs.com/oauth/token';
+const ESOLOGS_CLIENT_API = 'https://www.esologs.com/api/v2/client';
+
+// ─── Token cache (module scope) ───────────────────────────────────────────────
+
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0; // Unix ms
+
+async function getCachedClientToken(env: Env): Promise<string> {
+  const now = Date.now();
+  if (cachedToken && now < tokenExpiresAt) return cachedToken;
+
+  const res = await fetch(ESOLOGS_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: env.ESOLOGS_CLIENT_ID,
+      client_secret: env.ESOLOGS_CLIENT_SECRET,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`ESO Logs OAuth failed (${res.status}): ${body}`);
+  }
+
+  const json = (await res.json()) as { access_token: string; expires_in?: number };
+  if (!json.access_token) throw new Error('ESO Logs OAuth: no access_token in response');
+
+  const expiresIn = json.expires_in ?? 3600;
+  cachedToken = json.access_token;
+  tokenExpiresAt = now + (expiresIn - 60) * 1000; // refresh 60 s early
+
+  return cachedToken;
+}
+
+// ─── Proxy handler ────────────────────────────────────────────────────────────
+
+export async function handleGraphqlProxy(c: Context<{ Bindings: Env }>): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  let token: string;
+  try {
+    token = await getCachedClientToken(c.env);
+  } catch {
+    return c.json({ error: 'Failed to obtain upstream API token' }, 502);
+  }
+
+  // Forward the ?query=<operationName> hint if present (used by ESO Logs for tracing)
+  const operationHint = c.req.query('query');
+  const upstreamUrl = operationHint
+    ? `${ESOLOGS_CLIENT_API}?query=${encodeURIComponent(operationHint)}`
+    : ESOLOGS_CLIENT_API;
+
+  const upstream = await fetch(upstreamUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  // Invalidate cached token on 401 so the next request triggers a fresh fetch
+  if (upstream.status === 401) {
+    cachedToken = null;
+    tokenExpiresAt = 0;
+  }
+
+  const responseBody = await upstream.text();
+  return new Response(responseBody, {
+    status: upstream.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -63,6 +63,7 @@ import {
   checkPackVoteRateLimit,
 } from './db/queries';
 import { moderateImage, MAX_IMAGE_BYTES } from './image-moderation';
+import { handleGraphqlProxy } from './graphql-proxy';
 import type { Env, RecommendedAddonEntry, RecommendedAddons } from './types';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -139,6 +140,12 @@ app.use('*', async (c, next) => {
     c.res.headers.set('Cache-Control', 'no-store');
   }
 });
+
+// ─── ESO Logs GQL proxy ────────────────────────────────────────────────────────
+// Forwards POST /graphql to https://www.esologs.com/api/v2/client, injecting
+// a server-side OAuth token so unauthenticated users can query public data.
+
+app.post('/graphql', handleGraphqlProxy);
 
 // ─── Health check ─────────────────────────────────────────────────────────────
 

--- a/roster-hub-api/wrangler.toml
+++ b/roster-hub-api/wrangler.toml
@@ -15,8 +15,8 @@ binding = "AI"
 
 # Secrets (set via `wrangler secret put <NAME>`):
 #   IMGBB_API_KEY            — ImgBB API key for image uploads
-#   ESOLOGS_CLIENT_ID        — ESO Logs OAuth client ID (leaderboard sync)
-#   ESOLOGS_CLIENT_SECRET    — ESO Logs OAuth client secret (leaderboard sync)
+#   ESOLOGS_CLIENT_ID        — ESO Logs OAuth client ID (leaderboard sync + GQL proxy)
+#   ESOLOGS_CLIENT_SECRET    — ESO Logs OAuth client secret (leaderboard sync + GQL proxy)
 
 # Cleanup expired temp builds daily at 04:00 UTC
 [triggers]

--- a/src/EsoLogsClientContext.tsx
+++ b/src/EsoLogsClientContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useMemo, ReactNode, useState, useCall
 import { useLogger } from './contexts/LoggerContext';
 import { EsoLogsClient } from './esologsClient';
 import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from './features/auth/auth';
+import { getEnvVar } from './utils/envUtils';
 import { addBreadcrumb } from './utils/errorTracking';
 
 interface EsoLogsClientContextType {
@@ -22,6 +23,12 @@ export const EsoLogsClientContext = createContext<EsoLogsClientContextType | und
 // EsoLogsClientContext.isLoggedIn=false, which caused visible layout shifts.
 const initialToken = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY) || '';
 
+// Proxy URL for public /api/v2/client queries — routes through the Cloudflare
+// Worker so the server-side OAuth secret is never exposed to the browser.
+const workerBaseUrl =
+  getEnvVar('VITE_ROSTER_HUB_API_URL') ?? 'https://roster-hub-api.eso-toolkit.workers.dev';
+const CLIENT_API_PROXY_URL = `${workerBaseUrl}/graphql`;
+
 export const EsoLogsClientProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(!!initialToken);
   const logger = useLogger('EsoLogsClient');
@@ -30,7 +37,7 @@ export const EsoLogsClientProvider: React.FC<{ children: ReactNode }> = ({ child
 
   const client = useMemo(() => {
     logger.info('Creating new EsoLogsClient instance');
-    return new EsoLogsClient(initialToken);
+    return new EsoLogsClient(initialToken, CLIENT_API_PROXY_URL);
   }, [logger]);
 
   // Method to set auth token from AuthContext

--- a/src/esologsClient.test.ts
+++ b/src/esologsClient.test.ts
@@ -6,22 +6,23 @@ import { EsoLogsClient, createEsoLogsClient } from './esologsClient';
 describe('EsoLogsClient', () => {
   const mockAccessToken = 'mock-access-token';
   const newMockAccessToken = 'new-mock-access-token';
+  const mockProxyUrl = 'http://localhost:8787/graphql';
 
   describe('Class-based implementation with composition', () => {
     it('should create an instance with access token', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       expect(client).toBeInstanceOf(EsoLogsClient);
       expect(client.getAccessToken()).toBe(mockAccessToken);
     });
 
     it('should contain an Apollo client instance', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
       expect(apolloClient).toBeInstanceOf(ApolloClient);
     });
 
     it('should update access token and recreate internal client', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       expect(client.getAccessToken()).toBe(mockAccessToken);
       const originalClient = client.getClient();
 
@@ -34,7 +35,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should delegate Apollo client methods', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Mock the Apollo client methods with proper types
@@ -89,14 +90,14 @@ describe('EsoLogsClient', () => {
 
   describe('Backward compatibility', () => {
     it('should work with factory function', () => {
-      const client = createEsoLogsClient(mockAccessToken);
+      const client = createEsoLogsClient(mockAccessToken, mockProxyUrl);
       expect(client).toBeInstanceOf(EsoLogsClient);
       expect(client.getAccessToken()).toBe(mockAccessToken);
     });
 
     it('should return same type from factory function', () => {
-      const client1 = new EsoLogsClient(mockAccessToken);
-      const client2 = createEsoLogsClient(mockAccessToken);
+      const client1 = new EsoLogsClient(mockAccessToken, mockProxyUrl);
+      const client2 = createEsoLogsClient(mockAccessToken, mockProxyUrl);
 
       // Both should be instances of EsoLogsClient
       expect(client1.constructor).toBe(client2.constructor);
@@ -105,7 +106,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should maintain same public interface', () => {
-      const client = createEsoLogsClient(mockAccessToken);
+      const client = createEsoLogsClient(mockAccessToken, mockProxyUrl);
 
       // Should have access token management
       expect(typeof client.getAccessToken).toBe('function');
@@ -124,7 +125,7 @@ describe('EsoLogsClient', () => {
 
   describe('Smart endpoint routing', () => {
     it('should use user endpoint for user-specific operations', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Mock the httpLink to capture the URI being used
@@ -161,7 +162,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should use client endpoint for public operations', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Mock the httpLink to capture the URI being used
@@ -198,7 +199,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should default to client endpoint for operations without names', () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Mock the httpLink
@@ -222,7 +223,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should use client endpoint when no access token is provided', () => {
-      const client = new EsoLogsClient(''); // Empty token
+      const client = new EsoLogsClient('', mockProxyUrl); // Empty token
       const apolloClient = client.getClient();
 
       // Mock the httpLink
@@ -248,7 +249,7 @@ describe('EsoLogsClient', () => {
 
   describe('Network error handling', () => {
     it('should surface a user-friendly message when a network error occurs (no statusCode)', async () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Simulate a network-level failure (no HTTP response — statusCode undefined)
@@ -261,7 +262,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should surface a user-friendly message when statusCode is 0', async () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       // Simulate a status-0 network failure
@@ -276,7 +277,7 @@ describe('EsoLogsClient', () => {
     it('converts an ApolloError with nested networkError.statusCode 429 to a human-readable message (ESO-582)', async () => {
       // ApolloClient.query() throws an ApolloError whose .networkError is the
       // ServerError — the statusCode sits one level deeper than the raw thrown error.
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       const apolloError = Object.assign(
@@ -294,7 +295,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should surface a user-friendly message when a 429 rate-limit error occurs (direct statusCode)', async () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       const rateLimitError = Object.assign(new Error('Too Many Requests'), { statusCode: 429 });
@@ -306,7 +307,7 @@ describe('EsoLogsClient', () => {
     });
 
     it('should rethrow other errors unchanged', async () => {
-      const client = new EsoLogsClient(mockAccessToken);
+      const client = new EsoLogsClient(mockAccessToken, mockProxyUrl);
       const apolloClient = client.getClient();
 
       const serverError = Object.assign(new Error('Internal Server Error'), { statusCode: 500 });

--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -62,10 +62,12 @@ export class EsoLogsClient {
   });
 
   private accessToken: string;
+  private clientApiProxyUrl: string;
   private client: ApolloClient;
 
-  constructor(accessToken: string) {
+  constructor(accessToken: string, clientApiProxyUrl: string) {
     this.accessToken = accessToken;
+    this.clientApiProxyUrl = clientApiProxyUrl;
     this.client = this.createApolloClient(accessToken);
   }
 
@@ -225,7 +227,7 @@ export class EsoLogsClient {
         const baseUrl =
           isUserOperation && accessToken
             ? 'https://www.esologs.com/api/v2/user'
-            : 'https://www.esologs.com/api/v2/client';
+            : this.clientApiProxyUrl;
 
         // Log which endpoint is being used for debugging
         logger.debug(`Operation ${operation.operationName} using endpoint: ${baseUrl}`);
@@ -270,6 +272,10 @@ export class EsoLogsClient {
     // query results across different user identities.
     EsoLogsClient.CACHE.reset();
     this.client = this.createApolloClient(newAccessToken);
+  }
+
+  public getClientApiProxyUrl(): string {
+    return this.clientApiProxyUrl;
   }
 
   /**
@@ -379,6 +385,6 @@ export class EsoLogsClient {
     this.client.stop();
   }
 } // Factory function for backward compatibility
-export function createEsoLogsClient(accessToken: string): EsoLogsClient {
-  return new EsoLogsClient(accessToken);
+export function createEsoLogsClient(accessToken: string, clientApiProxyUrl: string): EsoLogsClient {
+  return new EsoLogsClient(accessToken, clientApiProxyUrl);
 }

--- a/src/graphql/testing/graphqlTestHarness.ts
+++ b/src/graphql/testing/graphqlTestHarness.ts
@@ -75,7 +75,7 @@ class GraphqlTestHarness {
       );
     }
 
-    this.client = createEsoLogsClient(accessToken);
+    this.client = createEsoLogsClient(accessToken, 'https://www.esologs.com/api/v2/client');
     this.shouldDisposeClient = true;
   }
 

--- a/src/test/decorators/storybookDecorators.tsx
+++ b/src/test/decorators/storybookDecorators.tsx
@@ -98,7 +98,7 @@ const MockReduxProvider: React.FC<{ children: React.ReactNode }> = ({ children }
 // Mock ESOLogs Client Provider for Storybook
 const MockEsoLogsClientProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const mockClient = React.useMemo(() => {
-    return new EsoLogsClient('some-token');
+    return new EsoLogsClient('some-token', 'https://www.esologs.com/api/v2/client');
   }, []);
 
   // Mock EsoLogsClient context value


### PR DESCRIPTION
## Summary

- Adds a `POST /graphql` proxy endpoint to the existing `roster-hub-api` Cloudflare Worker
- The proxy uses client-credentials OAuth (server secret stored in CF secrets) to forward public GQL queries to `https://www.esologs.com/api/v2/client`
- Frontend Apollo client now routes all non-user queries through this proxy, removing the login requirement for public data browsing (reports, game data, leaderboards)
- User-specific operations (`/api/v2/user`) continue to use the user's own OAuth token directly

## Changes

| File | What |
|------|------|
| `roster-hub-api/src/graphql-proxy.ts` | New handler — cached token fetch + request forwarding |
| `roster-hub-api/src/index.ts` | `POST /graphql` route wired to handler |
| `src/esologsClient.ts` | Constructor takes `clientApiProxyUrl` param, uses it for client-endpoint queries |
| `src/EsoLogsClientContext.tsx` | Reads proxy URL from `VITE_ROSTER_HUB_API_URL` env var via `envUtils` |
| `src/esologsClient.test.ts` | Updated to pass proxy URL arg |

## Test plan

- [ ] Verify `npm run validate` and `npm test` pass (done locally — 170 suites, 2718 tests)
- [ ] Deploy Worker with `wrangler deploy` and confirm `POST /graphql` returns data
- [ ] Verify unauthenticated users can load report pages without login prompt
- [ ] Verify logged-in user-specific features (My Reports) still work via `/api/v2/user`
- [ ] Monitor Worker rate limit usage under normal traffic

Jira: [ESO-765](https://bkrupa.atlassian.net/browse/ESO-765)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ESO-765]: https://bkrupa.atlassian.net/browse/ESO-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ