### PR TITLE
fix(charts): add chartRegistration.ts to sideEffects whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,8 @@
     "*.sass",
     "*.less",
     "./src/index.tsx",
-    "./src/setupTests.ts"
+    "./src/setupTests.ts",
+    "./src/utils/chartRegistration.ts"
   ],
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- The `sideEffects` array in `package.json` excluded `chartRegistration.ts`, causing Rollup to tree-shake the Chart.js scale/plugin registration out of the production build
- This made every chart panel crash with `"category" is not a registered scale` — most visibly the **Damage Done** tab on fight reports
- Adding the file to the whitelist restores the registration in production builds (charts chunk grew from 134 KB → 219 KB, confirming the scales are now bundled)

## Root cause
`chartRegistration.ts` is imported purely for its side effects (`import '../utils/chartRegistration'`). With a restrictive `sideEffects` whitelist in `package.json`, Rollup correctly dropped it during tree-shaking. The bug only affects production — Vite's dev server does not tree-shake.

## Test plan
- [ ] Verify production build completes without errors
- [ ] Navigate to https://esotk.com/report/YArFDbq7BdhwL691/fight/4/damage-done — Damage Done panel renders without error
- [ ] Check browser console for absence of `"category" is not a registered scale` error
- [ ] Verify other chart panels (Insights, Penetration, Critical Damage, Damage Reduction) also render correctly