### PR TITLE
Add rich tooltips for skills and gear sets in build detail

### DIFF
--- a/src/components/roster/build-detail-panel.tsx
+++ b/src/components/roster/build-detail-panel.tsx
@@ -20,6 +20,7 @@ import { deriveItemNameForSlot } from '../../features/loadout-manager/utils/item
 import { getChampionPointAbilityName } from '../../types/champion-points';
 import { getEsoHubSetUrl, getEsoHubSkillLineUrl } from '../../utils/esoHubLinks';
 import { getGearSetTooltipPropsByName } from '../../utils/gearSetTooltipMapper';
+import { RICH_TOOLTIP_SLOT_PROPS } from '../../utils/richTooltipSlotProps';
 import { buildTooltipPropsFromAbilityId } from '../../utils/skillTooltipMapper';
 import { GearSetTooltip } from '../GearSetTooltip';
 import { LazySkillTooltip as SkillTooltipCard } from '../LazySkillTooltip';
@@ -160,20 +161,7 @@ const SkillTile: React.FC<{
       placement="top"
       enterTouchDelay={0}
       leaveTouchDelay={3000}
-      slotProps={{
-        tooltip: {
-          sx: richProps
-            ? {
-                maxWidth: 320,
-                p: 0,
-                backgroundColor: 'transparent !important',
-                border: 'none !important',
-                boxShadow: 'none !important',
-              }
-            : {},
-        },
-        arrow: richProps ? { sx: { display: 'none' } } : {},
-      }}
+      slotProps={richProps ? RICH_TOOLTIP_SLOT_PROPS : undefined}
     >
       {esoHubUrl ? (
         <Box
@@ -481,18 +469,7 @@ const GearDisplay: React.FC<{
             enterTouchDelay={0}
             leaveTouchDelay={3000}
             arrow
-            slotProps={{
-              tooltip: {
-                sx: {
-                  maxWidth: 320,
-                  p: 0,
-                  backgroundColor: 'transparent !important',
-                  border: 'none !important',
-                  boxShadow: 'none !important',
-                },
-              },
-              arrow: { sx: { display: 'none' } },
-            }}
+            slotProps={RICH_TOOLTIP_SLOT_PROPS}
           >
             {row}
           </Tooltip>

--- a/src/components/roster/build-detail-panel.tsx
+++ b/src/components/roster/build-detail-panel.tsx
@@ -19,6 +19,10 @@ import type { GearConfig, SkillsConfig } from '../../features/loadout-manager/ty
 import { deriveItemNameForSlot } from '../../features/loadout-manager/utils/itemIconResolver';
 import { getChampionPointAbilityName } from '../../types/champion-points';
 import { getEsoHubSetUrl, getEsoHubSkillLineUrl } from '../../utils/esoHubLinks';
+import { getGearSetTooltipPropsByName } from '../../utils/gearSetTooltipMapper';
+import { buildTooltipPropsFromAbilityId } from '../../utils/skillTooltipMapper';
+import { GearSetTooltip } from '../GearSetTooltip';
+import { LazySkillTooltip as SkillTooltipCard } from '../LazySkillTooltip';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -88,6 +92,21 @@ const SkillTile: React.FC<{
   const accent = isUltimate ? 'rgba(255,179,0,' : 'rgba(56,189,248,';
   const esoHubUrl = skill?.category ? getEsoHubSkillLineUrl(skill.category) : undefined;
 
+  const richProps = React.useMemo(
+    () => (abilityId ? buildTooltipPropsFromAbilityId(abilityId) : null),
+    [abilityId],
+  );
+
+  const tooltipTitle = richProps ? (
+    <SkillTooltipCard
+      {...richProps}
+      iconUrl={richProps.iconUrl || iconUrl || undefined}
+      abilityId={abilityId}
+    />
+  ) : (
+    (skill?.name ?? `Ability #${abilityId}`)
+  );
+
   const tile = (
     <Box
       sx={{
@@ -135,7 +154,27 @@ const SkillTile: React.FC<{
   );
 
   return (
-    <Tooltip title={skill?.name ?? `Ability #${abilityId}`} arrow placement="top">
+    <Tooltip
+      title={tooltipTitle}
+      arrow
+      placement="top"
+      enterTouchDelay={0}
+      leaveTouchDelay={3000}
+      slotProps={{
+        tooltip: {
+          sx: richProps
+            ? {
+                maxWidth: 320,
+                p: 0,
+                backgroundColor: 'transparent !important',
+                border: 'none !important',
+                boxShadow: 'none !important',
+              }
+            : {},
+        },
+        arrow: richProps ? { sx: { display: 'none' } } : {},
+      }}
+    >
       {esoHubUrl ? (
         <Box
           component="a"
@@ -323,6 +362,17 @@ const GearDisplay: React.FC<{
 }> = ({ gear, isDarkMode }) => {
   const populatedSlots = GEAR_SLOT_ORDER.filter((slotIdx) => gear[slotIdx]);
 
+  const setPieceCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const slotIdx of populatedSlots) {
+      const piece = gear[slotIdx];
+      if (!piece) continue;
+      const info = getItemInfo(Number(piece.id));
+      if (info?.setName) counts.set(info.setName, (counts.get(info.setName) ?? 0) + 1);
+    }
+    return counts;
+  }, [gear, populatedSlots]);
+
   if (populatedSlots.length === 0) return null;
 
   return (
@@ -336,10 +386,12 @@ const GearDisplay: React.FC<{
         const itemName = deriveItemNameForSlot(itemId, SLOT_INDEX_TO_TYPE[slotIdx]);
         const setName = itemInfo?.setName;
         const weight = piece.weight ? WEIGHT_LABELS[piece.weight] : null;
+        const gearTooltipProps = setName
+          ? getGearSetTooltipPropsByName(setName, setPieceCounts.get(setName) ?? 0)
+          : null;
 
-        return (
+        const row = (
           <Box
-            key={slotIdx}
             sx={{
               display: 'flex',
               alignItems: 'center',
@@ -415,6 +467,35 @@ const GearDisplay: React.FC<{
               />
             )}
           </Box>
+        );
+
+        if (!gearTooltipProps) {
+          return <React.Fragment key={slotIdx}>{row}</React.Fragment>;
+        }
+
+        return (
+          <Tooltip
+            key={slotIdx}
+            title={<GearSetTooltip {...gearTooltipProps} />}
+            placement="top"
+            enterTouchDelay={0}
+            leaveTouchDelay={3000}
+            arrow
+            slotProps={{
+              tooltip: {
+                sx: {
+                  maxWidth: 320,
+                  p: 0,
+                  backgroundColor: 'transparent !important',
+                  border: 'none !important',
+                  boxShadow: 'none !important',
+                },
+              },
+              arrow: { sx: { display: 'none' } },
+            }}
+          >
+            {row}
+          </Tooltip>
         );
       })}
     </Box>

--- a/src/components/roster/build-detail-panel.tsx
+++ b/src/components/roster/build-detail-panel.tsx
@@ -92,10 +92,10 @@ const SkillTile: React.FC<{
   const accent = isUltimate ? 'rgba(255,179,0,' : 'rgba(56,189,248,';
   const esoHubUrl = skill?.category ? getEsoHubSkillLineUrl(skill.category) : undefined;
 
-  const richProps = React.useMemo(
-    () => (abilityId ? buildTooltipPropsFromAbilityId(abilityId) : null),
-    [abilityId],
-  );
+  // Recomputed every render: buildTooltipPropsFromAbilityId may return null
+  // until abilityIdMapper finishes its async load, and memoizing on abilityId
+  // alone would pin that null so the tooltip never upgrades from plain text.
+  const richProps = abilityId ? buildTooltipPropsFromAbilityId(abilityId) : null;
 
   const tooltipTitle = richProps ? (
     <SkillTooltipCard

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -35,6 +35,7 @@ import { useTheme } from '@mui/material/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { GearSetTooltip } from '../components/GearSetTooltip';
 import { BuildDetailPanel } from '../components/roster/build-detail-panel';
 import { getDiscordBotApiUrl } from '../features/auth/discord-auth';
 import {
@@ -64,6 +65,7 @@ import {
 } from '../types/trial-encounters';
 import { encodeBuildToURL } from '../utils/buildEncoding';
 import { getEsoHubSetUrl, getEsoHubSkillLineUrl } from '../utils/esoHubLinks';
+import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
 import { buildVariantSx, getGearChipProps } from '../utils/playerCardStyleUtils';
 import { DARK_ROLE_COLORS, LIGHT_ROLE_COLORS_SOLID } from '../utils/roleColors';
 import { decodeRosterFromURL } from '../utils/rosterEncoding';
@@ -176,6 +178,42 @@ const getSetChipSx = (
     return buildVariantSx(SLOT_HINT_VARIANT[entry.slotHint], theme);
   }
   return result.sx ?? {};
+};
+
+/**
+ * Wrap a gear-set chip in a rich GearSetTooltip (matching /bv) when we have
+ * tooltip data for the set. Falls back to the bare chip for unrecognised sets.
+ */
+const GearSetChipWithTooltip: React.FC<{
+  entry: GearSetEntry;
+  chip: React.ReactElement;
+}> = ({ entry, chip }) => {
+  const tooltipProps = getGearSetTooltipPropsByName(entry.name, entry.count);
+  if (!tooltipProps) return chip;
+
+  return (
+    <Tooltip
+      title={<GearSetTooltip {...tooltipProps} />}
+      placement="top"
+      enterTouchDelay={0}
+      leaveTouchDelay={3000}
+      arrow
+      slotProps={{
+        tooltip: {
+          sx: {
+            maxWidth: 320,
+            p: 0,
+            backgroundColor: 'transparent !important',
+            border: 'none !important',
+            boxShadow: 'none !important',
+          },
+        },
+        arrow: { sx: { display: 'none' } },
+      }}
+    >
+      {chip}
+    </Tooltip>
+  );
 };
 
 const formatSkillLines = (
@@ -430,17 +468,22 @@ const TankCard: React.FC<TankCardProps> = ({ tank, slotNum, label, color, isDark
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
               {gearSets.map((entry) => (
-                <Chip
+                <GearSetChipWithTooltip
                   key={entry.name}
-                  component="a"
-                  href={getEsoHubSetUrl(entry.name)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  clickable
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  label={entry.name}
-                  size="small"
-                  sx={getSetChipSx(entry, theme)}
+                  entry={entry}
+                  chip={
+                    <Chip
+                      component="a"
+                      href={getEsoHubSetUrl(entry.name)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      clickable
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      label={entry.name}
+                      size="small"
+                      sx={getSetChipSx(entry, theme)}
+                    />
+                  }
                 />
               ))}
             </Box>
@@ -713,17 +756,22 @@ const HealerCard: React.FC<HealerCardProps> = ({ healer, slotNum, label, color, 
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
               {gearSets.map((entry) => (
-                <Chip
+                <GearSetChipWithTooltip
                   key={entry.name}
-                  component="a"
-                  href={getEsoHubSetUrl(entry.name)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  clickable
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  label={entry.name}
-                  size="small"
-                  sx={getSetChipSx(entry, theme)}
+                  entry={entry}
+                  chip={
+                    <Chip
+                      component="a"
+                      href={getEsoHubSetUrl(entry.name)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      clickable
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      label={entry.name}
+                      size="small"
+                      sx={getSetChipSx(entry, theme)}
+                    />
+                  }
                 />
               ))}
               {healer.arenaWeapon && (
@@ -1047,11 +1095,10 @@ const DPSRow: React.FC<DPSRowProps> = ({ slot, color, isDarkMode }) => {
             sx={{ mt: 0.75, display: 'flex', flexWrap: 'wrap', gap: 0.75, alignItems: 'center' }}
           >
             {gearSets.map((entry) => (
-              <Chip
+              <GearSetChipWithTooltip
                 key={entry.name}
-                label={entry.name}
-                size="small"
-                sx={getSetChipSx(entry, theme)}
+                entry={entry}
+                chip={<Chip label={entry.name} size="small" sx={getSetChipSx(entry, theme)} />}
               />
             ))}
             {slot.arenaWeapon && (

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -67,6 +67,7 @@ import { encodeBuildToURL } from '../utils/buildEncoding';
 import { getEsoHubSetUrl, getEsoHubSkillLineUrl } from '../utils/esoHubLinks';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
 import { buildVariantSx, getGearChipProps } from '../utils/playerCardStyleUtils';
+import { RICH_TOOLTIP_SLOT_PROPS } from '../utils/richTooltipSlotProps';
 import { DARK_ROLE_COLORS, LIGHT_ROLE_COLORS_SOLID } from '../utils/roleColors';
 import { decodeRosterFromURL } from '../utils/rosterEncoding';
 import { dpsSlotToBuild, tankSlotToBuild, healerSlotToBuild } from '../utils/rosterSlotToBuild';
@@ -198,18 +199,7 @@ const GearSetChipWithTooltip: React.FC<{
       enterTouchDelay={0}
       leaveTouchDelay={3000}
       arrow
-      slotProps={{
-        tooltip: {
-          sx: {
-            maxWidth: 320,
-            p: 0,
-            backgroundColor: 'transparent !important',
-            border: 'none !important',
-            boxShadow: 'none !important',
-          },
-        },
-        arrow: { sx: { display: 'none' } },
-      }}
+      slotProps={RICH_TOOLTIP_SLOT_PROPS}
     >
       {chip}
     </Tooltip>

--- a/src/utils/richTooltipSlotProps.ts
+++ b/src/utils/richTooltipSlotProps.ts
@@ -8,9 +8,14 @@ import type { TooltipProps } from '@mui/material';
  *  - Transparent wrapper so only the inner card is visible.
  *  - maxHeight uses `dvh` so it tracks the dynamic viewport (mobile URL bar).
  *  - Content stays scrollable via wheel/touch, but the native scrollbar is
- *    hidden (scrollbar-width: none + ::-webkit-scrollbar) so the browser
- *    can't flash a thin gutter during Grow transitions when the user
- *    hovers between rich tooltips in quick succession.
+ *    hidden (scrollbar-width: none + ::-webkit-scrollbar) so the tooltip
+ *    card never shows a scroll gutter.
+ *  - popperOptions.strategy = 'fixed' positions the popper via
+ *    `position: fixed` instead of `absolute`. With absolute positioning the
+ *    portal-rendered tooltip briefly extended the document during its
+ *    first measure pass, causing the page scrollbar to flash when hovering
+ *    between tooltips quickly; fixed strategy positions relative to the
+ *    viewport and never contributes to page scroll height.
  *  - preventOverflow { altAxis: true } lets Popper slide the tooltip along
  *    the cross axis when flipping alone can't fit it.
  *  - flip fallbackPlacements cover all four sides so the tooltip will land
@@ -27,21 +32,25 @@ export const RICH_TOOLTIP_SLOT_PROPS: NonNullable<TooltipProps['slotProps']> = {
       maxHeight: 'min(520px, calc(100dvh - 24px))',
       overflowY: 'auto',
       overflowX: 'hidden',
+      overscrollBehavior: 'contain',
       scrollbarWidth: 'none',
       '&::-webkit-scrollbar': { display: 'none' },
     },
   },
   arrow: { sx: { display: 'none' } },
   popper: {
-    modifiers: [
-      { name: 'preventOverflow', options: { altAxis: true, padding: 12 } },
-      {
-        name: 'flip',
-        options: {
-          fallbackPlacements: ['top', 'bottom', 'right', 'left'],
-          padding: 12,
+    popperOptions: {
+      strategy: 'fixed',
+      modifiers: [
+        { name: 'preventOverflow', options: { altAxis: true, padding: 12 } },
+        {
+          name: 'flip',
+          options: {
+            fallbackPlacements: ['top', 'bottom', 'right', 'left'],
+            padding: 12,
+          },
         },
-      },
-    ],
+      ],
+    },
   },
 };

--- a/src/utils/richTooltipSlotProps.ts
+++ b/src/utils/richTooltipSlotProps.ts
@@ -7,8 +7,10 @@ import type { TooltipProps } from '@mui/material';
  * Modern viewport-fit strategy:
  *  - Transparent wrapper so only the inner card is visible.
  *  - maxHeight uses `dvh` so it tracks the dynamic viewport (mobile URL bar).
- *  - overflowY: auto lets the card scroll inside the tooltip when its natural
- *    height exceeds the viewport, instead of being clipped offscreen.
+ *  - Content stays scrollable via wheel/touch, but the native scrollbar is
+ *    hidden (scrollbar-width: none + ::-webkit-scrollbar) so the browser
+ *    can't flash a thin gutter during Grow transitions when the user
+ *    hovers between rich tooltips in quick succession.
  *  - preventOverflow { altAxis: true } lets Popper slide the tooltip along
  *    the cross axis when flipping alone can't fit it.
  *  - flip fallbackPlacements cover all four sides so the tooltip will land
@@ -25,7 +27,8 @@ export const RICH_TOOLTIP_SLOT_PROPS: NonNullable<TooltipProps['slotProps']> = {
       maxHeight: 'min(520px, calc(100dvh - 24px))',
       overflowY: 'auto',
       overflowX: 'hidden',
-      scrollbarWidth: 'thin',
+      scrollbarWidth: 'none',
+      '&::-webkit-scrollbar': { display: 'none' },
     },
   },
   arrow: { sx: { display: 'none' } },

--- a/src/utils/richTooltipSlotProps.ts
+++ b/src/utils/richTooltipSlotProps.ts
@@ -1,0 +1,44 @@
+import type { TooltipProps } from '@mui/material';
+
+/**
+ * Shared slotProps for MUI Tooltip when the title is a rich React node
+ * (e.g. GearSetTooltip, SkillTooltipCard) rather than plain text.
+ *
+ * Modern viewport-fit strategy:
+ *  - Transparent wrapper so only the inner card is visible.
+ *  - maxHeight uses `dvh` so it tracks the dynamic viewport (mobile URL bar).
+ *  - overflowY: auto lets the card scroll inside the tooltip when its natural
+ *    height exceeds the viewport, instead of being clipped offscreen.
+ *  - preventOverflow { altAxis: true } lets Popper slide the tooltip along
+ *    the cross axis when flipping alone can't fit it.
+ *  - flip fallbackPlacements cover all four sides so the tooltip will land
+ *    on whichever side has the most room.
+ */
+export const RICH_TOOLTIP_SLOT_PROPS: NonNullable<TooltipProps['slotProps']> = {
+  tooltip: {
+    sx: {
+      maxWidth: 320,
+      p: 0,
+      backgroundColor: 'transparent !important',
+      border: 'none !important',
+      boxShadow: 'none !important',
+      maxHeight: 'min(520px, calc(100dvh - 24px))',
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      scrollbarWidth: 'thin',
+    },
+  },
+  arrow: { sx: { display: 'none' } },
+  popper: {
+    modifiers: [
+      { name: 'preventOverflow', options: { altAxis: true, padding: 12 } },
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['top', 'bottom', 'right', 'left'],
+          padding: 12,
+        },
+      },
+    ],
+  },
+};

--- a/src/utils/richTooltipSlotProps.ts
+++ b/src/utils/richTooltipSlotProps.ts
@@ -7,15 +7,14 @@ import type { TooltipProps } from '@mui/material';
  * Modern viewport-fit strategy:
  *  - Transparent wrapper so only the inner card is visible.
  *  - maxHeight uses `dvh` so it tracks the dynamic viewport (mobile URL bar).
- *  - Content stays scrollable via wheel/touch, but the native scrollbar is
- *    hidden (scrollbar-width: none + ::-webkit-scrollbar) so the tooltip
- *    card never shows a scroll gutter.
+ *  - overflow: hidden — most tooltips are well under the cap, and letting
+ *    the browser render any scrollbar on the popper caused a flash when
+ *    hovering between tooltips quickly. Overflow on a rare oversized card
+ *    clips the bottom; the user can click through to ESO-Hub for full
+ *    detail.
  *  - popperOptions.strategy = 'fixed' positions the popper via
- *    `position: fixed` instead of `absolute`. With absolute positioning the
- *    portal-rendered tooltip briefly extended the document during its
- *    first measure pass, causing the page scrollbar to flash when hovering
- *    between tooltips quickly; fixed strategy positions relative to the
- *    viewport and never contributes to page scroll height.
+ *    `position: fixed` instead of `absolute` so it never contributes to
+ *    document scroll height.
  *  - preventOverflow { altAxis: true } lets Popper slide the tooltip along
  *    the cross axis when flipping alone can't fit it.
  *  - flip fallbackPlacements cover all four sides so the tooltip will land
@@ -30,11 +29,7 @@ export const RICH_TOOLTIP_SLOT_PROPS: NonNullable<TooltipProps['slotProps']> = {
       border: 'none !important',
       boxShadow: 'none !important',
       maxHeight: 'min(520px, calc(100dvh - 24px))',
-      overflowY: 'auto',
-      overflowX: 'hidden',
-      overscrollBehavior: 'contain',
-      scrollbarWidth: 'none',
-      '&::-webkit-scrollbar': { display: 'none' },
+      overflow: 'hidden',
     },
   },
   arrow: { sx: { display: 'none' } },


### PR DESCRIPTION
## Summary

This PR enhances the build detail panel by adding rich, interactive tooltips for skills and gear sets. 

**Changes:**
- **Skill tooltips**: Skills now display detailed tooltips with ability information (icon, stats, description) when hovering over skill tiles. The tooltip is built from ability data and styled to match the game's UI.
- **Gear set tooltips**: Gear pieces now show tooltips displaying the associated gear set information and how many pieces of that set are equipped. The tooltip includes set bonuses and other relevant details.
- **Improved UX**: Both tooltip types support touch interactions with configurable delays (0ms enter, 3000ms leave) and custom styling to display rich content without the default Material-UI tooltip appearance.

The implementation reuses existing utility functions (`buildTooltipPropsFromAbilityId`, `getGearSetTooltipPropsByName`) and components (`SkillTooltipCard`, `GearSetTooltip`) to maintain consistency across the application.

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`

https://claude.ai/code/session_01JWho6wS1dUvArQu37k7iPm