### PR TITLE
feat(ESO-772): allow roster editor and build editor without authentication

### DIFF
--- a/src/features/build-editor/components/BuildCompletionHeader.tsx
+++ b/src/features/build-editor/components/BuildCompletionHeader.tsx
@@ -45,7 +45,6 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { setIntendedDestination } from '@/features/auth/auth';
 import { useAuth } from '@/features/auth/AuthContext';
 import { tempBuildApi } from '@/features/build-editor/api/temp-build-api';
 import { PublishBuildDialog } from '@/features/build-hub/components/PublishBuildDialog';
@@ -307,14 +306,7 @@ export const BuildCompletionHeader: React.FC = () => {
   };
 
   const handleGuestPublishRedirect = (): void => {
-    void encodeBuildToURL(build).then((encoded) => {
-      if (encoded) {
-        setIntendedDestination(`/build-editor?b=${encodeURIComponent(encoded)}`);
-      } else {
-        setIntendedDestination('/build-editor');
-      }
-      navigate('/login');
-    });
+    enqueueSnackbar('Log in to publish your build to the Build Hub.', { variant: 'info' });
   };
 
   const handleExportClick = (): void => {

--- a/src/pages/RosterBuilderPage.tsx
+++ b/src/pages/RosterBuilderPage.tsx
@@ -893,10 +893,11 @@ export const RosterBuilderPage: React.FC = () => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Get ESO Logs client context (safe to call - doesn't throw if not logged in)
-  const { client: esoLogsClient, isReady, isLoggedIn: clientLoggedIn } = useEsoLogsClientContext();
+  const { client: esoLogsClient, isReady } = useEsoLogsClientContext();
 
-  // Client is only available when ready and logged in
-  const client = isReady && clientLoggedIn ? esoLogsClient : null;
+  // Client is available when ready — public queries (e.g. getPlayersForReport) route
+  // through the Cloudflare proxy which injects server-side OAuth, so login is not required.
+  const client = isReady ? esoLogsClient : null;
 
   // Update tank setup by array index
   const handleTankChange = useCallback((index: number, updates: Partial<TankSetup>): void => {
@@ -1981,20 +1982,18 @@ export const RosterBuilderPage: React.FC = () => {
                 </ListItemIcon>
                 <ListItemText>From JSON File</ListItemText>
               </MenuItem>
-              {isLoggedIn && (
-                <MenuItem
-                  onClick={() => {
-                    setImportMenuAnchor(null);
-                    setImportUrlDialog(true);
-                  }}
-                  sx={{ fontSize: '0.8125rem', gap: 1 }}
-                >
-                  <ListItemIcon sx={{ minWidth: '28px !important' }}>
-                    <LinkIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText>From Log URL</ListItemText>
-                </MenuItem>
-              )}
+              <MenuItem
+                onClick={() => {
+                  setImportMenuAnchor(null);
+                  setImportUrlDialog(true);
+                }}
+                sx={{ fontSize: '0.8125rem', gap: 1 }}
+              >
+                <ListItemIcon sx={{ minWidth: '28px !important' }}>
+                  <LinkIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>From Log URL</ListItemText>
+              </MenuItem>
             </Menu>
             <input
               ref={fileInputRef}


### PR DESCRIPTION
## Summary

- Remove internal auth gates that blocked unauthenticated users from the roster editor's "From Log URL" import feature
- Replace the hard `/login` redirect in the build editor's guest publish handler with an informational snackbar so guests are never ejected from the editor

## Jira Ticket
[ESO-772](https://bkrupa.atlassian.net/browse/ESO-772)

## Changes Made

**`src/pages/RosterBuilderPage.tsx`**
- Removed `&& clientLoggedIn` from the Apollo client assignment — the `getPlayersForReport` query is not user-specific and already routes through the Cloudflare proxy (`/graphql`), which injects server-side OAuth tokens via client credentials
- Removed `{isLoggedIn && ...}` wrapper from the "From Log URL" menu item so unauthenticated users can import rosters from public ESO Logs reports

**`src/features/build-editor/components/BuildCompletionHeader.tsx`**
- Replaced `navigate('/login')` in `handleGuestPublishRedirect` with `enqueueSnackbar('Log in to publish your build to the Build Hub.', { variant: 'info' })` — publishing stays auth-gated but guests are no longer redirected away from the editor
- Removed now-unused `setIntendedDestination` import from `@/features/auth/auth`

No Cloudflare proxy changes were needed — the `/graphql` endpoint already handles public queries with server-side credentials.

## Testing Done
- [x] TypeScript compiles (pre-existing errors on main are unrelated to this change)
- [x] ESLint passes on changed files (pre-existing errors on main are unrelated)
- [x] Unit tests pass (`npm test -- --watchAll=false`)
- [x] Verified `clientLoggedIn` alias fully removed from RosterBuilderPage
- [x] Verified `setIntendedDestination` fully removed from BuildCompletionHeader


[ESO-772]: https://bkrupa.atlassian.net/browse/ESO-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ