### PR TITLE
Decode HTML entities in pack hub API responses

### DIFF
--- a/src/features/pack-hub/api/pack-hub-api.ts
+++ b/src/features/pack-hub/api/pack-hub-api.ts
@@ -6,6 +6,7 @@
  * serve different data stores. This one is used by roster-hub and pack-hub features.
  */
 
+import { decodeHtmlEntities } from '../../../utils/decodeHtmlEntities';
 import type {
   HubPack,
   ListPacksResponse,
@@ -87,9 +88,18 @@ function hydrateAddons(raw: string | PackAddonEntry[]): PackAddonEntry[] {
 }
 
 function hydratePack(pack: HubPack): HubPack {
+  const addons = hydrateAddons(pack.addons as unknown as string | PackAddonEntry[]);
   return {
     ...pack,
-    addons: hydrateAddons(pack.addons as unknown as string | PackAddonEntry[]),
+    author_name: decodeHtmlEntities(pack.author_name),
+    title: decodeHtmlEntities(pack.title),
+    description: decodeHtmlEntities(pack.description),
+    tags: pack.tags.map(decodeHtmlEntities),
+    addons: addons.map((a) => ({
+      ...a,
+      name: decodeHtmlEntities(a.name),
+      note: a.note ? decodeHtmlEntities(a.note) : a.note,
+    })),
   };
 }
 

--- a/src/utils/decodeHtmlEntities.test.ts
+++ b/src/utils/decodeHtmlEntities.test.ts
@@ -2,9 +2,7 @@ import { decodeHtmlEntities } from './decodeHtmlEntities';
 
 describe('decodeHtmlEntities', () => {
   it("decodes &#x27; to an apostrophe (Spike's Trial Necessities case)", () => {
-    expect(decodeHtmlEntities('Spike&#x27;s Trial Necessities')).toBe(
-      "Spike's Trial Necessities",
-    );
+    expect(decodeHtmlEntities('Spike&#x27;s Trial Necessities')).toBe("Spike's Trial Necessities");
   });
 
   it('decodes all entities produced by the server escapeHtml', () => {

--- a/src/utils/decodeHtmlEntities.test.ts
+++ b/src/utils/decodeHtmlEntities.test.ts
@@ -1,0 +1,32 @@
+import { decodeHtmlEntities } from './decodeHtmlEntities';
+
+describe('decodeHtmlEntities', () => {
+  it("decodes &#x27; to an apostrophe (Spike's Trial Necessities case)", () => {
+    expect(decodeHtmlEntities('Spike&#x27;s Trial Necessities')).toBe(
+      "Spike's Trial Necessities",
+    );
+  });
+
+  it('decodes all entities produced by the server escapeHtml', () => {
+    expect(decodeHtmlEntities('&amp; &lt; &gt; &quot; &#x27;')).toBe(`& < > " '`);
+  });
+
+  it('decodes &amp; last so escaped entities survive a round-trip', () => {
+    // `&amp;#x27;` is the result of double-escaping `&#x27;` — decoding once
+    // should yield `&#x27;` (not `'`), because only a single layer of
+    // escaping was applied.
+    expect(decodeHtmlEntities('&amp;#x27;')).toBe('&#x27;');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(decodeHtmlEntities('Hello world')).toBe('Hello world');
+    expect(decodeHtmlEntities('')).toBe('');
+  });
+
+  it('does not decode entities outside the server allow-list', () => {
+    // The server never produces &nbsp; or &#39; — we should not decode them
+    // either, to keep behavior aligned with the server's escape set.
+    expect(decodeHtmlEntities('a&nbsp;b')).toBe('a&nbsp;b');
+    expect(decodeHtmlEntities('a&#39;b')).toBe('a&#39;b');
+  });
+});

--- a/src/utils/decodeHtmlEntities.ts
+++ b/src/utils/decodeHtmlEntities.ts
@@ -1,0 +1,21 @@
+/**
+ * decodeHtmlEntities — reverse of the server-side `escapeHtml` used by
+ * roster-hub-api when sanitizing user-provided text (titles, descriptions,
+ * display names, tags). The server stores text with HTML entities encoded
+ * (e.g. `Spike&#x27;s Trial` ) as defense-in-depth against stored XSS, but
+ * React already escapes text nodes on render — so entity-encoded text would
+ * otherwise display literally to users (e.g. `Spike&#x27;s` instead of
+ * `Spike's`).
+ *
+ * Only the five entities produced by the server `escapeHtml` are decoded,
+ * matching the server's allow-list exactly so no additional entities leak
+ * through.
+ */
+export function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&');
+}


### PR DESCRIPTION
## Summary

Add HTML entity decoding to pack hub API responses to properly display user-provided text (titles, descriptions, author names, tags, and addon names/notes). The server stores text with HTML entities encoded as a defense-in-depth measure against stored XSS, but since React already escapes text nodes on render, the encoded entities were displaying literally to users (e.g., `Spike&#x27;s` instead of `Spike's`).

This change introduces a `decodeHtmlEntities` utility function that reverses the server's `escapeHtml` encoding by decoding only the five entities the server produces (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#x27;`), matching the server's allow-list exactly. The function is then applied to all user-provided text fields in the pack hydration pipeline.

The decoding order (ampersand last) ensures that double-escaped entities survive a round-trip correctly, maintaining alignment with the server's escaping behavior.

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`

https://claude.ai/code/session_01XpDu9jdkborGQbxTMT5xQt