### PR TITLE
feat(hub): use short ?id= URLs for published builds and rosters

### DIFF
--- a/src/features/build-hub/api/build-hub-api.ts
+++ b/src/features/build-hub/api/build-hub-api.ts
@@ -25,7 +25,9 @@ async function apiFetch<T>(path: string, options: RequestInit = {}, token?: stri
   const res = await fetch(`${BASE_URL}${path}`, { ...options, headers });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error((err as { error?: string }).error ?? res.statusText);
+    const error = new Error((err as { error?: string }).error ?? res.statusText);
+    (error as Error & { status: number }).status = res.status;
+    throw error;
   }
   return res.json() as Promise<T>;
 }

--- a/src/features/build-hub/components/BuildCard.tsx
+++ b/src/features/build-hub/components/BuildCard.tsx
@@ -128,7 +128,8 @@ export const BuildCard: React.FC<BuildCardProps> = React.memo(
 
         <CardActionArea
           onClick={() =>
-            navigate(`/bv?b=${encodeURIComponent(build.build_data)}`, {
+            navigate(`/bv?id=${build.id}`, {
+              state: { buildData: build.build_data },
               vtType: 'forward',
               morph: { ref: cardRef, name: 'build-hero' },
             })

--- a/src/features/roster-hub/api/roster-hub-api.ts
+++ b/src/features/roster-hub/api/roster-hub-api.ts
@@ -81,7 +81,9 @@ async function request<T>(path: string, options: RequestInit = {}, token?: strin
     } catch {
       // ignore parse failure
     }
-    throw new Error(message);
+    const error = new Error(message);
+    (error as Error & { status: number }).status = res.status;
+    throw error;
   }
 
   return res.json() as Promise<T>;

--- a/src/features/roster-hub/components/RosterCard.tsx
+++ b/src/features/roster-hub/components/RosterCard.tsx
@@ -245,7 +245,8 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
         {/* Clickable area — opens preview */}
         <CardActionArea
           onClick={() =>
-            navigate(`/rv?r=${encodeURIComponent(roster.roster_data)}`, {
+            navigate(`/rv?id=${roster.id}`, {
+              state: { rosterData: roster.roster_data, recommendedAddons: roster.recommended_addons },
               vtType: 'forward',
               morph: { ref: cardRef, name: 'roster-hero' },
             })

--- a/src/features/roster-hub/components/RosterCard.tsx
+++ b/src/features/roster-hub/components/RosterCard.tsx
@@ -246,7 +246,10 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
         <CardActionArea
           onClick={() =>
             navigate(`/rv?id=${roster.id}`, {
-              state: { rosterData: roster.roster_data, recommendedAddons: roster.recommended_addons },
+              state: {
+                rosterData: roster.roster_data,
+                recommendedAddons: roster.recommended_addons,
+              },
               vtType: 'forward',
               morph: { ref: cardRef, name: 'roster-hero' },
             })

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -11,6 +11,7 @@ import {
   CallSplit as CallSplitIcon,
   Check as CheckIcon,
   ContentCopy as CopyIcon,
+  DataObject as DataObjectIcon,
   Edit as EditIcon,
   ExpandMore as ExpandMoreIcon,
   FitnessCenter as FitnessIcon,
@@ -65,6 +66,7 @@ import {
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { selectSavedBuilds } from '../store/saved_builds';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
+import { exportBuildToCSPSLua } from '../features/build-editor/utils/cspsExport';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
 import { buildTooltipPropsFromAbilityId } from '../utils/skillTooltipMapper';
@@ -1887,6 +1889,7 @@ export const BuildViewPage: React.FC = () => {
   const [activeSetup, setActiveSetup] = useState(0);
   const [encodedParam, setEncodedParam] = useState('');
   const [justCopied, setJustCopied] = useState(false);
+  const [justExported, setJustExported] = useState(false);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -1929,6 +1932,23 @@ export const BuildViewPage: React.FC = () => {
         window.setTimeout(() => setJustCopied(false), 1800);
       })
       .catch(() => setSnackbar({ open: true, message: 'Failed to copy', severity: 'error' }));
+  };
+
+  const handleExportCSPS = (): void => {
+    if (!build) return;
+    try {
+      const lua = exportBuildToCSPSLua(build);
+      navigator.clipboard
+        .writeText(lua)
+        .then(() => {
+          setSnackbar({ open: true, message: 'CSPS data copied!', severity: 'success' });
+          setJustExported(true);
+          window.setTimeout(() => setJustExported(false), 1800);
+        })
+        .catch(() => setSnackbar({ open: true, message: 'Failed to copy', severity: 'error' }));
+    } catch {
+      setSnackbar({ open: true, message: 'Could not generate CSPS export', severity: 'error' });
+    }
   };
 
   const ownedSavedBuild = build
@@ -2161,7 +2181,7 @@ export const BuildViewPage: React.FC = () => {
                   sx={{
                     position: 'relative',
                     display: { xs: 'grid', sm: 'inline-flex' },
-                    gridTemplateColumns: { xs: 'minmax(0, 1fr) minmax(0, 1.3fr)', sm: 'none' },
+                    gridTemplateColumns: { xs: '1fr 1fr', sm: 'none' },
                     alignItems: 'stretch',
                     gap: { xs: 0.75, sm: 0.75 },
                     width: { xs: '100%', sm: 'auto' },
@@ -2291,6 +2311,116 @@ export const BuildViewPage: React.FC = () => {
                     </Button>
                   </Tooltip>
 
+                  {/* Export CSPS — copies Caro's Skill Point Saver data to clipboard */}
+                  <Tooltip
+                    title={justExported ? 'CSPS data copied' : "Export for Caro's Skill Point Saver"}
+                    placement="bottom"
+                    enterDelay={400}
+                  >
+                    <Button
+                      component={motion.button}
+                      whileTap={prefersReduced ? undefined : { scale: 0.965 }}
+                      transition={{ type: 'spring', stiffness: 520, damping: 28 }}
+                      onClick={handleExportCSPS}
+                      disableRipple
+                      aria-live="polite"
+                      aria-label={justExported ? 'CSPS data copied to clipboard' : 'Export CSPS build data'}
+                      sx={{
+                        position: 'relative',
+                        minHeight: { xs: 48, sm: 40 },
+                        px: { xs: 1.25, sm: 1.75 },
+                        gap: 0.75,
+                        borderRadius: '11px',
+                        textTransform: 'none',
+                        fontFamily: '"Space Grotesk", Inter, system-ui, sans-serif',
+                        fontSize: { xs: '0.85rem', sm: '0.78rem' },
+                        fontWeight: 600,
+                        letterSpacing: '-0.005em',
+                        color: justExported
+                          ? classTheme.accent
+                          : isDark
+                            ? 'rgba(255,255,255,0.82)'
+                            : 'rgba(15,23,42,0.74)',
+                        background: justExported
+                          ? alpha(classTheme.accent, isDark ? 0.1 : 0.07)
+                          : 'transparent',
+                        border: `1px solid ${
+                          justExported
+                            ? alpha(classTheme.accent, isDark ? 0.45 : 0.32)
+                            : 'transparent'
+                        }`,
+                        transition:
+                          'color 220ms ease, background-color 220ms ease, border-color 220ms ease',
+                        '&:hover': {
+                          background: justExported
+                            ? alpha(classTheme.accent, isDark ? 0.14 : 0.09)
+                            : isDark
+                              ? 'rgba(255,255,255,0.05)'
+                              : 'rgba(15,23,42,0.04)',
+                          borderColor: justExported
+                            ? alpha(classTheme.accent, 0.55)
+                            : isDark
+                              ? 'rgba(255,255,255,0.12)'
+                              : 'rgba(15,23,42,0.1)',
+                        },
+                        '&:focus-visible': {
+                          outline: `2px solid ${alpha(classTheme.accent, 0.7)}`,
+                          outlineOffset: 2,
+                        },
+                      }}
+                    >
+                      <Box
+                        aria-hidden
+                        sx={{
+                          position: 'relative',
+                          width: 16,
+                          height: 16,
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <AnimatePresence mode="wait" initial={false}>
+                          {justExported ? (
+                            <motion.span
+                              key="check"
+                              initial={prefersReduced ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+                              animate={prefersReduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+                              exit={prefersReduced ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+                              transition={{ type: 'spring', stiffness: 600, damping: 24 }}
+                              style={{
+                                position: 'absolute',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              <CheckIcon sx={{ fontSize: '1rem !important' }} />
+                            </motion.span>
+                          ) : (
+                            <motion.span
+                              key="export"
+                              initial={prefersReduced ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+                              animate={prefersReduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+                              exit={prefersReduced ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+                              transition={{ type: 'spring', stiffness: 600, damping: 24 }}
+                              style={{
+                                position: 'absolute',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              <DataObjectIcon sx={{ fontSize: '0.95rem !important' }} />
+                            </motion.span>
+                          )}
+                        </AnimatePresence>
+                      </Box>
+                      {justExported ? 'Copied' : 'Export CSPS'}
+                    </Button>
+                  </Tooltip>
+
                   {/* Divider between cluster items (desktop only, inside the group) */}
                   <Box
                     aria-hidden
@@ -2325,6 +2455,7 @@ export const BuildViewPage: React.FC = () => {
                           : 'Open your own editable copy of this build in the editor'
                       }
                       sx={{
+                        gridColumn: { xs: '1 / -1', sm: 'auto' },
                         position: 'relative',
                         overflow: 'hidden',
                         minHeight: { xs: 48, sm: 40 },

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -54,6 +54,7 @@ import { calculateBuildStats } from '../features/build-editor/engine/stat-engine
 import { BE_TOKENS } from '../features/build-editor/theme/buildEditorTokens';
 import { CLASS_COLOR_MAP } from '../features/build-editor/theme/classColorMap';
 import type { Build, BuildSetup, CombatRole } from '../features/build-editor/types/build.types';
+import { exportBuildToCSPSLua } from '../features/build-editor/utils/cspsExport';
 import { BuildViewShell } from '../features/build-viewer/components/BuildViewShell';
 import { ViewAttributeBar } from '../features/build-viewer/components/ViewAttributeBar';
 import { getItemInfo, getSetItemsBySlot } from '../features/loadout-manager/data/itemIdMap';
@@ -66,7 +67,6 @@ import {
 } from '../features/loadout-manager/utils/itemIconResolver';
 import { selectSavedBuilds } from '../store/saved_builds';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
-import { exportBuildToCSPSLua } from '../features/build-editor/utils/cspsExport';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
 import { buildTooltipPropsFromAbilityId } from '../utils/skillTooltipMapper';
@@ -2313,7 +2313,9 @@ export const BuildViewPage: React.FC = () => {
 
                   {/* Export CSPS — copies Caro's Skill Point Saver data to clipboard */}
                   <Tooltip
-                    title={justExported ? 'CSPS data copied' : "Export for Caro's Skill Point Saver"}
+                    title={
+                      justExported ? 'CSPS data copied' : "Export for Caro's Skill Point Saver"
+                    }
                     placement="bottom"
                     enterDelay={400}
                   >
@@ -2324,7 +2326,9 @@ export const BuildViewPage: React.FC = () => {
                       onClick={handleExportCSPS}
                       disableRipple
                       aria-live="polite"
-                      aria-label={justExported ? 'CSPS data copied to clipboard' : 'Export CSPS build data'}
+                      aria-label={
+                        justExported ? 'CSPS data copied to clipboard' : 'Export CSPS build data'
+                      }
                       sx={{
                         position: 'relative',
                         minHeight: { xs: 48, sm: 40 },

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -1,7 +1,7 @@
 /**
  * BuildViewPage — read-only, shareable view of a build.
  *
- * Accessible via direct link: /bv?b=<encoded>
+ * Accessible via direct link: /bv?b=<encoded> or /bv?id=<hubBuildId>
  * Uses the same glassmorphism design system as the build editor but in
  * read-only presentation mode.
  */
@@ -36,7 +36,7 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { GearSetTooltip } from '../components/GearSetTooltip';
 import { LazySkillTooltip as SkillTooltipCard } from '../components/LazySkillTooltip';
@@ -55,6 +55,7 @@ import { BE_TOKENS } from '../features/build-editor/theme/buildEditorTokens';
 import { CLASS_COLOR_MAP } from '../features/build-editor/theme/classColorMap';
 import type { Build, BuildSetup, CombatRole } from '../features/build-editor/types/build.types';
 import { exportBuildToCSPSLua } from '../features/build-editor/utils/cspsExport';
+import { buildHubApi } from '../features/build-hub/api/build-hub-api';
 import { BuildViewShell } from '../features/build-viewer/components/BuildViewShell';
 import { ViewAttributeBar } from '../features/build-viewer/components/ViewAttributeBar';
 import { getItemInfo, getSetItemsBySlot } from '../features/loadout-manager/data/itemIdMap';
@@ -1880,14 +1881,17 @@ export const BuildViewPage: React.FC = () => {
   const isDark = theme.palette.mode === 'dark';
   const prefersReduced = useReducedMotion();
   const skillCacheReady = useSkillCacheReady();
+  const location = useLocation();
   const navigate = useNavigate();
   const savedBuilds = useSelector(selectSavedBuilds);
 
   const [build, setBuild] = useState<Build | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
   const [activeSetup, setActiveSetup] = useState(0);
   const [encodedParam, setEncodedParam] = useState('');
+  const [hubBuildId, setHubBuildId] = useState('');
   const [justCopied, setJustCopied] = useState(false);
   const [justExported, setJustExported] = useState(false);
   const [snackbar, setSnackbar] = useState<{
@@ -1896,34 +1900,84 @@ export const BuildViewPage: React.FC = () => {
     severity: 'success' | 'error';
   }>({ open: false, message: '', severity: 'success' });
 
-  useEffect(() => {
+  const loadBuild = React.useCallback(() => {
+    let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    setFetchError(false);
+
     const params = new URLSearchParams(window.location.search);
     const encoded = params.get('b') ?? '';
-    setEncodedParam(encoded);
+    const idParam = params.get('id') ?? '';
+    const routerData = (location.state as { buildData?: string } | null)?.buildData;
 
-    if (!encoded) {
+    const onDecoded = (decoded: Build | null, buildData: string): void => {
+      if (cancelled) return;
+      if (decoded) {
+        setBuild(decoded);
+        setEncodedParam(buildData);
+      } else {
+        setNotFound(true);
+      }
+      setLoading(false);
+    };
+
+    const handleFetchError = (err: unknown): void => {
+      if (cancelled) return;
+      if ((err as { status?: number }).status === 404) {
+        setNotFound(true);
+      } else {
+        setFetchError(true);
+      }
+      setLoading(false);
+    };
+
+    if (encoded) {
+      setEncodedParam(encoded);
+      void decodeBuildFromURL(encoded)
+        .then((decoded) => onDecoded(decoded, encoded))
+        .catch(() => {
+          if (cancelled) return;
+          setNotFound(true);
+          setLoading(false);
+        });
+    } else if (idParam) {
+      setHubBuildId(idParam);
+      if (routerData) {
+        void decodeBuildFromURL(routerData)
+          .then((decoded) => onDecoded(decoded, routerData))
+          .catch(() => {
+            if (cancelled) return;
+            setNotFound(true);
+            setLoading(false);
+          });
+      } else {
+        void buildHubApi
+          .get(idParam)
+          .then(({ build: hubBuild }) =>
+            decodeBuildFromURL(hubBuild.build_data).then((decoded) =>
+              onDecoded(decoded, hubBuild.build_data),
+            ),
+          )
+          .catch(handleFetchError);
+      }
+    } else {
       setNotFound(true);
       setLoading(false);
-      return;
     }
 
-    void decodeBuildFromURL(encoded)
-      .then((decoded) => {
-        if (decoded) {
-          setBuild(decoded);
-        } else {
-          setNotFound(true);
-        }
-        setLoading(false);
-      })
-      .catch(() => {
-        setNotFound(true);
-        setLoading(false);
-      });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [location.state]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => loadBuild(), []);
 
   const handleCopyLink = (): void => {
-    const url = `${window.location.origin}${window.location.pathname}?b=${encodedParam}`;
+    const url = hubBuildId
+      ? `${window.location.origin}${window.location.pathname}?id=${hubBuildId}`
+      : `${window.location.origin}${window.location.pathname}?b=${encodedParam}`;
     navigator.clipboard
       .writeText(url)
       .then(() => {
@@ -1974,13 +2028,33 @@ export const BuildViewPage: React.FC = () => {
     );
   }
 
+  // ── Fetch error (transient) ──
+  if (fetchError) {
+    return (
+      <Container maxWidth="sm" sx={{ pt: 8, pb: 6 }}>
+        <GlassPanel variant="default" sx={{ p: 3 }}>
+          <Alert severity="warning" sx={{ borderRadius: '12px', mb: 2 }}>
+            Could not load the build. The server may be temporarily unavailable.
+          </Alert>
+          <Button
+            variant="outlined"
+            onClick={loadBuild}
+            sx={{ borderRadius: '10px', textTransform: 'none' }}
+          >
+            Retry
+          </Button>
+        </GlassPanel>
+      </Container>
+    );
+  }
+
   // ── Not found ──
   if (notFound || !build) {
     return (
       <Container maxWidth="sm" sx={{ pt: 8, pb: 6 }}>
         <GlassPanel variant="default" sx={{ p: 3 }}>
           <Alert severity="error" sx={{ borderRadius: '12px', mb: 2 }}>
-            No build found in the URL. Please check the link and try again.
+            No build found. The link may be invalid or the build may have been removed.
           </Alert>
           <Button
             variant="outlined"

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -33,6 +33,7 @@ import {
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { BuildDetailPanel } from '../components/roster/build-detail-panel';
 import { getDiscordBotApiUrl } from '../features/auth/discord-auth';
@@ -1375,6 +1376,7 @@ export const RosterViewPage: React.FC = () => {
   const theme = useTheme();
   const isDarkMode = theme.palette.mode === 'dark';
   const roleColors = isDarkMode ? DARK_ROLE_COLORS : LIGHT_ROLE_COLORS_SOLID;
+  const location = useLocation();
 
   // Preload skill cache so BuildDetailPanel can resolve ability names/icons
   useEffect(() => {
@@ -1384,7 +1386,9 @@ export const RosterViewPage: React.FC = () => {
   const [roster, setRoster] = useState<RaidRoster | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
   const [encodedParam, setEncodedParam] = useState<string>('');
+  const [hubRosterId, setHubRosterId] = useState<string>('');
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: React.ReactNode;
@@ -1418,12 +1422,20 @@ export const RosterViewPage: React.FC = () => {
   // Clean up deep-link fallback on unmount
   useEffect(() => () => cancelDeepLinkRef.current?.(), []);
 
-  // Decode roster from ?r= or fetch by ?id= on mount
-  useEffect(() => {
+  const loadRoster = React.useCallback(() => {
     let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    setFetchError(false);
+
     const params = new URLSearchParams(window.location.search);
     const encoded = params.get('r') ?? '';
     const hubId = params.get('id') ?? '';
+    const routerState = location.state as {
+      rosterData?: string;
+      recommendedAddons?: RecommendedAddons | null;
+    } | null;
+    const routerData = routerState?.rosterData;
 
     const onDecoded = (decoded: RaidRoster | null, rosterData: string): void => {
       if (cancelled) return;
@@ -1437,6 +1449,17 @@ export const RosterViewPage: React.FC = () => {
       if (window.parent !== window) {
         window.parent.postMessage({ type: 'roster-preview-ready' }, window.location.origin);
       }
+    };
+
+    const handleFetchError = (err: unknown): void => {
+      if (cancelled) return;
+      const status = (err as { status?: number }).status;
+      if (status === 404) {
+        setNotFound(true);
+      } else {
+        setFetchError(true);
+      }
+      setLoading(false);
     };
 
     // If navigated from hub, fetch recommended addons
@@ -1469,23 +1492,43 @@ export const RosterViewPage: React.FC = () => {
           setLoading(false);
         });
     } else if (hubId) {
-      // Direct-publish rosters (direct-* IDs) are stored in the bot's KV, not the hub API
-      const fetchRosterData = hubId.startsWith('direct-')
-        ? fetch(`${getDiscordBotApiUrl()}/discord/roster/${encodeURIComponent(hubId)}/data`)
-            .then((res) => {
-              if (!res.ok) throw new Error('Not found');
-              return res.json() as Promise<{ roster_data: string }>;
-            })
-            .then((json) => json.roster_data)
-        : rosterHubApi.get(hubId).then((res) => res.roster.roster_data);
+      setHubRosterId(hubId);
 
-      void fetchRosterData
-        .then((data) => decodeRosterFromURL(data).then((decoded) => onDecoded(decoded, data)))
-        .catch(() => {
-          if (cancelled) return;
-          setNotFound(true);
-          setLoading(false);
-        });
+      if (routerData) {
+        if (routerState?.recommendedAddons) {
+          setRecommendedAddons(routerState.recommendedAddons);
+        }
+        void decodeRosterFromURL(routerData)
+          .then((decoded) => onDecoded(decoded, routerData))
+          .catch(() => {
+            if (cancelled) return;
+            setNotFound(true);
+            setLoading(false);
+          });
+      } else {
+        // Direct-publish rosters (direct-* IDs) are stored in the bot's KV, not the hub API
+        const fetchRosterData = hubId.startsWith('direct-')
+          ? fetch(`${getDiscordBotApiUrl()}/discord/roster/${encodeURIComponent(hubId)}/data`)
+              .then((res) => {
+                if (!res.ok) {
+                  const error = new Error('Not found');
+                  (error as Error & { status: number }).status = res.status;
+                  throw error;
+                }
+                return res.json() as Promise<{ roster_data: string }>;
+              })
+              .then((json) => json.roster_data)
+          : rosterHubApi.get(hubId).then((res) => {
+              if (!cancelled && res.roster.recommended_addons) {
+                setRecommendedAddons(res.roster.recommended_addons);
+              }
+              return res.roster.roster_data;
+            });
+
+        void fetchRosterData
+          .then((data) => decodeRosterFromURL(data).then((decoded) => onDecoded(decoded, data)))
+          .catch(handleFetchError);
+      }
     } else {
       setNotFound(true);
       setLoading(false);
@@ -1494,12 +1537,16 @@ export const RosterViewPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [location.state]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => loadRoster(), []);
 
   // Copy this shareable link to clipboard
   const handleCopyLink = (): void => {
-    // Use current pathname so the link works in subdirectory deployments
-    const url = `${window.location.origin}${window.location.pathname}?r=${encodedParam}`;
+    const url = hubRosterId
+      ? `${window.location.origin}${window.location.pathname}?id=${hubRosterId}`
+      : `${window.location.origin}${window.location.pathname}?r=${encodedParam}`;
     navigator.clipboard
       .writeText(url)
       .then(() => {
@@ -1559,6 +1606,24 @@ export const RosterViewPage: React.FC = () => {
     );
   }
 
+  // ---- Fetch error (transient) ----
+  if (fetchError) {
+    return (
+      <Container maxWidth="sm" sx={{ pt: 8, pb: 6 }}>
+        <Alert severity="warning" sx={{ borderRadius: '14px', mb: 2 }}>
+          Could not load the roster. The server may be temporarily unavailable.
+        </Alert>
+        <Button
+          variant="outlined"
+          onClick={loadRoster}
+          sx={{ borderRadius: '10px', textTransform: 'none' }}
+        >
+          Retry
+        </Button>
+      </Container>
+    );
+  }
+
   // ---- Not found state ----
   if (notFound || !roster) {
     return (
@@ -1570,7 +1635,7 @@ export const RosterViewPage: React.FC = () => {
             mb: 2,
           }}
         >
-          No roster found in the URL. Please check the link and try again.
+          No roster found. The link may be invalid or the roster may have been removed.
         </Alert>
         <Button
           variant="outlined"

--- a/tests/roster-builder.smoke.spec.ts
+++ b/tests/roster-builder.smoke.spec.ts
@@ -152,7 +152,7 @@ test.describe('Share link round-trip — DPS gear not silently dropped', () => {
 test.describe('RosterViewPage — /rv', () => {
   test('shows error when no r= param is provided', async ({ page }) => {
     await page.goto('/rv');
-    await expect(page.getByText(/No roster found in the URL/)).toBeVisible();
+    await expect(page.getByText(/No roster found/)).toBeVisible();
     await expect(page.getByRole('button', { name: /Open Roster Builder/ })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Published builds and rosters now use clean `/bv?id=<id>` and `/rv?id=<id>` URLs instead of massive encoded payloads — much more user-friendly for sharing
- Hub cards pass data via React Router state for instant rendering without a second API call
- Transient API failures show a retry button instead of false "not found" errors; true 404s still show the removed/invalid message
- Unpublished/private sharing via `?b=` and `?r=` encoded URLs is fully preserved

## Changes
| File | What changed |
|------|-------------|
| `BuildCard.tsx` / `RosterCard.tsx` | Navigate with `?id=` + pass data via router state |
| `BuildViewPage.tsx` | Add `?id=` fetch support, router state fast path, retry UI |
| `RosterViewPage.tsx` | Track hub ID for copy link, router state fast path, retry UI, hydrate recommended addons |
| `build-hub-api.ts` / `roster-hub-api.ts` | Attach HTTP status to thrown errors for 404 vs transient discrimination |

## Test plan
- [ ] Click a build from Build Hub → loads instantly, URL shows `?id=<uuid>`
- [ ] Click "Copy Link" on a hub build → short `?id=` URL copied
- [ ] Open that copied link in a new tab → build loads from API
- [ ] Click a roster from Roster Hub → loads instantly with recommended addons
- [ ] Click "Copy Link" on a hub roster → short `?id=` URL copied
- [ ] Open that copied link in a new tab → roster loads from API
- [ ] View a build from My Builds → still uses `?b=` encoded URL
- [ ] View a roster from My Rosters → still uses `?r=` encoded URL
- [ ] Simulate API down (e.g. bad ID) → shows retry button, not "not found"
- [ ] Use a deleted/invalid ID → shows "not found" message
- [ ] Direct-publish roster (`?id=direct-*`) → loads from Discord bot KV
- [ ] "Open in Editor" / "Open in Builder" still works from both load paths

> **Note:** This branch is based on `feat/bv-csps-export`. Once that PR merges, this PR's diff will shrink to just the URL shortening changes.