### PR TITLE
fix(auth): remove unnecessary AuthenticatedRoute from public pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -567,13 +567,11 @@ const AppRoutes: React.FC = () => {
             <Route
               path="/latest-reports"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <LatestReports />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <LatestReports />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route
@@ -611,13 +609,11 @@ const AppRoutes: React.FC = () => {
             <Route
               path="/parse-analysis/:reportId?/:fightId?"
               element={
-                <AuthenticatedRoute>
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <ParseAnalysisPage />
-                    </Suspense>
-                  </ErrorBoundary>
-                </AuthenticatedRoute>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <ParseAnalysisPage />
+                  </Suspense>
+                </ErrorBoundary>
               }
             />
             <Route

--- a/src/features/auth/AuthenticatedRoute.tsx
+++ b/src/features/auth/AuthenticatedRoute.tsx
@@ -15,7 +15,8 @@ interface AuthenticatedRouteProps {
 /**
  * A wrapper component that protects routes requiring user identity by redirecting
  * unauthenticated users to the login page. Only used for user-specific pages
- * (My Reports, Latest Reports, etc.) — public pages no longer use this guard.
+ * (My Reports, WhoAmI, etc.) — public pages use the Cloudflare Worker GQL
+ * proxy and do not need this guard.
  *
  * @param children - The component(s) to render if the user is authenticated
  * @param redirectTo - The path to redirect to if not authenticated (defaults to '/login')


### PR DESCRIPTION
## Summary
- Removed `AuthenticatedRoute` wrapper from `/latest-reports` — only queries `reportData.reports` (public endpoint via Cloudflare Worker proxy)
- Removed `AuthenticatedRoute` wrapper from `/parse-analysis` — only queries `reportData.report(code)` and `reportData.playerDetails()` (also public)
- Updated `AuthenticatedRoute` docstring to accurately reflect remaining usage (`/my-reports`, `/whoami`)

## Context
These routes were incorrectly gated behind login even though they make no user-specific API calls. The Cloudflare Worker GQL proxy (ESO-765) handles API auth server-side for public queries, so no user token is needed.

## Test plan
- [ ] Visit `/latest-reports` while logged out — page loads and shows reports
- [ ] Visit `/parse-analysis/<reportId>` while logged out — page loads and shows parse data
- [ ] Visit `/my-reports` while logged out — still redirects to `/login`
- [ ] Visit `/whoami` while logged out — still redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)