### PR TITLE
fix(reports): fix broken pagination on Latest Reports page

### DIFF
--- a/src/features/latest_reports/LatestReports.tsx
+++ b/src/features/latest_reports/LatestReports.tsx
@@ -114,8 +114,13 @@ export const LatestReports: React.FC = () => {
           loading: false,
           pagination: {
             currentPage: reportPagination.current_page || 1,
-            totalPages: reportPagination.last_page || 1,
-            totalReports: 0, // We don't care about total count
+            totalPages:
+              reportPagination.last_page > 0
+                ? reportPagination.last_page
+                : reportPagination.has_more_pages
+                  ? (reportPagination.current_page || 1) + 1
+                  : reportPagination.current_page || 1,
+            totalReports: 0,
             perPage: reportPagination.per_page || REPORTS_PER_PAGE,
             hasMorePages: reportPagination.has_more_pages || false,
           },
@@ -290,8 +295,8 @@ export const LatestReports: React.FC = () => {
                 mb={isDesktop ? 3 : 2}
               >
                 <Typography variant="body1" color="text.secondary">
-                  Showing page {state.pagination.currentPage} of {state.pagination.totalPages} -{' '}
-                  {state.pagination.totalReports} total reports
+                  Page {state.pagination.currentPage}
+                  {state.pagination.hasMorePages ? '+' : ` of ${state.pagination.totalPages}`}
                 </Typography>
 
                 <Chip


### PR DESCRIPTION
## Summary
- ESO Logs API returns `last_page: -1` when total pages are unknown — this was passed directly to MUI `Pagination count={-1}`, disabling all navigation buttons
- Status text showed misleading "page 1 of -1 - 0 total reports"
- Now derives `totalPages` from `has_more_pages` and current page
- Shows "Page 1+" when more pages exist, or "Page 1 of 3" when the API provides a real count

## Test plan
- [ ] Verify Latest Reports page shows reports and pagination buttons are enabled
- [ ] Click "Next" to confirm page 2 loads
- [ ] Verify "Previous" is disabled on page 1 and enabled on page 2