### PR TITLE
fix(roster-hub): display updated_at instead of created_at on roster cards

### DIFF
--- a/src/features/roster-hub/components/RosterCard.tsx
+++ b/src/features/roster-hub/components/RosterCard.tsx
@@ -435,7 +435,7 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
                     letterSpacing: '0.01em',
                   }}
                 >
-                  {formatDate(roster.created_at)}
+                  {formatDate(roster.updated_at ?? roster.created_at)}
                 </Typography>
               </Box>
             </Box>


### PR DESCRIPTION
## Summary
- Roster cards in the Roster Hub were showing `created_at` (set once on initial insert) instead of `updated_at` (refreshed daily by the leaderboard cron sync)
- This caused all #1 leaderboard rosters to appear ~1 week old even though the backend syncs them every day at 04:00 UTC
- Falls back to `created_at` for rosters without an `updated_at` value

## Test plan
- [x] Verify leaderboard #1 rosters show recent timestamps (e.g. "8h ago" instead of "1w ago")
- [x] Verify user-created rosters still display correctly