### PR TITLE
refactor(ui): modernize synergies tab with glassmorphism and card layout

### DIFF
--- a/src/components/SynergyPanelSkeleton.tsx
+++ b/src/components/SynergyPanelSkeleton.tsx
@@ -1,178 +1,194 @@
-import { Box, Skeleton } from '@mui/material';
+import { Box, Skeleton, useTheme } from '@mui/material';
 import React from 'react';
 
 /**
  * Skeleton for the Synergies tab.
- * Mirrors: summary chips → "Who is taking synergies?" header → player cards grid →
- *          "Synergy Abilities" header → ability table → "Activation Timeline" header → timeline table.
+ * Mirrors: header → stats row → player cards grid → ability cards grid → timeline list.
  */
-export const SynergyPanelSkeleton: React.FC = () => (
-  <Box sx={{ mt: 1 }}>
-    {/* Summary header row: title + toggle + chips */}
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3, flexWrap: 'wrap' }}>
-      <Skeleton variant="text" width={180} height={32} />
-      {/* Alkosh-only toggle */}
-      <Skeleton variant="rounded" width={130} height={24} sx={{ borderRadius: 1 }} />
-      {/* activations chip */}
-      <Skeleton variant="rounded" width={100} height={24} sx={{ borderRadius: 12 }} />
-      {/* synergies chip */}
-      <Skeleton variant="rounded" width={88} height={24} sx={{ borderRadius: 12 }} />
-      {/* players chip */}
-      <Skeleton variant="rounded" width={76} height={24} sx={{ borderRadius: 12 }} />
-      {/* View on ESO Logs chip */}
-      <Skeleton variant="rounded" width={130} height={24} sx={{ borderRadius: 12 }} />
-    </Box>
+export const SynergyPanelSkeleton: React.FC = () => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
 
-    {/* "Who is taking synergies?" section header */}
-    <Skeleton variant="text" width={220} height={24} sx={{ mb: 1.5 }} />
+  const glass = {
+    borderRadius: '16px',
+    background: isDark
+      ? 'linear-gradient(135deg, rgb(110 170 240 / 20%) 0%, rgb(152 131 227 / 12%) 50%, rgb(173 192 255 / 6%) 100%)'
+      : 'linear-gradient(135deg, rgba(255,255,255,0.92) 0%, rgba(241,245,249,0.78) 100%)',
+    border: isDark ? '1px solid rgba(255,255,255,0.12)' : '1px solid rgba(59,130,246,0.22)',
+    backdropFilter: 'blur(10px)',
+    WebkitBackdropFilter: 'blur(10px)',
+  } as const;
 
-    {/* Player cards grid */}
-    <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: {
-          xs: '1fr',
-          sm: 'repeat(2, 1fr)',
-          md: 'repeat(3, 1fr)',
-          lg: 'repeat(4, 1fr)',
-        },
-        gap: 2,
-        mb: 4,
-      }}
-    >
-      {Array.from({ length: 4 }).map((_, i) => (
-        <Skeleton key={i} variant="rounded" height={110} sx={{ borderRadius: 3 }} />
-      ))}
-    </Box>
-
-    {/* "Synergy Abilities" section header */}
-    <Skeleton variant="text" width={170} height={24} sx={{ mb: 1.5 }} />
-
-    {/* Synergy abilities table */}
-    <Box
-      sx={{
-        borderRadius: 2,
-        border: '1px solid',
-        borderColor: 'divider',
-        overflow: 'hidden',
-        mb: 4,
-      }}
-    >
-      {/* Table header */}
+  return (
+    <Box sx={{ mt: 2 }}>
+      {/* Header row */}
       <Box
         sx={{
           display: 'flex',
-          px: 2,
-          py: 1,
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          backgroundColor: 'action.hover',
+          alignItems: 'center',
+          gap: 1.5,
+          mb: 2.5,
+          flexWrap: 'wrap',
         }}
       >
-        <Box sx={{ flex: 2 }}>
-          <Skeleton variant="text" width="50%" height={16} />
-        </Box>
-        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
-          <Skeleton variant="text" width="70%" height={16} />
-        </Box>
-        <Box sx={{ flex: 2, pl: 2 }}>
-          <Skeleton variant="text" width="40%" height={16} />
-        </Box>
+        <Skeleton variant="text" width={120} height={32} />
+        <Skeleton variant="rounded" width={32} height={24} sx={{ borderRadius: 1 }} />
+        <Skeleton variant="text" width={220} height={20} />
+        <Box sx={{ flex: 1, minWidth: 8 }} />
+        <Skeleton variant="rounded" width={130} height={26} sx={{ borderRadius: 1 }} />
+        <Skeleton variant="rounded" width={100} height={26} sx={{ borderRadius: 13 }} />
       </Box>
 
-      {/* Ability rows */}
-      {Array.from({ length: 6 }).map((_, i) => (
-        <Box
-          key={i}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            px: 2,
-            py: 1,
-            minHeight: 44,
-            borderBottom: i < 5 ? '1px solid' : 'none',
-            borderColor: 'divider',
-          }}
-        >
-          {/* Ability icon + name */}
-          <Box sx={{ flex: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Skeleton variant="circular" width={24} height={24} sx={{ flexShrink: 0 }} />
-            <Skeleton variant="text" width={`${50 + (i % 3) * 12}%`} height={16} />
-          </Box>
-          {/* Total activations */}
-          <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
-            <Skeleton variant="text" width={32} height={16} />
-          </Box>
-          {/* Player chips */}
-          <Box sx={{ flex: 2, pl: 2, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-            <Skeleton variant="rounded" width={80} height={20} sx={{ borderRadius: 10 }} />
-            {i % 2 === 0 && (
-              <Skeleton variant="rounded" width={68} height={20} sx={{ borderRadius: 10 }} />
-            )}
-          </Box>
-        </Box>
-      ))}
-    </Box>
-
-    {/* "Activation Timeline" section header */}
-    <Skeleton variant="text" width={190} height={24} sx={{ mb: 1.5 }} />
-
-    {/* Timeline table */}
-    <Box
-      sx={{
-        borderRadius: 2,
-        border: '1px solid',
-        borderColor: 'divider',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Table header */}
+      {/* Stats row */}
       <Box
         sx={{
-          display: 'flex',
-          px: 2,
-          py: 1,
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          backgroundColor: 'action.hover',
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: 'repeat(2, 1fr)',
+            sm: 'repeat(3, 1fr)',
+            md: 'repeat(5, 1fr)',
+          },
+          gap: 1.25,
+          mb: 3,
         }}
       >
-        {['Time', 'Player', 'Synergy'].map((_, idx) => (
-          <Box key={idx} sx={{ flex: idx === 2 ? 2 : 1 }}>
-            <Skeleton variant="text" width="40%" height={16} />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} variant="rounded" height={56} sx={{ borderRadius: 1 }} />
+        ))}
+      </Box>
+
+      {/* Player section header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Skeleton variant="rounded" width={28} height={28} sx={{ borderRadius: '8px' }} />
+        <Skeleton variant="text" width={220} height={22} />
+      </Box>
+
+      {/* Player cards grid */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: 'repeat(3, 1fr)',
+            xl: 'repeat(4, 1fr)',
+          },
+          gap: 2,
+          mb: 3.5,
+        }}
+      >
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Box key={i} sx={{ ...glass, p: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.5 }}>
+              <Skeleton variant="circular" width={36} height={36} />
+              <Box sx={{ flex: 1 }}>
+                <Skeleton variant="text" width="70%" height={18} />
+                <Skeleton variant="text" width="55%" height={14} />
+              </Box>
+              <Skeleton variant="text" width={40} height={28} />
+            </Box>
+            <Skeleton variant="rounded" height={4} sx={{ borderRadius: 2, mb: 1.25 }} />
+            {Array.from({ length: 3 }).map((__, j) => (
+              <Box key={j} sx={{ display: 'flex', alignItems: 'center', gap: 0.75, py: 0.5 }}>
+                <Skeleton variant="rounded" width={20} height={20} sx={{ borderRadius: 1 }} />
+                <Skeleton variant="text" sx={{ flex: 1 }} height={14} />
+                <Skeleton variant="text" width={18} height={14} />
+              </Box>
+            ))}
           </Box>
         ))}
       </Box>
 
-      {/* Timeline rows */}
-      {Array.from({ length: 8 }).map((_, i) => (
+      {/* Ability section header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Skeleton variant="rounded" width={28} height={28} sx={{ borderRadius: '8px' }} />
+        <Skeleton variant="text" width={170} height={22} />
+      </Box>
+
+      {/* Ability cards grid */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            md: 'repeat(2, 1fr)',
+            xl: 'repeat(3, 1fr)',
+          },
+          gap: 2,
+          mb: 3.5,
+        }}
+      >
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Box key={i} sx={{ ...glass, p: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25 }}>
+              <Skeleton variant="rounded" width={44} height={44} sx={{ borderRadius: '10px' }} />
+              <Box sx={{ flex: 1 }}>
+                <Skeleton variant="text" width="75%" height={18} />
+                <Skeleton variant="text" width="50%" height={14} />
+              </Box>
+              <Skeleton variant="text" width={44} height={28} />
+            </Box>
+            <Skeleton variant="rounded" height={4} sx={{ borderRadius: 2, mb: 1.25 }} />
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+              <Skeleton variant="rounded" width={80} height={24} sx={{ borderRadius: 12 }} />
+              <Skeleton variant="rounded" width={96} height={24} sx={{ borderRadius: 12 }} />
+              <Skeleton variant="rounded" width={72} height={24} sx={{ borderRadius: 12 }} />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      {/* Timeline section header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <Skeleton variant="rounded" width={28} height={28} sx={{ borderRadius: '8px' }} />
+        <Skeleton variant="text" width={200} height={22} />
+      </Box>
+
+      {/* Timeline list */}
+      <Box sx={{ ...glass, overflow: 'hidden' }}>
         <Box
-          key={i}
           sx={{
-            display: 'flex',
-            alignItems: 'center',
+            display: 'grid',
+            gridTemplateColumns: '72px 1fr 1.4fr',
+            gap: 1.5,
             px: 2,
-            py: 0.75,
-            minHeight: 40,
-            borderBottom: i < 7 ? '1px solid' : 'none',
-            borderColor: 'divider',
+            py: 1.25,
+            borderBottom: isDark
+              ? '1px solid rgba(148,163,184,0.12)'
+              : '1px solid rgba(148,163,184,0.18)',
           }}
         >
-          {/* Time */}
-          <Box sx={{ flex: 1 }}>
-            <Skeleton variant="text" width={40} height={16} />
-          </Box>
-          {/* Player */}
-          <Box sx={{ flex: 1 }}>
-            <Skeleton variant="text" width={`${45 + (i % 4) * 10}%`} height={16} />
-          </Box>
-          {/* Synergy icon + name */}
-          <Box sx={{ flex: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Skeleton variant="circular" width={20} height={20} sx={{ flexShrink: 0 }} />
-            <Skeleton variant="text" width={`${40 + (i % 3) * 12}%`} height={16} />
-          </Box>
+          <Skeleton variant="text" width={36} height={14} />
+          <Skeleton variant="text" width={50} height={14} />
+          <Skeleton variant="text" width={60} height={14} />
         </Box>
-      ))}
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '72px 1fr 1.4fr',
+              gap: 1.5,
+              alignItems: 'center',
+              px: 2,
+              py: 1,
+              borderBottom:
+                i < 7
+                  ? isDark
+                    ? '1px solid rgba(148,163,184,0.06)'
+                    : '1px solid rgba(148,163,184,0.1)'
+                  : 'none',
+            }}
+          >
+            <Skeleton variant="text" width={40} height={14} />
+            <Skeleton variant="text" width={`${50 + (i % 4) * 10}%`} height={14} />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <Skeleton variant="rounded" width={22} height={22} sx={{ borderRadius: '5px' }} />
+              <Skeleton variant="text" width={`${45 + (i % 3) * 12}%`} height={14} />
+            </Box>
+          </Box>
+        ))}
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};

--- a/src/features/report_details/synergy/SynergyPanelView.tsx
+++ b/src/features/report_details/synergy/SynergyPanelView.tsx
@@ -1,25 +1,23 @@
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import GroupsIcon from '@mui/icons-material/Groups';
+import HandshakeIcon from '@mui/icons-material/Handshake';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import TimelineIcon from '@mui/icons-material/Timeline';
 import {
   Avatar,
   Box,
-  Card,
-  CardContent,
   Chip,
   FormControlLabel,
   Link as MuiLink,
-  Skeleton,
   Switch,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
+  Tooltip,
   Typography,
   useTheme,
 } from '@mui/material';
 import React, { useMemo, useState } from 'react';
+
+import { MetricPill } from '@/components/MetricPill';
+import { SynergyPanelSkeleton } from '@/components/SynergyPanelSkeleton';
 
 import type { FightFragment, ReportActorFragment } from '../../../graphql/gql/graphql';
 
@@ -33,6 +31,50 @@ function formatFightTime(ms: number): string {
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
+
+const MONO_FONT = '"JetBrains Mono", "Fira Code", "SF Mono", monospace';
+
+const glassSurface = (mode: 'light' | 'dark') =>
+  ({
+    borderRadius: '16px',
+    background:
+      mode === 'dark'
+        ? 'linear-gradient(135deg, rgb(110 170 240 / 20%) 0%, rgb(152 131 227 / 12%) 50%, rgb(173 192 255 / 6%) 100%)'
+        : 'linear-gradient(135deg, rgba(255,255,255,0.92) 0%, rgba(241,245,249,0.78) 100%)',
+    border:
+      mode === 'dark' ? '1px solid rgba(255,255,255,0.12)' : '1px solid rgba(59,130,246,0.22)',
+    backdropFilter: 'blur(10px)',
+    WebkitBackdropFilter: 'blur(10px)',
+    boxShadow:
+      mode === 'dark'
+        ? '0 8px 32px 0 rgba(0,0,0,0.37), inset 0 1px 0 rgba(255,255,255,0.16)'
+        : '0 4px 16px 0 rgba(15,23,42,0.06), inset 0 1px 0 rgba(255,255,255,0.8)',
+  }) as const;
+
+/** Rank badge colors for top contributors. */
+const rankPalette: Record<number, { bg: string; border: string; text: string }> = {
+  1: {
+    bg: 'linear-gradient(145deg, #fbbf24 0%, #f59e0b 50%, #d97706 100%)',
+    border: 'rgba(251,191,36,0.6)',
+    text: '#fff',
+  },
+  2: {
+    bg: 'linear-gradient(145deg, #e5e7eb 0%, #9ca3af 50%, #6b7280 100%)',
+    border: 'rgba(209,213,219,0.55)',
+    text: '#fff',
+  },
+  3: {
+    bg: 'linear-gradient(145deg, #fbbf24 0%, #b45309 50%, #78350f 100%)',
+    border: 'rgba(180,83,9,0.5)',
+    text: '#fff',
+  },
+};
+
+const defaultRank = {
+  bg: 'linear-gradient(145deg, #38bdf8 0%, #0284c7 50%, #075985 100%)',
+  border: 'rgba(56,189,248,0.5)',
+  text: '#fff',
+};
 
 interface SynergyPanelViewProps {
   data: SynergyPanelData;
@@ -52,7 +94,8 @@ export const SynergyPanelView: React.FC<SynergyPanelViewProps> = ({
   fightId,
 }) => {
   const theme = useTheme();
-  const isDarkMode = theme.palette.mode === 'dark';
+  const mode = theme.palette.mode;
+  const isDark = mode === 'dark';
   const [alkoshOnly, setAlkoshOnly] = useState(false);
 
   const filteredData = useMemo(
@@ -60,31 +103,114 @@ export const SynergyPanelView: React.FC<SynergyPanelViewProps> = ({
     [data, alkoshOnly],
   );
 
+  const topSynergy = filteredData.byAbility[0];
+  const topPlayer = filteredData.byPlayer[0];
+  const maxAbilityCount = topSynergy?.totalCount ?? 1;
+  const maxPlayerCount = topPlayer?.totalCount ?? 1;
+
   if (isLoading) {
     return <SynergyPanelSkeleton />;
   }
 
   if (data.totalCount === 0) {
     return (
-      <Box sx={{ textAlign: 'center', py: 6 }}>
-        <GroupsIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 1 }} />
-        <Typography variant="h6" color="text.secondary">
-          No synergies activated
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="h6" sx={{ mb: 2, fontWeight: 800, letterSpacing: '-0.02em' }}>
+          Synergies
         </Typography>
-        <Typography variant="body2" color="text.disabled">
-          No players activated any synergy abilities during this fight.
-        </Typography>
+        <Box
+          sx={{
+            p: 4,
+            textAlign: 'center',
+            ...glassSurface(mode),
+          }}
+        >
+          <HandshakeIcon
+            sx={{
+              fontSize: 44,
+              color: isDark ? 'rgba(148,163,184,0.5)' : 'rgba(71,85,105,0.5)',
+              mb: 1,
+            }}
+          />
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 800,
+              letterSpacing: '-0.02em',
+              color: isDark ? '#e5e7eb' : '#1e293b',
+              mb: 0.5,
+            }}
+          >
+            No synergies activated
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{ color: theme.palette.text.secondary, fontSize: '0.78rem', opacity: 0.85 }}
+          >
+            No players activated any synergy abilities during this fight.
+          </Typography>
+        </Box>
       </Box>
     );
   }
 
+  const allSynergiesUrl = buildAllSynergiesUrl(reportCode, fightId);
+
   return (
-    <Box sx={{ mt: 1 }}>
-      {/* Summary header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3, flexWrap: 'wrap' }}>
-        <Typography variant="h6" sx={{ fontWeight: 600 }}>
-          Synergy Tracking
+    <Box sx={{ mt: 2 }}>
+      {/* ─── Header ─── */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 1.5,
+          mb: 2.5,
+        }}
+      >
+        <Typography
+          variant="h6"
+          sx={{
+            fontWeight: 800,
+            letterSpacing: '-0.02em',
+            mr: 0.5,
+          }}
+        >
+          Synergies
         </Typography>
+
+        <Chip
+          label={filteredData.totalCount}
+          size="small"
+          sx={{
+            fontWeight: 800,
+            fontSize: '0.78rem',
+            fontFamily: MONO_FONT,
+            height: 24,
+            minWidth: 24,
+            background: isDark ? 'rgba(56,189,248,0.12)' : 'rgba(14,165,233,0.08)',
+            color: isDark ? '#7dd3fc' : '#0369a1',
+            border: isDark ? '1px solid rgba(56,189,248,0.25)' : '1px solid rgba(14,165,233,0.2)',
+            '& .MuiChip-label': { px: 0.75 },
+          }}
+        />
+
+        <Typography
+          variant="caption"
+          sx={{
+            fontSize: '0.72rem',
+            fontWeight: 500,
+            color: theme.palette.text.secondary,
+            opacity: 0.8,
+          }}
+        >
+          across {filteredData.byPlayer.length} player
+          {filteredData.byPlayer.length !== 1 ? 's' : ''} and {filteredData.byAbility.length} abilit
+          {filteredData.byAbility.length !== 1 ? 'ies' : 'y'}
+        </Typography>
+
+        <Box sx={{ flex: 1, minWidth: 8 }} />
+
         <FormControlLabel
           control={
             <Switch
@@ -94,48 +220,110 @@ export const SynergyPanelView: React.FC<SynergyPanelViewProps> = ({
             />
           }
           label={
-            <Typography variant="body2" color="text.secondary">
+            <Typography
+              variant="caption"
+              sx={{
+                fontSize: '0.72rem',
+                fontWeight: 600,
+                letterSpacing: '0.03em',
+                color: theme.palette.text.secondary,
+              }}
+            >
               Alkosh only
             </Typography>
           }
-          sx={{ ml: 0 }}
+          sx={{ ml: 0, mr: 0 }}
         />
-        <Chip
-          label={`${filteredData.totalCount} activation${filteredData.totalCount !== 1 ? 's' : ''}`}
-          size="small"
-          color="primary"
-          variant="outlined"
-        />
-        <Chip
-          label={`${filteredData.byAbility.length} synerg${filteredData.byAbility.length !== 1 ? 'ies' : 'y'}`}
-          size="small"
-          variant="outlined"
-        />
-        <Chip
-          label={`${filteredData.byPlayer.length} player${filteredData.byPlayer.length !== 1 ? 's' : ''}`}
-          size="small"
-          variant="outlined"
-        />
-        {(() => {
-          const allSynergiesUrl = buildAllSynergiesUrl(reportCode, fightId);
-          return allSynergiesUrl ? (
-            <Chip
-              icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-              label="View on ESO Logs"
-              size="small"
-              variant="outlined"
-              color="info"
-              clickable
-              onClick={() => window.open(allSynergiesUrl, '_blank', 'noopener,noreferrer')}
-            />
-          ) : null;
-        })()}
+
+        {allSynergiesUrl && (
+          <Chip
+            icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+            label="ESO Logs"
+            size="small"
+            clickable
+            onClick={() => window.open(allSynergiesUrl, '_blank', 'noopener,noreferrer')}
+            sx={{
+              height: 26,
+              fontWeight: 600,
+              fontSize: '0.72rem',
+              background: isDark ? 'rgba(148,163,184,0.06)' : 'rgba(241,245,249,0.6)',
+              border: isDark
+                ? '1px solid rgba(148,163,184,0.14)'
+                : '1px solid rgba(148,163,184,0.2)',
+              color: theme.palette.text.primary,
+              transition: 'all 0.15s ease',
+              '&:hover': {
+                transform: 'translateY(-1px)',
+                background: isDark ? 'rgba(148,163,184,0.12)' : 'rgba(241,245,249,0.9)',
+                boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.2)' : '0 2px 8px rgba(0,0,0,0.06)',
+              },
+              '& .MuiChip-icon': { color: 'inherit', ml: 0.75 },
+            }}
+          />
+        )}
       </Box>
 
-      {/* Per-player breakdown */}
-      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Who is taking synergies?
-      </Typography>
+      {/* ─── Stats Row ─── */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: 'repeat(2, 1fr)',
+            sm: 'repeat(3, 1fr)',
+            md: 'repeat(5, 1fr)',
+          },
+          gap: 1.25,
+          mb: 3,
+        }}
+      >
+        <MetricPill
+          label="Activations"
+          value={filteredData.totalCount}
+          intent="info"
+          variant="solid"
+        />
+        <MetricPill
+          label="Synergies"
+          value={filteredData.byAbility.length}
+          intent="info"
+          variant="outline"
+        />
+        <MetricPill
+          label="Players"
+          value={filteredData.byPlayer.length}
+          intent="info"
+          variant="outline"
+        />
+        <MetricPill
+          label="Top Synergy"
+          value={topSynergy?.abilityName ?? '—'}
+          intent="success"
+          variant="solid"
+          tooltip={
+            topSynergy
+              ? `${topSynergy.abilityName ?? 'Ability'} — ${topSynergy.totalCount} activation${topSynergy.totalCount !== 1 ? 's' : ''}`
+              : undefined
+          }
+        />
+        <MetricPill
+          label="Most Active"
+          value={topPlayer?.playerName ?? '—'}
+          intent="success"
+          variant="solid"
+          tooltip={
+            topPlayer
+              ? `${topPlayer.playerName} — ${topPlayer.totalCount} synergy activation${topPlayer.totalCount !== 1 ? 's' : ''}`
+              : undefined
+          }
+        />
+      </Box>
+
+      {/* ─── Who is taking synergies? ─── */}
+      <SectionHeader
+        icon={<GroupsIcon sx={{ fontSize: 18 }} />}
+        title="Who is taking synergies?"
+        subtitle={`${filteredData.byPlayer.length} contributor${filteredData.byPlayer.length !== 1 ? 's' : ''}`}
+      />
       <Box
         sx={{
           display: 'grid',
@@ -143,97 +331,127 @@ export const SynergyPanelView: React.FC<SynergyPanelViewProps> = ({
             xs: '1fr',
             sm: 'repeat(2, 1fr)',
             md: 'repeat(3, 1fr)',
-            lg: 'repeat(4, 1fr)',
+            xl: 'repeat(4, 1fr)',
           },
           gap: 2,
-          mb: 4,
+          mb: 3.5,
         }}
       >
-        {filteredData.byPlayer.map((player) => (
+        {filteredData.byPlayer.map((player, idx) => (
           <PlayerSynergyCard
             key={player.playerID}
             player={player}
-            isDarkMode={isDarkMode}
+            rank={idx + 1}
+            maxCount={maxPlayerCount}
+            mode={mode}
             reportCode={reportCode}
             fightId={fightId}
           />
         ))}
       </Box>
 
-      {/* Synergy breakdown by ability */}
-      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Synergy Abilities
-      </Typography>
-      <TableContainer
+      {/* ─── Synergy Abilities ─── */}
+      <SectionHeader
+        icon={<EmojiEventsIcon sx={{ fontSize: 18 }} />}
+        title="Synergy Abilities"
+        subtitle={`${filteredData.byAbility.length} used`}
+      />
+      <Box
         sx={{
-          mb: 4,
-          borderRadius: 2,
-          border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            md: 'repeat(2, 1fr)',
+            xl: 'repeat(3, 1fr)',
+          },
+          gap: 2,
+          mb: 3.5,
         }}
       >
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Synergy</TableCell>
-              <TableCell align="right">Total Activations</TableCell>
-              <TableCell>Activated By</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredData.byAbility.map((ability) => (
-              <AbilityRow key={ability.abilityGameID} ability={ability} actorsById={actorsById} />
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+        {filteredData.byAbility.map((ability) => (
+          <AbilityCard
+            key={ability.abilityGameID}
+            ability={ability}
+            maxCount={maxAbilityCount}
+            actorsById={actorsById}
+            mode={mode}
+          />
+        ))}
+      </Box>
 
-      {/* Timeline of all activations */}
-      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1.5 }}>
-        Activation Timeline
-      </Typography>
-      <TableContainer
+      {/* ─── Activation Timeline ─── */}
+      <SectionHeader
+        icon={<TimelineIcon sx={{ fontSize: 18 }} />}
+        title="Activation Timeline"
+        subtitle={`${filteredData.activations.length} event${filteredData.activations.length !== 1 ? 's' : ''}`}
+      />
+      <ActivationTimeline
+        activations={filteredData.activations}
+        fight={fight}
+        actorsById={actorsById}
+        mode={mode}
+      />
+    </Box>
+  );
+};
+
+/** Section header with icon + title + subtitle. */
+const SectionHeader: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+}> = ({ icon, title, subtitle }) => {
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        mb: 1.5,
+      }}
+    >
+      <Box
         sx={{
-          borderRadius: 2,
-          border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-          maxHeight: 400,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 28,
+          height: 28,
+          borderRadius: '8px',
+          background:
+            theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : 'rgba(14,165,233,0.08)',
+          color: theme.palette.mode === 'dark' ? '#7dd3fc' : '#0369a1',
         }}
       >
-        <Table size="small" stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell>Time</TableCell>
-              <TableCell>Player</TableCell>
-              <TableCell>Synergy</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredData.activations.map((activation, index) => {
-              const fightTime = activation.timestamp - fight.startTime;
-              const actor = actorsById[activation.sourceID];
-              return (
-                <TableRow key={`${activation.timestamp}-${activation.sourceID}-${index}`}>
-                  <TableCell sx={{ fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
-                    {formatFightTime(fightTime)}
-                  </TableCell>
-                  <TableCell>{actor?.name ?? `Player ${activation.sourceID}`}</TableCell>
-                  <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      {activation.abilityIcon && (
-                        <Avatar
-                          src={`https://assets.eso-hub.com/abilities/${activation.abilityIcon}.webp`}
-                          alt=""
-                          sx={{ width: 20, height: 20 }}
-                        />
-                      )}
-                      {activation.abilityName ?? `Ability ${activation.abilityGameID}`}
-                    </Box>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+        {icon}
+      </Box>
+      <Typography
+        variant="subtitle2"
+        sx={{
+          fontWeight: 700,
+          fontSize: '0.92rem',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {title}
+      </Typography>
+      {subtitle && (
+        <Typography
+          variant="caption"
+          sx={{
+            fontSize: '0.68rem',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: theme.palette.text.secondary,
+            opacity: 0.7,
+            ml: 0.5,
+          }}
+        >
+          · {subtitle}
+        </Typography>
+      )}
     </Box>
   );
 };
@@ -281,160 +499,622 @@ function buildAllSynergiesUrl(reportCode: string | null, fightId: number | null)
   return `https://www.esologs.com/reports/${reportCode}?fight=${fightId}&type=casts&pins=${SYNERGY_PINS_EXPRESSION}`;
 }
 
-/** Card showing synergy usage for a single player. */
+/** Glass card showing synergy usage for a single player. */
 const PlayerSynergyCard: React.FC<{
   player: SynergyByPlayer;
-  isDarkMode: boolean;
+  rank: number;
+  maxCount: number;
+  mode: 'light' | 'dark';
   reportCode: string | null;
   fightId: number | null;
-}> = ({ player, isDarkMode, reportCode, fightId }) => (
-  <Card
-    variant="outlined"
-    sx={{
-      borderRadius: 3,
-      backgroundColor: isDarkMode ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
-      border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-    }}
-  >
-    <CardContent sx={{ '&:last-child': { pb: 2 } }}>
-      <Box
-        sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}
-      >
-        <Box sx={{ minWidth: 0 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+}> = ({ player, rank, maxCount, mode, reportCode, fightId }) => {
+  const isDark = mode === 'dark';
+  const rankStyle = rankPalette[rank] ?? defaultRank;
+  const sharePct = Math.max(2, Math.round((player.totalCount / maxCount) * 100));
+
+  const sortedSynergies = useMemo(
+    () => Object.entries(player.synergies).sort(([, a], [, b]) => b.count - a.count),
+    [player.synergies],
+  );
+
+  return (
+    <Box
+      sx={{
+        ...glassSurface(mode),
+        position: 'relative',
+        overflow: 'hidden',
+        p: 2,
+        transition: 'all 0.3s ease',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 3,
+          background: rankStyle.bg,
+          opacity: 0.9,
+        },
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          boxShadow: isDark
+            ? '0 12px 40px 0 rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.25)'
+            : '0 8px 24px 0 rgba(15,23,42,0.1), inset 0 1px 0 rgba(255,255,255,0.8)',
+        },
+      }}
+    >
+      {/* Header: rank avatar + name + total */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.5 }}>
+        <Avatar
+          sx={{
+            width: 36,
+            height: 36,
+            background: rankStyle.bg,
+            fontSize: '0.78rem',
+            fontWeight: 900,
+            fontFamily: MONO_FONT,
+            color: rankStyle.text,
+            border: `2px solid ${rankStyle.border}`,
+            boxShadow: `0 4px 12px ${rankStyle.border}`,
+            textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+            flexShrink: 0,
+          }}
+        >
+          #{rank}
+        </Avatar>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="subtitle2"
+            sx={{
+              fontWeight: 700,
+              fontSize: '0.88rem',
+              letterSpacing: '-0.01em',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {player.playerName}
           </Typography>
           {player.displayName && (
             <Typography
               variant="caption"
-              color="text.secondary"
-              sx={{ display: 'block', lineHeight: 1.3 }}
+              sx={{
+                display: 'block',
+                fontSize: '0.68rem',
+                color: 'text.secondary',
+                opacity: 0.75,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                lineHeight: 1.3,
+              }}
             >
               {player.displayName}
             </Typography>
           )}
         </Box>
-        <Chip label={player.totalCount} size="small" color="primary" />
+        <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+          <Typography
+            sx={{
+              fontSize: '1.5rem',
+              fontWeight: 800,
+              lineHeight: 1,
+              fontFamily: MONO_FONT,
+              color: isDark ? '#7dd3fc' : '#0369a1',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {player.totalCount}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              fontSize: '0.6rem',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              color: 'text.secondary',
+              opacity: 0.7,
+            }}
+          >
+            total
+          </Typography>
+        </Box>
       </Box>
+
+      {/* Share bar */}
+      <Box
+        sx={{
+          position: 'relative',
+          height: 4,
+          borderRadius: 2,
+          background: isDark ? 'rgba(148,163,184,0.1)' : 'rgba(148,163,184,0.15)',
+          overflow: 'hidden',
+          mb: 1.25,
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            height: '100%',
+            width: `${sharePct}%`,
+            borderRadius: 2,
+            background: rankStyle.bg,
+            transition: 'width 0.5s cubic-bezier(0.4,0,0.2,1)',
+          },
+        }}
+      />
+
+      {/* Synergies breakdown */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-        {Object.entries(player.synergies).map(([abilityId, info]) => {
+        {sortedSynergies.map(([abilityId, info]) => {
           const esoLogsUrl = buildEsoLogsUrl(
             reportCode,
             fightId,
             Number(abilityId),
             player.playerID,
           );
-          return (
+          const rowContent = (
             <Box
-              key={abilityId}
-              sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                minWidth: 0,
+                py: 0.25,
+                pr: 0.5,
+                borderRadius: 1,
+                transition: 'background 0.15s ease',
+                '&:hover': {
+                  background: isDark ? 'rgba(148,163,184,0.08)' : 'rgba(148,163,184,0.08)',
+                },
+              }}
             >
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-                {info.abilityIcon && (
-                  <Avatar
-                    src={`https://assets.eso-hub.com/abilities/${info.abilityIcon}.webp`}
-                    alt=""
-                    sx={{ width: 16, height: 16 }}
-                  />
-                )}
-                {esoLogsUrl ? (
-                  <MuiLink
-                    href={esoLogsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 0.3,
-                      textDecoration: 'none',
-                      '&:hover': { textDecoration: 'underline' },
-                    }}
-                  >
-                    {info.abilityName ?? `Ability ${abilityId}`}
-                    <OpenInNewIcon sx={{ fontSize: 12, opacity: 0.6 }} />
-                  </MuiLink>
-                ) : (
-                  <Typography variant="body2" color="text.secondary">
-                    {info.abilityName ?? `Ability ${abilityId}`}
-                  </Typography>
-                )}
-              </Box>
-              <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                {info.count}
+              {info.abilityIcon && (
+                <Avatar
+                  src={`https://assets.eso-hub.com/abilities/${info.abilityIcon}.webp`}
+                  alt=""
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    flexShrink: 0,
+                    borderRadius: '4px',
+                    border: isDark
+                      ? '1px solid rgba(148,163,184,0.2)'
+                      : '1px solid rgba(148,163,184,0.25)',
+                  }}
+                  variant="rounded"
+                />
+              )}
+              <Typography
+                variant="body2"
+                sx={{
+                  flex: 1,
+                  fontSize: '0.78rem',
+                  fontWeight: 500,
+                  color: 'text.primary',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                }}
+              >
+                {info.abilityName ?? `Ability ${abilityId}`}
               </Typography>
+              <Box
+                component="span"
+                sx={{
+                  fontFamily: MONO_FONT,
+                  fontWeight: 800,
+                  fontSize: '0.78rem',
+                  color: isDark ? '#e5e7eb' : '#1e293b',
+                  fontVariantNumeric: 'tabular-nums',
+                  ml: 0.5,
+                }}
+              >
+                {info.count}
+              </Box>
+              {esoLogsUrl && (
+                <OpenInNewIcon
+                  sx={{
+                    fontSize: 11,
+                    opacity: 0.5,
+                    color: 'text.secondary',
+                  }}
+                />
+              )}
             </Box>
+          );
+
+          return esoLogsUrl ? (
+            <MuiLink
+              key={abilityId}
+              href={esoLogsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              {rowContent}
+            </MuiLink>
+          ) : (
+            <Box key={abilityId}>{rowContent}</Box>
           );
         })}
       </Box>
-    </CardContent>
-  </Card>
-);
-
-/** Table row for a single synergy ability. */
-const AbilityRow: React.FC<{
-  ability: SynergyByAbility;
-  actorsById: Record<string | number, { name?: string | null }>;
-}> = ({ ability, actorsById }) => {
-  // Count per player for this ability
-  const playerCounts = new Map<number, number>();
-  for (const act of ability.activations) {
-    playerCounts.set(act.sourceID, (playerCounts.get(act.sourceID) ?? 0) + 1);
-  }
-
-  return (
-    <TableRow>
-      <TableCell>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          {ability.abilityIcon && (
-            <Avatar
-              src={`https://assets.eso-hub.com/abilities/${ability.abilityIcon}.webp`}
-              alt=""
-              sx={{ width: 24, height: 24 }}
-            />
-          )}
-          {ability.abilityName ?? `Ability ${ability.abilityGameID}`}
-        </Box>
-      </TableCell>
-      <TableCell align="right">{ability.totalCount}</TableCell>
-      <TableCell>
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-          {Array.from(playerCounts.entries())
-            .sort((a, b) => b[1] - a[1])
-            .map(([playerId, count]) => {
-              const name = actorsById[playerId]?.name ?? `Player ${playerId}`;
-              return (
-                <Chip key={playerId} label={`${name}: ${count}`} size="small" variant="outlined" />
-              );
-            })}
-        </Box>
-      </TableCell>
-    </TableRow>
+    </Box>
   );
 };
 
-/** Loading skeleton for the synergy panel. */
-const SynergyPanelSkeleton: React.FC = () => (
-  <Box sx={{ mt: 1 }}>
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
-      <Skeleton width={180} height={32} />
-      <Skeleton width={100} height={24} sx={{ borderRadius: '12px' }} />
-    </Box>
-    <Skeleton width={200} height={24} sx={{ mb: 1.5 }} />
+/** Glass card for a single synergy ability. */
+const AbilityCard: React.FC<{
+  ability: SynergyByAbility;
+  maxCount: number;
+  actorsById: Record<string | number, { name?: string | null }>;
+  mode: 'light' | 'dark';
+}> = ({ ability, maxCount, actorsById, mode }) => {
+  const theme = useTheme();
+  const isDark = mode === 'dark';
+  const sharePct = Math.max(2, Math.round((ability.totalCount / maxCount) * 100));
+
+  const playerCounts = useMemo(() => {
+    const counts = new Map<number, number>();
+    for (const act of ability.activations) {
+      counts.set(act.sourceID, (counts.get(act.sourceID) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  }, [ability.activations]);
+
+  return (
     <Box
       sx={{
-        display: 'grid',
-        gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
-        gap: 2,
-        mb: 4,
+        ...glassSurface(mode),
+        position: 'relative',
+        overflow: 'hidden',
+        p: 2,
+        transition: 'all 0.3s ease',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          boxShadow: isDark
+            ? '0 12px 40px 0 rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.25)'
+            : '0 8px 24px 0 rgba(15,23,42,0.1), inset 0 1px 0 rgba(255,255,255,0.8)',
+        },
       }}
     >
-      {Array.from({ length: 4 }).map((_, i) => (
-        <Skeleton key={i} variant="rounded" height={100} sx={{ borderRadius: 3 }} />
-      ))}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25 }}>
+        {ability.abilityIcon ? (
+          <Avatar
+            src={`https://assets.eso-hub.com/abilities/${ability.abilityIcon}.webp`}
+            alt=""
+            variant="rounded"
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: '10px',
+              border: isDark
+                ? '1px solid rgba(148,163,184,0.25)'
+                : '1px solid rgba(148,163,184,0.3)',
+              boxShadow: isDark ? '0 4px 12px rgba(0,0,0,0.3)' : '0 2px 8px rgba(15,23,42,0.08)',
+              flexShrink: 0,
+            }}
+          />
+        ) : (
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: '10px',
+              background: isDark ? 'rgba(148,163,184,0.15)' : 'rgba(148,163,184,0.1)',
+              flexShrink: 0,
+            }}
+          />
+        )}
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="subtitle2"
+            sx={{
+              fontWeight: 700,
+              fontSize: '0.9rem',
+              letterSpacing: '-0.01em',
+              lineHeight: 1.25,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {ability.abilityName ?? `Ability ${ability.abilityGameID}`}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              fontSize: '0.68rem',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              color: 'text.secondary',
+              opacity: 0.75,
+              mt: 0.25,
+            }}
+          >
+            {playerCounts.length} contributor
+            {playerCounts.length !== 1 ? 's' : ''}
+          </Typography>
+        </Box>
+        <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+          <Typography
+            sx={{
+              fontSize: '1.5rem',
+              fontWeight: 800,
+              lineHeight: 1,
+              fontFamily: MONO_FONT,
+              color: isDark ? '#7dd3fc' : '#0369a1',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {ability.totalCount}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              fontSize: '0.6rem',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              color: 'text.secondary',
+              opacity: 0.7,
+            }}
+          >
+            casts
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Progress bar showing share of top ability */}
+      <Box
+        sx={{
+          position: 'relative',
+          height: 4,
+          borderRadius: 2,
+          background: isDark ? 'rgba(148,163,184,0.1)' : 'rgba(148,163,184,0.15)',
+          overflow: 'hidden',
+          mb: 1.25,
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            height: '100%',
+            width: `${sharePct}%`,
+            borderRadius: 2,
+            background: 'linear-gradient(90deg, #38bdf8 0%, #22d3ee 50%, #a78bfa 100%)',
+            transition: 'width 0.5s cubic-bezier(0.4,0,0.2,1)',
+          },
+        }}
+      />
+
+      {/* Contributor chips */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+        {playerCounts.map(([playerId, count]) => {
+          const name = actorsById[playerId]?.name ?? `Player ${playerId}`;
+          return (
+            <Chip
+              key={playerId}
+              label={
+                <Box
+                  component="span"
+                  sx={{ display: 'inline-flex', alignItems: 'center', gap: '5px' }}
+                >
+                  {name}
+                  <Box
+                    component="span"
+                    sx={{
+                      fontWeight: 800,
+                      fontSize: '0.65rem',
+                      minWidth: 16,
+                      height: 16,
+                      px: 0.5,
+                      borderRadius: '4px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontFamily: MONO_FONT,
+                      background: isDark ? 'rgba(56,189,248,0.2)' : 'rgba(14,165,233,0.12)',
+                      color: isDark ? '#7dd3fc' : '#0369a1',
+                    }}
+                  >
+                    {count}
+                  </Box>
+                </Box>
+              }
+              size="small"
+              sx={{
+                height: 24,
+                background: isDark ? 'rgba(148,163,184,0.06)' : 'rgba(241,245,249,0.6)',
+                border: isDark
+                  ? '1px solid rgba(148,163,184,0.14)'
+                  : '1px solid rgba(148,163,184,0.2)',
+                color: theme.palette.text.primary,
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                transition: 'all 0.15s ease',
+                '&:hover': {
+                  transform: 'translateY(-1px)',
+                  background: isDark ? 'rgba(148,163,184,0.12)' : 'rgba(241,245,249,0.9)',
+                },
+                '& .MuiChip-label': { px: 0.9 },
+              }}
+            />
+          );
+        })}
+      </Box>
     </Box>
-    <Skeleton width={160} height={24} sx={{ mb: 1.5 }} />
-    <Skeleton variant="rounded" height={200} sx={{ borderRadius: 2 }} />
-  </Box>
-);
+  );
+};
+
+/** Compact timeline list of all synergy activations. */
+const ActivationTimeline: React.FC<{
+  activations: SynergyPanelData['activations'];
+  fight: FightFragment;
+  actorsById: Record<string | number, { name?: string | null }>;
+  mode: 'light' | 'dark';
+}> = ({ activations, fight, actorsById, mode }) => {
+  const theme = useTheme();
+  const isDark = mode === 'dark';
+
+  return (
+    <Box
+      sx={{
+        ...glassSurface(mode),
+        overflow: 'hidden',
+        maxHeight: 440,
+        overflowY: 'auto',
+        p: 0,
+        // Subtle scrollbar
+        '&::-webkit-scrollbar': { width: 8 },
+        '&::-webkit-scrollbar-track': { background: 'transparent' },
+        '&::-webkit-scrollbar-thumb': {
+          background: isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.3)',
+          borderRadius: 4,
+        },
+      }}
+    >
+      {/* Sticky header */}
+      <Box
+        sx={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 1,
+          display: 'grid',
+          gridTemplateColumns: '72px 1fr 1.4fr',
+          gap: 1.5,
+          alignItems: 'center',
+          px: 2,
+          py: 1.25,
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          background: isDark ? 'rgba(15,23,42,0.7)' : 'rgba(255,255,255,0.7)',
+          borderBottom: isDark
+            ? '1px solid rgba(148,163,184,0.12)'
+            : '1px solid rgba(148,163,184,0.18)',
+        }}
+      >
+        {['Time', 'Player', 'Synergy'].map((label) => (
+          <Typography
+            key={label}
+            variant="caption"
+            sx={{
+              fontSize: '0.62rem',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              color: theme.palette.text.secondary,
+              opacity: 0.75,
+            }}
+          >
+            {label}
+          </Typography>
+        ))}
+      </Box>
+
+      {activations.map((activation, index) => {
+        const fightTime = activation.timestamp - fight.startTime;
+        const actor = actorsById[activation.sourceID];
+        const playerName = actor?.name ?? `Player ${activation.sourceID}`;
+        return (
+          <Box
+            key={`${activation.timestamp}-${activation.sourceID}-${index}`}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '72px 1fr 1.4fr',
+              gap: 1.5,
+              alignItems: 'center',
+              px: 2,
+              py: 1,
+              borderBottom:
+                index < activations.length - 1
+                  ? isDark
+                    ? '1px solid rgba(148,163,184,0.06)'
+                    : '1px solid rgba(148,163,184,0.1)'
+                  : 'none',
+              background:
+                index % 2 === 0
+                  ? 'transparent'
+                  : isDark
+                    ? 'rgba(148,163,184,0.025)'
+                    : 'rgba(148,163,184,0.035)',
+              transition: 'background 0.15s ease',
+              '&:hover': {
+                background: isDark ? 'rgba(56,189,248,0.06)' : 'rgba(14,165,233,0.05)',
+              },
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: MONO_FONT,
+                fontSize: '0.78rem',
+                fontWeight: 700,
+                color: isDark ? '#94a3b8' : '#64748b',
+                whiteSpace: 'nowrap',
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {formatFightTime(fightTime)}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.82rem',
+                fontWeight: 600,
+                color: theme.palette.text.primary,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {playerName}
+            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                minWidth: 0,
+              }}
+            >
+              {activation.abilityIcon && (
+                <Tooltip title={activation.abilityName ?? ''} arrow placement="top">
+                  <Avatar
+                    src={`https://assets.eso-hub.com/abilities/${activation.abilityIcon}.webp`}
+                    alt=""
+                    variant="rounded"
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: '5px',
+                      border: isDark
+                        ? '1px solid rgba(148,163,184,0.2)'
+                        : '1px solid rgba(148,163,184,0.25)',
+                      flexShrink: 0,
+                    }}
+                  />
+                </Tooltip>
+              )}
+              <Typography
+                sx={{
+                  fontSize: '0.82rem',
+                  fontWeight: 500,
+                  color: theme.palette.text.primary,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {activation.abilityName ?? `Ability ${activation.abilityGameID}`}
+              </Typography>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};


### PR DESCRIPTION
Replace the table-heavy synergies panel with a card-driven layout
matching the design language established by the deaths tab:

- Header gains a tabular-numeric activation badge, filter toggle, and
  a styled "ESO Logs" action chip
- New 5-column MetricPill stats row surfaces totals, synergy count,
  active player count, top synergy, and most-active player
- Player cards: rank-tiered avatars (gold/silver/bronze + accent),
  share-of-max progress bar, per-ability rows with icons, monospace
  counts, and hover lift
- Ability cards (replacing the flat table): large rounded icon tile,
  contributor count, gradient share bar, and contributor chips that
  use mono-numeric count badges
- Activation timeline restyled as a compact glass list with sticky
  blur header, alternating rows, tabular-numeric fight times, and
  tooltip-bearing ability avatars
- Empty state becomes a glass card with a Handshake icon
- Skeleton rewritten to mirror the new hierarchy for smooth loading

https://claude.ai/code/session_01AuEdkKyvf3J1bQx79aBNSy