### PR TITLE
fix(ui): pluralize Latest Report nav item

### DIFF
--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -724,7 +724,7 @@ export const HeaderBar: React.FC = () => {
         action: handleSampleReport,
       },
       {
-        text: 'Latest Report',
+        text: 'Latest Reports',
         desc: 'Recently uploaded',
         icon: '📊',
         accent: '#06b6d4',


### PR DESCRIPTION
## Summary
- Pluralizes the "Latest Report" header nav item to "Latest Reports" for consistency with the page title and other references

## Test plan
- [ ] Verify the header nav dropdown shows "Latest Reports"
- [ ] Confirm the link still navigates to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)