### PR TITLE
fix(ui): Fix Kalpa deep link protocol and launch method

### DIFF
--- a/src/features/build-hub/api/packs-api.ts
+++ b/src/features/build-hub/api/packs-api.ts
@@ -114,23 +114,15 @@ export const packsApi = {
 
 export const KALPA_DOWNLOAD_URL = 'https://github.com/ESO-Toolkit/kalpa';
 
-export interface DeepLinkOptions {
-  /** When true, tells the addon manager to skip addons already installed and preserve their settings. */
-  preserveSettings?: boolean;
-}
-
 /**
  * Generate a deep link URL that opens Kalpa (ESO Addon Manager)
- * and installs a specific pack.
+ * and navigates to a specific pack.
  *
- * Usage: `eso-addon-manager://pack/trial-essentials?preserve_settings=true`
+ * Kalpa registers the `kalpa://` protocol scheme via Tauri's deep-link plugin.
+ * Supported paths: `kalpa://pack/{id}`, `kalpa://install-pack/{id}`, `kalpa://share/{code}`
  */
-export function getAddonManagerDeepLink(packId: string, options: DeepLinkOptions = {}): string {
-  const { preserveSettings = true } = options;
-  const params = new URLSearchParams();
-  if (preserveSettings) params.set('preserve_settings', 'true');
-  const qs = params.toString();
-  return `eso-addon-manager://pack/${packId}${qs ? `?${qs}` : ''}`;
+export function getAddonManagerDeepLink(packId: string): string {
+  return `kalpa://pack/${packId}`;
 }
 
 /**

--- a/src/features/build-hub/api/packs-api.ts
+++ b/src/features/build-hub/api/packs-api.ts
@@ -132,3 +132,53 @@ export function getAddonManagerDeepLink(packId: string, options: DeepLinkOptions
   const qs = params.toString();
   return `eso-addon-manager://pack/${packId}${qs ? `?${qs}` : ''}`;
 }
+
+/**
+ * Attempt to launch a deep-link URI without triggering the OS "open with" dialog.
+ *
+ * Uses a hidden iframe to silently probe the protocol handler. If the handler
+ * is registered and the app opens (page loses visibility), the attempt is
+ * considered successful and the fallback is skipped. Otherwise `onFallback`
+ * fires after `timeoutMs` so the caller can show a download prompt.
+ *
+ * @returns A cancel function to abort the pending fallback (for unmount cleanup).
+ */
+export function tryLaunchDeepLink(
+  uri: string,
+  onFallback: () => void,
+  timeoutMs = 1500,
+): () => void {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let iframe: HTMLIFrameElement | undefined;
+
+  const cleanup = (): void => {
+    cancelled = true;
+    if (timer != null) clearTimeout(timer);
+    if (iframe?.parentNode) iframe.parentNode.removeChild(iframe);
+    document.removeEventListener('visibilitychange', onVisChange);
+  };
+
+  const onVisChange = (): void => {
+    // The protocol handler stole focus — Kalpa opened successfully.
+    if (document.hidden && !cancelled) cleanup();
+  };
+
+  document.addEventListener('visibilitychange', onVisChange);
+
+  // Probe via hidden iframe — fails silently when the protocol is unregistered,
+  // avoiding the OS "how do you want to open this?" dialog.
+  iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  iframe.src = uri;
+  document.body.appendChild(iframe);
+
+  timer = setTimeout(() => {
+    if (!cancelled) {
+      cleanup();
+      onFallback();
+    }
+  }, timeoutMs);
+
+  return cleanup;
+}

--- a/src/features/build-hub/components/GetAddonsButton.tsx
+++ b/src/features/build-hub/components/GetAddonsButton.tsx
@@ -25,7 +25,7 @@ export const GetAddonsButton: React.FC<GetAddonsButtonProps> = ({
   iconOnly = false,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
-  const deepLink = getAddonManagerDeepLink(packId, { preserveSettings: true });
+  const deepLink = getAddonManagerDeepLink(packId);
   const cancelRef = React.useRef<(() => void) | undefined>(undefined);
 
   React.useEffect(() => () => cancelRef.current?.(), []);

--- a/src/features/build-hub/components/GetAddonsButton.tsx
+++ b/src/features/build-hub/components/GetAddonsButton.tsx
@@ -3,7 +3,7 @@ import { Button, Tooltip } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 
-import { KALPA_DOWNLOAD_URL, getAddonManagerDeepLink } from '../api/packs-api';
+import { KALPA_DOWNLOAD_URL, getAddonManagerDeepLink, tryLaunchDeepLink } from '../api/packs-api';
 
 interface GetAddonsButtonProps {
   /** The pack ID to link to (e.g. "trial-essentials"). */
@@ -26,33 +26,41 @@ export const GetAddonsButton: React.FC<GetAddonsButtonProps> = ({
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const deepLink = getAddonManagerDeepLink(packId, { preserveSettings: true });
+  const cancelRef = React.useRef<(() => void) | undefined>(undefined);
+
+  React.useEffect(() => () => cancelRef.current?.(), []);
 
   const handleClick = (e: React.MouseEvent): void => {
     e.stopPropagation();
-
-    // Try to open the deep link — this will launch the addon manager if installed.
-    // If not installed, the browser silently fails. We copy the link as a fallback.
-    window.location.href = deepLink;
-
-    // After a short delay, assume Kalpa isn't installed and prompt to download
-    setTimeout(() => {
+    cancelRef.current?.();
+    cancelRef.current = tryLaunchDeepLink(deepLink, () => {
       void navigator.clipboard.writeText(deepLink).catch(() => {});
-      enqueueSnackbar('Kalpa not detected — download it to install addon packs', {
+      enqueueSnackbar("Kalpa didn't open — launch it manually or download it", {
         variant: 'info',
-        autoHideDuration: 6000,
+        autoHideDuration: 8000,
         action: () => (
-          <Button
-            size="small"
-            href={KALPA_DOWNLOAD_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
-          >
-            Download
-          </Button>
+          <>
+            <Button
+              size="small"
+              component="a"
+              href={deepLink}
+              sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+            >
+              Launch
+            </Button>
+            <Button
+              size="small"
+              href={KALPA_DOWNLOAD_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+            >
+              Download
+            </Button>
+          </>
         ),
       });
-    }, 1500);
+    });
   };
 
   if (iconOnly) {

--- a/src/features/pack-hub/components/PackCard.tsx
+++ b/src/features/pack-hub/components/PackCard.tsx
@@ -52,7 +52,7 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
 
     const handleCopyLink = (e: React.MouseEvent): void => {
       e.stopPropagation();
-      const deepLink = getAddonManagerDeepLink(pack.id, { preserveSettings: true });
+      const deepLink = getAddonManagerDeepLink(pack.id);
       void navigator.clipboard.writeText(deepLink).then(
         () => enqueueSnackbar('Deep link copied to clipboard!', { variant: 'success' }),
         () => enqueueSnackbar('Failed to copy link', { variant: 'error' }),
@@ -61,7 +61,7 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
 
     const handleInstall = (e: React.MouseEvent): void => {
       e.stopPropagation();
-      const deepLink = getAddonManagerDeepLink(pack.id, { preserveSettings: true });
+      const deepLink = getAddonManagerDeepLink(pack.id);
       cancelDeepLinkRef.current?.();
       cancelDeepLinkRef.current = tryLaunchDeepLink(deepLink, () => {
         void navigator.clipboard.writeText(deepLink).catch(() => {});

--- a/src/features/pack-hub/components/PackCard.tsx
+++ b/src/features/pack-hub/components/PackCard.tsx
@@ -15,7 +15,11 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 
 import { formatRelativeDate } from '../../../utils/formatRelativeDate';
-import { KALPA_DOWNLOAD_URL, getAddonManagerDeepLink } from '../../build-hub/api/packs-api';
+import {
+  KALPA_DOWNLOAD_URL,
+  getAddonManagerDeepLink,
+  tryLaunchDeepLink,
+} from '../../build-hub/api/packs-api';
 import { VoteButton } from '../../roster-hub/components/VoteButton';
 import type { HubPack } from '../types/pack-hub.types';
 import { PACK_TAG_COLORS, PACK_TYPE_ACCENT, PACK_TYPE_LABELS } from '../types/pack-hub.types';
@@ -36,9 +40,9 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
     const { enqueueSnackbar } = useSnackbar();
     const theme = useTheme();
     const isDark = theme.palette.mode === 'dark';
-    const installTimerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+    const cancelDeepLinkRef = React.useRef<(() => void) | undefined>(undefined);
 
-    React.useEffect(() => () => clearTimeout(installTimerRef.current), []);
+    React.useEffect(() => () => cancelDeepLinkRef.current?.(), []);
 
     const tagAccent = pack.tags.map((t) => PACK_TAG_COLORS[t]).find((c): c is string => c != null);
     const accentColor = tagAccent ?? PACK_TYPE_ACCENT[pack.pack_type] ?? '#c4a44a';
@@ -58,25 +62,35 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
     const handleInstall = (e: React.MouseEvent): void => {
       e.stopPropagation();
       const deepLink = getAddonManagerDeepLink(pack.id, { preserveSettings: true });
-      window.location.href = deepLink;
-      installTimerRef.current = setTimeout(() => {
+      cancelDeepLinkRef.current?.();
+      cancelDeepLinkRef.current = tryLaunchDeepLink(deepLink, () => {
         void navigator.clipboard.writeText(deepLink).catch(() => {});
-        enqueueSnackbar('Kalpa not detected — download it to install addon packs', {
+        enqueueSnackbar("Kalpa didn't open — launch it manually or download it", {
           variant: 'info',
-          autoHideDuration: 6000,
+          autoHideDuration: 8000,
           action: () => (
-            <Button
-              size="small"
-              href={KALPA_DOWNLOAD_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
-            >
-              Download
-            </Button>
+            <>
+              <Button
+                size="small"
+                component="a"
+                href={deepLink}
+                sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+              >
+                Launch
+              </Button>
+              <Button
+                size="small"
+                href={KALPA_DOWNLOAD_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+              >
+                Download
+              </Button>
+            </>
           ),
         });
-      }, 1500);
+      });
     };
 
     return (

--- a/src/features/roster-hub/components/RosterCard.tsx
+++ b/src/features/roster-hub/components/RosterCard.tsx
@@ -1,6 +1,7 @@
 import { ContentCopy, DeleteOutline, EditOutlined, Extension, MoreVert } from '@mui/icons-material';
 import {
   Box,
+  Button,
   Card,
   CardActionArea,
   CardActions,
@@ -20,7 +21,11 @@ import React, { useRef } from 'react';
 
 import discordIcon from '../../../assets/discord-icon.svg';
 import { useViewTransitionNavigate } from '../../../hooks/useViewTransitionNavigate';
-import { getAddonManagerDeepLink } from '../../build-hub/api/packs-api';
+import {
+  KALPA_DOWNLOAD_URL,
+  getAddonManagerDeepLink,
+  tryLaunchDeepLink,
+} from '../../build-hub/api/packs-api';
 import type { HubRoster } from '../types/roster-hub.types';
 
 import { VoteButton } from './VoteButton';
@@ -117,19 +122,42 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
     const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null);
     const menuOpen = Boolean(menuAnchor);
 
+    const cancelDeepLinkRef = React.useRef<(() => void) | undefined>(undefined);
+    React.useEffect(() => () => cancelDeepLinkRef.current?.(), []);
+
     const handleGetAddons = (e: React.MouseEvent): void => {
       e.stopPropagation();
       const packId = roster.recommended_addons?.packId ?? 'trial-essentials';
       const deepLink = getAddonManagerDeepLink(packId);
-      window.location.href = deepLink;
-      setTimeout(() => {
-        void navigator.clipboard.writeText(deepLink).then(() => {
-          enqueueSnackbar('Deep link copied — install ESO Addon Manager to use it', {
-            variant: 'info',
-            autoHideDuration: 4000,
-          });
+      cancelDeepLinkRef.current?.();
+      cancelDeepLinkRef.current = tryLaunchDeepLink(deepLink, () => {
+        void navigator.clipboard.writeText(deepLink).catch(() => {});
+        enqueueSnackbar("Kalpa didn't open — launch it manually or download it", {
+          variant: 'info',
+          autoHideDuration: 8000,
+          action: () => (
+            <>
+              <Button
+                size="small"
+                component="a"
+                href={deepLink}
+                sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+              >
+                Launch
+              </Button>
+              <Button
+                size="small"
+                href={KALPA_DOWNLOAD_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: '#fff', fontWeight: 700, textTransform: 'none' }}
+              >
+                Download
+              </Button>
+            </>
+          ),
         });
-      }, 1500);
+      });
     };
 
     const handleMenuOpen = (e: React.MouseEvent<HTMLElement>): void => {

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -1340,7 +1340,7 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
               <CPTreeDetail
                 label="Warfare"
-                color="#ef5350"
+                color="#42a5f5"
                 icon={<WarfareIcon sx={{ fontSize: 14 }} />}
                 slots={setup.cp.warfare.slots}
                 passives={setup.cp.warfare.passives}
@@ -1348,7 +1348,7 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
               />
               <CPTreeDetail
                 label="Fitness"
-                color="#66bb6a"
+                color="#ef5350"
                 icon={<FitnessIcon sx={{ fontSize: 14 }} />}
                 slots={setup.cp.fitness.slots}
                 passives={setup.cp.fitness.passives}
@@ -1356,7 +1356,7 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
               />
               <CPTreeDetail
                 label="Craft"
-                color="#42a5f5"
+                color="#66bb6a"
                 icon={null}
                 slots={setup.cp.craft.slots}
                 passives={setup.cp.craft.passives}

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -36,7 +36,11 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { BuildDetailPanel } from '../components/roster/build-detail-panel';
 import { getDiscordBotApiUrl } from '../features/auth/discord-auth';
-import { KALPA_DOWNLOAD_URL, getAddonManagerDeepLink } from '../features/build-hub/api/packs-api';
+import {
+  KALPA_DOWNLOAD_URL,
+  getAddonManagerDeepLink,
+  tryLaunchDeepLink,
+} from '../features/build-hub/api/packs-api';
 import { preloadSkillData } from '../features/loadout-manager/data/skillLineSkills';
 import { rosterHubApi } from '../features/roster-hub/api/roster-hub-api';
 import type {
@@ -1334,7 +1338,7 @@ export const RosterViewPage: React.FC = () => {
   }>({ open: false, message: '', severity: 'success' });
   const [recommendedAddons, setRecommendedAddons] = useState<RecommendedAddons | null>(null);
   const [addonsLoading, setAddonsLoading] = useState(false);
-  const deepLinkTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelDeepLinkRef = React.useRef<(() => void) | null>(null);
 
   // Default addons shown when no hub roster or no custom recommendations
   const DEFAULT_ADDONS: RecommendedAddonEntry[] = [
@@ -1356,13 +1360,8 @@ export const RosterViewPage: React.FC = () => {
     { esouiId: 3170, name: "Wizard's Wardrobe", note: 'Gear & skill setup management' },
   ];
 
-  // Clean up deep-link fallback timer on unmount
-  useEffect(
-    () => () => {
-      if (deepLinkTimerRef.current) clearTimeout(deepLinkTimerRef.current);
-    },
-    [],
-  );
+  // Clean up deep-link fallback on unmount
+  useEffect(() => () => cancelDeepLinkRef.current?.(), []);
 
   // Decode roster from ?r= or fetch by ?id= on mount
   useEffect(() => {
@@ -1906,17 +1905,25 @@ export const RosterViewPage: React.FC = () => {
                       startIcon={<ExtensionIcon sx={{ fontSize: '0.85rem !important' }} />}
                       onClick={() => {
                         const deepLink = getAddonManagerDeepLink(packId);
-                        window.location.href = deepLink;
-                        // Fallback: if Kalpa is not installed, the browser silently fails.
-                        // After a delay, prompt the user to download Kalpa.
-                        if (deepLinkTimerRef.current) clearTimeout(deepLinkTimerRef.current);
-                        deepLinkTimerRef.current = setTimeout(() => {
+                        cancelDeepLinkRef.current?.();
+                        cancelDeepLinkRef.current = tryLaunchDeepLink(deepLink, () => {
                           void navigator.clipboard.writeText(deepLink).catch(() => {});
                           setSnackbar({
                             open: true,
                             message: (
                               <>
-                                Kalpa not detected.{' '}
+                                Kalpa didn&apos;t open.{' '}
+                                <a
+                                  href={deepLink}
+                                  style={{
+                                    color: 'inherit',
+                                    fontWeight: 700,
+                                    textDecoration: 'underline',
+                                  }}
+                                >
+                                  Launch manually
+                                </a>
+                                {' or '}
                                 <a
                                   href={KALPA_DOWNLOAD_URL}
                                   target="_blank"
@@ -1927,14 +1934,14 @@ export const RosterViewPage: React.FC = () => {
                                     textDecoration: 'underline',
                                   }}
                                 >
-                                  Download it here
+                                  download it
                                 </a>
                               </>
                             ),
                             severity: 'info',
-                            autoHideDuration: 6000,
+                            autoHideDuration: 8000,
                           });
-                        }, 1500);
+                        });
                       }}
                       sx={{
                         borderRadius: '8px',


### PR DESCRIPTION
## Summary
- **Fix wrong protocol scheme**: Deep links used `eso-addon-manager://` but Kalpa registers `kalpa://` via Tauri's deep-link plugin — Windows showed its app picker ("agent grid") because no handler existed for the old protocol
- **Use hidden iframe instead of window.location.href**: Avoids triggering the OS "How do you want to open this?" dialog entirely — the iframe probe fails silently when the protocol is unregistered, then shows a snackbar with explicit "Launch" and "Download" options
- **Remove unused `preserveSettings` query param**: Kalpa's deep-link parser strips everything after the path segment, so the param was never consumed

## Changed files
- `src/features/build-hub/api/packs-api.ts` — protocol fix (`kalpa://`), added `tryLaunchDeepLink()` utility, removed `DeepLinkOptions`
- `src/features/build-hub/components/GetAddonsButton.tsx` — use iframe probe + fallback snackbar
- `src/features/pack-hub/components/PackCard.tsx` — same
- `src/features/roster-hub/components/RosterCard.tsx` — same
- `src/pages/RosterViewPage.tsx` — same

## Test plan
- [ ] Click Install on a pack card with Kalpa installed — should open Kalpa to the pack
- [ ] Click Install without Kalpa — should show snackbar with "Launch" and "Download" buttons, no OS dialog
- [ ] Verify "Download" links to https://github.com/ESO-Toolkit/kalpa
- [ ] Test on RosterViewPage shared roster install button — same behavior
- [ ] Verify "Copy deep link" copies `kalpa://pack/{id}` format