### PR TITLE
fix(build-editor): gate off-hand when main-hand is a 2H weapon (Staff/Greatsword/Bow/...)

### DIFF
--- a/src/features/build-editor/components/pickers/EquipmentPicker.tsx
+++ b/src/features/build-editor/components/pickers/EquipmentPicker.tsx
@@ -21,27 +21,27 @@ import type {
   GearConfig,
   GearPiece,
 } from '../../../loadout-manager/types/loadout.types';
-import { deriveItemNameForSlot } from '../../../loadout-manager/utils/itemIconResolver';
+import {
+  deriveItemNameForSlot,
+  isTwoHandedWeapon,
+} from '../../../loadout-manager/utils/itemIconResolver';
 import { EQUIP_SLOTS, type EquipSlotDef } from '../../data/esoStaticData';
 import { GearSlotCard } from '../primitives/GearSlotCard';
 
 import { GearPickerDialog } from './GearPicker';
 
 // ── 2H weapon logic ─────────────────────────────────────────────────────────
-
-const TWO_HANDED_KEYWORDS = ['greatsword', 'battle axe', 'battleaxe', 'maul', 'bow', 'staff'];
+//
+// Greatswords, Battle Axes, Mauls, Bows, and all Staves occupy BOTH bar
+// slots in ESO, so the off-hand is locked + auto-cleared when a 2H is in
+// the main-hand. Classification comes from the UESP icon token (via
+// `isTwoHandedWeapon`) — name-keyword matching doesn't work because
+// itemIdMap stores generic names like "<Set> Weapon".
 
 const FRONT_MAIN = 4;
 const FRONT_OFF = 5;
 const BACK_MAIN = 20;
 const BACK_OFF = 21;
-
-function isTwoHanded(itemId: number | null | undefined): boolean {
-  if (!itemId) return false;
-  const info = getItemInfo(itemId);
-  if (!info) return false;
-  return TWO_HANDED_KEYWORDS.some((kw) => info.name.toLowerCase().includes(kw));
-}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -165,8 +165,8 @@ export const EquipmentPicker: React.FC<EquipmentPickerProps> = ({
     const result: Partial<Record<number, string>> = {};
     const fId = gear[FRONT_MAIN]?.id != null ? Number(gear[FRONT_MAIN].id) : null;
     const bId = gear[BACK_MAIN]?.id != null ? Number(gear[BACK_MAIN].id) : null;
-    if (isTwoHanded(fId)) result[FRONT_OFF] = 'Front bar weapon uses both hands';
-    if (isTwoHanded(bId)) result[BACK_OFF] = 'Back bar weapon uses both hands';
+    if (isTwoHandedWeapon(fId)) result[FRONT_OFF] = 'Front bar weapon uses both hands';
+    if (isTwoHandedWeapon(bId)) result[BACK_OFF] = 'Back bar weapon uses both hands';
     return result;
   }, [gear]);
 
@@ -190,7 +190,7 @@ export const EquipmentPicker: React.FC<EquipmentPickerProps> = ({
       // Auto-clear off-hand when a 2H weapon is selected
       if (
         (pickerSlot.slot === FRONT_MAIN || pickerSlot.slot === BACK_MAIN) &&
-        isTwoHanded(itemId)
+        isTwoHandedWeapon(itemId)
       ) {
         const offSlot = pickerSlot.slot === FRONT_MAIN ? FRONT_OFF : BACK_OFF;
         next[offSlot] = { id: undefined };

--- a/src/features/build-editor/components/pickers/EquipmentPicker.tsx
+++ b/src/features/build-editor/components/pickers/EquipmentPicker.tsx
@@ -13,7 +13,7 @@
 
 import { Box, Stack, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { getItemInfo } from '../../../loadout-manager/data/itemIdMap';
 import type {
@@ -23,6 +23,7 @@ import type {
 } from '../../../loadout-manager/types/loadout.types';
 import {
   deriveItemNameForSlot,
+  fetchIsTwoHandedWeapon,
   isTwoHandedWeapon,
 } from '../../../loadout-manager/utils/itemIconResolver';
 import { EQUIP_SLOTS, type EquipSlotDef } from '../../data/esoStaticData';
@@ -161,20 +162,62 @@ export const EquipmentPicker: React.FC<EquipmentPickerProps> = ({
 }) => {
   const [pickerSlot, setPickerSlot] = useState<EquipSlotDef | null>(null);
 
-  const disabledSlots = useMemo<Partial<Record<number, string>>>(() => {
-    const result: Partial<Record<number, string>> = {};
-    const fId = gear[FRONT_MAIN]?.id != null ? Number(gear[FRONT_MAIN].id) : null;
-    const bId = gear[BACK_MAIN]?.id != null ? Number(gear[BACK_MAIN].id) : null;
-    if (isTwoHandedWeapon(fId)) result[FRONT_OFF] = 'Front bar weapon uses both hands';
-    if (isTwoHandedWeapon(bId)) result[BACK_OFF] = 'Back bar weapon uses both hands';
-    return result;
-  }, [gear]);
+  const frontMainId = gear[FRONT_MAIN]?.id != null ? Number(gear[FRONT_MAIN].id) : null;
+  const backMainId = gear[BACK_MAIN]?.id != null ? Number(gear[BACK_MAIN].id) : null;
+
+  // 2H status tracked in state so the async UESP fallback can update the
+  // gate after initial render — otherwise a build rehydrated from storage
+  // with an uncached 2H weapon would render an enabled off-hand until some
+  // unrelated re-render happened.
+  //
+  // Seed with the sync classifier so local-data hits (99%+ of items) are
+  // correct on first render and don't need to wait for a microtask.
+  const [twoHandedStatus, setTwoHandedStatus] = useState(() => ({
+    front: isTwoHandedWeapon(frontMainId),
+    back: isTwoHandedWeapon(backMainId),
+  }));
 
   // Refs so handleOpen/handleClear can have empty (or near-empty) dep arrays.
   // Stable handler refs are required for the memoized SlotRow — otherwise
   // every gear edit produces fresh closures and defeats React.memo.
   const gearRef = useRef(gear);
   gearRef.current = gear;
+
+  // Re-classify asynchronously whenever either main-hand changes, and
+  // auto-clear the off-hand retroactively if async classification reveals
+  // a 2H weapon the sync path missed (e.g. a newly-added weapon that
+  // required a UESP fetch). Single source of truth for both the lock
+  // state AND the auto-clear behavior.
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      fetchIsTwoHandedWeapon(frontMainId),
+      fetchIsTwoHandedWeapon(backMainId),
+    ]).then(([front, back]) => {
+      if (cancelled) return;
+      setTwoHandedStatus({ front, back });
+      const currentGear = gearRef.current;
+      const frontOffOccupied = currentGear[FRONT_OFF]?.id != null;
+      const backOffOccupied = currentGear[BACK_OFF]?.id != null;
+      if ((front && frontOffOccupied) || (back && backOffOccupied)) {
+        const next: GearConfig = { ...currentGear };
+        if (front && frontOffOccupied) next[FRONT_OFF] = { id: undefined };
+        if (back && backOffOccupied) next[BACK_OFF] = { id: undefined };
+        onChange(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [frontMainId, backMainId, onChange]);
+
+  const disabledSlots = useMemo<Partial<Record<number, string>>>(() => {
+    const result: Partial<Record<number, string>> = {};
+    if (twoHandedStatus.front) result[FRONT_OFF] = 'Front bar weapon uses both hands';
+    if (twoHandedStatus.back) result[BACK_OFF] = 'Back bar weapon uses both hands';
+    return result;
+  }, [twoHandedStatus]);
+
   const disabledSlotsRef = useRef(disabledSlots);
   disabledSlotsRef.current = disabledSlots;
 
@@ -186,13 +229,12 @@ export const EquipmentPicker: React.FC<EquipmentPickerProps> = ({
   const handleSelect = useCallback(
     (itemId: number): void => {
       if (!pickerSlot) return;
-      const next: GearConfig = { ...gearRef.current, [pickerSlot.slot]: { id: itemId } };
-      // Auto-clear off-hand when a 2H weapon is selected
-      if (
-        (pickerSlot.slot === FRONT_MAIN || pickerSlot.slot === BACK_MAIN) &&
-        isTwoHandedWeapon(itemId)
-      ) {
-        const offSlot = pickerSlot.slot === FRONT_MAIN ? FRONT_OFF : BACK_OFF;
+      const slot = pickerSlot.slot;
+      const next: GearConfig = { ...gearRef.current, [slot]: { id: itemId } };
+      // Sync fast-path auto-clear (local-data items). The useEffect above
+      // handles the uncached case retroactively once the UESP fetch lands.
+      if ((slot === FRONT_MAIN || slot === BACK_MAIN) && isTwoHandedWeapon(itemId)) {
+        const offSlot = slot === FRONT_MAIN ? FRONT_OFF : BACK_OFF;
         next[offSlot] = { id: undefined };
       }
       onChange(next);

--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -18,7 +18,9 @@ import { updateGear } from '../store/loadoutSlice';
 import { GearConfig, GearPiece } from '../types/loadout.types';
 import {
   applyWeaponTypeToName,
+  fetchIsTwoHandedWeapon,
   fetchItemIconUrl,
+  isTwoHandedFromName,
   isTwoHandedWeapon,
 } from '../utils/itemIconResolver';
 import { getItemData, getItemIdFromLink } from '../utils/itemLinkParser';
@@ -529,7 +531,7 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
     return states;
   }, [gear]);
 
-  const isTwoHandedByItemId = (itemId: number | null): boolean => {
+  const isTwoHandedByItemIdSync = (itemId: number | null): boolean => {
     if (!itemId) {
       return false;
     }
@@ -550,16 +552,60 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
     return false;
   };
 
-  const isTwoHandedGearPiece = (gearPiece?: GearPiece): boolean => {
+  const isTwoHandedGearPieceSync = (gearPiece?: GearPiece): boolean => {
     if (!gearPiece) {
       return false;
     }
     const itemId = resolveGearPieceItemId(gearPiece);
-    return isTwoHandedByItemId(itemId);
+    if (isTwoHandedByItemIdSync(itemId)) {
+      return true;
+    }
+    // Last-resort text fallback for degraded gear records (imports with only
+    // a stale name string, or gear referencing items that aren't in the
+    // current itemIdMap). Only consulted when item-ID classification fails,
+    // and only against the item's own name — not the set name, to avoid
+    // false-positives on sets like "Bow of the Wild Hunt".
+    if (itemId == null || !getItemInfo(itemId)) {
+      const extended = gearPiece as ExtendedGearPiece;
+      if (isTwoHandedFromName(extended?.name)) {
+        return true;
+      }
+    }
+    return false;
   };
 
-  const isFrontTwoHanded = isTwoHandedGearPiece(gear[FRONT_MAIN_SLOT]);
-  const isBackTwoHanded = isTwoHandedGearPiece(gear[BACK_MAIN_SLOT]);
+  // 2H status tracked in state so the async UESP fallback can update the
+  // gate after initial render — otherwise a loadout rehydrated from storage
+  // with an uncached 2H weapon would render an enabled off-hand until some
+  // unrelated re-render happened.
+  const frontMainPiece = gear[FRONT_MAIN_SLOT];
+  const backMainPiece = gear[BACK_MAIN_SLOT];
+  const frontMainId = frontMainPiece ? resolveGearPieceItemId(frontMainPiece) : null;
+  const backMainId = backMainPiece ? resolveGearPieceItemId(backMainPiece) : null;
+
+  const [asyncTwoHandedStatus, setAsyncTwoHandedStatus] = useState({
+    front: false,
+    back: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      fetchIsTwoHandedWeapon(frontMainId),
+      fetchIsTwoHandedWeapon(backMainId),
+    ]).then(([front, back]) => {
+      if (cancelled) return;
+      setAsyncTwoHandedStatus({ front, back });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [frontMainId, backMainId]);
+
+  // Compose: sync signals (icon-local, slot-mask, text fallback) + async
+  // icon-fetch signal. Either firing means "gate the off-hand".
+  const isFrontTwoHanded = asyncTwoHandedStatus.front || isTwoHandedGearPieceSync(frontMainPiece);
+  const isBackTwoHanded = asyncTwoHandedStatus.back || isTwoHandedGearPieceSync(backMainPiece);
 
   const slotDisableReasons = useMemo<Partial<Record<number, string>>>(() => {
     const reasons: Partial<Record<number, string>> = {};
@@ -676,7 +722,7 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
       [pickerSlot.index]: newGearPiece,
     };
 
-    if (isTwoHandedByItemId(resolvedItemId)) {
+    if (isTwoHandedByItemIdSync(resolvedItemId)) {
       const offhandSlot = getMatchingOffhandSlot(pickerSlot.index);
       if (offhandSlot !== null && updatedGear[offhandSlot]) {
         const adjustedGear = { ...updatedGear };
@@ -693,6 +739,28 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
         gear: updatedGear,
       }),
     );
+
+    // Async catch-up: if the sync path missed 2H classification (item not
+    // yet in local icon data), retroactively clear the off-hand once the
+    // UESP fetch resolves.
+    const offhandSlot = getMatchingOffhandSlot(pickerSlot.index);
+    if (offhandSlot !== null && !isTwoHandedByItemIdSync(resolvedItemId)) {
+      void fetchIsTwoHandedWeapon(resolvedItemId).then((is2H) => {
+        if (!is2H) return;
+        dispatch(
+          updateGear({
+            trialId,
+            pageIndex,
+            setupIndex,
+            gear: (() => {
+              const cleared = { ...updatedGear };
+              delete cleared[offhandSlot];
+              return cleared;
+            })(),
+          }),
+        );
+      });
+    }
   };
 
   const handleClosePicker = (): void => {

--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -16,7 +16,11 @@ import { validateItemForSlot, getItemInfo, type SlotType } from '../data/itemIdM
 import { getCollectionItem, findCollectionItemBySetAndSlotType } from '../data/itemSetCollections';
 import { updateGear } from '../store/loadoutSlice';
 import { GearConfig, GearPiece } from '../types/loadout.types';
-import { applyWeaponTypeToName, fetchItemIconUrl } from '../utils/itemIconResolver';
+import {
+  applyWeaponTypeToName,
+  fetchItemIconUrl,
+  isTwoHandedWeapon,
+} from '../utils/itemIconResolver';
 import { getItemData, getItemIdFromLink } from '../utils/itemLinkParser';
 import { registerManualSlot } from '../utils/wizardWardrobeSlotRegistry';
 
@@ -63,9 +67,10 @@ const FRONT_OFF_SLOT = 5;
 const BACK_MAIN_SLOT = 20;
 const BACK_OFF_SLOT = 21;
 
-const TWO_HANDED_KEYWORDS = ['greatsword', 'battle axe', 'battleaxe', 'maul', 'bow', 'staff'];
 // Slot mask values from LibSets/Wizard's Wardrobe exports that map to 2H weapons.
-// Staff labels verified against data/eso-globals-item-set-collections.json slotMasks table.
+// Kept as a secondary signal because WW exports expose the mask directly, so we
+// can classify even when the icon isn't available yet. The primary signal is
+// `isTwoHandedWeapon(itemId)` (icon-based) — see isTwoHandedGearPiece below.
 const TWO_HANDED_SLOT_MASKS = new Set<number>([
   134_217_728, // Two-handed sword
   268_435_456, // Maul
@@ -524,38 +529,31 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
     return states;
   }, [gear]);
 
-  const isTwoHandedFromText = (text?: string | null): boolean => {
-    if (!text) {
-      return false;
-    }
-    const normalized = text.toLowerCase();
-    return TWO_HANDED_KEYWORDS.some((keyword) => normalized.includes(keyword));
-  };
-
   const isTwoHandedByItemId = (itemId: number | null): boolean => {
     if (!itemId) {
       return false;
     }
 
+    // Primary signal: UESP icon token (Greatsword/Battle Axe/Maul/Bow/Staff).
+    // Works for any item with local icon data, regardless of the stored name.
+    if (isTwoHandedWeapon(itemId)) {
+      return true;
+    }
+
+    // Secondary: Wizard's Wardrobe slotMask carries the 2H flag even for
+    // items whose icons aren't in the pre-fetched JSON yet.
     const collectionItem = getCollectionItem(itemId);
     if (collectionItem?.slotMask && TWO_HANDED_SLOT_MASKS.has(collectionItem.slotMask)) {
       return true;
     }
 
-    const itemInfo = getItemInfo(itemId);
-    return itemInfo ? isTwoHandedFromText(itemInfo.name) : false;
+    return false;
   };
 
   const isTwoHandedGearPiece = (gearPiece?: GearPiece): boolean => {
     if (!gearPiece) {
       return false;
     }
-
-    const extendedPiece = gearPiece as ExtendedGearPiece;
-    if (isTwoHandedFromText(extendedPiece?.name) || isTwoHandedFromText(extendedPiece?.setName)) {
-      return true;
-    }
-
     const itemId = resolveGearPieceItemId(gearPiece);
     return isTwoHandedByItemId(itemId);
   };

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -317,6 +317,36 @@ describe('isTwoHandedWeapon', () => {
     // an arbitrary fallback pick.
     expect(isTwoHandedWeapon(2558)).toBe(false);
   });
+
+  describe('slot-specificity guard (regression: false-positive 2H lock on generic IDs)', () => {
+    // Generic LibSets set IDs have no `slot` field in itemIdMap, but they
+    // collide with unrelated items in UESP's icon database — so their
+    // icon can happen to match a 2H weapon token. Pre-guard, these falsely
+    // locked/cleared the off-hand for imported/legacy loadouts carrying
+    // generic IDs. Post-guard, the stored metadata's absence of a weapon
+    // slot is authoritative: don't classify.
+    it('ID 685 ("Bloodthorn\'s Touch Gear", no slot) has a staff icon but must NOT classify as 2H', () => {
+      // getItemIconUrl(685) returns gear_breton_staff_d — the "staff" token
+      // would false-positive if we didn't gate on itemInfo.slot first.
+      expect(getItemIconUrl(685)).toMatch(/_staff_/);
+      expect(isTwoHandedWeapon(685)).toBe(false);
+    });
+
+    it('ID 139 ("Dreugh King Slayer Gear", no slot, shield icon) stays false', () => {
+      expect(isTwoHandedWeapon(139)).toBe(false);
+    });
+
+    it('ID 1088 ("Hide of the Werewolf Gear", no slot, armor icon) stays false', () => {
+      expect(isTwoHandedWeapon(1088)).toBe(false);
+    });
+
+    it('slot-specific weapon items are unaffected by the guard (positive control)', () => {
+      // 97230 = "Mother's Sorrow Weapon" with slot='weapon' and staff icon.
+      // The stored slot field says weapon, so the guard lets icon-based
+      // classification proceed and correctly returns true.
+      expect(isTwoHandedWeapon(97230)).toBe(true);
+    });
+  });
 });
 
 describe('fetchIsTwoHandedWeapon (async classification path)', () => {
@@ -345,6 +375,14 @@ describe('fetchIsTwoHandedWeapon (async classification path)', () => {
     await expect(fetchIsTwoHandedWeapon(undefined)).resolves.toBe(false);
     await expect(fetchIsTwoHandedWeapon(0)).resolves.toBe(false);
     await expect(fetchIsTwoHandedWeapon(-1)).resolves.toBe(false);
+  });
+
+  it('applies the same slot-specificity guard as the sync variant (ID 685)', async () => {
+    // Symmetry check: the async path must reject generic IDs before
+    // classification too, otherwise the cold-cache useEffect in
+    // EquipmentPicker/GearSelector would re-introduce the false-positive
+    // lock on imported/legacy loadouts.
+    await expect(fetchIsTwoHandedWeapon(685)).resolves.toBe(false);
   });
 });
 

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -15,8 +15,10 @@
 import {
   applyWeaponTypeToName,
   deriveItemNameForSlot,
+  fetchIsTwoHandedWeapon,
   GENERIC_WEAPON_SUFFIXES,
   getItemIconUrl,
+  isTwoHandedFromName,
   isTwoHandedWeapon,
   parseWeaponTypeFromIconUrl,
 } from '../itemIconResolver';
@@ -314,5 +316,72 @@ describe('isTwoHandedWeapon', () => {
     // unreliable for classification. Must not gate the off-hand based on
     // an arbitrary fallback pick.
     expect(isTwoHandedWeapon(2558)).toBe(false);
+  });
+});
+
+describe('fetchIsTwoHandedWeapon (async classification path)', () => {
+  // These item IDs are in local icon data (itemIcons.json), so the async
+  // wrapper resolves synchronously from the same source the sync helper
+  // uses. We can't easily cover the UESP fallback branch without network
+  // mocking, but the code path is the same shape as the local hit — once
+  // fetchItemIconUrl resolves a URL, classification is identical.
+  it.each([
+    [97222, true, 'Battle Axe'],
+    [97223, true, 'Maul'],
+    [97224, true, 'Greatsword'],
+    [97226, true, 'Bow'],
+    [97230, true, 'Staff'],
+    [97219, false, 'Axe (1H)'],
+    [97221, false, 'Sword (1H)'],
+    [97225, false, 'Dagger (1H)'],
+    [97231, false, 'Shield'],
+    [97232, false, 'Chest armor'],
+  ])('classifies %i as %s (%s)', async (itemId, expected) => {
+    await expect(fetchIsTwoHandedWeapon(itemId)).resolves.toBe(expected);
+  });
+
+  it('returns false for null / undefined / 0 / negative', async () => {
+    await expect(fetchIsTwoHandedWeapon(null)).resolves.toBe(false);
+    await expect(fetchIsTwoHandedWeapon(undefined)).resolves.toBe(false);
+    await expect(fetchIsTwoHandedWeapon(0)).resolves.toBe(false);
+    await expect(fetchIsTwoHandedWeapon(-1)).resolves.toBe(false);
+  });
+});
+
+describe('isTwoHandedFromName (text fallback for stale/imported gear)', () => {
+  it.each([
+    "Mother's Sorrow Greatsword",
+    "Mother's Sorrow Battle Axe",
+    "Mother's Sorrow Battleaxe",
+    "Mother's Sorrow Maul",
+    "Mother's Sorrow Bow",
+    "Mother's Sorrow Staff",
+    "Mother's Sorrow Restoration Staff",
+    "Mother's Sorrow Inferno Staff",
+    'Greatsword of the Legion',
+  ])('returns true for "%s"', (name) => {
+    expect(isTwoHandedFromName(name)).toBe(true);
+  });
+
+  it.each([
+    "Mother's Sorrow Sword",
+    "Mother's Sorrow Dagger",
+    "Mother's Sorrow Mace",
+    "Mother's Sorrow Axe", // 1H axe — must not match "battle axe" token
+    "Mother's Sorrow Shield",
+    "Mother's Sorrow Weapon",
+    "Mother's Sorrow Gear",
+    "Mother's Sorrow Ring",
+    'Elbow Brace', // word-boundary guard: "bow" inside "elbow" must NOT match
+    'Staffa of the Magi', // fictional word containing "staff" prefix
+    'Swordbreaker Amulet', // fictional, no 2H token
+  ])('returns false for "%s"', (name) => {
+    expect(isTwoHandedFromName(name)).toBe(false);
+  });
+
+  it('returns false for null / undefined / empty', () => {
+    expect(isTwoHandedFromName(null)).toBe(false);
+    expect(isTwoHandedFromName(undefined)).toBe(false);
+    expect(isTwoHandedFromName('')).toBe(false);
   });
 });

--- a/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts
@@ -17,6 +17,7 @@ import {
   deriveItemNameForSlot,
   GENERIC_WEAPON_SUFFIXES,
   getItemIconUrl,
+  isTwoHandedWeapon,
   parseWeaponTypeFromIconUrl,
 } from '../itemIconResolver';
 
@@ -257,5 +258,61 @@ describe('deriveItemNameForSlot (slot-specificity guard — regression for /bv f
     // caller passing a bow URL must not produce "Mother's Sorrow Bow".
     const bowIconOverride = `${CDN}/gear_argonian_bow_d.png`;
     expect(deriveItemNameForSlot(97232, 'chest', bowIconOverride)).toBe("Mother's Sorrow Chest");
+  });
+});
+
+describe('isTwoHandedWeapon', () => {
+  // Real Mother's Sorrow item IDs with their UESP icon classifications:
+  //   97219 1haxe,  97220 1hhammer,  97221 1hsword,
+  //   97222 2haxe,  97223 2hhammer,  97224 2hsword,
+  //   97225 dagger, 97226 bow,       97227-30 staff, 97231 shield.
+  describe('two-handed weapons (main + off occupied)', () => {
+    it.each([
+      [97222, 'Battle Axe'],
+      [97223, 'Maul'],
+      [97224, 'Greatsword'],
+      [97226, 'Bow'],
+      [97230, 'Staff'],
+    ])('returns true for %i (%s)', (itemId) => {
+      expect(isTwoHandedWeapon(itemId)).toBe(true);
+    });
+  });
+
+  describe('one-handed weapons (dual-wield / one-hand+shield eligible)', () => {
+    it.each([
+      [97219, 'Axe'],
+      [97220, 'Mace'],
+      [97221, 'Sword'],
+      [97225, 'Dagger'],
+    ])('returns false for %i (%s)', (itemId) => {
+      expect(isTwoHandedWeapon(itemId)).toBe(false);
+    });
+  });
+
+  it('returns false for shield (off-hand only, not 2H)', () => {
+    expect(isTwoHandedWeapon(97231)).toBe(false);
+  });
+
+  it('returns false for armor items', () => {
+    expect(isTwoHandedWeapon(97232)).toBe(false); // chest
+    expect(isTwoHandedWeapon(97235)).toBe(false); // head
+  });
+
+  it('returns false for null / undefined / 0 / negative', () => {
+    expect(isTwoHandedWeapon(null)).toBe(false);
+    expect(isTwoHandedWeapon(undefined)).toBe(false);
+    expect(isTwoHandedWeapon(0)).toBe(false);
+    expect(isTwoHandedWeapon(-1)).toBe(false);
+  });
+
+  it('returns false for unknown itemIds (no local icon data)', () => {
+    expect(isTwoHandedWeapon(99999999)).toBe(false);
+  });
+
+  it('returns false for generic set IDs (no definitive weapon type)', () => {
+    // Item 2558 = "Mother's Sorrow Gear" — no slot field, icon lookup is
+    // unreliable for classification. Must not gate the off-hand based on
+    // an arbitrary fallback pick.
+    expect(isTwoHandedWeapon(2558)).toBe(false);
   });
 });

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -171,9 +171,12 @@ const TWO_HANDED_WEAPON_LABELS = new Set<string>([
 
 /**
  * True when `itemId` resolves (via its UESP icon) to a weapon that occupies
- * both bar slots. Returns false when the item isn't a known weapon, when the
- * icon isn't in local data, or when classification is ambiguous — callers
- * should treat a `false` return as "don't gate" rather than "definitely 1H".
+ * both bar slots. Synchronous — reads only the pre-fetched local data + the
+ * already-warmed fallback cache. Returns `false` when the icon isn't
+ * resolvable yet; callers relying on this for equip-rule enforcement must
+ * pair it with an async recompute (see `fetchIsTwoHandedWeapon`) so
+ * newly-added items and rehydrated gear configs don't silently skip the
+ * gate on first render.
  *
  * Preferred over name-keyword checks (`name.includes('greatsword')`), which
  * never match because itemIdMap stores generic names like "<Set> Weapon".
@@ -183,6 +186,38 @@ export function isTwoHandedWeapon(itemId: number | null | undefined): boolean {
   const url = getItemIconUrl(itemId);
   const label = parseWeaponTypeFromIconUrl(url);
   return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);
+}
+
+/**
+ * Async counterpart to `isTwoHandedWeapon` — triggers the UESP fallback
+ * fetch for items that aren't in local data yet, so equip-rule enforcement
+ * doesn't silently fail on newly-added weapons. Use this when gating the
+ * off-hand slot; sync `isTwoHandedWeapon` is fine for cosmetic indicators
+ * that can afford to re-render once the icon lands.
+ */
+export async function fetchIsTwoHandedWeapon(itemId: number | null | undefined): Promise<boolean> {
+  if (!itemId || itemId <= 0) return false;
+  const url = await fetchItemIconUrl(itemId);
+  const label = parseWeaponTypeFromIconUrl(url);
+  return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);
+}
+
+/**
+ * Text-based 2H fallback for degraded gear records (imports with only a
+ * stale `name` string, rehydrated state where the itemId no longer maps
+ * to any known item). Uses whole-word regex so substrings like "elbow"
+ * don't false-match the `bow` token.
+ *
+ * Intentionally LAST-RESORT — callers should always prefer
+ * `isTwoHandedWeapon`/`fetchIsTwoHandedWeapon` on the canonical item ID
+ * first. Scope checks to the item's own display name, not the set name,
+ * because set names like "Bow of the Wild Hunt" would false-positive.
+ */
+const TWO_HANDED_NAME_RE = /\b(greatsword|battle\s?axe|maul|bow|staff)\b/i;
+
+export function isTwoHandedFromName(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return TWO_HANDED_NAME_RE.test(text);
 }
 
 /**

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -170,19 +170,31 @@ const TWO_HANDED_WEAPON_LABELS = new Set<string>([
 ]);
 
 /**
- * True when `itemId` resolves (via its UESP icon) to a weapon that occupies
- * both bar slots. Synchronous — reads only the pre-fetched local data + the
- * already-warmed fallback cache. Returns `false` when the icon isn't
- * resolvable yet; callers relying on this for equip-rule enforcement must
- * pair it with an async recompute (see `fetchIsTwoHandedWeapon`) so
- * newly-added items and rehydrated gear configs don't silently skip the
- * gate on first render.
+ * True when the itemId is a slot-specific weapon whose icon classifies as
+ * a two-handed type (Greatsword / Battle Axe / Maul / Bow / Staff).
  *
- * Preferred over name-keyword checks (`name.includes('greatsword')`), which
- * never match because itemIdMap stores generic names like "<Set> Weapon".
+ * IMPORTANT slot-specificity guard: generic LibSets IDs (e.g. 685 =
+ * "Bloodthorn's Touch Gear", no `slot` field) collide with unrelated
+ * entries in UESP's icon database — `getItemIconUrl(685)` returns
+ * `gear_breton_staff_d`. Treating that as a 2H match would false-positive
+ * lock and auto-clear the off-hand for imported/legacy loadouts that
+ * carry generic IDs. Only classify when the stored itemId's own metadata
+ * says it's a weapon/offhand slot item.
+ *
+ * Synchronous — reads only the pre-fetched local data + the already-warmed
+ * fallback cache. Returns `false` when the icon isn't resolvable yet;
+ * callers relying on this for equip-rule enforcement must pair it with an
+ * async recompute (see `fetchIsTwoHandedWeapon`) so newly-added items and
+ * rehydrated gear configs don't silently skip the gate on first render.
+ *
+ * Preferred over name-keyword checks (`name.includes('greatsword')`),
+ * which never match because itemIdMap stores generic names like
+ * "<Set> Weapon".
  */
 export function isTwoHandedWeapon(itemId: number | null | undefined): boolean {
   if (!itemId || itemId <= 0) return false;
+  const info = getItemInfo(itemId);
+  if (info?.slot !== 'weapon' && info?.slot !== 'offhand') return false;
   const url = getItemIconUrl(itemId);
   const label = parseWeaponTypeFromIconUrl(url);
   return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);
@@ -194,9 +206,15 @@ export function isTwoHandedWeapon(itemId: number | null | undefined): boolean {
  * doesn't silently fail on newly-added weapons. Use this when gating the
  * off-hand slot; sync `isTwoHandedWeapon` is fine for cosmetic indicators
  * that can afford to re-render once the icon lands.
+ *
+ * Applies the same slot-specificity guard as the sync variant — see
+ * `isTwoHandedWeapon` for why generic set IDs must be rejected before
+ * icon classification.
  */
 export async function fetchIsTwoHandedWeapon(itemId: number | null | undefined): Promise<boolean> {
   if (!itemId || itemId <= 0) return false;
+  const info = getItemInfo(itemId);
+  if (info?.slot !== 'weapon' && info?.slot !== 'offhand') return false;
   const url = await fetchItemIconUrl(itemId);
   const label = parseWeaponTypeFromIconUrl(url);
   return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -152,6 +152,40 @@ export function parseWeaponTypeFromIconUrl(url: string | null | undefined): stri
 }
 
 /**
+ * Two-handed weapon labels per ESO equip rules: these occupy BOTH main-hand
+ * AND off-hand slots, so a second weapon (or shield) can't coexist with them
+ * on the same bar. Staves collapse to "Staff" here because icons don't
+ * distinguish Inferno/Frost/Lightning/Restoration — all four are 2H anyway,
+ * so the distinction doesn't matter for slot gating.
+ *
+ * Source: UESP Online:Weapons — Two-handed weapons include Greatswords,
+ * Battle Axes, Mauls; Bows; all Staves.
+ */
+const TWO_HANDED_WEAPON_LABELS = new Set<string>([
+  'Battle Axe',
+  'Greatsword',
+  'Maul',
+  'Bow',
+  'Staff',
+]);
+
+/**
+ * True when `itemId` resolves (via its UESP icon) to a weapon that occupies
+ * both bar slots. Returns false when the item isn't a known weapon, when the
+ * icon isn't in local data, or when classification is ambiguous — callers
+ * should treat a `false` return as "don't gate" rather than "definitely 1H".
+ *
+ * Preferred over name-keyword checks (`name.includes('greatsword')`), which
+ * never match because itemIdMap stores generic names like "<Set> Weapon".
+ */
+export function isTwoHandedWeapon(itemId: number | null | undefined): boolean {
+  if (!itemId || itemId <= 0) return false;
+  const url = getItemIconUrl(itemId);
+  const label = parseWeaponTypeFromIconUrl(url);
+  return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);
+}
+
+/**
  * Generic slot-name suffixes that itemIdMap uses when a specific weapon-type
  * name isn't available. Callers strip the trailing match and splice in a
  * specific type (Sword/Dagger/Bow/…) once the icon is resolved.


### PR DESCRIPTION
## Summary

The build editor (and loadout manager) let users equip two two-handed weapons at once — Staff + Staff, Greatsword + Greatsword, Bow + Bow, etc. In ESO, two-handed weapons occupy **both** main-hand and off-hand slots on a bar, so any of those combinations is invalid.

The off-hand gating and auto-clear logic exists in the code, but the 2H-detection predicate has always been broken: it matched keywords against `info.name`, and `info.name` is stored as generic `"<Set> Weapon"` (e.g. `"Mother's Sorrow Weapon"`) — never containing `"staff"`, `"greatsword"`, etc. Result: `isTwoHanded` always returned `false`, so the off-hand was never locked and never auto-cleared.

This PR swaps the keyword match for icon-based classification. UESP icon filenames (`gear_argonian_2hsword_d`, `gear_argonian_staff_d`, etc.) already encode the weapon type — that's the same signal used for the weapon-type display labels shipped in #1014.

## Root Cause

`src/features/build-editor/components/pickers/EquipmentPicker.tsx:39-44` (pre-fix):

```ts
const TWO_HANDED_KEYWORDS = ['greatsword', 'battle axe', 'battleaxe', 'maul', 'bow', 'staff'];
function isTwoHanded(itemId: number | null | undefined): boolean {
  if (!itemId) return false;
  const info = getItemInfo(itemId);
  if (!info) return false;
  return TWO_HANDED_KEYWORDS.some((kw) => info.name.toLowerCase().includes(kw));
}
```

For itemId `97230` (Mother's Sorrow Staff):

- `info.name` = `"Mother's Sorrow Weapon"` (generic suffix from itemIdMap).
- `.includes('staff')` → `false`.
- Off-hand stays open.

`GearSelector.tsx` had the same keyword path plus a secondary `TWO_HANDED_SLOT_MASKS` check — the slot mask works for Wizard's Wardrobe imports but not for items picked fresh in the UI.

## Change

### New helper — `src/features/loadout-manager/utils/itemIconResolver.ts`

```ts
const TWO_HANDED_WEAPON_LABELS = new Set(['Battle Axe', 'Greatsword', 'Maul', 'Bow', 'Staff']);

export function isTwoHandedWeapon(itemId: number | null | undefined): boolean {
  if (!itemId || itemId <= 0) return false;
  const url = getItemIconUrl(itemId);
  const label = parseWeaponTypeFromIconUrl(url);
  return label !== null && TWO_HANDED_WEAPON_LABELS.has(label);
}
```

Classification via the icon token — the same infrastructure introduced in #1014 for the specific weapon-type display labels. Returns `false` for unknown items (safe default: don't gate).

### `src/features/build-editor/components/pickers/EquipmentPicker.tsx`

- Dropped the `TWO_HANDED_KEYWORDS` constant and the local `isTwoHanded`.
- Imported `isTwoHandedWeapon` and used it at both call sites: `disabledSlots` computation (off-hand gating) and `handleSelect` (auto-clear when a 2H lands in main).

### `src/features/loadout-manager/components/GearSelector.tsx`

- `isTwoHandedByItemId` now calls `isTwoHandedWeapon(itemId)` as the primary signal.
- Kept `TWO_HANDED_SLOT_MASKS` as a secondary signal for WW imports where the mask is available before the icon resolves.
- Removed `isTwoHandedFromText` and the now-dead `TWO_HANDED_KEYWORDS` constant.
- `isTwoHandedGearPiece` no longer inspects `extendedPiece.name` / `setName` — went straight through `resolveGearPieceItemId` + `isTwoHandedByItemId`.

### Tests — `src/features/loadout-manager/utils/__tests__/itemIconResolver.test.ts`

14 new cases for `isTwoHandedWeapon` drive real item IDs through the full `getItemIconUrl` → `parseWeaponTypeFromIconUrl` → classification chain:

- **2H returns `true`**: 97222 (Battle Axe), 97223 (Maul), 97224 (Greatsword), 97226 (Bow), 97230 (Staff).
- **1H returns `false`**: 97219 (Axe), 97220 (Mace), 97221 (Sword), 97225 (Dagger).
- **Shield returns `false`** (97231) — shields are off-hand-only, not 2H.
- **Armor returns `false`** (97232 chest, 97235 head).
- **Edge cases return `false`**: null / undefined / 0 / negative / unknown itemIds.
- **Generic set IDs return `false`** (2558 = "Mother's Sorrow Gear", no slot metadata) — matches the correctness guard from #1014; we can't definitively classify, so don't gate.

## Testing Done

- [x] `npx tsc --noEmit` clean.
- [x] `npx prettier --check` clean on all touched files.
- [x] `npx jest --testPathPatterns=itemIconResolver` — 58/58 pass (up from 44).
- [x] `npx jest --testPathPatterns="loadout-manager|build-editor"` — 241/241 pass (1 skipped suite, 13 skipped tests — both pre-existing).
- [x] **In browser**: equipped Staff (97230) in `slot 4` — Off-Hand card now renders with `aria-disabled="true"`, opacity `0.3`, empty content. Previously both slots accepted independent weapons.

## Related

- #1014 (merged) — weapon-label display fix that introduced the `parseWeaponTypeFromIconUrl` helper this PR reuses for classification.

## Out of scope

- Trait/enchant clearing when a 2H weapon auto-clears the off-hand (current behavior leaves them on the empty slot; fine since the UI doesn't show them until a new item is picked).
- The dual-wield UI hint (showing which off-hand items are valid paired with a given 1H in main). Off-hand picker currently accepts any off-hand-eligible item.

## Checklist

- [x] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`
