### PR TITLE
fix(build-view): show specific weapon type (Sword/Dagger/Bow/...) instead of generic "Weapon"

### DIFF
--- a/src/components/roster/build-detail-panel.tsx
+++ b/src/components/roster/build-detail-panel.tsx
@@ -14,7 +14,9 @@ import type { BuildChampionPoints } from '../../features/build-editor/types/buil
 import { getChampionPointById } from '../../features/loadout-manager/data/championPointData';
 import { getItemInfo } from '../../features/loadout-manager/data/itemIdMap';
 import { getSkillById } from '../../features/loadout-manager/data/skillLineSkills';
+import type { SlotType } from '../../features/loadout-manager/data/slotTypes';
 import type { GearConfig, SkillsConfig } from '../../features/loadout-manager/types/loadout.types';
+import { deriveItemNameForSlot } from '../../features/loadout-manager/utils/itemIconResolver';
 import { getChampionPointAbilityName } from '../../types/champion-points';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -47,6 +49,24 @@ const GEAR_SLOT_NAMES: Record<number, string> = {
   21: 'Back Off',
 };
 const GEAR_SLOT_ORDER = [0, 2, 3, 16, 6, 8, 9, 1, 11, 12, 4, 5, 20, 21];
+
+/** Maps ESO equipment slot indices to the SlotType used in itemIdMap. */
+const SLOT_INDEX_TO_TYPE: Record<number, SlotType> = {
+  0: 'head',
+  1: 'neck',
+  2: 'chest',
+  3: 'shoulders',
+  4: 'weapon',
+  5: 'offhand',
+  6: 'waist',
+  8: 'legs',
+  9: 'feet',
+  11: 'ring',
+  12: 'ring',
+  16: 'hand',
+  20: 'weapon',
+  21: 'offhand',
+};
 
 const WEIGHT_LABELS: Record<string, string> = {
   light: 'L',
@@ -290,9 +310,10 @@ const GearDisplay: React.FC<{
       {populatedSlots.map((slotIdx) => {
         const piece = gear[slotIdx];
         if (!piece) return null;
-        const itemInfo = getItemInfo(Number(piece.id));
+        const itemId = Number(piece.id);
+        const itemInfo = getItemInfo(itemId);
         const slotName = GEAR_SLOT_NAMES[slotIdx] ?? `Slot ${slotIdx}`;
-        const itemName = itemInfo?.name ?? `Item #${piece.id}`;
+        const itemName = deriveItemNameForSlot(itemId, SLOT_INDEX_TO_TYPE[slotIdx]);
         const setName = itemInfo?.setName;
         const weight = piece.weight ? WEIGHT_LABELS[piece.weight] : null;
 

--- a/src/features/build-editor/components/pickers/EquipmentPicker.tsx
+++ b/src/features/build-editor/components/pickers/EquipmentPicker.tsx
@@ -21,6 +21,7 @@ import type {
   GearConfig,
   GearPiece,
 } from '../../../loadout-manager/types/loadout.types';
+import { deriveItemNameForSlot } from '../../../loadout-manager/utils/itemIconResolver';
 import { EQUIP_SLOTS, type EquipSlotDef } from '../../data/esoStaticData';
 import { GearSlotCard } from '../primitives/GearSlotCard';
 
@@ -77,12 +78,13 @@ const SlotRowComponent: React.FC<SlotRowProps> = ({
 }) => {
   const itemId = piece?.id != null ? Number(piece.id) : null;
   const info = itemId ? getItemInfo(itemId) : null;
+  const itemName = itemId ? deriveItemNameForSlot(itemId, def.slotType) : null;
 
   return (
     <GearSlotCard
       slotDef={def}
       itemId={itemId}
-      itemName={info?.name ?? null}
+      itemName={itemName}
       setName={info?.setName ?? null}
       isDisabled={Boolean(disabledReason)}
       disabledReason={disabledReason}

--- a/src/features/build-editor/components/pickers/GearPicker.tsx
+++ b/src/features/build-editor/components/pickers/GearPicker.tsx
@@ -47,6 +47,7 @@ import {
   getItemsBySlot,
   validateItemForSlot,
 } from '@features/loadout-manager/data/itemIdMap';
+import { deriveItemNameForSlot } from '@features/loadout-manager/utils/itemIconResolver';
 
 import {
   getSetType,
@@ -197,12 +198,14 @@ interface SetCategorySectionProps {
   group: SetGroup;
   currentItemId: number | null;
   onSelect: (itemId: number) => void;
+  targetSlot: SlotType;
 }
 
 const SetCategorySection: React.FC<SetCategorySectionProps> = ({
   group,
   currentItemId,
   onSelect,
+  targetSlot,
 }) => {
   const isDark = useTheme().palette.mode === 'dark';
   const [expanded, setExpanded] = useState(false);
@@ -322,7 +325,7 @@ const SetCategorySection: React.FC<SetCategorySectionProps> = ({
                       lineHeight: 1.3,
                     }}
                   >
-                    {item.info.name}
+                    {deriveItemNameForSlot(item.itemId, targetSlot)}
                   </Typography>
                   <Typography
                     sx={{
@@ -524,7 +527,9 @@ export const GearPickerDialog: React.FC<GearPickerDialogProps> = ({
                       color: isDark ? 'rgba(255,255,255,0.70)' : 'rgba(0,0,0,0.65)',
                     }}
                   >
-                    {currentInfo.name}
+                    {currentItemId != null
+                      ? deriveItemNameForSlot(currentItemId, targetSlot)
+                      : currentInfo.name}
                   </Typography>
                   <Chip
                     label={currentInfo.setName}
@@ -648,7 +653,7 @@ export const GearPickerDialog: React.FC<GearPickerDialogProps> = ({
                                 lineHeight: 1.3,
                               }}
                             >
-                              {item.info.name}
+                              {deriveItemNameForSlot(item.itemId, targetSlot)}
                             </Typography>
                             <Chip
                               label={item.info.setName}
@@ -771,6 +776,7 @@ export const GearPickerDialog: React.FC<GearPickerDialogProps> = ({
                     group={group}
                     currentItemId={currentItemId}
                     onSelect={handleSelect}
+                    targetSlot={targetSlot}
                   />
                 ))
               )}

--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -16,7 +16,7 @@ import { validateItemForSlot, getItemInfo, type SlotType } from '../data/itemIdM
 import { getCollectionItem, findCollectionItemBySetAndSlotType } from '../data/itemSetCollections';
 import { updateGear } from '../store/loadoutSlice';
 import { GearConfig, GearPiece } from '../types/loadout.types';
-import { fetchItemIconUrl } from '../utils/itemIconResolver';
+import { applyWeaponTypeToName, fetchItemIconUrl } from '../utils/itemIconResolver';
 import { getItemData, getItemIdFromLink } from '../utils/itemLinkParser';
 import { registerManualSlot } from '../utils/wizardWardrobeSlotRegistry';
 
@@ -210,6 +210,7 @@ const SlotIcon: React.FC<{ name: string; size?: number; color?: string }> = ({
 // ---------------------------------------------------------------------------
 interface GearTileProps {
   slotName: string;
+  slotType: SlotType;
   gearPiece?: ExtendedGearPiece;
   onRemove: () => void;
   onAdd: () => void;
@@ -221,6 +222,7 @@ interface GearTileProps {
 
 const GearTile: React.FC<GearTileProps> = ({
   slotName,
+  slotType,
   gearPiece,
   onRemove,
   onAdd,
@@ -278,7 +280,12 @@ const GearTile: React.FC<GearTileProps> = ({
   }, [resolvedItemId]);
 
   const setName = gearPiece?.setName || itemData?.setName;
-  const primaryItemName = gearPiece?.name || itemData?.name || setName;
+  const rawPrimaryItemName = gearPiece?.name || itemData?.name || setName;
+  // Swap generic "Weapon"/"Gear" suffixes for the specific type, following
+  // the already-resolved iconUrl state (covers async UESP fallback too).
+  const primaryItemName = rawPrimaryItemName
+    ? applyWeaponTypeToName(rawPrimaryItemName, iconUrl, slotType)
+    : rawPrimaryItemName;
   const showItemIdFallback = resolvedItemId && !resolvedSetId && !setName ? resolvedItemId : null;
   const fallbackLabel = resolvedSetId
     ? `Set ID ${resolvedSetId}`
@@ -681,6 +688,7 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
     <GearTile
       key={slot}
       slotName={name}
+      slotType={slotType}
       gearPiece={gear[slot] as ExtendedGearPiece}
       onRemove={() => handleRemoveGear(slot)}
       onAdd={() => handleAddGear(slot, name, slotType)}

--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -283,9 +283,20 @@ const GearTile: React.FC<GearTileProps> = ({
   const rawPrimaryItemName = gearPiece?.name || itemData?.name || setName;
   // Swap generic "Weapon"/"Gear" suffixes for the specific type, following
   // the already-resolved iconUrl state (covers async UESP fallback too).
-  const primaryItemName = rawPrimaryItemName
-    ? applyWeaponTypeToName(rawPrimaryItemName, iconUrl, slotType)
-    : rawPrimaryItemName;
+  //
+  // Guard on the ORIGINAL gearPiece.id's slot, not `resolvedItemId`'s —
+  // collection lookup may have remapped a generic piece to a canonical
+  // slot-specific item whose icon is an arbitrary choice for the set.
+  // Only assert a weapon type when the stored id itself uniquely
+  // identifies one.
+  const originalItemId = gearPiece?.id != null ? Number(gearPiece.id) : null;
+  const originalInfo = originalItemId ? getItemInfo(originalItemId) : undefined;
+  const itemIsSlotSpecificWeapon =
+    originalInfo?.slot === 'weapon' || originalInfo?.slot === 'offhand';
+  const primaryItemName =
+    rawPrimaryItemName && itemIsSlotSpecificWeapon
+      ? applyWeaponTypeToName(rawPrimaryItemName, iconUrl, slotType)
+      : rawPrimaryItemName;
   const showItemIdFallback = resolvedItemId && !resolvedSetId && !setName ? resolvedItemId : null;
   const fallbackLabel = resolvedSetId
     ? `Set ID ${resolvedSetId}`

--- a/src/features/loadout-manager/components/ItemPickerDialog.tsx
+++ b/src/features/loadout-manager/components/ItemPickerDialog.tsx
@@ -31,6 +31,7 @@ import {
   type SlotType,
   validateItemForSlot,
 } from '../data/itemIdMap';
+import { deriveItemNameForSlot } from '../utils/itemIconResolver';
 import { getSlotCoverageStats } from '../utils/itemSlotValidator';
 
 interface ItemPickerDialogProps {
@@ -217,14 +218,16 @@ export const ItemPickerDialog: React.FC<ItemPickerDialogProps> = ({
             onInputChange={handleInputChange}
             onChange={handleOptionSelect}
             filterOptions={filterOptions}
-            getOptionLabel={(option) => option.info.name}
+            getOptionLabel={(option) => deriveItemNameForSlot(option.itemId, targetSlot)}
             isOptionEqualToValue={(option, value) => option.itemId === value.itemId}
             noOptionsText={noOptionsText}
             renderOption={(props, option) => (
               <li {...props} key={option.itemId}>
                 <Stack spacing={0.5} width="100%">
                   <Stack direction="row" spacing={1} alignItems="center">
-                    <Typography fontWeight={600}>{option.info.name}</Typography>
+                    <Typography fontWeight={600}>
+                      {deriveItemNameForSlot(option.itemId, targetSlot)}
+                    </Typography>
                     <Chip
                       label={option.info.setName}
                       size="small"
@@ -276,7 +279,9 @@ export const ItemPickerDialog: React.FC<ItemPickerDialogProps> = ({
               </Typography>
               <Stack spacing={0.5}>
                 <Stack direction="row" spacing={1} alignItems="center">
-                  <Typography fontWeight={600}>{currentItem.info.name}</Typography>
+                  <Typography fontWeight={600}>
+                    {deriveItemNameForSlot(currentItem.itemId, targetSlot)}
+                  </Typography>
                   <Chip
                     label={currentItem.info.setName}
                     size="small"

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -12,7 +12,13 @@
  *     URLs of the same CDN shape.
  */
 
-import { parseWeaponTypeFromIconUrl } from '../itemIconResolver';
+import {
+  applyWeaponTypeToName,
+  deriveItemNameForSlot,
+  GENERIC_WEAPON_SUFFIXES,
+  getItemIconUrl,
+  parseWeaponTypeFromIconUrl,
+} from '../itemIconResolver';
 
 const CDN = 'https://esoicons.uesp.net/esoui/art/icons';
 
@@ -76,5 +82,127 @@ describe('parseWeaponTypeFromIconUrl', () => {
     expect(
       parseWeaponTypeFromIconUrl(`${CDN}/crafting_enchantment_baxe_bloodstone_r1.png`),
     ).toBeNull();
+  });
+});
+
+describe('applyWeaponTypeToName', () => {
+  it('replaces " Weapon" suffix with the specific type', () => {
+    expect(
+      applyWeaponTypeToName(
+        "Mother's Sorrow Weapon",
+        `${CDN}/gear_argonian_1hsword_d.png`,
+        'weapon',
+      ),
+    ).toBe("Mother's Sorrow Sword");
+  });
+
+  it('replaces " Off-Hand" suffix (shield in off-hand)', () => {
+    expect(
+      applyWeaponTypeToName(
+        "Mother's Sorrow Off-Hand",
+        `${CDN}/gear_argonian_shield_d.png`,
+        'offhand',
+      ),
+    ).toBe("Mother's Sorrow Shield");
+  });
+
+  it('replaces " Gear" suffix for generic set IDs once the icon is resolved', () => {
+    expect(
+      applyWeaponTypeToName("Mother's Sorrow Gear", `${CDN}/gear_argonian_1haxe_d.png`, 'weapon'),
+    ).toBe("Mother's Sorrow Axe");
+  });
+
+  it('no-ops when slot is not weapon/offhand', () => {
+    expect(
+      applyWeaponTypeToName(
+        "Mother's Sorrow Chest",
+        `${CDN}/gear_argonian_light_robe_d.png`,
+        'chest',
+      ),
+    ).toBe("Mother's Sorrow Chest");
+  });
+
+  it('no-ops when the icon URL has no weapon token', () => {
+    expect(
+      applyWeaponTypeToName(
+        "Mother's Sorrow Weapon",
+        `${CDN}/gear_argonian_light_hands_d.png`,
+        'weapon',
+      ),
+    ).toBe("Mother's Sorrow Weapon");
+  });
+
+  it('no-ops when the raw name has no recognized suffix', () => {
+    expect(
+      applyWeaponTypeToName('Totally Custom Name', `${CDN}/gear_argonian_1hsword_d.png`, 'weapon'),
+    ).toBe('Totally Custom Name');
+  });
+
+  it('no-ops on null/undefined icon URL (falls back to generic name)', () => {
+    expect(applyWeaponTypeToName("Mother's Sorrow Weapon", null, 'weapon')).toBe(
+      "Mother's Sorrow Weapon",
+    );
+    expect(applyWeaponTypeToName("Mother's Sorrow Weapon", undefined, 'weapon')).toBe(
+      "Mother's Sorrow Weapon",
+    );
+  });
+
+  it('does not double up if the suffix already matches the weapon type', () => {
+    // If a name already says "Sword" it won't match any generic suffix, so no-op.
+    expect(
+      applyWeaponTypeToName(
+        "Mother's Sorrow Sword",
+        `${CDN}/gear_argonian_1hsword_d.png`,
+        'weapon',
+      ),
+    ).toBe("Mother's Sorrow Sword");
+  });
+});
+
+describe('GENERIC_WEAPON_SUFFIXES', () => {
+  it('contains the four known generic slot-name endings', () => {
+    expect([...GENERIC_WEAPON_SUFFIXES]).toEqual([' Weapon', ' Off-Hand', ' Offhand', ' Gear']);
+  });
+});
+
+describe('deriveItemNameForSlot (integration — real itemIds through local icon data)', () => {
+  // These item IDs are real Mother's Sorrow weapons from itemIdMap, chosen
+  // because they exercise the full chain: getItemInfo → getItemIconUrl →
+  // parseWeaponTypeFromIconUrl → applyWeaponTypeToName.
+  it.each([
+    [97219, 'weapon' as const, "Mother's Sorrow Axe"],
+    [97221, 'weapon' as const, "Mother's Sorrow Sword"],
+    [97225, 'weapon' as const, "Mother's Sorrow Dagger"],
+    [97226, 'weapon' as const, "Mother's Sorrow Bow"],
+    [97230, 'weapon' as const, "Mother's Sorrow Staff"],
+    [97231, 'offhand' as const, "Mother's Sorrow Shield"],
+  ])('resolves item %i in slot %s → %s', (itemId, slotType, expected) => {
+    // Sanity-check the upstream link first — if the icon JSON changes shape,
+    // we want a specific failure here, not a silent regression elsewhere.
+    const iconUrl = getItemIconUrl(itemId);
+    expect(iconUrl).toMatch(/\/icons\/gear_/);
+    expect(deriveItemNameForSlot(itemId, slotType)).toBe(expected);
+  });
+
+  it('iconUrlOverride wins over local icon lookup (async UESP fallback path)', () => {
+    // Item 97221 locally resolves to a 1hsword icon → "Sword". Force-override
+    // to a bow icon; the helper must follow the override (so it stays in
+    // lockstep with whatever the component is rendering after an async fetch).
+    const bowUrl = `${CDN}/gear_argonian_bow_d.png`;
+    expect(deriveItemNameForSlot(97221, 'weapon', bowUrl)).toBe("Mother's Sorrow Bow");
+  });
+
+  it('returns raw name for non-weapon slots (no type derivation)', () => {
+    expect(deriveItemNameForSlot(97232, 'chest')).toMatch(/Chest$/);
+  });
+
+  it('returns "Item #X" placeholder for unknown itemIds', () => {
+    expect(deriveItemNameForSlot(99999999, 'weapon')).toBe('Item #99999999');
+  });
+
+  it('handles null/undefined itemId gracefully', () => {
+    expect(deriveItemNameForSlot(null, 'weapon')).toBe('Item #?');
+    expect(deriveItemNameForSlot(undefined, 'weapon')).toBe('Item #?');
+    expect(deriveItemNameForSlot(0, 'weapon')).toBe('Item #?');
   });
 });

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -206,3 +206,37 @@ describe('deriveItemNameForSlot (integration — real itemIds through local icon
     expect(deriveItemNameForSlot(0, 'weapon')).toBe('Item #?');
   });
 });
+
+describe('deriveItemNameForSlot (slot-specificity guard — regression for /bv false-assertion bug)', () => {
+  // Generic set IDs (no slot field in itemIdMap) must NOT be rewritten to a
+  // specific weapon type. In BuildViewPage, the icon for these comes from a
+  // getSetItemsBySlot(setName, slot)[0] fallback — an arbitrary choice among
+  // several weapon variants. Asserting the fallback's type as definitive
+  // would silently corrupt shared build displays.
+  //
+  // Item 2558 is "Mother's Sorrow Gear" — a LibSets set-level ID with no
+  // `slot` field. Mother's Sorrow has 12 slot='weapon' entries (axe, sword,
+  // dagger, bow, staff variants, etc.) so the first-match fallback is a
+  // coin flip.
+  it('keeps generic set IDs as "<Set> Gear" even when caller has a weapon-shaped icon URL', () => {
+    const bowIconOverride = `${CDN}/gear_argonian_bow_d.png`;
+    expect(deriveItemNameForSlot(2558, 'weapon', bowIconOverride)).toBe("Mother's Sorrow Gear");
+  });
+
+  it('keeps generic set IDs as "<Set> Gear" with no override (local icon lookup)', () => {
+    expect(deriveItemNameForSlot(2558, 'weapon')).toBe("Mother's Sorrow Gear");
+  });
+
+  it('still rewrites for slot-specific item IDs (positive control)', () => {
+    // Same call shape, but itemInfo.slot === 'weapon' — the derivation is
+    // safe because the itemId uniquely identifies the weapon type.
+    expect(deriveItemNameForSlot(97221, 'weapon')).toBe("Mother's Sorrow Sword");
+  });
+
+  it('keeps non-weapon-slot items unchanged even if caller forces a weapon icon URL', () => {
+    // Item 97232 = "Mother's Sorrow Chest" (slot='chest'). An adversarial
+    // caller passing a bow URL must not produce "Mother's Sorrow Bow".
+    const bowIconOverride = `${CDN}/gear_argonian_bow_d.png`;
+    expect(deriveItemNameForSlot(97232, 'chest', bowIconOverride)).toBe("Mother's Sorrow Chest");
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for icon-URL parsing — specifically the weapon-type derivation used
+ * by BuildViewPage to replace the generic " Weapon" suffix with a specific
+ * type (Sword, Dagger, Bow, …).
+ *
+ * The parser operates on the already-resolved icon URL so it stays aligned
+ * with:
+ *   - the local-data path (synchronous `getItemIconUrl`)
+ *   - the page-level `resolvedIconId` correction for generic/slot-mismatched
+ *     item IDs
+ *   - the async UESP fallback path (`fetchItemIconUrl`), which also emits
+ *     URLs of the same CDN shape.
+ */
+
+import { parseWeaponTypeFromIconUrl } from '../itemIconResolver';
+
+const CDN = 'https://esoicons.uesp.net/esoui/art/icons';
+
+describe('parseWeaponTypeFromIconUrl', () => {
+  it.each([
+    ['1haxe', 'Axe'],
+    ['1hsword', 'Sword'],
+    ['1hhammer', 'Mace'],
+    ['1hmace', 'Mace'],
+    ['1hdagger', 'Dagger'],
+    ['2haxe', 'Battle Axe'],
+    ['2hsword', 'Greatsword'],
+    ['2hhammer', 'Maul'],
+    ['2hmace', 'Maul'],
+    ['dagger', 'Dagger'],
+    ['bow', 'Bow'],
+    ['staff', 'Staff'],
+    ['shield', 'Shield'],
+  ])('maps token %s to %s', (token, label) => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_argonian_${token}_d.png`)).toBe(label);
+  });
+
+  it('handles multi-segment style names like gear_ancient_elf_staff_a', () => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_ancient_elf_staff_a.png`)).toBe('Staff');
+  });
+
+  it('handles tokens at end of filename (no trailing letter suffix)', () => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_blackiron_staff.png`)).toBe('Staff');
+  });
+
+  it('returns null for armor icons', () => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_argonian_light_hands_d.png`)).toBeNull();
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_argonian_light_head_d.png`)).toBeNull();
+  });
+
+  it('returns null for non-gear icons', () => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/ability_mundusstones_001.png`)).toBeNull();
+  });
+
+  it('returns null for null or empty input', () => {
+    expect(parseWeaponTypeFromIconUrl(null)).toBeNull();
+    expect(parseWeaponTypeFromIconUrl(undefined)).toBeNull();
+    expect(parseWeaponTypeFromIconUrl('')).toBeNull();
+  });
+
+  it('returns null for malformed URLs that do not point at the icon CDN path', () => {
+    expect(
+      parseWeaponTypeFromIconUrl('https://example.com/gear_argonian_1hsword_d.png'),
+    ).toBeNull();
+    expect(parseWeaponTypeFromIconUrl('gear_argonian_1hsword_d')).toBeNull();
+  });
+
+  it('tolerates query strings and fragments on the URL', () => {
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_argonian_1hsword_d.png?v=2`)).toBe('Sword');
+    expect(parseWeaponTypeFromIconUrl(`${CDN}/gear_argonian_bow_d.png#anchor`)).toBe('Bow');
+  });
+
+  it('does not false-match on unrelated tokens (e.g. "axe" inside a style name)', () => {
+    // "baxe" is a real non-weapon substring (crafting_enchantment_baxe_…) —
+    // the regex anchors on `_<token>_` so this must not match as "1haxe".
+    expect(
+      parseWeaponTypeFromIconUrl(`${CDN}/crafting_enchantment_baxe_bloodstone_r1.png`),
+    ).toBeNull();
+  });
+});

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -19,6 +19,8 @@ import { Logger } from '@/utils/logger';
 
 // Pre-fetched icon data: { icons: string[], items: Record<string, number> }
 import iconData from '../data/itemIcons.json';
+import { getItemInfo } from '../data/itemIdMap';
+import type { SlotType } from '../data/slotTypes';
 
 const logger = new Logger({ contextPrefix: 'ItemIconResolver' });
 
@@ -102,6 +104,63 @@ export function parseWeaponTypeFromIconUrl(url: string | null | undefined): stri
   if (!fileMatch) return null;
   const tokenMatch = fileMatch[1].match(WEAPON_ICON_TOKEN_RE);
   return tokenMatch ? (WEAPON_ICON_TOKEN_LABELS[tokenMatch[1]] ?? null) : null;
+}
+
+/**
+ * Generic slot-name suffixes that itemIdMap uses when a specific weapon-type
+ * name isn't available. Callers strip the trailing match and splice in a
+ * specific type (Sword/Dagger/Bow/…) once the icon is resolved.
+ *
+ * Order matters — longer/more-specific suffixes (" Off-Hand") must come
+ * before shorter overlaps (" Hand") would if we ever added them.
+ */
+export const GENERIC_WEAPON_SUFFIXES = [' Weapon', ' Off-Hand', ' Offhand', ' Gear'] as const;
+
+/**
+ * Replace a generic slot-name suffix on an item name with the specific weapon
+ * type parsed from its icon URL. No-ops when the slot isn't a weapon slot,
+ * when the icon URL doesn't expose a weapon token, or when the raw name
+ * doesn't end in a recognized generic suffix.
+ *
+ * The `slotType` gate intentionally uses the SLOT POSITION (weapon / offhand)
+ * rather than the item's own `slot` tag, so generic set IDs (e.g. 2558 =
+ * "Mother's Sorrow Gear") still get a specific label once the caller has
+ * corrected the icon to a concrete slot-specific item.
+ */
+export function applyWeaponTypeToName(
+  rawName: string,
+  iconUrl: string | null | undefined,
+  slotType: SlotType | undefined,
+): string {
+  const isWeaponSlot = slotType === 'weapon' || slotType === 'offhand';
+  if (!isWeaponSlot) return rawName;
+  const weaponType = parseWeaponTypeFromIconUrl(iconUrl);
+  if (!weaponType) return rawName;
+  const suffix = GENERIC_WEAPON_SUFFIXES.find((s) => rawName.endsWith(s));
+  if (!suffix) return rawName;
+  return rawName.slice(0, -suffix.length) + ' ' + weaponType;
+}
+
+/**
+ * Resolve an item's display name for a given slot — the single callable
+ * used by the /bv, /rv, build-editor, and loadout-manager UIs so they all
+ * agree on how to render weapon labels.
+ *
+ * Synchronous: reads `getItemInfo` + local icon data. Callers that already
+ * track an async-resolved icon URL (e.g. BuildViewPage's `iconUrl` state
+ * from `fetchItemIconUrl`) should pass it via `iconUrlOverride` so the
+ * label follows whatever icon they're rendering.
+ */
+export function deriveItemNameForSlot(
+  itemId: number | null | undefined,
+  slotType: SlotType | undefined,
+  iconUrlOverride?: string | null,
+): string {
+  const id = itemId ?? 0;
+  const info = id > 0 ? getItemInfo(id) : undefined;
+  const rawName = info?.name ?? `Item #${id || '?'}`;
+  const url = iconUrlOverride !== undefined ? iconUrlOverride : getItemIconUrl(id);
+  return applyWeaponTypeToName(rawName, url, slotType);
 }
 
 /**

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -90,16 +90,18 @@ const WEAPON_ICON_TOKEN_RE = new RegExp(
 
 /**
  * Derive the specific weapon-type label (e.g. "Sword", "Dagger", "Bow") from
- * an item ID by parsing the token embedded in its UESP icon filename.
- * Returns null when the item isn't in the local icon data or its icon
- * doesn't match a known weapon token.
+ * an already-resolved icon URL. Pure parser over the URL's filename so the
+ * label stays in lockstep with whatever icon the caller decided to render —
+ * including the async UESP fallback path and the page-level `resolvedIconId`
+ * correction for generic/slot-mismatched item IDs. Returns null when the URL
+ * doesn't match the UESP CDN shape or its icon token isn't a weapon.
  */
-export function getWeaponTypeLabel(itemId: number | null | undefined): string | null {
-  if (!itemId || itemId <= 0) return null;
-  const iconName = lookupIconName(itemId);
-  if (!iconName) return null;
-  const match = iconName.match(WEAPON_ICON_TOKEN_RE);
-  return match ? (WEAPON_ICON_TOKEN_LABELS[match[1]] ?? null) : null;
+export function parseWeaponTypeFromIconUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const fileMatch = url.match(/\/icons\/([^/?#]+)\.png(?:[?#]|$)/i);
+  if (!fileMatch) return null;
+  const tokenMatch = fileMatch[1].match(WEAPON_ICON_TOKEN_RE);
+  return tokenMatch ? (WEAPON_ICON_TOKEN_LABELS[tokenMatch[1]] ?? null) : null;
 }
 
 /**

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -150,6 +150,14 @@ export function applyWeaponTypeToName(
  * track an async-resolved icon URL (e.g. BuildViewPage's `iconUrl` state
  * from `fetchItemIconUrl`) should pass it via `iconUrlOverride` so the
  * label follows whatever icon they're rendering.
+ *
+ * SAFETY GUARD: only derives a specific weapon type when the STORED itemId
+ * uniquely identifies one (itemInfo.slot is 'weapon' or 'offhand'). For
+ * generic set IDs with no slot field, the caller's icon is commonly a
+ * `getSetItemsBySlot(...)[0]` fallback — an arbitrary variant of the set.
+ * Asserting a weapon type from that would silently lie about the user's
+ * actual chosen weapon in shared/read-only views. Generic items keep their
+ * generic label regardless of what icon is rendered.
  */
 export function deriveItemNameForSlot(
   itemId: number | null | undefined,
@@ -159,6 +167,8 @@ export function deriveItemNameForSlot(
   const id = itemId ?? 0;
   const info = id > 0 ? getItemInfo(id) : undefined;
   const rawName = info?.name ?? `Item #${id || '?'}`;
+  const itemIsSlotSpecificWeapon = info?.slot === 'weapon' || info?.slot === 'offhand';
+  if (!itemIsSlotSpecificWeapon) return rawName;
   const url = iconUrlOverride !== undefined ? iconUrlOverride : getItemIconUrl(id);
   return applyWeaponTypeToName(rawName, url, slotType);
 }

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -47,12 +47,59 @@ function iconNameToUrl(iconName: string): string {
  * Returns a CDN URL, or null if the item isn't in the local data.
  */
 function lookupLocal(itemId: number): string | null {
+  const iconName = lookupIconName(itemId);
+  return iconName ? iconNameToUrl(iconName) : null;
+}
+
+/** Look up the raw icon filename (without CDN prefix or extension) from local data. */
+function lookupIconName(itemId: number): string | null {
   const typedData = iconData as { icons: string[]; items: Record<string, number> };
   const index = typedData.items[String(itemId)];
   if (index === undefined) return null;
-  const iconName = typedData.icons[index];
+  return typedData.icons[index] ?? null;
+}
+
+/**
+ * UESP gear-icon tokens → ESO weapon type labels.
+ * Derived from icon filenames like `gear_argonian_1hsword_d`. The icon is the
+ * only per-item weapon-type signal available — itemIdMap only tags the slot
+ * (`weapon` / `offhand`), not the specific weapon. Staff icons don't
+ * distinguish fire/frost/lightning/resto, so they map to a generic "Staff".
+ */
+const WEAPON_ICON_TOKEN_LABELS: Record<string, string> = {
+  '1haxe': 'Axe',
+  '1hsword': 'Sword',
+  '1hhammer': 'Mace',
+  '1hmace': 'Mace',
+  '1hammer': 'Mace',
+  '1hhamer': 'Mace',
+  '1hdagger': 'Dagger',
+  '2haxe': 'Battle Axe',
+  '2hsword': 'Greatsword',
+  '2hhammer': 'Maul',
+  '2hmace': 'Maul',
+  dagger: 'Dagger',
+  bow: 'Bow',
+  staff: 'Staff',
+  shield: 'Shield',
+};
+
+const WEAPON_ICON_TOKEN_RE = new RegExp(
+  `_(${Object.keys(WEAPON_ICON_TOKEN_LABELS).join('|')})(?:_|$)`,
+);
+
+/**
+ * Derive the specific weapon-type label (e.g. "Sword", "Dagger", "Bow") from
+ * an item ID by parsing the token embedded in its UESP icon filename.
+ * Returns null when the item isn't in the local icon data or its icon
+ * doesn't match a known weapon token.
+ */
+export function getWeaponTypeLabel(itemId: number | null | undefined): string | null {
+  if (!itemId || itemId <= 0) return null;
+  const iconName = lookupIconName(itemId);
   if (!iconName) return null;
-  return iconNameToUrl(iconName);
+  const match = iconName.match(WEAPON_ICON_TOKEN_RE);
+  return match ? (WEAPON_ICON_TOKEN_LABELS[match[1]] ?? null) : null;
 }
 
 /**

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -53,7 +53,7 @@ import type { SlotType } from '../features/loadout-manager/data/slotTypes';
 import {
   getItemIconUrl,
   fetchItemIconUrl,
-  parseWeaponTypeFromIconUrl,
+  applyWeaponTypeToName,
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
@@ -451,8 +451,18 @@ const GearSlotDisplay: React.FC<{
   const expectedSlot = SLOT_INDEX_TO_TYPE[slotIndex];
   const resolvedIconId = (() => {
     if (!itemInfo) return itemId; // not in itemIdMap → treat as real UESP ID
-    if (itemInfo.slot && itemInfo.slot === (expectedSlot ?? itemInfo.slot)) return itemId;
-    // Generic set ID or slot mismatch: find the slot-specific item for this set + slot
+    if (itemInfo.slot) {
+      // Dual-wield: a weapon-slot item legitimately belongs in an off-hand
+      // slot (slot 5 / 21). ESO allows Sword/Dagger/Axe/Mace off-hands but
+      // not shields in the main hand, so the asymmetry is intentional.
+      const slotMatch =
+        itemInfo.slot === expectedSlot ||
+        !expectedSlot ||
+        (itemInfo.slot === 'weapon' && expectedSlot === 'offhand');
+      if (slotMatch) return itemId;
+    }
+    // Generic set ID or unsupported slot mismatch: find the slot-specific
+    // item for this set + slot so we render the right icon.
     if (!expectedSlot) return null;
     const slotItems = getSetItemsBySlot(itemInfo.setName, expectedSlot);
     return slotItems[0] ?? null; // use first match (all CP160 variants share the same icon)
@@ -469,25 +479,13 @@ const GearSlotDisplay: React.FC<{
     });
   }, [resolvedIconId, iconUrl]);
 
-  // itemIdMap stores generic names (" Weapon", " Off-Hand", " Gear") for
-  // weapon items because the specific type (Sword, Dagger, Bow, Staff, …)
-  // isn't in the data. Parse it out of the UESP icon filename instead.
-  //
-  // Key the trigger on `expectedSlot` (the position on the character), not
-  // `itemInfo.slot` — generic set IDs like 2558 have no slot field at all,
-  // and we still want a specific label for those once `resolvedIconId` has
-  // corrected to a concrete weapon. Read from `iconUrl` so the label stays
-  // in lockstep with the resolved icon (including the async UESP fallback,
-  // whose URL lands in `iconUrl` state after the fetch completes).
+  // Swap the generic " Weapon"/" Off-Hand"/" Gear" suffix for a specific
+  // type (Sword, Dagger, Bow, …) parsed from the resolved icon URL. Uses
+  // `iconUrl` state so the label stays in lockstep with whatever icon is
+  // actually rendered — including the async UESP fallback, which updates
+  // `iconUrl` after the fetch completes.
   const rawName = itemInfo?.name ?? `Item #${itemId}`;
-  const isWeaponSlot = expectedSlot === 'weapon' || expectedSlot === 'offhand';
-  const weaponTypeLabel = isWeaponSlot ? parseWeaponTypeFromIconUrl(iconUrl) : null;
-  const genericWeaponSuffix = weaponTypeLabel
-    ? [' Weapon', ' Off-Hand', ' Offhand', ' Gear'].find((s) => rawName.endsWith(s))
-    : undefined;
-  const displayName = genericWeaponSuffix
-    ? rawName.slice(0, -genericWeaponSuffix.length) + ' ' + weaponTypeLabel
-    : rawName;
+  const displayName = applyWeaponTypeToName(rawName, iconUrl, expectedSlot);
   const setName = itemInfo?.setName;
   const traitLabel = trait ? getTraitName(trait) : null;
   const enchantLabel = enchant ? getEnchantName(enchant) : null;
@@ -560,6 +558,7 @@ const GearSlotDisplay: React.FC<{
       {/* Item name + set name + trait/enchant */}
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Typography
+          title={displayName}
           sx={{
             fontSize: '0.72rem',
             fontWeight: 600,

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -53,6 +53,7 @@ import type { SlotType } from '../features/loadout-manager/data/slotTypes';
 import {
   getItemIconUrl,
   fetchItemIconUrl,
+  getWeaponTypeLabel,
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
@@ -468,7 +469,18 @@ const GearSlotDisplay: React.FC<{
     });
   }, [resolvedIconId, iconUrl]);
 
-  const displayName = itemInfo?.name ?? `Item #${itemId}`;
+  // itemIdMap only tags items with slot='weapon'/'offhand' — not the specific
+  // type. Derive Sword/Dagger/Bow/Staff/Shield/… from the UESP icon filename
+  // and swap the generic suffix (" Weapon", " Off-Hand", " Offhand") for it.
+  const rawName = itemInfo?.name ?? `Item #${itemId}`;
+  const weaponTypeLabel =
+    itemInfo?.slot === 'weapon' || itemInfo?.slot === 'offhand' ? getWeaponTypeLabel(itemId) : null;
+  const genericWeaponSuffix = weaponTypeLabel
+    ? [' Weapon', ' Off-Hand', ' Offhand'].find((s) => rawName.endsWith(s))
+    : undefined;
+  const displayName = genericWeaponSuffix
+    ? rawName.slice(0, -genericWeaponSuffix.length) + ' ' + weaponTypeLabel
+    : rawName;
   const setName = itemInfo?.setName;
   const traitLabel = trait ? getTraitName(trait) : null;
   const enchantLabel = enchant ? getEnchantName(enchant) : null;

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -53,7 +53,7 @@ import type { SlotType } from '../features/loadout-manager/data/slotTypes';
 import {
   getItemIconUrl,
   fetchItemIconUrl,
-  applyWeaponTypeToName,
+  deriveItemNameForSlot,
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
@@ -484,8 +484,12 @@ const GearSlotDisplay: React.FC<{
   // `iconUrl` state so the label stays in lockstep with whatever icon is
   // actually rendered — including the async UESP fallback, which updates
   // `iconUrl` after the fetch completes.
-  const rawName = itemInfo?.name ?? `Item #${itemId}`;
-  const displayName = applyWeaponTypeToName(rawName, iconUrl, expectedSlot);
+  //
+  // `deriveItemNameForSlot` guards on the STORED itemId's slot metadata,
+  // so generic set IDs (no slot field → arbitrary fallback icon from
+  // `getSetItemsBySlot(...)[0]`) keep their generic label rather than
+  // falsely asserting a weapon type the user may not have chosen.
+  const displayName = deriveItemNameForSlot(itemId, expectedSlot, iconUrl);
   const setName = itemInfo?.setName;
   const traitLabel = trait ? getTraitName(trait) : null;
   const enchantLabel = enchant ? getEnchantName(enchant) : null;

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -53,7 +53,7 @@ import type { SlotType } from '../features/loadout-manager/data/slotTypes';
 import {
   getItemIconUrl,
   fetchItemIconUrl,
-  getWeaponTypeLabel,
+  parseWeaponTypeFromIconUrl,
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
@@ -448,9 +448,9 @@ const GearSlotDisplay: React.FC<{
   //      whose numeric values collide with unrelated items in UESP's icon database.
   //
   // For type 2, resolve the correct slot-specific ID via getSetItemsBySlot so we get the right icon.
+  const expectedSlot = SLOT_INDEX_TO_TYPE[slotIndex];
   const resolvedIconId = (() => {
     if (!itemInfo) return itemId; // not in itemIdMap → treat as real UESP ID
-    const expectedSlot = SLOT_INDEX_TO_TYPE[slotIndex];
     if (itemInfo.slot && itemInfo.slot === (expectedSlot ?? itemInfo.slot)) return itemId;
     // Generic set ID or slot mismatch: find the slot-specific item for this set + slot
     if (!expectedSlot) return null;
@@ -469,14 +469,21 @@ const GearSlotDisplay: React.FC<{
     });
   }, [resolvedIconId, iconUrl]);
 
-  // itemIdMap only tags items with slot='weapon'/'offhand' — not the specific
-  // type. Derive Sword/Dagger/Bow/Staff/Shield/… from the UESP icon filename
-  // and swap the generic suffix (" Weapon", " Off-Hand", " Offhand") for it.
+  // itemIdMap stores generic names (" Weapon", " Off-Hand", " Gear") for
+  // weapon items because the specific type (Sword, Dagger, Bow, Staff, …)
+  // isn't in the data. Parse it out of the UESP icon filename instead.
+  //
+  // Key the trigger on `expectedSlot` (the position on the character), not
+  // `itemInfo.slot` — generic set IDs like 2558 have no slot field at all,
+  // and we still want a specific label for those once `resolvedIconId` has
+  // corrected to a concrete weapon. Read from `iconUrl` so the label stays
+  // in lockstep with the resolved icon (including the async UESP fallback,
+  // whose URL lands in `iconUrl` state after the fetch completes).
   const rawName = itemInfo?.name ?? `Item #${itemId}`;
-  const weaponTypeLabel =
-    itemInfo?.slot === 'weapon' || itemInfo?.slot === 'offhand' ? getWeaponTypeLabel(itemId) : null;
+  const isWeaponSlot = expectedSlot === 'weapon' || expectedSlot === 'offhand';
+  const weaponTypeLabel = isWeaponSlot ? parseWeaponTypeFromIconUrl(iconUrl) : null;
   const genericWeaponSuffix = weaponTypeLabel
-    ? [' Weapon', ' Off-Hand', ' Offhand'].find((s) => rawName.endsWith(s))
+    ? [' Weapon', ' Off-Hand', ' Offhand', ' Gear'].find((s) => rawName.endsWith(s))
     : undefined;
   const displayName = genericWeaponSuffix
     ? rawName.slice(0, -genericWeaponSuffix.length) + ' ' + weaponTypeLabel


### PR DESCRIPTION
## Summary

On `/bv` (Build View) every weapon slot rendered a generic label like "Mother's Sorrow Weapon" — and on the roster view, build editor, and loadout manager the same generic labels showed everywhere item names appear. ESO builds are very sensitive to weapon type (a staff build plays nothing like a dagger build), so "Weapon" effectively hid a load-bearing piece of the build.

This PR derives the specific weapon type from the UESP icon filename (`gear_argonian_1hsword_d` → Sword), centralizes the logic behind one helper, and applies it everywhere item names render. A correctness guard prevents false assertions for generic set IDs whose real weapon type isn't knowable from the stored data.

## Problem

- `itemIdMap` only tags items with `slot: 'weapon' | 'offhand'` — never the specific type (Sword, Dagger, Axe, Mace, Greatsword, Battle Axe, Maul, Bow, Staff, Shield). Names stored are always `"<Set> Weapon"` / `"<Set> Off-Hand"` / `"<Set> Gear"`.
- `GearPiece` in the build/loadout data model has no `weaponType` field — the user's choice is encoded only in the item ID, and the map doesn't decode it.
- The same bug manifested in 5+ separate render sites that all read `info.name` directly.
- `/bv`'s icon resolver had a dual-wield bug that force-redirected weapon-slot items in off-hand positions to `getSetItemsBySlot(setName, 'offhand')[0]` — which for Mother's Sorrow and most sets is a shield, overwriting legitimate dual-wield daggers / swords.

## Approach

The UESP icon filenames embed the weapon type (e.g. `gear_argonian_bow_d`, `gear_ancient_elf_staff_a`). Parse it out at render time and swap the generic suffix:

1. **`parseWeaponTypeFromIconUrl(url)`** — pure URL → type parser. Regex matches `_<token>_` against the known weapon tokens (`1hsword`, `dagger`, `bow`, `staff`, …). Anchored on `_` boundaries so `crafting_enchantment_baxe_…` doesn't false-match as Axe.
2. **`applyWeaponTypeToName(rawName, iconUrl, slotType)`** — swaps the generic `" Weapon"` / `" Off-Hand"` / `" Offhand"` / `" Gear"` suffix for the parsed type. No-ops when the slot isn't a weapon slot, the URL has no weapon token, or the name has no generic suffix.
3. **`deriveItemNameForSlot(itemId, slotType, iconUrlOverride?)`** — single convenience callable for the UI. Synchronous; accepts an optional override URL so callers that already resolve an async icon (BuildViewPage, GearSelector) can keep the label in lockstep with the rendered icon.

### Correctness guard (Codex adversarial-review feedback)

Generic LibSets IDs like `2558` = "Mother's Sorrow Gear" have no `slot` field. `BuildViewPage`'s `resolvedIconId` falls back to `getSetItemsBySlot(setName, slot)[0]` for these — an **arbitrary** pick among Mother's Sorrow's 12 weapon variants (axe, sword, dagger, bow, staff, …). Reading the weapon type off that fallback and asserting it as definitive would silently misrepresent shared read-only builds.

`deriveItemNameForSlot` therefore only rewrites the label when `itemInfo.slot === 'weapon' | 'offhand'` — i.e. when the **stored** itemId uniquely identifies a weapon type. Generic set IDs keep their generic "<Set> Gear" label regardless of what icon the caller happens to render.

`GearSelector.tsx` is called out specially: it guards on the **original** `gearPiece.id`'s slot, not `resolvedItemId`'s. Collection lookup (`findCollectionItemBySetAndSlotType`) can remap generic pieces to canonical slot-specific items whose icon is an arbitrary choice; using the resolved ID's slot would reintroduce the false-assertion bug.

### Dual-wield fix

`BuildViewPage.tsx`'s `resolvedIconId` block previously treated any `itemInfo.slot !== expectedSlot` as a mismatch and redirected to the canonical off-hand shield. Weapon items in off-hand positions are a legitimate dual-wield configuration in ESO. Accept `itemInfo.slot === 'weapon'` in off-hand slots (keep the asymmetry — shields still can't go in main-hand).

## Changes

### Core helpers — `src/features/loadout-manager/utils/itemIconResolver.ts`

- `parseWeaponTypeFromIconUrl`, `applyWeaponTypeToName`, `deriveItemNameForSlot`, `GENERIC_WEAPON_SUFFIXES` — new exports.
- Staff icons don't distinguish Inferno / Frost / Lightning / Restoration, so staves collapse to "Staff" — still far better than "Weapon". Documented limitation; disambiguation would need a data-layer enrichment.

### `/bv` — `src/pages/BuildViewPage.tsx`

- Uses `deriveItemNameForSlot(itemId, expectedSlot, iconUrl)` so the label follows whatever icon is rendered (local lookup + async UESP fallback).
- Dual-wield redirect fix in the `resolvedIconId` block.
- `title` attribute added so truncated names are recoverable on hover.

### Roster view — `src/components/roster/build-detail-panel.tsx`

- Added `SLOT_INDEX_TO_TYPE` map alongside `GEAR_SLOT_NAMES`; calls `deriveItemNameForSlot(itemId, slotType)`.

### Build editor — `src/features/build-editor/components/pickers/`

- `EquipmentPicker.tsx` — slot-row cards pass a derived `itemName` prop into `GearSlotCard` (used when the card falls back to item name instead of set name).
- `GearPicker.tsx` — currently-equipped header, browse-mode set-group item list, and search-results list all show specific types. `targetSlot` threaded into `SetCategorySection` so nested items have access.

### Loadout manager — `src/features/loadout-manager/components/`

- `ItemPickerDialog.tsx` — autocomplete `getOptionLabel`, dropdown options, and currently-equipped panel.
- `GearSelector.tsx` — tile tooltip/caption uses `applyWeaponTypeToName` with the already-resolved async `iconUrl` state, matching BuildViewPage's pattern. Guards on original gearPiece.id's slot (not resolvedItemId's — that's the `findCollectionItemBySetAndSlotType` concern above).

### Tests — `src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts`

44 unit + integration tests covering:

- Every weapon-type token mapping.
- Multi-segment style names (e.g. `gear_ancient_elf_staff_a`).
- Armor and non-gear icons (negative).
- Null / empty / malformed URL inputs.
- Query-string / fragment tolerance.
- False-match guards (`crafting_enchantment_baxe_…` must not resolve as Axe).
- Suffix replacement (" Weapon", " Off-Hand", " Offhand", " Gear") and no-op cases.
- Integration: real item IDs → `getItemIconUrl` → `parseWeaponTypeFromIconUrl` → label.
- **Regression for the correctness guard** (the critical one Codex flagged):
  - `deriveItemNameForSlot(2558, 'weapon', bowIconUrl)` → `"Mother's Sorrow Gear"` (NOT "Mother's Sorrow Bow") — proves the override URL cannot override the slot-specificity guard.
  - `deriveItemNameForSlot(2558, 'weapon')` → `"Mother's Sorrow Gear"` (no override, same result).
  - `deriveItemNameForSlot(97221, 'weapon')` → `"Mother's Sorrow Sword"` (positive control).
  - `deriveItemNameForSlot(97232, 'chest', bowIconUrl)` → `"Mother's Sorrow Chest"` (non-weapon slot isn't vulnerable).

## Testing Done

- [x] `npx tsc --noEmit` clean.
- [x] `npx prettier --check` clean on all touched files.
- [x] `npx jest --testPathPatterns=itemIconResolver` — 44/44 pass.
- [x] `npx jest --testPathPatterns="loadout-manager|build-editor"` — 223/223 pass (1 skipped suite, 13 skipped tests — both pre-existing).
- [x] `/bv` with slot-specific item IDs (97221/97225/97226/97230) → shows Sword / Dagger / Bow / Staff.
- [x] `/bv` with generic set ID (2558 × 4 slots) → shows "Mother's Sorrow Gear" in all four slots (icon still renders an axe / shield fallback; label correctly stays generic).
- [x] `/bv` with dual-wield (weapon item in off-hand slot) → renders the weapon's icon and label, not the shield it previously force-redirected to.
- [x] Build editor GearPicker — expanded Mother's Sorrow set shows all 12 variants as Axe / Mace / Sword / Battle Axe / Maul / Dagger / Bow / Greatsword / Staff (×4), was all "Weapon".

## Out of scope

- Staff fire/frost/lightning/resto disambiguation — icons don't distinguish; needs data-layer work (e.g. enriching `itemIdMap` with `weaponType` via a data refresh script).
- `EquipmentPicker.isTwoHanded` keyword match on `info.name` (`info.name.toLowerCase().includes('greatsword')`) — pre-existing, broken by design because names say "Weapon" not "Greatsword". Flagged but not fixed here.

## Checklist

- [x] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`
