### PR TITLE
fix(ui): remove leaked currentColor border on primary glass panels

### DIFF
--- a/src/features/build-editor/components/primitives/GlassPanel.tsx
+++ b/src/features/build-editor/components/primitives/GlassPanel.tsx
@@ -3,8 +3,10 @@
  * Glassmorphism container with backdrop-filter, border, and shadow.
  * Adapts to dark/light mode automatically.
  *
- * variant='primary'  — Gradient border mask (CSS mask technique) + inner top glow slit.
+ * variant='primary'  — Solid translucent border + inner top glow slit.
  *                      Used for Identity, Equipment, Skills, Champion sections.
+ *                      (Previously used a gradient borderImage; removed because
+ *                      the accent color bleed read as a debug outline.)
  * variant='default'  — Standard glass panel with solid translucent border.
  * variant='subtle'   — Quieter border + minimal shadow (Settings, Screenshots).
  */
@@ -40,19 +42,19 @@ export const GlassPanel = React.memo<GlassPanelProps>(function GlassPanel({
   const isPrimary = variant === 'primary';
   const isSubtle = variant === 'subtle';
 
-  // Primary uses border:none + gradient border via ::before mask technique.
-  // Default/subtle use a solid translucent border.
-  const solidBorder = isPrimary
-    ? 'none'
-    : `1px solid ${
-        isSubtle
-          ? isDark
-            ? 'rgba(255, 255, 255, 0.05)'
-            : 'rgba(15, 23, 42, 0.06)'
-          : isDark
-            ? BE_TOKENS.glass.border
-            : BE_TOKENS.glass.borderLight
-      }`;
+  // All variants use a solid translucent border. Primary used to carry a
+  // gradient `borderImage`, but the shorthand left `border-color` falling
+  // back to `currentColor` in some composite paths, producing a visible
+  // "debug" outline around every primary panel.
+  const solidBorder = `1px solid ${
+    isSubtle
+      ? isDark
+        ? 'rgba(255, 255, 255, 0.05)'
+        : 'rgba(15, 23, 42, 0.06)'
+      : isDark
+        ? BE_TOKENS.glass.border
+        : BE_TOKENS.glass.borderLight
+  }`;
 
   const shadow = isPrimary
     ? isDark
@@ -87,12 +89,10 @@ export const GlassPanel = React.memo<GlassPanelProps>(function GlassPanel({
           boxShadow: shadow,
           transition: 'box-shadow 0.3s ease, border-color 0.25s ease',
 
-          // ── Primary tier: gradient border via border-image ─────────────
+          // ── Primary tier: inner top glow slit ──────────────────────────
+          // Subtle horizontal light streak at the top inside edge — the only
+          // remaining visual accent that distinguishes primary panels.
           ...(isPrimary && {
-            borderImage:
-              'linear-gradient(135deg, rgba(var(--be-accent-rgb, 56, 189, 248), 0.55) 0%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.10) 50%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.22) 100%) 1',
-            border: '1px solid',
-            // Inner glow slit — a horizontal light streak at the top inside edge
             '&::after': {
               content: '""',
               position: 'absolute',


### PR DESCRIPTION
## Summary

`GlassPanel` variant `'primary'` set `border: '1px solid'` with no color so a `borderImage` gradient could paint the edge. Some compositing paths leave `currentColor` painted underneath the image, leaving a visible ~1px off-white outline around every primary panel in the build editor and `/bv` (Identity, Equipment, Skills, Champion, Consumables, etc.). It read as a debug box rather than a design accent.

Collapse primary's border treatment to the same solid translucent token the default variant uses. Keep the `::after` glow slit so primary panels still have a subtle accent that distinguishes them from default panels.

## Root Cause

`src/features/build-editor/components/primitives/GlassPanel.tsx:91-108` (pre-fix) set:

```js
borderImage: 'linear-gradient(135deg, ...rgba(var(--be-accent-rgb, 56, 189, 248), 0.55)...)',
border: '1px solid',   // ← no color → currentColor
```

Reading the computed style in Chrome devtools confirmed:

```
border: 0.571429px solid rgb(229, 231, 235);   // currentColor leak
border-image: linear-gradient(...) 1 / 1 / 0 stretch;
```

The `border-image` paints correctly on top, but the `border-color` still renders at composite time in some browsers, producing the "debug" outline screenshots show.

## Change

- Removed the `borderImage` gradient and the colorless `border: '1px solid'` override on the primary variant.
- Primary now uses the same `solidBorder` as default — `1px solid rgba(255, 255, 255, 0.09)` (dark) / `rgba(15, 23, 42, 0.13)` (light).
- Kept the `&::after` top-edge glow slit, which was already the main visual distinguisher between primary and default.
- Updated the header comment to document the decision.

## Testing Done

- [x] Reloaded `/build-editor` and `/bv` against `http://localhost:3000`.
- [x] Verified computed style on `.MuiBox-root` glass panels: `border: 0.571429px solid rgba(255, 255, 255, 0.09)`, `border-image: none`.
- [x] Screenshots before/after show the bright orange outline is gone; panel hierarchy still readable via the top glow slit + shadow.
- [x] No other variants touched — default and subtle are unchanged.

## Checklist

- [x] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`
