### PR TITLE
fix(auth): show log URL input to unauthenticated visitors on landing page

### DIFF
--- a/src/components/UnauthenticatedLandingSection.tsx
+++ b/src/components/UnauthenticatedLandingSection.tsx
@@ -1,130 +1,245 @@
-import { LockOpen as LockOpenIcon } from '@mui/icons-material';
-import { Box, Button, Typography, useTheme } from '@mui/material';
-import React from 'react';
+import { Link as LinkIcon, LockOpen as LockOpenIcon } from '@mui/icons-material';
+import { Box, Button, TextField, useTheme } from '@mui/material';
+import React, { useState } from 'react';
 
 import { startPKCEAuth } from '../features/auth/auth';
 import { useViewTransitionNavigate } from '../hooks/useViewTransitionNavigate';
+import { clearAllEvents } from '../store/events_data/actions';
+import { clearMasterData } from '../store/master_data/masterDataSlice';
+import { clearReport } from '../store/report/reportSlice';
+import { useAppDispatch } from '../store/useAppDispatch';
+
+import { LogInputContainer } from './LandingPage';
 
 export const UnauthenticatedLandingSection: React.FC = () => {
+  const [logUrl, setLogUrl] = useState('');
   const navigate = useViewTransitionNavigate();
+  const dispatch = useAppDispatch();
   const theme = useTheme();
+
+  const handleLogUrlChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setLogUrl(e.target.value);
+  };
+
+  const extractReportInfo = (url: string): { reportId: string; fightId: string | null } | null => {
+    const reportMatch = url.match(/reports\/([A-Za-z0-9]+)/);
+    if (!reportMatch) return null;
+
+    const reportId = reportMatch[1];
+    let fightId: string | null = null;
+
+    const hashFightMatch = url.match(/#fight=(\d+)/);
+    if (hashFightMatch) {
+      fightId = hashFightMatch[1];
+    }
+
+    const queryFightMatch = url.match(/[?&]fight=(\d+)/);
+    if (queryFightMatch) {
+      fightId = queryFightMatch[1];
+    }
+
+    const pathFightMatch = url.match(/reports\/[A-Za-z0-9]+\/(\d+)/);
+    if (pathFightMatch) {
+      fightId = pathFightMatch[1];
+    }
+
+    return { reportId, fightId };
+  };
+
+  const handleLoadLog = (): void => {
+    const result = extractReportInfo(logUrl);
+    if (result) {
+      dispatch(clearAllEvents());
+      dispatch(clearMasterData());
+      dispatch(clearReport());
+
+      if (result.fightId) {
+        navigate(`/report/${result.reportId}/fight/${result.fightId}/insights`, { vtType: 'up' });
+      } else {
+        navigate(`/report/${result.reportId}`, { vtType: 'up' });
+      }
+    } else {
+      alert('Invalid ESOLogs report URL');
+    }
+  };
 
   const handleLogin = (): void => {
     startPKCEAuth();
   };
 
   return (
-    <Box sx={{ textAlign: 'center' }}>
-      <Button
-        variant="contained"
-        size="large"
-        onClick={handleLogin}
-        startIcon={<LockOpenIcon />}
-        sx={{
-          py: 2,
-          px: 6,
-          borderRadius: '16px',
-          fontSize: '1.2rem',
-          fontWeight: 700,
-          background: 'linear-gradient(135deg, #38bdf8 0%, #00e1ff 50%, #0ea5e9 100%)',
-          color: '#ffffff',
-          boxShadow: '0 20px 60px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
-          border:
-            theme.palette.mode === 'dark'
-              ? '1px solid rgba(56, 189, 248, 0.2)'
-              : '1px solid rgba(30, 41, 59, 0.15)',
-          position: 'relative',
-          overflow: 'hidden',
-          transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
-          textTransform: 'uppercase',
-          letterSpacing: '1px',
-          textShadow: `
-            0 2px 4px rgba(0, 0, 0, 0.7),
-            0 4px 8px rgba(0, 0, 0, 0.5),
-            0 0 15px rgba(14, 165, 233, 0.6),
-            0 0 30px rgba(56, 189, 248, 0.4)
-          `,
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            height: '1px',
-            background:
-              theme.palette.mode === 'dark'
-                ? 'linear-gradient(90deg, transparent, rgba(56, 189, 248, 0.6), transparent)'
-                : 'linear-gradient(90deg, transparent, rgba(30, 41, 59, 0.3), transparent)',
-          },
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            top: 0,
-            left: '-100%',
-            width: '100%',
-            height: '100%',
-            background:
-              'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent)',
-            transition: 'left 0.6s ease',
-          },
-          '&:hover': {
-            background: 'linear-gradient(135deg, #0ea5e9 0%, #38bdf8 50%, #00e1ff 100%)',
-            transform: 'translateY(-4px)',
-            boxShadow:
-              '0 25px 80px rgba(0, 0, 0, 0.5), 0 0 40px rgba(56, 189, 248, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2)',
-            borderColor:
-              theme.palette.mode === 'dark' ? 'rgba(56, 189, 248, 0.4)' : 'rgba(30, 41, 59, 0.25)',
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        gap: 1,
+        maxWidth: '600px',
+        width: '100%',
+        mx: 'auto',
+        [theme.breakpoints.down('sm')]: {
+          maxWidth: '100%',
+        },
+      }}
+    >
+      <LogInputContainer sx={{ m: 0 }}>
+        <TextField
+          label="ESOLogs.com Log URL"
+          variant="outlined"
+          value={logUrl}
+          onChange={handleLogUrlChange}
+          sx={{
+            flex: 1,
+            '& .MuiOutlinedInput-root': {
+              backgroundColor: 'transparent',
+              borderRadius: { xs: '8px 8px 0 0', sm: '16px 0 0 16px' },
+              height: { xs: '56px', sm: '64px' },
+              padding: '0 1.5rem',
+              border: 'none',
+              '& fieldset': {
+                border: 'none',
+              },
+              '&:hover fieldset': {
+                border: 'none',
+              },
+              '&.Mui-focused fieldset': {
+                border: 'none',
+              },
+            },
+            '& .MuiInputLabel-root': {
+              color: theme.palette.mode === 'dark' ? '#94a3b8' : '#64748b',
+              left: '3.5rem',
+              top: { xs: '2px', sm: '4px' },
+              fontSize: { xs: '0.85rem', sm: '0.95rem' },
+              '&.Mui-focused': {
+                color: '#38bdf8',
+              },
+              '&.MuiInputLabel-shrink': {
+                transform: {
+                  xs: 'translate(3.5rem, -12px) scale(0.75)',
+                  sm: 'translate(3.5rem, -10px) scale(0.75)',
+                },
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(15, 23, 42, 0.9)'
+                    : 'rgba(248, 250, 252, 0.95)',
+                padding: '2px 8px',
+                borderRadius: '4px',
+              },
+            },
+            '& .MuiInputBase-input': {
+              padding: { xs: '16px 0', sm: '18px 0' },
+              color: theme.palette.mode === 'dark' ? '#e5e7eb' : '#1e293b',
+              fontSize: { xs: '0.9rem', sm: '1rem' },
+            },
+          }}
+          InputProps={{
+            startAdornment: <LinkIcon sx={{ mr: 1, color: '#38bdf8', ml: 0 }} />,
+          }}
+        />
+        <Button
+          variant="contained"
+          color="secondary"
+          sx={{
+            minWidth: 200,
+            height: 64,
+            background: 'linear-gradient(135deg, #38bdf8 0%, #00e1ff 50%, #0ea5e9 100%)',
+            color: '#ffffff',
+            fontWeight: 700,
+            fontSize: { xs: '1rem', sm: '1.1rem' },
+            borderRadius: { xs: '0 0 8px 8px', sm: '0 16px 16px 0' },
+            border: 'none',
+            boxShadow: 'none',
+            position: 'relative',
+            overflow: 'hidden',
+            transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+            textTransform: 'uppercase',
+            letterSpacing: '1px',
+            textShadow: `
+              0 2px 4px rgba(0, 0, 0, 0),
+              0 4px 8px rgba(0, 0, 0, 0.7),
+              0 8px 16px rgba(0, 0, 0, 0.5),
+              0 0 15px rgba(14, 165, 233, 0.6),
+              0 0 30px rgba(56, 189, 248, 0.4),
+              0 1px 0 rgba(255, 255, 255, 0.2)
+            `,
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.2) 0%, transparent 50%)',
+              opacity: 0,
+              transition: 'opacity 0.3s ease',
+            },
             '&::after': {
-              left: '100%',
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: '-100%',
+              width: '100%',
+              height: '100%',
+              background:
+                'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent)',
+              transition: 'left 0.6s ease',
             },
-          },
-          '&:active': {
-            transform: 'translateY(-2px)',
-          },
-          [theme.breakpoints.down('sm')]: {
-            py: 1.5,
-            px: 4,
-            fontSize: '1.1rem',
-            borderRadius: '12px',
             '&:hover': {
-              transform: 'none',
+              background: 'linear-gradient(135deg, #0ea5e9 0%, #38bdf8 50%, #00e1ff 100%)',
+              transform: { xs: 'none', sm: 'scale(1.02)' },
+              '&::before': {
+                opacity: 1,
+              },
+              '&::after': {
+                left: '100%',
+              },
             },
-          },
-        }}
-      >
-        Connect to ESO Logs
-      </Button>
-      <Typography
-        variant="body2"
+            '&:active': {
+              transform: { xs: 'none', sm: 'scale(1.01)' },
+            },
+          }}
+          onClick={handleLoadLog}
+        >
+          Analyze Log
+        </Button>
+      </LogInputContainer>
+
+      <Box
         sx={{
-          mt: 2,
-          color: theme.palette.text.secondary,
-          opacity: 0.8,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mt: 1.5,
+          gap: 1,
         }}
       >
-        Connect your ESO Logs account to analyze combat logs
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          mt: 1,
-          color: theme.palette.text.secondary,
-          opacity: 0.7,
-          fontSize: '0.875rem',
-        }}
-      >
-        Want to learn more about privacy and data security?{' '}
-        <span
-          onClick={() => navigate('/login', { vtType: 'up' })}
-          style={{
-            color: theme.palette.primary.main,
-            textDecoration: 'underline',
-            cursor: 'pointer',
+        <Button
+          variant="text"
+          size="small"
+          onClick={handleLogin}
+          startIcon={<LockOpenIcon sx={{ fontSize: 16 }} />}
+          sx={{
+            textTransform: 'none',
+            fontWeight: 400,
+            fontSize: '0.875rem',
+            color:
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, 0.7)'
+                : 'rgba(51, 65, 85, 0.7)',
+            '&:hover': {
+              textDecoration: 'underline',
+              backgroundColor: 'transparent',
+              color:
+                theme.palette.mode === 'dark'
+                  ? 'rgba(255, 255, 255, 0.9)'
+                  : 'rgba(51, 65, 85, 0.9)',
+            },
           }}
         >
-          Visit our login page
-        </span>
-      </Typography>
+          Connect to ESO Logs for personal reports
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/components/UnauthenticatedLandingSection.tsx
+++ b/src/components/UnauthenticatedLandingSection.tsx
@@ -224,9 +224,7 @@ export const UnauthenticatedLandingSection: React.FC = () => {
             fontWeight: 400,
             fontSize: '0.875rem',
             color:
-              theme.palette.mode === 'dark'
-                ? 'rgba(255, 255, 255, 0.7)'
-                : 'rgba(51, 65, 85, 0.7)',
+              theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.7)' : 'rgba(51, 65, 85, 0.7)',
             '&:hover': {
               textDecoration: 'underline',
               backgroundColor: 'transparent',


### PR DESCRIPTION
## Summary
- The landing page's `UnauthenticatedLandingSection` was only showing a "Connect to ESO Logs" login button, creating a login wall even though #997 (e681ba1b) removed auth gates from report routes
- Replace the login-only hero with the same log URL input + "Analyze Log" button that authenticated users see, so unauthenticated visitors can paste a report URL and browse immediately
- Login is now a subtle secondary link below the input for user-specific features (My Reports, voting, etc.)

## Test plan
- [ ] Visit esotk.com while logged out — should see the log URL input instead of a login button
- [ ] Paste a valid ESOLogs report URL and click "Analyze Log" — should navigate to the report
- [ ] Click "Connect to ESO Logs for personal reports" — should initiate OAuth flow
- [ ] Visit while logged in — behavior unchanged (shows authenticated section with latest report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)