### PR TITLE
fix(api): check edge cache before rate limiting to prevent 429 cascades

### DIFF
--- a/roster-hub-api/src/db/queries.ts
+++ b/roster-hub-api/src/db/queries.ts
@@ -1506,12 +1506,3 @@ export async function checkPackVoteRateLimit(db: D1Database, userId: string): Pr
   return (row?.cnt ?? 0) < 30;
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// GraphQL proxy — legacy D1 rate-limit cleanup (table drain)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-export async function cleanupGraphqlRateLimits(db: D1Database): Promise<void> {
-  await db
-    .prepare(`DELETE FROM graphql_rate_limits WHERE created_at < datetime('now', '-60 seconds')`)
-    .run();
-}

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -126,7 +126,7 @@ export async function handleGraphqlProxy(
     if (bucket.count >= rateLimit) {
       return c.json(
         { error: `Rate limit exceeded. Max ${rateLimit} GraphQL requests per minute.` },
-        429,
+        { status: 429, headers: { 'Retry-After': '60' } },
       );
     }
     bucket.count++;

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -111,8 +111,14 @@ export async function handleGraphqlProxy(
     'unknown';
   const now = Date.now();
 
-  for (const [k, val] of rateCounts) {
-    if (val.expires <= now) rateCounts.delete(k);
+  // Probabilistic cleanup (~1-in-50 requests) instead of sweeping
+  // every request. The per-IP bucket check below already handles
+  // expiry for the current caller; stale entries from other IPs only
+  // waste memory, so lazy cleanup is fine.
+  if (Math.random() < 0.02) {
+    for (const [k, val] of rateCounts) {
+      if (val.expires <= now) rateCounts.delete(k);
+    }
   }
 
   const bucket = rateCounts.get(ip);

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -126,7 +126,7 @@ export async function handleGraphqlProxy(
     if (bucket.count >= rateLimit) {
       return c.json(
         { error: `Rate limit exceeded. Max ${rateLimit} GraphQL requests per minute.` },
-        { status: 429, headers: { 'Retry-After': '60' } },
+        { status: 429, headers: { 'Retry-After': '60', 'X-Rate-Limit-Source': 'proxy' } },
       );
     }
     bucket.count++;

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -77,7 +77,11 @@ async function buildCacheKey(url: string, bodyStr: string): Promise<string> {
 
 // ─── Proxy handler ────────────────────────────────────────────────────────────
 
-export async function handleGraphqlProxy(c: Context<{ Bindings: Env }>): Promise<Response> {
+export async function handleGraphqlProxy(
+  c: Context<{ Bindings: Env }>,
+  rateCounts: Map<string, { count: number; expires: number }>,
+  rateLimit: number,
+): Promise<Response> {
   let body: unknown;
   let bodyStr: string;
   try {
@@ -87,11 +91,10 @@ export async function handleGraphqlProxy(c: Context<{ Bindings: Env }>): Promise
     return c.json({ error: 'Invalid JSON body' }, 400);
   }
 
-  // Forward the ?query=<operationName> hint if present (used by ESO Logs for tracing)
   const operationHint = c.req.query('query');
   const isCacheable = Boolean(operationHint && CACHEABLE_OPERATIONS.has(operationHint));
 
-  // Check cache for immutable event data
+  // Check edge cache BEFORE rate limiting — cache hits are free
   const cache = caches.default;
   let cacheKey: Request | undefined;
   if (isCacheable) {
@@ -99,6 +102,30 @@ export async function handleGraphqlProxy(c: Context<{ Bindings: Env }>): Promise
     cacheKey = new Request(`https://cache.internal/${key}`, { method: 'GET' });
     const cached = await cache.match(cacheKey);
     if (cached) return cached;
+  }
+
+  // Cache miss — apply per-IP rate limiting
+  const ip =
+    c.req.header('CF-Connecting-IP') ??
+    c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ??
+    'unknown';
+  const now = Date.now();
+
+  for (const [k, val] of rateCounts) {
+    if (val.expires <= now) rateCounts.delete(k);
+  }
+
+  const bucket = rateCounts.get(ip);
+  if (bucket && bucket.expires > now) {
+    if (bucket.count >= rateLimit) {
+      return c.json(
+        { error: `Rate limit exceeded. Max ${rateLimit} GraphQL requests per minute.` },
+        429,
+      );
+    }
+    bucket.count++;
+  } else {
+    rateCounts.set(ip, { count: 1, expires: now + 60_000 });
   }
 
   let token: string;

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -161,27 +161,7 @@ const GRAPHQL_RATE_LIMIT = 300; // max requests per minute per IP
 const graphqlRateCounts = new Map<string, { count: number; expires: number }>();
 
 app.post('/graphql', async (c) => {
-  const ip =
-    c.req.header('CF-Connecting-IP') ??
-    c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ??
-    'unknown';
-  const now = Date.now();
-
-  for (const [key, val] of graphqlRateCounts) {
-    if (val.expires <= now) graphqlRateCounts.delete(key);
-  }
-
-  const bucket = graphqlRateCounts.get(ip);
-  if (bucket && bucket.expires > now) {
-    if (bucket.count >= GRAPHQL_RATE_LIMIT) {
-      return c.json({ error: 'Rate limit exceeded. Max 300 GraphQL requests per minute.' }, 429);
-    }
-    bucket.count++;
-  } else {
-    graphqlRateCounts.set(ip, { count: 1, expires: now + 60_000 });
-  }
-
-  return handleGraphqlProxy(c);
+  return handleGraphqlProxy(c, graphqlRateCounts, GRAPHQL_RATE_LIMIT);
 });
 
 // ─── Health check ─────────────────────────────────────────────────────────────

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -133,6 +133,7 @@ app.use('*', async (c, next) => {
     origin: isAllowed ? origin : allowedOrigins[0],
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],
+    exposeHeaders: ['Retry-After', 'X-Rate-Limit-Source'],
     maxAge: 86400,
   });
   return corsMiddleware(c, next);

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -61,7 +61,6 @@ import {
   togglePackVote,
   checkPackCreateRateLimit,
   checkPackVoteRateLimit,
-  cleanupGraphqlRateLimits,
 } from './db/queries';
 import { moderateImage, MAX_IMAGE_BYTES } from './image-moderation';
 import { handleGraphqlProxy } from './graphql-proxy';
@@ -1498,9 +1497,10 @@ app.get('/search-addons', async (c) => {
   const ip = c.req.header('CF-Connecting-IP') ?? 'unknown';
   const now = Date.now();
 
-  // Prune expired buckets to prevent unbounded map growth
-  for (const [key, val] of searchRateCounts) {
-    if (val.expires <= now) searchRateCounts.delete(key);
+  if (Math.random() < 0.02) {
+    for (const [key, val] of searchRateCounts) {
+      if (val.expires <= now) searchRateCounts.delete(key);
+    }
   }
 
   const bucket = searchRateCounts.get(ip);
@@ -1608,7 +1608,6 @@ export default {
 
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
     await cleanupExpiredTempBuilds(env.DB);
-    await cleanupGraphqlRateLimits(env.DB);
     await syncLeaderboardRosters(env);
   },
 };

--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -210,7 +210,10 @@ export class EsoLogsClient {
       // backoff, and proxy 429s are not retried. The query() catch
       // block surfaces a human-readable message to the UI.
       const networkStatusCode = (error as { statusCode?: number })?.statusCode;
-      if (networkStatusCode === 429) return;
+      if (networkStatusCode === 429) {
+        logger.debug('Rate limited (429)', { operation: operation.operationName });
+        return;
+      }
       logger.error('GraphQL operation error', error, {
         operation: operation.operationName,
       });

--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -97,9 +97,9 @@ export class EsoLogsClient {
   }
 
   private createApolloClient(accessToken: string): ApolloClient {
-    // Retry link: retries transient network errors and upstream (ESO Logs)
-    // 429s. Does NOT retry proxy 429s — retries against our own rate limiter
-    // just compound the problem.
+    // Retry link: retries transient network errors and upstream 429s.
+    // Proxy 429s are identified by the X-Rate-Limit-Source header and
+    // skipped — retries against our own rate limiter compound the problem.
     const retryLink = new RetryLink({
       delay: {
         initial: 1000,
@@ -111,15 +111,14 @@ export class EsoLogsClient {
         retryIf: (error: unknown, operation: { operationName?: string }) => {
           const statusCode = (error as { statusCode?: number })?.statusCode;
           if (statusCode === 429) {
-            // Only retry 429s for direct ESO Logs /user requests — our
-            // proxy 429s just compound the rate limit problem
-            if (this.isUserSpecificOperation(operation.operationName)) {
-              logger.warn('Upstream rate limit (429) — retrying', {
-                operation: operation.operationName,
-              });
-              return true;
+            const resp = (error as { response?: Response })?.response;
+            if (resp?.headers?.get('X-Rate-Limit-Source') === 'proxy') {
+              return false;
             }
-            return false;
+            logger.warn('Upstream rate limit (429) — retrying', {
+              operation: operation.operationName,
+            });
+            return true;
           }
           if (error != null && statusCode === undefined) {
             logger.warn('Network error — retrying with backoff');

--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -97,9 +97,9 @@ export class EsoLogsClient {
   }
 
   private createApolloClient(accessToken: string): ApolloClient {
-    // Retry link: retries transient network errors (status 0 / no statusCode —
-    // CORS block, DNS failure, dropped connection). Does NOT retry 429s because
-    // retries against our own rate limiter just compound the problem.
+    // Retry link: retries transient network errors and upstream (ESO Logs)
+    // 429s. Does NOT retry proxy 429s — retries against our own rate limiter
+    // just compound the problem.
     const retryLink = new RetryLink({
       delay: {
         initial: 1000,
@@ -108,8 +108,19 @@ export class EsoLogsClient {
       },
       attempts: {
         max: 3,
-        retryIf: (error: unknown) => {
+        retryIf: (error: unknown, operation: { operationName?: string }) => {
           const statusCode = (error as { statusCode?: number })?.statusCode;
+          if (statusCode === 429) {
+            // Only retry 429s for direct ESO Logs /user requests — our
+            // proxy 429s just compound the rate limit problem
+            if (this.isUserSpecificOperation(operation.operationName)) {
+              logger.warn('Upstream rate limit (429) — retrying', {
+                operation: operation.operationName,
+              });
+              return true;
+            }
+            return false;
+          }
           if (error != null && statusCode === undefined) {
             logger.warn('Network error — retrying with backoff');
             return true;
@@ -195,16 +206,11 @@ export class EsoLogsClient {
         });
       }
 
-      // Log the error for debugging — skip noisy 429 logs since RetryLink already
-      // warned on each attempt and the query() catch block will surface a
-      // human-readable message to the UI.
+      // Skip noisy 429 logs — RetryLink handles upstream 429s with
+      // backoff, and proxy 429s are not retried. The query() catch
+      // block surfaces a human-readable message to the UI.
       const networkStatusCode = (error as { statusCode?: number })?.statusCode;
-      if (networkStatusCode === 429) {
-        logger.warn('API rate limit (429) — all retries exhausted', {
-          operation: operation.operationName,
-        });
-        return;
-      }
+      if (networkStatusCode === 429) return;
       logger.error('GraphQL operation error', error, {
         operation: operation.operationName,
       });
@@ -245,7 +251,7 @@ export class EsoLogsClient {
     });
 
     return new ApolloClient({
-      // retryLink must come first so it intercepts 429s before errorLink logs them
+      // retryLink first: retries upstream 429s + network errors before errorLink
       link: from([retryLink, errorLink, authLink, customHttpLink]),
       cache: EsoLogsClient.CACHE,
     });

--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -97,28 +97,19 @@ export class EsoLogsClient {
   }
 
   private createApolloClient(accessToken: string): ApolloClient {
-    // Retry link: automatically retries requests that fail with HTTP 429 (rate limit)
-    // or transient network errors (status 0 / no statusCode — CORS block, DNS failure,
-    // dropped connection, etc.). Uses exponential backoff with jitter to avoid
-    // thundering-herd retries.
+    // Retry link: retries transient network errors (status 0 / no statusCode —
+    // CORS block, DNS failure, dropped connection). Does NOT retry 429s because
+    // retries against our own rate limiter just compound the problem.
     const retryLink = new RetryLink({
       delay: {
-        initial: 1000, // wait 1 s before the first retry
-        max: 15000, // cap at 15 s
-        jitter: true, // randomise to spread concurrent retries
+        initial: 1000,
+        max: 15000,
+        jitter: true,
       },
       attempts: {
         max: 3,
         retryIf: (error: unknown) => {
           const statusCode = (error as { statusCode?: number })?.statusCode;
-          if (statusCode === 429) {
-            logger.warn('API rate limit hit (429) — retrying with backoff', {
-              operation: 'pending',
-            });
-            return true;
-          }
-          // Also retry on network-level errors (no statusCode means the request
-          // never reached the server — transient connectivity failure).
           if (error != null && statusCode === undefined) {
             logger.warn('Network error — retrying with backoff');
             return true;

--- a/src/features/latest_reports/LatestReports.tsx
+++ b/src/features/latest_reports/LatestReports.tsx
@@ -114,8 +114,13 @@ export const LatestReports: React.FC = () => {
           loading: false,
           pagination: {
             currentPage: reportPagination.current_page || 1,
-            totalPages: reportPagination.last_page || 1,
-            totalReports: 0, // We don't care about total count
+            totalPages:
+              reportPagination.last_page > 0
+                ? reportPagination.last_page
+                : reportPagination.has_more_pages
+                  ? (reportPagination.current_page || 1) + 1
+                  : reportPagination.current_page || 1,
+            totalReports: 0,
             perPage: reportPagination.per_page || REPORTS_PER_PAGE,
             hasMorePages: reportPagination.has_more_pages || false,
           },
@@ -290,8 +295,8 @@ export const LatestReports: React.FC = () => {
                 mb={isDesktop ? 3 : 2}
               >
                 <Typography variant="body1" color="text.secondary">
-                  Showing page {state.pagination.currentPage} of {state.pagination.totalPages} -{' '}
-                  {state.pagination.totalReports} total reports
+                  Page {state.pagination.currentPage}
+                  {state.pagination.hasMorePages ? '+' : ` of ${state.pagination.totalPages}`}
                 </Typography>
 
                 <Chip


### PR DESCRIPTION
## Summary
- **Server:** Move rate limiting _after_ the Cloudflare Cache API lookup so cached responses bypass the per-IP rate counter entirely. Previously every request—even cache hits—counted against the 300/min budget, exhausting it after browsing 2–3 fights.
- **Client:** Remove 429 retry from Apollo `RetryLink`. Retrying against our own rate limiter compounds the problem (each retry also counts). Network error retries for transient connectivity failures are kept.
- Includes the earlier pagination fix for Latest Reports and the in-memory rate limiter switch from PRs #1070/#1072.

## Root cause
The rate limit check in `index.ts` ran before the cache check in `graphql-proxy.ts`. Cache hits still consumed the budget. Buff event fetches (4+ sequential 30s intervals per fight × friendly + hostile) plus other event queries exhausted the 300/min limit within 2–3 fights. The `RetryLink` then fired 3 retries per 429—each also counting—creating a death spiral that blocked all GraphQL requests for that IP.

## Test plan
- [ ] Navigate to a report, click into a fight → Insights and Players tabs load with data
- [ ] Click through 3–4 fights quickly → no 429 errors in console, subsequent fights load from cache
- [ ] Open Network tab → repeated visits to the same fight show cache hits, not new upstream requests
- [ ] Force-expire the rate window (wait 60s or deploy fresh) → confirm non-cached requests still go through
- [ ] Verify Latest Reports pagination still works (page 2+)