### PR TITLE
fix(api): switch GraphQL rate limiting to in-memory, raise to 300/min

### DIFF
--- a/roster-hub-api/src/db/queries.ts
+++ b/roster-hub-api/src/db/queries.ts
@@ -1507,40 +1507,11 @@ export async function checkPackVoteRateLimit(db: D1Database, userId: string): Pr
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// GraphQL proxy — IP-based rate limiting
+// GraphQL proxy — legacy D1 rate-limit cleanup (table drain)
 // ═══════════════════════════════════════════════════════════════════════════════
-
-const GRAPHQL_RATE_LIMIT_WINDOW_SEC = 60;
-const GRAPHQL_RATE_LIMIT_MAX = 120;
-
-export async function checkGraphqlRateLimit(db: D1Database, ip: string): Promise<boolean> {
-  const row = await db
-    .prepare(
-      `SELECT COUNT(*) AS cnt FROM graphql_rate_limits
-       WHERE ip = ? AND created_at > datetime('now', '-${GRAPHQL_RATE_LIMIT_WINDOW_SEC} seconds')`,
-    )
-    .bind(ip)
-    .first<{ cnt: number }>();
-  return (row?.cnt ?? 0) < GRAPHQL_RATE_LIMIT_MAX;
-}
-
-export async function recordGraphqlRateLimit(db: D1Database, ip: string): Promise<void> {
-  await db
-    .prepare("INSERT INTO graphql_rate_limits (ip, created_at) VALUES (?, datetime('now'))")
-    .bind(ip)
-    .run();
-  // Prune expired entries on every write to keep the table bounded
-  await db
-    .prepare(
-      `DELETE FROM graphql_rate_limits WHERE created_at < datetime('now', '-${GRAPHQL_RATE_LIMIT_WINDOW_SEC} seconds')`,
-    )
-    .run();
-}
 
 export async function cleanupGraphqlRateLimits(db: D1Database): Promise<void> {
   await db
-    .prepare(
-      `DELETE FROM graphql_rate_limits WHERE created_at < datetime('now', '-${GRAPHQL_RATE_LIMIT_WINDOW_SEC} seconds')`,
-    )
+    .prepare(`DELETE FROM graphql_rate_limits WHERE created_at < datetime('now', '-60 seconds')`)
     .run();
 }

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -61,8 +61,6 @@ import {
   togglePackVote,
   checkPackCreateRateLimit,
   checkPackVoteRateLimit,
-  checkGraphqlRateLimit,
-  recordGraphqlRateLimit,
   cleanupGraphqlRateLimits,
 } from './db/queries';
 import { moderateImage, MAX_IMAGE_BYTES } from './image-moderation';
@@ -159,13 +157,30 @@ app.use('*', async (c, next) => {
 // Forwards POST /graphql to https://www.esologs.com/api/v2/client, injecting
 // a server-side OAuth token so unauthenticated users can query public data.
 
+const GRAPHQL_RATE_LIMIT = 300; // max requests per minute per IP
+const graphqlRateCounts = new Map<string, { count: number; expires: number }>();
+
 app.post('/graphql', async (c) => {
-  const ip = c.req.header('CF-Connecting-IP') ?? 'unknown';
-  const allowed = await checkGraphqlRateLimit(c.env.DB, ip);
-  if (!allowed) {
-    return c.json({ error: 'Rate limit exceeded. Max 120 GraphQL requests per minute.' }, 429);
+  const ip =
+    c.req.header('CF-Connecting-IP') ??
+    c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ??
+    'unknown';
+  const now = Date.now();
+
+  for (const [key, val] of graphqlRateCounts) {
+    if (val.expires <= now) graphqlRateCounts.delete(key);
   }
-  await recordGraphqlRateLimit(c.env.DB, ip);
+
+  const bucket = graphqlRateCounts.get(ip);
+  if (bucket && bucket.expires > now) {
+    if (bucket.count >= GRAPHQL_RATE_LIMIT) {
+      return c.json({ error: 'Rate limit exceeded. Max 300 GraphQL requests per minute.' }, 429);
+    }
+    bucket.count++;
+  } else {
+    graphqlRateCounts.set(ip, { count: 1, expires: now + 60_000 });
+  }
+
   return handleGraphqlProxy(c);
 });
 


### PR DESCRIPTION
## Summary
- The D1-backed IP rate limiter was firing 3 extra database queries per GraphQL request (SELECT COUNT, INSERT, DELETE) and the 120 req/min cap was too low for normal usage
- A single fight view fires 20–30 GraphQL requests; browsing multiple fights quickly exhausts the limit, causing 429 cascades amplified by RetryLink's 3 retries per failure
- Switched to an in-memory `Map` rate limiter (matching the existing addon-search pattern) and raised the limit to 300 req/min
- Added `X-Forwarded-For` fallback for IP detection

## Test plan
- [ ] Deploy Worker and verify fight reports load without 429 errors on production
- [ ] Confirm rate limiting still works by verifying the 300/min cap holds under stress
- [ ] Browse multiple fights in sequence to confirm no cascading failures