### PR TITLE
fix(build-view): normalize skill slot indices so ultimates display correctly

### DIFF
--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -848,12 +848,22 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
     return counts;
   }, [gearEntries]);
 
-  const frontBar = Object.entries(setup.skills[0] ?? {})
-    .map(([slot, id]) => ({ slot: Number(slot), id }))
-    .sort((a, b) => a.slot - b.slot);
-  const backBar = Object.entries(setup.skills[1] ?? {})
-    .map(([slot, id]) => ({ slot: Number(slot), id }))
-    .sort((a, b) => a.slot - b.slot);
+  // Normalize skill slot indices to display format (0-4 abilities, 5 ultimate).
+  // CSPS/combat-log builds use ESO-native slots 3-8; roster bridge builds already use 0-5.
+  // Detect format by checking for slot indices > 5 (only exists in 3-8 format).
+  const normalizeBar = (bar: Record<number, number>) => {
+    const entries = Object.entries(bar);
+    const isEsoNative = entries.some(([k]) => Number(k) > 5);
+    return entries
+      .map(([k, id]) => {
+        const s = Number(k);
+        return { slot: isEsoNative ? (s === 8 ? 5 : s - 3) : s, id };
+      })
+      .sort((a, b) => a.slot - b.slot);
+  };
+
+  const frontBar = normalizeBar(setup.skills[0] ?? {});
+  const backBar = normalizeBar(setup.skills[1] ?? {});
 
   const cpSlots = [
     ...setup.cp.warfare.slots.filter((s): s is number => s !== null),

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -851,7 +851,7 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
   // Normalize skill slot indices to display format (0-4 abilities, 5 ultimate).
   // CSPS/combat-log builds use ESO-native slots 3-8; roster bridge builds already use 0-5.
   // Detect format by checking for slot indices > 5 (only exists in 3-8 format).
-  const normalizeBar = (bar: Record<number, number>) => {
+  const normalizeBar = (bar: Record<number, number>): { slot: number; id: number }[] => {
     const entries = Object.entries(bar);
     const isEsoNative = entries.some(([k]) => Number(k) > 5);
     return entries


### PR DESCRIPTION
## Summary
- Fix /bv page showing wrong ability in the ultimate slot (e.g. Combat Prayer instead of Soul Siphon)
- Root cause: raw ESO slot indices (3-8) were passed to rendering logic that expects display indices (0-5), causing slot 5 (3rd regular ability) to be treated as the ultimate
- Auto-detect slot format by checking for indices > 5, remap ESO-native (3-8) bars while passing through already-normalized (0-5) roster bars unchanged

## Test plan
- [ ] Open `/bv?id=6t0e112p6a46` — verify the ultimate slot (R) shows Soul Siphon, not Combat Prayer
- [ ] Open any build from the Build Hub — verify skill bars render correctly
- [ ] Open a build from a roster view ("View Build" button) — verify skills render correctly with 0-5 indexed data