### PR TITLE
fix(calculator): use correct aura ID for Blessing at the Peak

### DIFF
--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -269,7 +269,7 @@ export enum KnownAbilities {
   FELINE_AMBUSH = 192901,
 
   // Blessing at the Peak - Earthen Heart passive that grants 10% critical damage
-  BLESSING_AT_THE_PEAK = 29473,
+  BLESSING_AT_THE_PEAK = 45001,
 
   // Taunted Debuffs
   TAUNT = 38254,


### PR DESCRIPTION
## Summary
- Fix `KnownAbilities.BLESSING_AT_THE_PEAK` from `29473` (skill-line ID) to `45001` (aura ID)
- Without this fix, `isAuraActive` never matches the passive in Dragonknight combat logs, so crit damage breakdown is 10% low when this passive should apply

## Context
PR #1083 added Blessing at the Peak but used the skill-line ID (`29473` from `ClassSkillId`) instead of the aura ID (`45001`) that appears in `combatantInfo.auras`. This follows the existing pattern — `HEMORRHAGE = 45060`, `PIERCING_SPEAR = 44046`, `FELINE_AMBUSH = 192901` all use aura IDs, not skill-line IDs.

## Test plan
- [ ] All 20 CritDamageUtils tests pass
- [ ] Upload a Dragonknight log with Earthen Heart abilities slotted — verify Blessing at the Peak appears in the crit damage breakdown