### PR TITLE
fix(build-view): show skill tooltips immediately on mobile touch

### DIFF
--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -453,6 +453,8 @@ const SkillSlot: React.FC<{
         }
         arrow
         placement="top"
+        enterTouchDelay={0}
+        leaveTouchDelay={3000}
       >
         {esoHubUrl ? (
           <Box


### PR DESCRIPTION
## Summary

Fix mobile tooltip regression on the `/bv` (Build View) page where skill tooltips required a 700ms long-press to appear instead of responding immediately to touch.

## Problem

On mobile, the skill slot tooltip in `BuildViewPage.tsx` uses MUI's default `enterTouchDelay` of **700ms**. Users must long-press a skill tile to see its name — which feels broken.

This was latent before the mobile UX overhaul (#1037, `d5be6ae`), which intentionally hid skill names on mobile (`{skill && !isMobile && <Typography>...`). Once skill names were hidden, the tooltip became the **only** way to see skill info on mobile, making the 700ms delay a UX regression.

## Root Cause

The `SkillSlot` `<Tooltip>` in `BuildViewPage.tsx` had no mobile touch event configuration:

```tsx
// Before — 700ms long-press required on mobile
<Tooltip title={...} arrow placement="top">
```

## Changes Made

- Add `enterTouchDelay={0}` and `leaveTouchDelay={3000}` to the `SkillSlot` tooltip in `BuildViewPage.tsx`, matching the pattern already used in `GearIcon.tsx`

```tsx
// After — responds immediately to tap, stays visible 3s
<Tooltip
  title={...}
  arrow
  placement="top"
  enterTouchDelay={0}
  leaveTouchDelay={3000}
>
```

## Testing Done

- [ ] TypeScript compiles (`npm run typecheck`) — pre-existing errors in `DatePicker.tsx` / `detectPerfTier.ts` are unrelated
- [ ] ESLint passes (`npm run lint`)
- [ ] Formatting passes (`npm run format:check`)
- [ ] Manually verify on mobile viewport: tapping a skill tile shows tooltip immediately
