### PR TITLE
fix(tests): stop clicking unrelated buttons in nightly live-log test

### DIFF
--- a/tests/nightly-regression-interactive.spec.ts
+++ b/tests/nightly-regression-interactive.spec.ts
@@ -498,45 +498,18 @@ test.describe('Nightly Regression - Interactive Features', () => {
 
       await page.waitForTimeout(5000);
 
-      // Look for live logging interface elements
-      const hasLiveCssElements = await page
-        .locator('.live-log, .live-logging, .real-time, [data-testid*="live"]')
-        .isVisible()
-        .catch(() => false);
-      const hasLiveText = await page
-        .getByText(/live/i)
-        .isVisible()
-        .catch(() => false);
-
-      const hasLiveInterface = hasLiveCssElements || hasLiveText;
-
-      // Take screenshot with error handling
+      // LiveLog is a passive polling wrapper around ReportFightDetails — it has
+      // no Start/Stop/Connect controls. Earlier heuristics here matched
+      // unrelated UI (e.g. "Enlivening Overflow" CP, footer "Connect with our
+      // team" CTA), so the test only takes a smoke-test screenshot.
       try {
         await page.screenshot({
           path: `test-results/nightly-regression-live-logging-${reportId}.png`,
           fullPage: true,
-          timeout: 15000, // Increased timeout
+          timeout: 15000,
         });
       } catch (screenshotError) {
         console.log('Screenshot failed but continuing test:', (screenshotError as Error).message);
-      }
-
-      if (hasLiveInterface) {
-        // Test live logging controls if available
-        const controls = page.locator(
-          'button:has-text("Start"), button:has-text("Stop"), button:has-text("Connect")',
-        );
-
-        if (await controls.first().isVisible({ timeout: 3000 })) {
-          await controls.first().click();
-          await page.waitForTimeout(2000);
-
-          await page.screenshot({
-            path: `test-results/nightly-regression-live-active-${reportId}.png`,
-            fullPage: true,
-            timeout: TEST_TIMEOUTS.screenshot,
-          });
-        }
       }
     });
   });


### PR DESCRIPTION
The "should load live logging interface" test in
nightly-regression-interactive.spec.ts kept timing out on chromium-desktop
with `locator.click: Timeout 30000ms exceeded — element is outside of the
viewport`.

Root cause is a test bug, not a product regression:

* LiveLog (`src/features/live_logging/LiveLog.tsx`) is a passive 30s-poll
  wrapper around ReportFightDetails. It does not render any Start/Stop/
  Connect controls; on an unseeded report it just shows
  `Waiting for fights to be uploaded...`.
* The `hasLiveText = getByText(/live/i)` heuristic false-positives on the
  Champion Point name "EnLIVEning Overflow" on every report page, so
  `hasLiveInterface` was always true.
* The `button:has-text("Start"), button:has-text("Stop"),
  button:has-text("Connect")` locator then matched an unrelated button
  via descendant-text on the footer "Connect with our team" CTA. Chromium
  reported the resolved element as offscreen and retried the click 50x
  until the 30s timeout (firefox/webkit's `isVisible({timeout:3000})`
  pre-check returned false, so they skipped the click and "passed").

Drop the heuristic plus the speculative control-click block. The test
keeps its navigation + screenshot smoke check, matching the pattern used
by sibling tests in this file.

https://claude.ai/code/session_01Gy5tqi1YYShiRe1LnRyf3K