### PR TITLE
feat(auth): remove login requirement for public pages (ESO-766)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -445,87 +445,73 @@ const AppRoutes: React.FC = () => {
             <Route
               path="/report/:reportId/fight/:fightId/:tabId"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <ReportFightDetails />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <ReportFightDetails />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId/fight/:fightId"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <ReportFightDetails />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <ReportFightDetails />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId/fight/:fightId/replay"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <FightReplay />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <FightReplay />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId/live"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <LiveLog>
-                        <ReportFightDetails />
-                      </LiveLog>
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <LiveLog>
+                      <ReportFightDetails />
+                    </LiveLog>
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId/summary"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <ReportSummaryPage />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <ReportSummaryPage />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId/dashboard"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <RaidDashboardPage />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <RaidDashboardPage />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
               path="/report/:reportId"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<ReportFightsLoadingFallback />}>
-                      <ReportFights />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<ReportFightsLoadingFallback />}>
+                    <ReportFights />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
@@ -750,13 +736,11 @@ const AppRoutes: React.FC = () => {
             <Route
               path="/build-hub"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <BuildHubPage />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <BuildHubPage />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route

--- a/src/EsoLogsClientContext.tsx
+++ b/src/EsoLogsClientContext.tsx
@@ -110,13 +110,18 @@ export const useEsoLogsClientContext = (): EsoLogsClientContextType => {
 
 /**
  * Hook to get the EsoLogsClient instance directly.
- * Throws an error if called when not authenticated or client is not ready.
+ * Throws an error if the client is not ready.
+ *
+ * Note: Authentication is no longer required — the Cloudflare Worker GQL proxy
+ * (ESO-765) injects tokens for public /api/v2/client queries. User-specific
+ * hooks should check `isLoggedIn` from AuthContext before making user-scoped
+ * requests.
  */
 export const useEsoLogsClientInstance = (): EsoLogsClient => {
-  const { client, isReady, isLoggedIn } = useEsoLogsClientContext();
+  const { client, isReady } = useEsoLogsClientContext();
 
-  if (!isReady || !client || !isLoggedIn) {
-    throw new Error('EsoLogsClient is not ready. User must be authenticated.');
+  if (!isReady || !client) {
+    throw new Error('EsoLogsClient is not ready.');
   }
 
   return client;

--- a/src/features/auth/AuthenticatedRoute.tsx
+++ b/src/features/auth/AuthenticatedRoute.tsx
@@ -3,7 +3,6 @@ import { Navigate, useLocation } from 'react-router-dom';
 
 import { useEsoLogsClientContext } from '@/EsoLogsClientContext';
 import { addBreadcrumb } from '@/utils/errorTracking';
-import { isSampleReport } from '@/utils/sampleReports';
 
 import { setIntendedDestination } from './auth';
 import { useAuth } from './AuthContext';
@@ -14,7 +13,9 @@ interface AuthenticatedRouteProps {
 }
 
 /**
- * A wrapper component that protects routes by redirecting unauthenticated users to the login page.
+ * A wrapper component that protects routes requiring user identity by redirecting
+ * unauthenticated users to the login page. Only used for user-specific pages
+ * (My Reports, Latest Reports, etc.) — public pages no longer use this guard.
  *
  * @param children - The component(s) to render if the user is authenticated
  * @param redirectTo - The path to redirect to if not authenticated (defaults to '/login')
@@ -27,18 +28,10 @@ export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = ({
   const location = useLocation();
   const { isReady, isLoggedIn: clientLoggedIn } = useEsoLogsClientContext();
 
-  // Allow unauthenticated access to bundled sample report overview pages.
-  // Only the fight-list route (/report/:code) matches; fight-detail sub-paths
-  // still require login so that deeper data loads go through the normal API.
-  const sampleReportMatch = location.pathname.match(/^\/report\/([^/]+)$/);
-  if (sampleReportMatch && isSampleReport(sampleReportMatch[1])) {
-    return <>{children}</>;
-  }
-
   // Show loading state while checking authentication or while client is not ready
   // Also ensure both auth states are in sync before rendering
   if (userLoading || !isReady || isLoggedIn !== clientLoggedIn) {
-    return null; // Or you could return a loading spinner here
+    return null;
   }
 
   // If not logged in, store the intended destination and redirect to login page

--- a/src/hooks/events/useCastEvents.ts
+++ b/src/hooks/events/useCastEvents.ts
@@ -29,7 +29,7 @@ export function useCastEvents(options?: UseCastEventsOptions): {
 } {
   const dispatch = useAppDispatch();
 
-  const { client, isReady, isLoggedIn } = useEsoLogsClientContext();
+  const { client, isReady } = useEsoLogsClientContext();
   const context = useResolvedReportFightContext(options?.context);
   const selectedFight = useFightForContext(context);
 
@@ -43,8 +43,7 @@ export function useCastEvents(options?: UseCastEventsOptions): {
   const restrictToFightWindow = options?.restrictToFightWindow ?? true;
 
   React.useEffect(() => {
-    // Only fetch if client is ready, user is logged in, and we have required data
-    if (context.reportCode && selectedFight && isReady && isLoggedIn && client) {
+    if (context.reportCode && selectedFight && isReady && client) {
       dispatch(
         fetchCastEvents({
           reportCode: context.reportCode,
@@ -61,7 +60,6 @@ export function useCastEvents(options?: UseCastEventsOptions): {
     selectedFight,
     client,
     isReady,
-    isLoggedIn,
     restrictToFightWindow,
   ]);
 

--- a/src/hooks/events/useDamageEvents.ts
+++ b/src/hooks/events/useDamageEvents.ts
@@ -28,7 +28,7 @@ export function useDamageEvents(options?: UseDamageEventsOptions): {
   isDamageEventsLoading: boolean;
   selectedFight: FightFragment | null;
 } {
-  const { client, isReady, isLoggedIn } = useEsoLogsClientContext();
+  const { client, isReady } = useEsoLogsClientContext();
   const dispatch = useAppDispatch();
   const context = useResolvedReportFightContext(options?.context);
   const selectedFight = useFightForContext(context);
@@ -44,8 +44,7 @@ export function useDamageEvents(options?: UseDamageEventsOptions): {
   const restrictToFightWindow = options?.restrictToFightWindow ?? true;
 
   React.useEffect(() => {
-    // Only fetch if client is ready, user is logged in, and we have required data
-    if (context.reportCode && selectedFight && isReady && isLoggedIn && client) {
+    if (context.reportCode && selectedFight && isReady && client) {
       dispatch(
         fetchDamageEvents({
           reportCode: context.reportCode,
@@ -62,7 +61,6 @@ export function useDamageEvents(options?: UseDamageEventsOptions): {
     selectedFight,
     client,
     isReady,
-    isLoggedIn,
     restrictToFightWindow,
   ]);
 

--- a/src/hooks/useReportData.ts
+++ b/src/hooks/useReportData.ts
@@ -10,25 +10,22 @@ import {
 } from '../store/report/reportSelectors';
 import { fetchReportData } from '../store/report/reportSlice';
 import { useAppDispatch } from '../store/useAppDispatch';
-import { isSampleReport } from '../utils/sampleReports';
 
 export function useReportData(): {
   reportData: ReportFragment | null;
   isReportLoading: boolean;
 } {
-  const { client, isReady, isLoggedIn } = useEsoLogsClientContext();
+  const { client, isReady } = useEsoLogsClientContext();
   const dispatch = useAppDispatch();
   const { reportId } = useSelectedReportAndFight();
 
   React.useEffect(() => {
-    // Fetch if client is ready and user is logged in.
-    // For bundled sample reports, also fetch even without login — the thunk
-    // will serve data from the static JSON instead of hitting the API.
-    const canFetch = isLoggedIn || isSampleReport(reportId);
-    if (reportId && isReady && canFetch && client) {
+    // Fetch if client is ready — the Cloudflare Worker GQL proxy handles
+    // token injection for public queries so no login is required.
+    if (reportId && isReady && client) {
       dispatch(fetchReportData({ reportId, client }));
     }
-  }, [dispatch, reportId, client, isReady, isLoggedIn]);
+  }, [dispatch, reportId, client, isReady]);
 
   const combinedReportData = useSelector(selectCombinedReportData);
   const isReportLoading = useSelector(selectReportLoadingState);

--- a/src/hooks/useReportMasterData.ts
+++ b/src/hooks/useReportMasterData.ts
@@ -31,7 +31,7 @@ interface UseReportMasterDataOptions {
 export function useReportMasterData(
   options?: UseReportMasterDataOptions,
 ): UseReportMasterDataResult {
-  const { client, isReady, isLoggedIn } = useEsoLogsClientContext();
+  const { client, isReady } = useEsoLogsClientContext();
   const dispatch = useAppDispatch();
   const context = useResolvedReportFightContext(options?.context);
 
@@ -48,10 +48,10 @@ export function useReportMasterData(
   const isLoaded = masterDataEntry?.status === 'succeeded';
 
   React.useEffect(() => {
-    if (context.reportCode && isReady && isLoggedIn && client) {
+    if (context.reportCode && isReady && client) {
       dispatch(fetchReportMasterData({ reportCode: context.reportCode, client }));
     }
-  }, [dispatch, context.reportCode, client, isReady, isLoggedIn]);
+  }, [dispatch, context.reportCode, client, isReady]);
 
   return React.useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- Remove `AuthenticatedRoute` wrapper from all `/report/*` routes and `/build-hub` so unauthenticated visitors can browse freely
- Update `useEsoLogsClientInstance()` to not gate on `isLoggedIn` — the Cloudflare Worker GQL proxy (ESO-765) injects tokens for public queries
- Remove `isLoggedIn` checks from data-fetching hooks (`useReportData`, `useReportMasterData`, `useDamageEvents`, `useCastEvents`)
- Clean up now-unnecessary sample report exception in `AuthenticatedRoute`

### Still auth-gated (correct)
`/latest-reports`, `/whoami`, `/my-reports`, `/parse-analysis`

### Already correct (no changes needed)
- **HeaderBar**: Shows login button for guests, hides "My Reports"
- **Hub pages** (Build/Roster/Pack): Show info alerts for guests, disable voting
- **LandingPage**: Shows login prompt for unauthenticated visitors

## Test plan

- [ ] Open a report URL without logging in — full fight data should load
- [ ] Browse `/build-hub`, `/roster-hub`, `/pack-hub`, `/leaderboards` without login
- [ ] `/my-reports` and `/latest-reports` should redirect to login
- [ ] Vote/comment buttons on public pages should prompt login, not be invisible
- [ ] No regressions for logged-in users

Depends on: #996 (ESO-765 Cloudflare Worker GQL proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)