### PR TITLE
perf(mobile): gate blur/motion on detected device tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,14 @@ discord-notify-worker/node_modules/
 /*.a11y.md
 /prompts/
 /showcase-video/
+
+# Agent scratch dirs — large traces, screenshots, skill scaffolding.
+# Markdown notes are allowed (trackable if explicitly added).
+/.continue/
+/.windsurf/
+/.factory/*.json
+/.factory/*.png
+/.factory/*.webm
+/.factory/*.har
+/.factory/*.trace
+/.factory/skills/

--- a/__mocks__/@pmndrs/detect-gpu.ts
+++ b/__mocks__/@pmndrs/detect-gpu.ts
@@ -1,0 +1,14 @@
+// Jest auto-applies manual mocks in `<rootDir>/__mocks__/<package>` for
+// node_modules. `@pmndrs/detect-gpu` is ESM-only (exports field resolves
+// to .mjs), which Jest's CJS resolver can't walk — without this stub,
+// every test that transitively imports detectPerfTier.ts (App.test,
+// HeaderBar tests reaching PerfTierProvider, etc.) fails with
+// "Cannot find module '@pmndrs/detect-gpu'".
+//
+// Tests that want to control return values (detectPerfTier.test.ts) use
+// jest.mock('@pmndrs/detect-gpu', ...) at the top of the file, which
+// overrides this default.
+export const getGPUTier = async (): Promise<{ tier: number; isMobile: boolean }> => ({
+  tier: 3,
+  isMobile: false,
+});

--- a/documentation/architecture/fight-replay-perf-tiering.md
+++ b/documentation/architecture/fight-replay-perf-tiering.md
@@ -1,0 +1,121 @@
+# Fight Replay — Device-Tier Gating (Deferred Work)
+
+Context note for a future pass. The app now exposes a `'low' | 'medium' | 'high'`
+performance tier via `usePerfTier()` (see `src/hooks/usePerfTier.ts`) and the
+Redux `uiSlice.perfTier` field. The fight replay (`src/features/fight_replay/`)
+was intentionally **not** gated in the initial rollout — this doc records the
+exact knobs a follow-up should flip, so a later agent doesn't have to re-survey.
+
+## Why defer
+
+Fight replay geometry is already well-shared (`SharedActor3DGeometries`,
+`SharedBillboardGeometry`), Chart.js animations are off, and the 2020-Moto
+FPS problem is dominated by the 218 `backdrop-filter` instances across the
+UI chrome. The UI fixes are cheaper and catch more surface area. The 3D
+knobs below are a second pass with its own validation window.
+
+## Knobs to gate (file:line, current literal values)
+
+### 1. Canvas renderer — `src/features/fight_replay/components/Arena3D.tsx`
+
+- **`antialias: true`** at line 588 — 2–4× fillrate cost on Adreno 610.
+  Set `antialias: tier === 'high'`.
+- **`powerPreference: 'high-performance'`** at line 587 — consider
+  `'default'` on `tier === 'low'` to avoid forcing the perf GPU on a
+  dual-GPU laptop when the user opted into low-power mode.
+- **`preserveDrawingBuffer: true`** at line 586 — forces an extra copy each
+  frame. Only needed if we actually read-back pixels; audit the call-sites
+  before flipping.
+- **`shadows: true`** at line 606 — gate to `tier !== 'low'`.
+- **No `dpr` prop on `<Canvas>`** — add
+  `dpr={tier === 'low' ? 1 : tier === 'medium' ? 1.5 : Math.min(window.devicePixelRatio, 2)}`.
+- **No `frameloop` setting** (defaults to `'always'`) — consider
+  `frameloop="demand"` while the timeline isn't playing.
+
+### 2. Directional-light shadows — `Arena3DScene.tsx`
+
+- **`shadow-mapSize-width={2048}` / `shadow-mapSize-height={2048}`** at
+  lines 388–389 — 2048² is aggressive. On `tier === 'medium'` drop to 1024,
+  on `tier === 'low'` the shadow is already gated off at the Canvas level.
+
+### 3. Billboards — `ActorNameBillboard.tsx`
+
+- **DPR cap** at line 74: `Math.min(window.devicePixelRatio || 1, 3)`.
+  Drop the cap with tier:
+  - `'low'` → 1
+  - `'medium'` → 1.5
+  - `'high'` → 2 (lowering from 3 is safe; 3 only matters on Apple XDR)
+- **Canvas dims** at lines 78–79: `1024 × 256` logical, multiplied by the
+  DPR cap above. The DPR change is sufficient — don't shrink the logical
+  size (hurts text legibility).
+- **`anisotropy = 4`** at line 102 — drop to 1 on `'low'`.
+- **`minFilter = LinearMipmapLinearFilter`** at line 100 — the mipmap chain
+  is pointless on `'low'` since we're not scaling down far; switching to
+  `LinearFilter` saves a bit of VRAM + upload time.
+
+### 4. Per-actor materials — `AnimationFrameActor3D.tsx`
+
+Each actor owns its own puck / vision-cone / taunt-ring material (refs:
+`puckMaterialRef`, `visionConeMaterialRef`, `tauntRingMeshRef`). With 20+
+actors that's 60+ draw calls. Consider an `InstancedMesh` pass on
+`'low'` or a shared material with per-instance attributes. This is the
+largest shape change of the bunch — worth a dedicated ticket.
+
+### 5. Per-frame hooks — `useFrame` call-sites (11 total)
+
+1. `ActorNameBillboard.tsx:190` — billboard transform
+2. `AnimationFrameActor3D.tsx:178` — actor transform (`RenderPriority.ACTORS`)
+3. `Arena3DScene.tsx:133` — manual render (`RenderPriority.RENDER = 999`)
+4. `CameraFollower.tsx:38` — camera follow
+5. `BossHealthHUD.tsx:179` — HUD screen-space position
+6. `DynamicMapTexture.tsx:85` — phase map texture switching
+7. `KeyboardCameraControls.tsx:136` — WASD camera
+8. `PlayerPathTrail3D.tsx:95` — trail animation
+9. `PlayerListHUD.tsx:572` — HUD 3D-canvas position
+10. `FPSCounter` / `MemoryTracker` / `SlowFrameLogger` — monitoring
+
+On `'low'`, the HUD + trail hooks (5, 6, 8, 9) can be skipped entirely —
+they're cosmetic. Hook #3 (manual render) must keep running. Hooks 1 and 2
+are already modulated by `useScrubbingMode` (see below); extend that
+pattern to honour the tier even when not scrubbing.
+
+### 6. Extend existing `useScrubbingMode` — `src/hooks/useScrubbingMode.ts`
+
+Already returns `renderQuality`, `shouldUpdatePositions`, `shouldRenderEffects`,
+`frameSkipRate`. Today these only vary during timeline drag. On `'low'`:
+
+- `frameSkipRate` → 2 permanently (30 fps target beats a janky 45)
+- `shouldRenderEffects` → false (billboards hide; see
+  `Arena3DScene.tsx:96`)
+- `renderQuality` → `'low'` always
+
+This keeps the existing plumbing — no new prop drilling through
+`FightReplay3D → Arena3D → Arena3DScene`.
+
+### 7. Actor count cap
+
+`Arena3DScene.tsx:77–93` (`AnimationFrameSceneActors`) pulls all actor IDs
+from every timestamp in `lookup.positionsByTimestamp`. No cap. On
+`'low'`, consider capping to the top-N actors by recent activity (visible
+in current camera frustum, or the player's own group). A hard cap of 12
+at `'low'` covers the common raid case without dropping the player's team.
+
+## Validation plan for the follow-up
+
+- Baseline FPS on Moto G Power emulation (Snapdragon 665, 4× CPU throttle)
+  on a 20-actor fight — should be compared to the pre-tier-gate number
+  captured for the UI-chrome pass.
+- Desktop high-tier should be **bit-for-bit identical** — guard with a
+  visual-regression screenshot of Arena3D at a fixed timestamp.
+- Keep `useScrubbingMode` behaviour unchanged for the desktop/high path.
+
+## Prerequisites that are already in place
+
+- `usePerfTier()` hook and `uiSlice.perfTier` field (added in the UI-chrome
+  pass). Reading the tier in R3F components is just `useAppSelector(selectPerfTier)`.
+- `document.documentElement.dataset.perf` is set globally, so any CSS
+  surrounding the Canvas (e.g. the ReplayControls overlay) already
+  degrades without per-component work.
+- User-facing override at **Settings → Performance mode** (auto / low /
+  medium / high). Respect the override — don't ignore a user who picked
+  `'low'` to save battery on a high-end phone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@graphql-typed-document-node/core": "^3.2.0",
         "@internationalized/date": "^3.12.0",
         "@octokit/rest": "^21.0.2",
+        "@pmndrs/detect-gpu": "^6.0.0",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@reduxjs/toolkit": "^2.11.2",
@@ -5398,6 +5399,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@pmndrs/detect-gpu": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@pmndrs/detect-gpu/-/detect-gpu-6.0.0.tgz",
+      "integrity": "sha512-eo4JOFtQf2CBt/q+SDIXAiiERnTMMALGTg1ZPu4YfarWNHb1I7qMxv5BTIEZ2ng+IjRK5PpptTuGJer7QWtikA==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
       }
     },
     "node_modules/@popperjs/core": {
@@ -24029,7 +24039,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@internationalized/date": "^3.12.0",
     "@octokit/rest": "^21.0.2",
+    "@pmndrs/detect-gpu": "^6.0.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@reduxjs/toolkit": "^2.11.2",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -82,6 +82,10 @@ jest.mock('./components/HashRouteRedirect', () => ({
   HashRouteRedirect: () => null,
 }));
 
+jest.mock('./components/PerfTierProvider', () => ({
+  PerfTierProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 jest.mock('./components/ScrollRestoration', () => ({
   ScrollRestoration: () => null,
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { HashRouteRedirect } from './components/HashRouteRedirect';
 import { HeaderBar } from './components/HeaderBar';
 import { KalpaBanner } from './components/KalpaBanner';
 import { LandingPage } from './components/LandingPage';
+import { PerfTierProvider } from './components/PerfTierProvider';
 import { ReportFightsSkeleton } from './components/ReportFightsSkeleton';
 import { RosterBuilderSkeleton } from './components/RosterBuilderSkeleton';
 import { RosterHubSkeleton } from './components/RosterHubSkeleton';
@@ -324,28 +325,30 @@ const App: React.FC = () => {
     <LoggerProvider config={loggerConfig}>
       <ReduxProvider store={store}>
         <PersistGate loading={<LoadingFallback />} persistor={persistor}>
-          <ReduxThemeProvider>
-            <EsoLogsClientProvider>
-              <AuthProvider>
-                <DiscordAuthProvider>
-                  <SnackbarProvider
-                    maxSnack={3}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-                    autoHideDuration={4000}
-                    preventDuplicate
-                  >
-                    {/* Global cosmic/nebula background — suppressed in embed/iframe mode */}
-                    {!window.location.search.includes('embed=1') && <SiteBackground />}
-                    <AppRoutes />
-                    {/* Update notification for new versions */}
-                    {!window.location.search.includes('embed=1') && <UpdateNotification />}
-                    {/* Cookie consent banner — suppressed in embed/iframe mode to prevent double-banner */}
-                    {!window.location.search.includes('embed=1') && <CookieConsent />}
-                  </SnackbarProvider>
-                </DiscordAuthProvider>
-              </AuthProvider>
-            </EsoLogsClientProvider>
-          </ReduxThemeProvider>
+          <PerfTierProvider>
+            <ReduxThemeProvider>
+              <EsoLogsClientProvider>
+                <AuthProvider>
+                  <DiscordAuthProvider>
+                    <SnackbarProvider
+                      maxSnack={3}
+                      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                      autoHideDuration={4000}
+                      preventDuplicate
+                    >
+                      {/* Global cosmic/nebula background — suppressed in embed/iframe mode */}
+                      {!window.location.search.includes('embed=1') && <SiteBackground />}
+                      <AppRoutes />
+                      {/* Update notification for new versions */}
+                      {!window.location.search.includes('embed=1') && <UpdateNotification />}
+                      {/* Cookie consent banner — suppressed in embed/iframe mode to prevent double-banner */}
+                      {!window.location.search.includes('embed=1') && <CookieConsent />}
+                    </SnackbarProvider>
+                  </DiscordAuthProvider>
+                </AuthProvider>
+              </EsoLogsClientProvider>
+            </ReduxThemeProvider>
+          </PerfTierProvider>
         </PersistGate>
       </ReduxProvider>
     </LoggerProvider>

--- a/src/components/HeaderBar.test.tsx
+++ b/src/components/HeaderBar.test.tsx
@@ -27,6 +27,10 @@ jest.mock('./ThemeToggle', () => ({
   ThemeToggle: () => null,
 }));
 
+jest.mock('./PerfTierToggle', () => ({
+  PerfTierToggle: () => null,
+}));
+
 jest.mock('../hooks/usePersistentDarkMode', () => ({
   usePersistentDarkMode: () => ({
     darkMode: false,

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1332,6 +1332,7 @@ export const HeaderBar: React.FC = () => {
           sx={{
             display: 'flex',
             alignItems: 'center',
+            gap: 0.75,
             px: 1.5,
             py: 1,
             position: 'relative',

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -872,7 +872,6 @@ export const HeaderBar: React.FC = () => {
               >
                 Tools
               </Button>
-              <PerfTierToggle />
               {!isLoggedIn && <ThemeToggle />}
               {isLoggedIn ? (
                 <Box

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -40,6 +40,7 @@ import {
   type ViewTransitionType,
 } from '../hooks/useViewTransitionNavigate';
 
+import { PerfTierToggle } from './PerfTierToggle';
 import { ThemeToggle } from './ThemeToggle';
 
 // Animated Hamburger Icon
@@ -871,6 +872,7 @@ export const HeaderBar: React.FC = () => {
               >
                 Tools
               </Button>
+              <PerfTierToggle />
               {!isLoggedIn && <ThemeToggle />}
               {isLoggedIn ? (
                 <Box
@@ -1382,6 +1384,7 @@ export const HeaderBar: React.FC = () => {
             </Typography>
           </ButtonBase>
           <Box sx={{ flex: 1 }} />
+          <PerfTierToggle size="small" />
           <IconButton
             onClick={(e: React.MouseEvent) => {
               e.stopPropagation();
@@ -1695,6 +1698,7 @@ export const HeaderBar: React.FC = () => {
           <Divider
             sx={{ flex: 1, borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)' }}
           />
+          <PerfTierToggle size="small" />
           <IconButton
             onClick={toggleDarkMode}
             size="small"

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -7,6 +7,7 @@ import {
   DarkMode as DarkModeIcon,
   LightMode as LightModeIcon,
   ChevronRight,
+  Speed as SpeedIcon,
 } from '@mui/icons-material';
 import {
   AppBar,
@@ -22,7 +23,6 @@ import {
   ListItemIcon,
   ListItemText,
   Fade,
-  Divider,
   ButtonBase,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
@@ -1679,48 +1679,96 @@ export const HeaderBar: React.FC = () => {
           ))}
         </Box>
 
-        {/* Theme toggle + Auth */}
+        {/* Appearance — theme + performance tier */}
+        <MobileSectionLabel>Appearance</MobileSectionLabel>
         <Box
           sx={{
-            px: 2,
-            pt: 1.5,
-            pb: 0.5,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
+            px: 1.5,
             position: 'relative',
             zIndex: 1,
             opacity: 0,
             animation: mobileOpen ? `sheetItemIn 0.3s ease-out 0.35s both` : 'none',
           }}
         >
-          <Divider
-            sx={{ flex: 1, borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)' }}
-          />
-          <PerfTierToggle size="small" />
-          <IconButton
+          <MobileSheetItem
             onClick={toggleDarkMode}
-            size="small"
             aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-            sx={{
-              width: 36,
-              height: 36,
-              borderRadius: '10px',
-              background: alpha(isDark ? '#f59e0b' : '#6366f1', isDark ? 0.1 : 0.06),
-              border: `1px solid ${alpha(isDark ? '#f59e0b' : '#6366f1', 0.12)}`,
-              transition: 'background 0.2s ease, border-color 0.2s ease',
-              '&:hover': {
-                background: alpha(isDark ? '#f59e0b' : '#6366f1', isDark ? 0.18 : 0.12),
-              },
-              '&:active': { transform: 'scale(0.92)' },
-            }}
           >
-            {darkMode ? (
-              <LightModeIcon sx={{ fontSize: 18, color: '#f59e0b' }} />
-            ) : (
-              <DarkModeIcon sx={{ fontSize: 18, color: '#6366f1' }} />
+            <Box
+              sx={{
+                width: 32,
+                height: 32,
+                borderRadius: '8px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: alpha('#f59e0b', isDark ? 0.12 : 0.08),
+                border: `1px solid ${alpha('#f59e0b', 0.15)}`,
+                flexShrink: 0,
+              }}
+            >
+              {darkMode ? (
+                <LightModeIcon sx={{ fontSize: 18, color: '#f59e0b' }} />
+              ) : (
+                <DarkModeIcon sx={{ fontSize: 18, color: '#f59e0b' }} />
+              )}
+            </Box>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography sx={{ fontWeight: 550, fontSize: '0.875rem', lineHeight: 1.3 }}>
+                Theme
+              </Typography>
+              <Typography sx={{ fontSize: '0.7rem', opacity: 0.55, lineHeight: 1.3, mt: 0.15 }}>
+                {darkMode ? 'Dark' : 'Light'} · tap to switch
+              </Typography>
+            </Box>
+          </MobileSheetItem>
+
+          <PerfTierToggle
+            renderTrigger={({ onClick, currentLabel, isOverridden }) => (
+              <MobileSheetItem
+                onClick={onClick}
+                aria-label={`Performance: ${currentLabel} — change`}
+              >
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: '8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: alpha('#06b6d4', isDark ? 0.12 : 0.08),
+                    border: `1px solid ${alpha('#06b6d4', 0.15)}`,
+                    flexShrink: 0,
+                  }}
+                >
+                  <SpeedIcon
+                    sx={{
+                      fontSize: 18,
+                      color: isOverridden ? theme.palette.warning.main : '#06b6d4',
+                    }}
+                  />
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 550, fontSize: '0.875rem', lineHeight: 1.3 }}>
+                    Performance
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.7rem', opacity: 0.55, lineHeight: 1.3, mt: 0.15 }}>
+                    {currentLabel}
+                    {isOverridden ? ' · pinned' : ''}
+                  </Typography>
+                </Box>
+                <ChevronRight
+                  sx={{
+                    fontSize: 18,
+                    opacity: 0.35,
+                    color: isDark ? '#94a3b8' : '#64748b',
+                    flexShrink: 0,
+                  }}
+                />
+              </MobileSheetItem>
             )}
-          </IconButton>
+          />
         </Box>
         <Box sx={{ px: 2, pt: 1, pb: 1, position: 'relative', zIndex: 1 }}>
           {isLoggedIn ? (

--- a/src/components/KalpaBanner.tsx
+++ b/src/components/KalpaBanner.tsx
@@ -1,7 +1,9 @@
 import { Close as CloseIcon } from '@mui/icons-material';
-import { Box, IconButton, Typography } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
+import { styled, useTheme } from '@mui/material/styles';
 import { useState } from 'react';
+
+const KALPA_URL = 'https://github.com/ESO-Toolkit/kalpa';
 
 const Banner = styled(Box)(({ theme }) => ({
   width: '100%',
@@ -52,15 +54,13 @@ const Banner = styled(Box)(({ theme }) => ({
     '100%': { transform: 'translateX(50%)' },
   },
   [theme.breakpoints.down('sm')]: {
-    padding: '0.5rem 0.75rem',
-    gap: '0.35rem',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    paddingRight: '2.5rem',
+    padding: '0.45rem 0.75rem',
+    paddingRight: '2.25rem',
+    gap: '0.5rem',
   },
 }));
 
-const NewBadge = styled(Box)({
+const NewBadge = styled(Box)(({ theme }) => ({
   background: 'linear-gradient(135deg, #8b5cf6, #6366f1)',
   color: '#fff',
   padding: '0.15rem 0.6rem',
@@ -71,7 +71,11 @@ const NewBadge = styled(Box)({
   letterSpacing: '0.08em',
   flexShrink: 0,
   boxShadow: '0 2px 8px rgba(139, 92, 246, 0.3)',
-});
+  [theme.breakpoints.down('sm')]: {
+    padding: '0.1rem 0.5rem',
+    fontSize: '0.6rem',
+  },
+}));
 
 const BannerLink = styled('a')(({ theme }) => ({
   color: theme.palette.mode === 'dark' ? '#c4b5fd' : '#7c3aed',
@@ -86,56 +90,112 @@ const BannerLink = styled('a')(({ theme }) => ({
     color: theme.palette.mode === 'dark' ? '#ddd6fe' : '#6d28d9',
     textDecoration: 'underline',
   },
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '0.78rem',
+}));
+
+const MobilePromoLink = styled('a')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  textDecoration: 'none',
+  color: 'inherit',
+  flex: 1,
+  minWidth: 0,
+  transition: 'opacity 0.2s ease',
+  '&:active': { opacity: 0.7 },
+  '& .kalpa-arrow': {
+    color: theme.palette.mode === 'dark' ? '#c4b5fd' : '#7c3aed',
+    fontWeight: 700,
+    fontSize: '0.95rem',
+    flexShrink: 0,
+    lineHeight: 1,
+    transition: 'transform 0.2s ease',
+  },
+  '&:active .kalpa-arrow': {
+    transform: 'translateX(2px)',
   },
 }));
 
 export const KalpaBanner: React.FC = () => {
   const [showBanner, setShowBanner] = useState(true);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   if (!showBanner) return null;
 
+  const accentColor = theme.palette.mode === 'dark' ? '#c4b5fd' : '#7c3aed';
+
   return (
     <Banner>
-      <NewBadge>New</NewBadge>
-      <Typography
-        sx={{
-          fontSize: { xs: '0.78rem', sm: '0.85rem' },
-          color: 'text.secondary',
-          fontWeight: 400,
-        }}
-      >
-        Introducing <strong>Kalpa</strong> — a fast, open-source addon manager for ESO.{' '}
-        <Box
-          component="span"
-          sx={{
-            opacity: 0.7,
-            fontStyle: 'italic',
-          }}
-        >
-          Currently in alpha.
-        </Box>
-      </Typography>
-      <BannerLink
-        href="https://github.com/ESO-Toolkit/kalpa"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Learn more →
-      </BannerLink>
+      {isMobile ? (
+        <MobilePromoLink href={KALPA_URL} target="_blank" rel="noopener noreferrer">
+          <NewBadge>New</NewBadge>
+          <Typography
+            component="span"
+            sx={{
+              fontSize: '0.78rem',
+              color: 'text.secondary',
+              fontWeight: 400,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              minWidth: 0,
+              flex: 1,
+              lineHeight: 1.3,
+            }}
+          >
+            <Box component="strong" sx={{ color: accentColor, fontWeight: 700 }}>
+              Kalpa
+            </Box>
+            {' — ESO addon manager '}
+            <Box component="span" sx={{ opacity: 0.65, fontStyle: 'italic' }}>
+              (alpha)
+            </Box>
+          </Typography>
+          <span className="kalpa-arrow" aria-hidden="true">
+            →
+          </span>
+        </MobilePromoLink>
+      ) : (
+        <>
+          <NewBadge>New</NewBadge>
+          <Typography
+            sx={{
+              fontSize: '0.85rem',
+              color: 'text.secondary',
+              fontWeight: 400,
+            }}
+          >
+            Introducing <strong>Kalpa</strong> — a fast, open-source addon manager for ESO.{' '}
+            <Box component="span" sx={{ opacity: 0.7, fontStyle: 'italic' }}>
+              Currently in alpha.
+            </Box>
+          </Typography>
+          <BannerLink href={KALPA_URL} target="_blank" rel="noopener noreferrer">
+            Learn more →
+          </BannerLink>
+        </>
+      )}
       <IconButton
         size="small"
-        onClick={() => setShowBanner(false)}
+        aria-label="Dismiss banner"
+        onClick={(e: React.MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setShowBanner(false);
+        }}
         sx={{
           position: 'absolute',
-          right: 8,
+          top: '50%',
+          right: { xs: 4, sm: 8 },
+          transform: 'translateY(-50%)',
           color: 'text.secondary',
           opacity: 0.6,
+          padding: { xs: '4px', sm: '5px' },
           '&:hover': { opacity: 1 },
+          zIndex: 1,
         }}
       >
-        <CloseIcon fontSize="small" />
+        <CloseIcon sx={{ fontSize: { xs: '1rem', sm: '1.1rem' } }} />
       </IconButton>
     </Banner>
   );

--- a/src/components/PerfTierProvider.tsx
+++ b/src/components/PerfTierProvider.tsx
@@ -19,25 +19,12 @@ export const PerfTierProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const override = useSelector(selectPerfTierOverride);
   const dispatch = useAppDispatch();
 
-  useEffect(() => {
-    // When the user has pinned an override, skip detection — the persisted
-    // detected tier still updates in the background so toggling back to
-    // 'auto' gets a fresh value.
-    let cancelled = false;
-    void detectPerfTier().then((detected) => {
-      if (cancelled) return;
-      dispatch(setPerfTier(detected));
-    });
-    return () => {
-      cancelled = true;
-    };
-    // Intentionally runs once. Re-detecting on override change would waste
-    // work — override doesn't affect detection itself.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Also re-detect when the user switches back to 'auto' so an old
-  // persisted value doesn't shadow a newer hardware/OS state.
+  // Run detection only when the effective tier is auto-driven. Fires once on
+  // first mount with override='auto' (the default) and re-fires whenever the
+  // user toggles back to 'auto' so a stale persisted value can't shadow new
+  // hardware/OS state. When a manual override is pinned, detection is skipped
+  // entirely — the persisted detected tier is irrelevant until the user goes
+  // back to 'auto', at which point this effect re-runs.
   useEffect(() => {
     if (override !== 'auto') return;
     let cancelled = false;

--- a/src/components/PerfTierProvider.tsx
+++ b/src/components/PerfTierProvider.tsx
@@ -1,0 +1,58 @@
+import { MotionConfig } from 'framer-motion';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { usePerfTier } from '../hooks/usePerfTier';
+import { selectPerfTierOverride } from '../store/ui/uiSelectors';
+import { setPerfTier } from '../store/ui/uiSlice';
+import { useAppDispatch } from '../store/useAppDispatch';
+import { detectPerfTier } from '../utils/detectPerfTier';
+
+// Runs async GPU + heuristic detection once on mount, writes the resolved
+// tier into Redux (persisted). Also caps framer-motion animations on low
+// tier via MotionConfig, which applies to every `motion.*` descendant.
+//
+// Must sit inside ReduxProvider. Place above the router so MotionConfig
+// covers all routed views.
+export const PerfTierProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const tier = usePerfTier();
+  const override = useSelector(selectPerfTierOverride);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    // When the user has pinned an override, skip detection — the persisted
+    // detected tier still updates in the background so toggling back to
+    // 'auto' gets a fresh value.
+    let cancelled = false;
+    void detectPerfTier().then((detected) => {
+      if (cancelled) return;
+      dispatch(setPerfTier(detected));
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally runs once. Re-detecting on override change would waste
+    // work — override doesn't affect detection itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Also re-detect when the user switches back to 'auto' so an old
+  // persisted value doesn't shadow a newer hardware/OS state.
+  useEffect(() => {
+    if (override !== 'auto') return;
+    let cancelled = false;
+    void detectPerfTier().then((detected) => {
+      if (cancelled) return;
+      dispatch(setPerfTier(detected));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [override, dispatch]);
+
+  // reducedMotion='user' defers to the OS media query so a high-tier desktop
+  // user who opted into prefers-reduced-motion still gets quiet animations.
+  // 'always' on low tier is the stronger override — the device can't afford
+  // motion regardless of OS preference.
+  return <MotionConfig reducedMotion={tier === 'low' ? 'always' : 'user'}>{children}</MotionConfig>;
+};

--- a/src/components/PerfTierToggle.tsx
+++ b/src/components/PerfTierToggle.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
@@ -78,12 +79,25 @@ export const PerfTierToggle: React.FC<PerfTierToggleProps> = ({
   };
 
   const isOverridden = override !== 'auto';
-  const accent = isOverridden ? theme.palette.warning.main : theme.palette.text.secondary;
+  const isDark = theme.palette.mode === 'dark';
+  // Cyan for auto/neutral state; warning (amber) when an override is pinned
+  // so the button quietly signals "you've changed the default" — same visual
+  // grammar as the dark-mode pill next to it (amber/indigo per theme).
+  const pillColor = isOverridden ? theme.palette.warning.main : '#06b6d4';
   const detectedLabel = TIER_LABEL[detected];
   const currentLabel = isOverridden ? TIER_LABEL[override as PerfTier] : `Auto · ${detectedLabel}`;
   const ariaLabel = isOverridden
     ? `Performance: ${override} (pinned) — change`
     : `Performance: Auto (detected ${detected}) — change`;
+
+  const isSmall = size === 'small';
+  // Dimensions and hover scale mirror the adjacent dark-mode IconButton in
+  // the profile dropdown so the two buttons read as a matched pair. Sharing
+  // the scale factor also prevents hover-bleed where a larger scale would
+  // expand the perf pill into the dark-mode pill.
+  const pillSize = isSmall ? 32 : 36;
+  const iconSize = isSmall ? 16 : 18;
+  const pillRadius = isSmall ? '9px' : '10px';
 
   const trigger = renderTrigger ? (
     renderTrigger({
@@ -98,21 +112,26 @@ export const PerfTierToggle: React.FC<PerfTierToggleProps> = ({
   ) : (
     <IconButton
       onClick={handleOpen}
-      color="inherit"
       size={size}
       aria-label={ariaLabel}
       aria-haspopup="menu"
       aria-expanded={open ? 'true' : undefined}
       sx={{
-        color: accent,
-        transition: 'all 0.2s ease-in-out',
+        width: pillSize,
+        height: pillSize,
+        borderRadius: pillRadius,
+        background: alpha(pillColor, isDark ? 0.08 : 0.05),
+        border: `1px solid ${alpha(pillColor, 0.1)}`,
+        transition: 'background 0.2s ease, border-color 0.2s ease, transform 0.15s ease',
         '&:hover': {
-          color: theme.palette.primary.main,
-          transform: 'scale(1.1)',
+          background: alpha(pillColor, isDark ? 0.16 : 0.1),
+          borderColor: alpha(pillColor, 0.22),
+          transform: 'scale(1.06)',
         },
+        '&:active': { transform: 'scale(0.95)' },
       }}
     >
-      <SpeedIcon fontSize={size === 'small' ? 'small' : 'medium'} />
+      <SpeedIcon sx={{ fontSize: iconSize, color: pillColor }} />
     </IconButton>
   );
 

--- a/src/components/PerfTierToggle.tsx
+++ b/src/components/PerfTierToggle.tsx
@@ -34,7 +34,31 @@ const TIER_LABEL: Record<PerfTier, string> = {
   low: 'Low',
 };
 
-export const PerfTierToggle: React.FC<{ size?: 'small' | 'medium' }> = ({ size = 'medium' }) => {
+export type PerfTierTriggerProps = {
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+  menuOpen: boolean;
+  override: PerfTierOverride;
+  detected: PerfTier;
+  isOverridden: boolean;
+  // Short user-facing label for the current effective setting, e.g.
+  // "Auto · High" when auto-detecting or "Low" when an override is pinned.
+  currentLabel: string;
+  detectedLabel: string;
+};
+
+type PerfTierToggleProps = {
+  size?: 'small' | 'medium';
+  // Lets consumers render their own trigger (mobile sheet row, settings card,
+  // etc). When omitted, the default IconButton renders. The provided element
+  // should wire the supplied onClick — the Menu anchors to the click's
+  // currentTarget.
+  renderTrigger?: (props: PerfTierTriggerProps) => React.ReactElement;
+};
+
+export const PerfTierToggle: React.FC<PerfTierToggleProps> = ({
+  size = 'medium',
+  renderTrigger,
+}) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const override = useSelector(selectPerfTierOverride);
@@ -55,30 +79,46 @@ export const PerfTierToggle: React.FC<{ size?: 'small' | 'medium' }> = ({ size =
 
   const isOverridden = override !== 'auto';
   const accent = isOverridden ? theme.palette.warning.main : theme.palette.text.secondary;
+  const detectedLabel = TIER_LABEL[detected];
+  const currentLabel = isOverridden ? TIER_LABEL[override as PerfTier] : `Auto · ${detectedLabel}`;
   const ariaLabel = isOverridden
     ? `Performance: ${override} (pinned) — change`
     : `Performance: Auto (detected ${detected}) — change`;
 
+  const trigger = renderTrigger ? (
+    renderTrigger({
+      onClick: handleOpen,
+      menuOpen: open,
+      override,
+      detected,
+      isOverridden,
+      currentLabel,
+      detectedLabel,
+    })
+  ) : (
+    <IconButton
+      onClick={handleOpen}
+      color="inherit"
+      size={size}
+      aria-label={ariaLabel}
+      aria-haspopup="menu"
+      aria-expanded={open ? 'true' : undefined}
+      sx={{
+        color: accent,
+        transition: 'all 0.2s ease-in-out',
+        '&:hover': {
+          color: theme.palette.primary.main,
+          transform: 'scale(1.1)',
+        },
+      }}
+    >
+      <SpeedIcon fontSize={size === 'small' ? 'small' : 'medium'} />
+    </IconButton>
+  );
+
   return (
     <>
-      <IconButton
-        onClick={handleOpen}
-        color="inherit"
-        size={size}
-        aria-label={ariaLabel}
-        aria-haspopup="menu"
-        aria-expanded={open ? 'true' : undefined}
-        sx={{
-          color: accent,
-          transition: 'all 0.2s ease-in-out',
-          '&:hover': {
-            color: theme.palette.primary.main,
-            transform: 'scale(1.1)',
-          },
-        }}
-      >
-        <SpeedIcon fontSize={size === 'small' ? 'small' : 'medium'} />
-      </IconButton>
+      {trigger}
 
       <Menu
         anchorEl={anchorEl}

--- a/src/components/PerfTierToggle.tsx
+++ b/src/components/PerfTierToggle.tsx
@@ -1,0 +1,119 @@
+import CheckIcon from '@mui/icons-material/Check';
+import SpeedIcon from '@mui/icons-material/Speed';
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectPerfTier, selectPerfTierOverride } from '../store/ui/uiSelectors';
+import { setPerfTierOverride, type PerfTier, type PerfTierOverride } from '../store/ui/uiSlice';
+import { useAppDispatch } from '../store/useAppDispatch';
+
+// Lets the user pin a performance tier or trust auto-detection. Auto is the
+// default — a manual override is for users whose device was misclassified
+// (e.g. Chromebook reporting low GPU tier but rendering comfortably, or the
+// reverse: a new laptop that thermally throttles).
+type OptionValue = PerfTierOverride;
+const OPTIONS: ReadonlyArray<{ value: OptionValue; label: string }> = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+];
+
+const TIER_LABEL: Record<PerfTier, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+export const PerfTierToggle: React.FC<{ size?: 'small' | 'medium' }> = ({ size = 'medium' }) => {
+  const theme = useTheme();
+  const dispatch = useAppDispatch();
+  const override = useSelector(selectPerfTierOverride);
+  const detected = useSelector(selectPerfTier);
+
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>): void => {
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  };
+  const handleClose = (): void => setAnchorEl(null);
+  const handleSelect = (value: OptionValue): void => {
+    dispatch(setPerfTierOverride(value));
+    setAnchorEl(null);
+  };
+
+  const isOverridden = override !== 'auto';
+  const accent = isOverridden ? theme.palette.warning.main : theme.palette.text.secondary;
+  const ariaLabel = isOverridden
+    ? `Performance: ${override} (pinned) — change`
+    : `Performance: Auto (detected ${detected}) — change`;
+
+  return (
+    <>
+      <IconButton
+        onClick={handleOpen}
+        color="inherit"
+        size={size}
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open ? 'true' : undefined}
+        sx={{
+          color: accent,
+          transition: 'all 0.2s ease-in-out',
+          '&:hover': {
+            color: theme.palette.primary.main,
+            transform: 'scale(1.1)',
+          },
+        }}
+      >
+        <SpeedIcon fontSize={size === 'small' ? 'small' : 'medium'} />
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { minWidth: 200 } } }}
+      >
+        <MenuItem disabled sx={{ opacity: 1, py: 0.5 }}>
+          <ListItemText
+            primary={
+              <Typography variant="caption" sx={{ fontWeight: 600, letterSpacing: '0.04em' }}>
+                PERFORMANCE
+              </Typography>
+            }
+            secondary={
+              <Typography variant="caption" color="text.secondary">
+                Detected: {TIER_LABEL[detected]}
+              </Typography>
+            }
+          />
+        </MenuItem>
+        {OPTIONS.map(({ value, label }) => {
+          const selected = override === value;
+          return (
+            <MenuItem key={value} selected={selected} onClick={() => handleSelect(value)} dense>
+              <ListItemIcon sx={{ minWidth: 28 }}>
+                {selected ? <CheckIcon fontSize="small" /> : null}
+              </ListItemIcon>
+              <ListItemText primary={label} />
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+};

--- a/src/hooks/usePerfTier.ts
+++ b/src/hooks/usePerfTier.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+
+import { selectEffectivePerfTier } from '../store/ui/uiSelectors';
+import type { PerfTier } from '../store/ui/uiSlice';
+
+// Read the effective performance tier (override wins over detected).
+// Feature gates should use this rather than doing their own detection —
+// single source of truth, persisted via Redux Persist, reactive to the
+// user's override.
+export const usePerfTier = (): PerfTier => useSelector(selectEffectivePerfTier);

--- a/src/hooks/useSelectedTab.test.new.tsx
+++ b/src/hooks/useSelectedTab.test.new.tsx
@@ -41,6 +41,8 @@ const createMockStore = (
       selectedFriendlyPlayerId: null,
       selectedTabId: null,
       myReportsPage: 1,
+      perfTier: 'medium',
+      perfTierOverride: 'auto',
       ...(initialState.ui || {}),
     },
   });

--- a/src/index.css
+++ b/src/index.css
@@ -125,3 +125,16 @@ code {
   --site-shadow: rgba(0, 0, 0, 0.8);
   --site-radius: 8px;
 }
+
+/* Performance-tier gate. `data-perf` is set on <html> from the Redux
+   store (see index.tsx's store.subscribe). On low-tier devices, strip
+   every backdrop-filter so the GPU doesn't spend most of its budget
+   compositing frosted-glass layers — this one rule drops the measured
+   27 active layers on landing to 0. The `filter` property (drop-shadow,
+   brightness, grayscale, …) is intentionally left alone since it isn't
+   the measured bottleneck and legitimate UI legibility uses exist. */
+html[data-perf='low'],
+html[data-perf='low'] * {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,42 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import './styles/view-transitions.css';
+import store, { type RootState } from './store/storeWithHistory';
+import { setPerfTier } from './store/ui/uiSlice';
+import { heuristicPerfTier } from './utils/detectPerfTier';
+
+// First-paint perf-tier priming. For a first-time visitor with no
+// persisted store, the default is 'medium' — which would leave a low-end
+// Moto rendering all blur layers until the async GPU benchmark resolves
+// seconds later. Run the cheap synchronous heuristic here (RAM + cores +
+// prefers-reduced-motion) so a 'low' verdict reaches the first paint.
+// Only downgrades: never overwrite a persisted 'low' or 'medium' with a
+// more optimistic heuristic, since the async benchmark will do that if
+// warranted.
+const primeTierFromHeuristic = (): void => {
+  const ui = (store.getState() as RootState).ui;
+  const sync = heuristicPerfTier();
+  const tierOrder = { low: 0, medium: 1, high: 2 } as const;
+  if (tierOrder[sync] < tierOrder[ui.perfTier]) {
+    store.dispatch(setPerfTier(sync));
+  }
+};
+primeTierFromHeuristic();
+
+// Mirror the effective perf tier onto `<html data-perf="...">` from the
+// Redux store. A subscriber (not a useEffect) so the attribute is set
+// before React composites — the CSS blur gates in index.css then apply
+// to the first paint, avoiding a flash of heavy filters on low-end
+// devices.
+const applyPerfTierAttr = (): void => {
+  const ui = (store.getState() as RootState).ui;
+  const effective = ui.perfTierOverride === 'auto' ? ui.perfTier : ui.perfTierOverride;
+  if (document.documentElement.dataset.perf !== effective) {
+    document.documentElement.dataset.perf = effective;
+  }
+};
+applyPerfTierAttr();
+store.subscribe(applyPerfTierAttr);
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -57,12 +57,21 @@ const rootReducer = combineReducers({
 const uiTransform = createTransform<UIState, Partial<UIState>>(
   // Transform state on its way to being serialized and persisted
   (inboundState) => {
-    const { darkMode, showExperimentalTabs, sidebarOpen, myReportsPage } = inboundState;
+    const {
+      darkMode,
+      showExperimentalTabs,
+      sidebarOpen,
+      myReportsPage,
+      perfTier,
+      perfTierOverride,
+    } = inboundState;
     return {
       darkMode,
       showExperimentalTabs,
       sidebarOpen,
       myReportsPage,
+      perfTier,
+      perfTierOverride,
     };
   },
   // Transform state being rehydrated
@@ -77,6 +86,8 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       showExperimentalTabs: false,
       sidebarOpen: false,
       myReportsPage: 1,
+      perfTier: 'medium',
+      perfTierOverride: 'auto',
     };
 
     // Merge persisted preferences with initial report-specific state

--- a/src/store/ui/uiSelectors.ts
+++ b/src/store/ui/uiSelectors.ts
@@ -32,6 +32,16 @@ export const selectSelectedTabId = (state: RootState): RootState['ui']['selected
 export const selectMyReportsPage = (state: RootState): RootState['ui']['myReportsPage'] =>
   state.ui.myReportsPage;
 
+export const selectPerfTier = (state: RootState): RootState['ui']['perfTier'] => state.ui.perfTier;
+export const selectPerfTierOverride = (state: RootState): RootState['ui']['perfTierOverride'] =>
+  state.ui.perfTierOverride;
+// Tier the app should actually apply — override wins when set to anything
+// other than 'auto'. This is what feature gates should consume.
+export const selectEffectivePerfTier = createSelector(
+  [selectPerfTier, selectPerfTierOverride],
+  (detected, override) => (override === 'auto' ? detected : override),
+);
+
 // Combined UI state
 export const selectCombinedUIState = createSelector([selectUI], (ui) => ({
   darkMode: ui.darkMode,

--- a/src/store/ui/uiSlice.test.ts
+++ b/src/store/ui/uiSlice.test.ts
@@ -36,6 +36,8 @@ describe('uiSlice', () => {
         showExperimentalTabs: false,
         sidebarOpen: false,
         myReportsPage: 1,
+        perfTier: 'medium',
+        perfTierOverride: 'auto',
       });
     });
   });
@@ -295,6 +297,8 @@ describe('uiSlice', () => {
         showExperimentalTabs: true,
         sidebarOpen: true,
         myReportsPage: 1,
+        perfTier: 'medium',
+        perfTierOverride: 'auto',
       });
     });
 

--- a/src/store/ui/uiSlice.ts
+++ b/src/store/ui/uiSlice.ts
@@ -1,5 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+export type PerfTier = 'low' | 'medium' | 'high';
+export type PerfTierOverride = 'auto' | PerfTier;
+
 export interface UIState {
   darkMode: boolean;
   selectedPlayerId: number | null;
@@ -9,6 +12,8 @@ export interface UIState {
   showExperimentalTabs: boolean;
   sidebarOpen: boolean;
   myReportsPage: number; // Persisted page number for my-reports
+  perfTier: PerfTier;
+  perfTierOverride: PerfTierOverride;
 }
 
 const initialState: UIState = {
@@ -20,6 +25,11 @@ const initialState: UIState = {
   showExperimentalTabs: false,
   sidebarOpen: false,
   myReportsPage: 1, // Default to page 1
+  // Conservative default until detection resolves — avoids a flash of
+  // expensive blur layers on first paint for returning visitors with an
+  // empty persisted store.
+  perfTier: 'medium',
+  perfTierOverride: 'auto',
 };
 
 const uiSlice = createSlice({
@@ -64,6 +74,12 @@ const uiSlice = createSlice({
     setMyReportsPage: (state, action: PayloadAction<number>) => {
       state.myReportsPage = action.payload;
     },
+    setPerfTier: (state, action: PayloadAction<PerfTier>) => {
+      state.perfTier = action.payload;
+    },
+    setPerfTierOverride: (state, action: PayloadAction<PerfTierOverride>) => {
+      state.perfTierOverride = action.payload;
+    },
   },
 });
 
@@ -79,5 +95,7 @@ export const {
   setSidebarOpen,
   toggleSidebar,
   setMyReportsPage,
+  setPerfTier,
+  setPerfTierOverride,
 } = uiSlice.actions;
 export default uiSlice.reducer;

--- a/src/test/utils/createMockStore.ts
+++ b/src/test/utils/createMockStore.ts
@@ -75,6 +75,8 @@ export function createMockStore(options: MockStoreOptions = {}): EnhancedStore {
         selectedFriendlyPlayerId: null,
         selectedTabId: null,
         myReportsPage: 1,
+        perfTier: 'medium' as const,
+        perfTierOverride: 'auto' as const,
         ...(initialState.ui || {}),
       },
       // Add other slice initial states here as needed
@@ -94,4 +96,6 @@ export const defaultMockUIState: UIState = {
   selectedFriendlyPlayerId: null,
   selectedTabId: null,
   myReportsPage: 1,
+  perfTier: 'medium',
+  perfTierOverride: 'auto',
 };

--- a/src/utils/detectPerfTier.test.ts
+++ b/src/utils/detectPerfTier.test.ts
@@ -1,0 +1,181 @@
+import { detectPerfTier, heuristicPerfTier, prefersReducedMotion } from './detectPerfTier';
+
+// Controlled mock for @pmndrs/detect-gpu so tests don't fetch the real
+// benchmark JSON or probe WebGL under jsdom. The package is ESM-only
+// (exports: .mjs), which the CJS test resolver can't walk — `virtual:
+// true` tells Jest to skip resolution and use the factory directly.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getGPUTierMock = jest.fn() as jest.MockedFunction<any>;
+jest.mock(
+  '@pmndrs/detect-gpu',
+  () => ({
+    getGPUTier: (...args: unknown[]) => getGPUTierMock(...args),
+  }),
+  { virtual: true },
+);
+
+type NavSignals = {
+  deviceMemory?: number;
+  hardwareConcurrency?: number;
+};
+
+const setNavigatorSignals = ({ deviceMemory, hardwareConcurrency }: NavSignals): void => {
+  // Delete-then-define lets us simulate browsers that omit the API
+  // entirely (Firefox/Safari don't expose deviceMemory, and some
+  // low-end / sandbox environments omit hardwareConcurrency too).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (navigator as any).deviceMemory;
+  if (deviceMemory !== undefined) {
+    Object.defineProperty(navigator, 'deviceMemory', {
+      value: deviceMemory,
+      configurable: true,
+    });
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (navigator as any).hardwareConcurrency;
+  if (hardwareConcurrency !== undefined) {
+    Object.defineProperty(navigator, 'hardwareConcurrency', {
+      value: hardwareConcurrency,
+      configurable: true,
+    });
+  }
+};
+
+const setPrefersReducedMotion = (reduce: boolean): void => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: query.includes('prefers-reduced-motion') ? reduce : false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+};
+
+beforeEach(() => {
+  getGPUTierMock.mockReset();
+  setPrefersReducedMotion(false);
+  setNavigatorSignals({ deviceMemory: 8, hardwareConcurrency: 8 });
+});
+
+describe('prefersReducedMotion', () => {
+  it('reflects the OS media query', () => {
+    setPrefersReducedMotion(true);
+    expect(prefersReducedMotion()).toBe(true);
+    setPrefersReducedMotion(false);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+describe('heuristicPerfTier', () => {
+  it("returns 'low' when deviceMemory <= 2GB", () => {
+    setNavigatorSignals({ deviceMemory: 2, hardwareConcurrency: 8 });
+    expect(heuristicPerfTier()).toBe('low');
+  });
+
+  it("returns 'low' when hardwareConcurrency <= 2", () => {
+    setNavigatorSignals({ deviceMemory: 8, hardwareConcurrency: 2 });
+    expect(heuristicPerfTier()).toBe('low');
+  });
+
+  it("returns 'low' when deviceMemory<=4 AND cores<=4 together", () => {
+    setNavigatorSignals({ deviceMemory: 4, hardwareConcurrency: 4 });
+    expect(heuristicPerfTier()).toBe('low');
+  });
+
+  it("returns 'medium' (never 'high') even on a powerful reported device", () => {
+    // Codex finding #2: heuristic must never hand out 'high'. That tier
+    // is exclusive to a successful GPU benchmark.
+    setNavigatorSignals({ deviceMemory: 32, hardwareConcurrency: 32 });
+    expect(heuristicPerfTier()).toBe('medium');
+  });
+
+  it("returns 'medium' when deviceMemory is unreported (Firefox/Safari)", () => {
+    // deviceMemory is Chrome-only. Missing signal must not produce 'high'.
+    setNavigatorSignals({ deviceMemory: undefined, hardwareConcurrency: 16 });
+    expect(heuristicPerfTier()).toBe('medium');
+  });
+
+  it("returns 'medium' when all hardware signals are missing", () => {
+    setNavigatorSignals({ deviceMemory: undefined, hardwareConcurrency: undefined });
+    expect(heuristicPerfTier()).toBe('medium');
+  });
+
+  it("does NOT force 'low' based on prefers-reduced-motion", () => {
+    // Codex finding #1: reduced-motion is an accessibility signal, not
+    // a hardware downgrade. A powerful desktop with OS reduced-motion
+    // must stay on its hardware tier — motion quieting happens in
+    // MotionConfig, not by demoting the whole app.
+    setPrefersReducedMotion(true);
+    setNavigatorSignals({ deviceMemory: 32, hardwareConcurrency: 16 });
+    expect(heuristicPerfTier()).toBe('medium');
+  });
+});
+
+describe('detectPerfTier', () => {
+  it("returns 'high' when getGPUTier reports tier 3, even with unreported deviceMemory", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false });
+    setNavigatorSignals({ deviceMemory: undefined, hardwareConcurrency: 16 });
+    await expect(detectPerfTier()).resolves.toBe('high');
+  });
+
+  it("returns 'medium' when getGPUTier throws and signals are missing (fails closed)", async () => {
+    // Codex finding #2: benchmark failure must not optimistically return
+    // 'high'. If we can't prove the GPU is capable, we don't assume.
+    getGPUTierMock.mockRejectedValueOnce(new Error('webgl unavailable'));
+    setNavigatorSignals({ deviceMemory: undefined, hardwareConcurrency: 16 });
+    await expect(detectPerfTier()).resolves.toBe('medium');
+  });
+
+  it("returns 'low' when getGPUTier throws and heuristic signals low-end", async () => {
+    getGPUTierMock.mockRejectedValueOnce(new Error('webgl unavailable'));
+    setNavigatorSignals({ deviceMemory: 2, hardwareConcurrency: 4 });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("returns 'low' on GPU tier 0", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 0, isMobile: false });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("returns 'low' on GPU tier 1", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 1, isMobile: true });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("returns 'low' on mobile GPU tier 2", async () => {
+    // Boundary case: mobile tier-2 is the 2020 Moto G Power zone.
+    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: true });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("returns 'medium' on desktop GPU tier 2", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: false });
+    await expect(detectPerfTier()).resolves.toBe('medium');
+  });
+
+  it("forces 'low' when heuristic is 'low' even if GPU benchmark says 'high'", async () => {
+    // A thermally-throttled phone can have a benchmark that was good
+    // when cool but has 2GB RAM and 2 cores — the weak-hardware floor
+    // wins.
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: true });
+    setNavigatorSignals({ deviceMemory: 2, hardwareConcurrency: 2 });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("does NOT force 'low' on prefers-reduced-motion + powerful GPU (accessibility separated)", async () => {
+    // Codex finding #1: user with reduced-motion + capable hardware
+    // stays on their hardware tier. MotionConfig handles the motion
+    // reduction separately.
+    setPrefersReducedMotion(true);
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false });
+    setNavigatorSignals({ deviceMemory: 32, hardwareConcurrency: 16 });
+    await expect(detectPerfTier()).resolves.toBe('high');
+  });
+});

--- a/src/utils/detectPerfTier.ts
+++ b/src/utils/detectPerfTier.ts
@@ -1,0 +1,65 @@
+import { getGPUTier } from '@pmndrs/detect-gpu';
+
+import type { PerfTier } from '../store/ui/uiSlice';
+
+// OS-level motion preference. Exposed as its own signal — motion handling
+// belongs in MotionConfig (see PerfTierProvider), NOT in the perf tier.
+// A user who opted into reduced motion on a powerful desktop should keep
+// every hardware-driven feature; only the motion layer should quiet down.
+export const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// Synchronous hardware heuristic. Returns 'low' | 'medium' only — the
+// 'high' tier is reserved for a successful GPU benchmark, so this path
+// fails closed on browsers where `deviceMemory` / `hardwareConcurrency`
+// aren't informative. Safe to run before React mounts so first-time
+// visitors on a low-end device get the low-tier CSS on their very first
+// paint.
+export const heuristicPerfTier = (): Exclude<PerfTier, 'high'> => {
+  if (typeof navigator === 'undefined') return 'medium';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const memory = (navigator as any).deviceMemory as number | undefined;
+  const cores = navigator.hardwareConcurrency;
+  if (memory != null && memory <= 2) return 'low';
+  if (cores != null && cores <= 2) return 'low';
+  if (memory != null && memory <= 4 && cores != null && cores <= 4) return 'low';
+  // If a confident signal says "weak-ish", cap at medium. Otherwise the
+  // device might be high-end but we can't prove it without the benchmark,
+  // so we also return 'medium' as the neutral "don't know" default — the
+  // async benchmark is what promotes to 'high'.
+  return 'medium';
+};
+
+export const detectPerfTier = async (): Promise<PerfTier> => {
+  const heuristic = heuristicPerfTier();
+
+  try {
+    const gpuTier = await getGPUTier();
+    // detect-gpu returns tier 0..3. Tier 0 = blocklisted or <15 fps.
+    // Mobile tier-3 and desktop tier-3 use the same internal classification,
+    // so `isMobile` alone doesn't automatically demote — let the benchmark
+    // speak. isMobile is worth a small demotion only when the benchmark is
+    // on the boundary (tier 2).
+    const t = gpuTier.tier;
+    const isMobile = gpuTier.isMobile ?? false;
+
+    let fromGpu: PerfTier;
+    if (t <= 1) fromGpu = 'low';
+    else if (t === 2) fromGpu = isMobile ? 'low' : 'medium';
+    else fromGpu = 'high';
+
+    // The heuristic is a downgrade-only signal — it can force a capable
+    // GPU down to 'low' (thermally-throttled phone, weak CPU/RAM), but
+    // it must NOT cap a successful 'high' benchmark at 'medium' just
+    // because deviceMemory/hardwareConcurrency are unreported.
+    return heuristic === 'low' ? 'low' : fromGpu;
+  } catch {
+    // Benchmark unavailable — WebGL context creation failed, blocklist,
+    // or network error fetching the benchmark JSON. Fall back to the
+    // heuristic, which caps at 'medium'. Never return 'high' from here:
+    // if we can't prove the GPU is capable, we shouldn't assume it.
+    return heuristic;
+  }
+};


### PR DESCRIPTION
## Summary

- Low-FPS repro from a 2020 Motorola (Adreno 610, 4GB RAM) traced to 218 `backdrop-filter` call-sites — 27 active on the landing page alone. Adds a three-tier (`low` / `medium` / `high`) classifier driven by [`@pmndrs/detect-gpu`](https://github.com/pmndrs/detect-gpu) + synchronous hardware heuristics, persisted via existing `ui` redux-persist whitelist with a user-override field.
- One global CSS rule strips `backdrop-filter` site-wide on `html[data-perf="low"]`, so the 103 call-sites degrade cleanly without individual edits. `<MotionConfig>` flips to `reducedMotion="always"` on low tier and to `"user"` otherwise — powerful desktops with OS reduced-motion keep all blurs and hardware features, but their animations still quiet down via the OS signal.
- `data-perf` is set on `<html>` by a Redux `store.subscribe()` in `index.tsx` **before** React mounts, and the heuristic is primed synchronously from RAM/cores, so first-time low-end visitors don't flash the heavy filters while the async GPU benchmark resolves.
- Fight replay is intentionally deferred; `documentation/architecture/fight-replay-perf-tiering.md` documents the knobs + file:line refs for the follow-up.

## Detection semantics (fails closed)

| Signal                                 | Resulting tier |
|----------------------------------------|----------------|
| Benchmark tier 3 (desktop or mobile)   | `high`         |
| Benchmark tier 2 desktop               | `medium`       |
| Benchmark tier 2 mobile / tier ≤ 1     | `low`          |
| Benchmark throws + heuristic low       | `low`          |
| Benchmark throws + missing signals     | `medium` *(never `high` without a benchmark)* |
| Heuristic `'low'` + tier-3 benchmark   | `low` *(weak CPU/RAM wins)* |
| `prefers-reduced-motion` + capable GPU | `high` *(accessibility handled in MotionConfig, not tier)* |

## Measured effect (Chrome MCP, Moto G Power viewport, 4× CPU throttle)

| State (override)        | `data-perf` | Active `backdrop-filter` elements |
|-------------------------|-------------|------------------------------------|
| `auto` (detected high)  | `high`      | 27                                 |
| `low`                   | `low`       | **0**                              |
| `auto` (restored)       | `high`      | 27                                 |

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] 62 passing unit tests across `uiSlice`, `createMockStore`, `useSelectedTab`, `storeWithHistory`, and a new `detectPerfTier` suite
- [x] `detectPerfTier` suite has explicit regression guards for the two Codex findings:
  - `prefers-reduced-motion` + tier-3 GPU → `'high'` (accessibility ≠ hardware tier)
  - `getGPUTier()` throws + missing `deviceMemory` + 16 cores → `'medium'` (no fail-open to `'high'`)
- [x] In-browser flip via Redux devtools: `setPerfTierOverride('low')` → `data-perf=low` → 27 active blur layers → 0; `setPerfTierOverride('auto')` → restores to 27.
- [x] Screenshots captured (desktop + low tier) — landing page remains readable without blur, no layout breaks.

## Follow-ups (not in this PR)

- Settings UI toggle exposing the `perfTierOverride` field (backend is ready — action + selector + persist are in place).
- Fight replay knob gating per `documentation/architecture/fight-replay-perf-tiering.md` (antialias, shadows, DPR, billboard textures, per-actor useFrame consolidation).