### PR TITLE
feat(ci): add manual Cloudflare Worker deploy workflow (ESO-768)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -11,6 +11,9 @@ on:
           - roster-hub-api
           - discord-bot
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,25 @@
+name: Deploy Cloudflare Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker to deploy'
+        required: true
+        type: choice
+        options:
+          - roster-hub-api
+          - discord-bot
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: ${{ inputs.worker }}


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only GitHub Actions workflow for deploying Cloudflare Workers
- Dropdown selector to choose between `roster-hub-api` and `discord-bot`
- Uses `cloudflare/wrangler-action@v3` with `CLOUDFLARE_API_TOKEN` secret

## Test plan
- [ ] Trigger workflow from Actions tab, select `roster-hub-api`, verify deploy succeeds
- [ ] Trigger workflow from Actions tab, select `discord-bot`, verify deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)