### PR TITLE
fix(loadout-manager): preserve weapon element when picking from set

### DIFF
--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -636,7 +636,14 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
     let resolvedItemId = itemId;
     let collectionItem = getCollectionItem(itemId);
 
-    if (collectionItem?.setId) {
+    // Collapse armor/jewelry picks to the set's canonical collection item so
+    // every variant of a given slot shares an icon/name. Weapon slots are
+    // intentionally excluded: the canonical item is whichever weapon has the
+    // lowest itemId for the set (typically a 1H Axe/Mace), so replacing a
+    // user-picked Restoration Staff with the canonical id silently loses the
+    // element / weapon-type choice.
+    const isWeaponSlot = pickerSlot.type === 'weapon' || pickerSlot.type === 'offhand';
+    if (collectionItem?.setId && !isWeaponSlot) {
       const canonicalCollectionItem = findCollectionItemBySetAndSlotType(
         collectionItem.setId,
         pickerSlot.type,


### PR DESCRIPTION
## Problem

The item picker in the loadout editor silently replaces the user's weapon choice with the set's "canonical" collection item — which is whichever weapon in the set has the lowest itemId. For every weapon-bearing set, that lowest id belongs to a 1H Axe or Mace, so picking a Restoration Staff (or any staff / 2H / bow) stored the wrong item.

### How I found this

Debugging this shared build:
https://esotk.com/bv?b=bZPPjuIwDMZfBfkcpPxvwnGk1d72BUYcMpBCRWhRWwYhxLuvbQpDV3ugfHacL7_W8Q2-YaUEDLD6vEEa8c9bIYVcCzhiEvpmPKcCAnawuoHE4mCq6AQol…

The build's skills are all Restoration Staff / Destruction Staff abilities, but the decoded gear slots show a Spell Power Cure Lightning Staff (front) and a Perfected Pillager's Ice Staff (back). Those ids aren't the canonical ones for either set, so something *had* passed specific weapon ids through. Tracing the picker flow surfaced this replacement.

## Root cause

`GearSelector.tsx:handleSelectItem` (formerly lines 636–652):

```ts
let resolvedItemId = itemId;
let collectionItem = getCollectionItem(itemId);

if (collectionItem?.setId) {
  const canonicalCollectionItem = findCollectionItemBySetAndSlotType(
    collectionItem.setId,
    pickerSlot.type,
  );
  if (canonicalCollectionItem) {
    resolvedItemId = canonicalCollectionItem.itemId;  // overwrites user pick
    ...
  }
}
```

`findCollectionItemBySetAndSlotType` (`itemSetCollections.ts:173,181`) keeps the item with the **lowest** itemId per `(setId, slotType)` key. For weapon slotType that's always a 1H Axe/Mace — verified against real data:

| Set | User picks | Gets stored |
|-----|------------|-------------|
| Spell Power Cure Restoration Staff (111883) | → | **Axe** (111872) |
| Spell Power Cure Lightning Staff (111882)   | → | **Axe** (111872) |
| Perfected Pillager's Restoration Staff (187641) | → | **Mace** (186944) |
| Perfected Pillager's Ice Staff (187021) | → | **Mace** (186944) |

For armor and jewelry slots the collection indexes a single canonical item per slot, so the collapse is a correct no-op. Weapons are the only slot type where the collapse destroys information.

## Fix

Skip the canonical replacement when the picker slot is `weapon` or `offhand`. Jewelry/armor behavior is unchanged.

```ts
const isWeaponSlot = pickerSlot.type === 'weapon' || pickerSlot.type === 'offhand';
if (collectionItem?.setId && !isWeaponSlot) {
  // canonical replacement for armor/jewelry only
  ...
}
```

The picker's option labels already call `applyWeaponTypeToName` (landed in #1028), so users see each staff element / weapon type distinctly; this just makes sure the id they click is the id that gets saved.

## Test plan

- [ ] Open a build, pick a weapon in Main Hand from a set with multiple weapon variants (e.g., Spell Power Cure Restoration Staff from the typeahead) → the slot shows a Restoration Staff icon + label, not an Axe
- [ ] Repeat for Back Main Hand → correct weapon type persists
- [ ] Pick a ring, neck, shoulders → armor/jewelry canonical collapse still happens (unchanged behavior)
- [ ] Encode the build and decode it: weapon itemIds round-trip unchanged
- [ ] `npm run typecheck` passes