### PR TITLE
fix(security): DeepSec audit round 2 — 30+ vulnerability fixes

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -42,8 +42,9 @@ jobs:
     steps:
       - name: Extract Jira ticket key from branch name
         id: jira-key
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
           # Match ESO-NNN at the start of the branch name
           if [[ "$BRANCH" =~ ^(ESO-[0-9]+) ]]; then
             TICKET="${BASH_REMATCH[1]}"

--- a/.github/workflows/rollbar-sourcemaps.yml
+++ b/.github/workflows/rollbar-sourcemaps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   upload-sourcemaps:
@@ -104,4 +104,3 @@ jobs:
           echo "Use the 'post_server_item' token from your Rollbar project settings"
           exit 1
         if: failure()
-

--- a/discord-bot/src/auth.ts
+++ b/discord-bot/src/auth.ts
@@ -147,5 +147,5 @@ export async function verifyWebhookSecret(env: Env, authHeader: string | null): 
   // timingSafeEqual is available in Cloudflare Workers runtime
   return (
     crypto.subtle as unknown as { timingSafeEqual(a: ArrayBuffer, b: ArrayBuffer): boolean }
-  ).timingSafeEqual(a.buffer, b.buffer);
+  ).timingSafeEqual(a.buffer as ArrayBuffer, b.buffer as ArrayBuffer);
 }

--- a/discord-bot/src/buttons/confirm-close.ts
+++ b/discord-bot/src/buttons/confirm-close.ts
@@ -7,9 +7,15 @@
  */
 
 import { deleteChannel, getMessages, isStaff, sendMessage } from '../discord.js';
-import { deleteTicket, getTicket } from '../kv.js';
+import { deleteTicket, getTicket, updateTicket } from '../kv.js';
 import { Colors, InteractionResponseType, MessageFlags } from '../types.js';
-import type { DiscordInteraction, DiscordMessage, Env, InteractionResponse, TicketState } from '../types.js';
+import type {
+  DiscordInteraction,
+  DiscordMessage,
+  Env,
+  InteractionResponse,
+  TicketState,
+} from '../types.js';
 import { ephemeral, formatDuration } from '../utils.js';
 
 export async function handleConfirmCloseButton(
@@ -35,10 +41,10 @@ export async function handleConfirmCloseButton(
     return ephemeral('This ticket is already closed.');
   }
 
-  // Immediately acknowledge so Discord doesn't time out
+  await updateTicket(env, channelId, { status: 'closed' });
+
   const closingUser = interaction.member?.user ?? interaction.user;
 
-  // Run the heavy async work after responding
   ctx.waitUntil(closeTicket(env, ticket, channelId, closingUser?.username ?? 'Unknown'));
 
   return {
@@ -91,15 +97,25 @@ async function closeTicket(
         { name: 'Category', value: ticket.aiRefinedCategory ?? ticket.category, inline: true },
         {
           name: 'Claimed by',
-          value: ticket.claimedBy ? `<@${ticket.claimedBy}> (${ticket.claimedByUsername})` : 'Unclaimed',
+          value: ticket.claimedBy
+            ? `<@${ticket.claimedBy}> (${ticket.claimedByUsername})`
+            : 'Unclaimed',
           inline: true,
         },
         { name: 'Closed by', value: closedByUsername, inline: true },
         { name: 'Duration', value: durationStr, inline: true },
         ...(ticket.githubIssueUrl
-          ? [{ name: 'GitHub Issue', value: `[#${ticket.githubIssueNumber}](${ticket.githubIssueUrl})`, inline: true }]
+          ? [
+              {
+                name: 'GitHub Issue',
+                value: `[#${ticket.githubIssueNumber}](${ticket.githubIssueUrl})`,
+                inline: true,
+              },
+            ]
           : []),
-        ...(ticket.aiSummary ? [{ name: 'AI Summary', value: ticket.aiSummary, inline: false }] : []),
+        ...(ticket.aiSummary
+          ? [{ name: 'AI Summary', value: ticket.aiSummary, inline: false }]
+          : []),
       ],
       footer: {
         text: `Ticket ID: ${ticket.id} • Total messages: ${messages.length}`,
@@ -126,4 +142,3 @@ async function closeTicket(
     console.error('[confirm-close] unexpected error during closeTicket:', err);
   }
 }
-

--- a/discord-bot/src/commands/ticket-setup.ts
+++ b/discord-bot/src/commands/ticket-setup.ts
@@ -20,7 +20,10 @@ export async function handleTicketSetup(
   interaction: DiscordInteraction,
   ctx: ExecutionContext,
 ): Promise<InteractionResponse> {
-  // Check admin permissions
+  if (interaction.guild_id !== env.GUILD_ID) {
+    return ephemeral('❌ This command can only be used in the ESO Toolkit server.');
+  }
+
   const permsStr = interaction.member?.permissions;
   if (!permsStr) {
     return ephemeral('❌ Could not verify your permissions.');
@@ -101,4 +104,3 @@ async function postPanel(env: Env, interaction: DiscordInteraction): Promise<voi
     } catch {}
   }
 }
-

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -59,6 +59,20 @@ function getAllowedOrigins(env: Env): Set<string> {
   return env.ENVIRONMENT === 'development' ? ALL_CORS_ORIGINS : PROD_CORS_ORIGINS;
 }
 
+async function checkKvRateLimit(
+  kv: KVNamespace,
+  key: string,
+  maxPerWindow: number,
+  windowSeconds: number,
+): Promise<boolean> {
+  const rlKey = `rl:${key}`;
+  const raw = await kv.get(rlKey);
+  const count = raw ? parseInt(raw, 10) : 0;
+  if (count >= maxPerWindow) return false;
+  await kv.put(rlKey, String(count + 1), { expirationTtl: windowSeconds });
+  return true;
+}
+
 function isAllowedRedirectUri(uri: string, env: Env): boolean {
   const uris = env.ENVIRONMENT === 'development' ? ALL_REDIRECT_URIS : PROD_REDIRECT_URIS;
   if (uris.has(uri)) return true;
@@ -84,6 +98,11 @@ export default {
       return withCors(request, env, await handleBotGuilds(request, env));
     }
     if (url.pathname === '/discord/oauth/token') {
+      const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+      const allowed = await checkKvRateLimit(env.TICKETS, `oauth:${ip}`, 10, 60);
+      if (!allowed) {
+        return withCors(request, env, jsonResponse({ error: 'Rate limit exceeded' }, 429));
+      }
       return withCors(request, env, await handleOAuthTokenExchange(request, env));
     }
 
@@ -347,6 +366,11 @@ async function handleRosterApi(request: Request, url: URL, env: Env): Promise<Re
     return handlePublish(body, env, auth.userId);
   }
   if (path === '/discord/roster/publish-direct') {
+    const userId = auth.userId ?? 'anon';
+    const allowed = await checkKvRateLimit(env.TICKETS, `pub:${userId}`, 5, 60);
+    if (!allowed) {
+      return jsonResponse({ error: 'Rate limit exceeded. Try again in a minute.' }, 429);
+    }
     return handlePublishDirect(body, env, auth.userId);
   }
 
@@ -401,8 +425,8 @@ async function handleRefresh(
   const authHeader = request.headers.get('Authorization');
   const isWebhook = await verifyWebhookSecret(env, authHeader);
 
+  let scopeGuildId: string | undefined;
   if (!isWebhook) {
-    // For user-initiated refresh, require an explicit guildId
     const guildId = body.guildId as string | undefined;
     if (!guildId) {
       return jsonResponse({ error: 'guildId is required for user-initiated refresh' }, 400);
@@ -411,9 +435,10 @@ async function handleRefresh(
     if (!auth.authorized) {
       return jsonResponse({ error: auth.error ?? 'Forbidden' }, 403);
     }
+    scopeGuildId = guildId;
   }
 
-  const result = await refreshRoster(env, rosterId);
+  const result = await refreshRoster(env, rosterId, scopeGuildId);
   if (!result.ok) {
     return jsonResponse({ error: result.error }, 400);
   }
@@ -438,7 +463,9 @@ async function handlePublishDirect(
     return jsonResponse({ error: 'roster_data exceeds maximum allowed size' }, 400);
   }
 
-  const rawTags = Array.isArray(body.tags) ? (body.tags as string[]).filter(Boolean) : undefined;
+  const rawTags = Array.isArray(body.tags)
+    ? (body.tags as unknown[]).filter((t): t is string => typeof t === 'string' && t.length > 0)
+    : undefined;
 
   const req: DirectPublishRequest = {
     guildId,
@@ -538,14 +565,29 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
       ...(typeof body.namePattern === 'string' &&
         body.namePattern.length <= 100 && { namePattern: body.namePattern }),
       ...(Array.isArray(body.allowedRoleIds) && {
-        allowedRoleIds: (body.allowedRoleIds as unknown[])
-          .filter((id): id is string => typeof id === 'string' && /^\d+$/.test(id)),
+        allowedRoleIds: (body.allowedRoleIds as unknown[]).filter(
+          (id): id is string => typeof id === 'string' && /^\d+$/.test(id),
+        ),
       }),
       ...(typeof body.rolePingIds === 'object' &&
-        body.rolePingIds !== null && {
-          rolePingIds: body.rolePingIds as GuildConfig['rolePingIds'],
+        body.rolePingIds !== null &&
+        !Array.isArray(body.rolePingIds) && {
+          rolePingIds: Object.fromEntries(
+            Object.entries(body.rolePingIds as Record<string, unknown>)
+              .filter(([, v]) => v === null || (typeof v === 'string' && /^\d{17,20}$/.test(v)))
+              .map(([k, v]) => [k, v as string | null]),
+          ) as GuildConfig['rolePingIds'],
         }),
-      ...(typeof body.timezone === 'string' && { timezone: body.timezone }),
+      ...(typeof body.timezone === 'string' &&
+        body.timezone.length <= 50 &&
+        (() => {
+          try {
+            Intl.DateTimeFormat(undefined, { timeZone: body.timezone as string });
+            return true;
+          } catch {
+            return false;
+          }
+        })() && { timezone: body.timezone }),
     };
 
     await upsertGuildConfig(env, updated);

--- a/discord-bot/src/modals/ticket-form.ts
+++ b/discord-bot/src/modals/ticket-form.ts
@@ -224,7 +224,19 @@ export async function handleTicketFormModal(
     };
   }
 
-  // Immediately defer — channel creation + AI + GitHub all take >3s
+  const rlKey = `rl:ticket:${user.id}`;
+  const rlCount = parseInt((await env.TICKETS.get(rlKey)) ?? '0', 10);
+  if (rlCount >= 3) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '❌ You are creating tickets too quickly. Please wait a few minutes.',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+  await env.TICKETS.put(rlKey, String(rlCount + 1), { expirationTtl: 300 });
+
   ctx.waitUntil(processTicketCreation(env, interaction, user, category, title, description));
 
   return {

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -257,7 +257,11 @@ export interface RefreshResult {
  * Refresh all Discord channels linked to a roster across all guilds.
  * Called by the webhook from roster-hub-api and by /roster refresh.
  */
-export async function refreshRoster(env: Env, rosterId: string): Promise<RefreshResult> {
+export async function refreshRoster(
+  env: Env,
+  rosterId: string,
+  scopeGuildId?: string,
+): Promise<RefreshResult> {
   // Fetch the latest snapshot — hub API for normal IDs, KV for direct-publish
   const fetchResult = await fetchRosterSnapshot(env, rosterId);
   let snapshot = fetchResult.status === 'ok' ? fetchResult.snapshot : null;
@@ -302,7 +306,10 @@ export async function refreshRoster(env: Env, rosterId: string): Promise<Refresh
   // Find all guilds that have this roster mapped by scanning KV prefix.
   // For direct-publish rosters with a known guild, check that guild first.
   // For hub rosters, scan all roster-map entries matching this rosterId.
-  const mappings = await findMappingsForRoster(env, rosterId);
+  let mappings = await findMappingsForRoster(env, rosterId);
+  if (scopeGuildId) {
+    mappings = mappings.filter((m) => m.guildId === scopeGuildId);
+  }
   if (mappings.length === 0) {
     return { ok: true, refreshedCount: 0 };
   }
@@ -577,7 +584,11 @@ async function createNewRosterChannel(
   const channelOptions: Parameters<typeof createChannel>[2] = {
     name: channelName,
     type: ChannelType.GUILD_TEXT,
-    topic: `ESO Toolkit Roster: ${snapshot.title.replace(/<@[!&]?\d+>|<#\d+>|@everyone|@here/g, '')} (ID: ${snapshot.id})`.slice(0, 1024),
+    topic:
+      `ESO Toolkit Roster: ${snapshot.title.replace(/<@[!&]?\d+>|<#\d+>|@everyone|@here/g, '')} (ID: ${snapshot.id})`.slice(
+        0,
+        1024,
+      ),
   };
   if (categoryId) {
     channelOptions.parent_id = categoryId;

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -105,6 +105,18 @@ const ALLOWED_OPERATIONS = new Set([
 
 const MAX_BODY_BYTES = 100_000; // 100 KB
 
+const OPERATION_NAME_RE = /\b(?:query|mutation|subscription)\s+([A-Za-z_]\w*)/g;
+
+function extractOperationNames(queryDoc: string): string[] {
+  const names: string[] = [];
+  let match;
+  while ((match = OPERATION_NAME_RE.exec(queryDoc)) !== null) {
+    names.push(match[1]);
+  }
+  OPERATION_NAME_RE.lastIndex = 0;
+  return names;
+}
+
 // Singleflight: coalesce concurrent identical cacheable requests so only one
 // hits upstream. Each caller clones the shared response.
 const inflight = new Map<string, Promise<Response>>();
@@ -118,9 +130,7 @@ async function buildCacheKey(url: string, bodyStr: string): Promise<string> {
 
 // ─── Proxy handler ────────────────────────────────────────────────────────────
 
-export async function handleGraphqlProxy(
-  c: Context<{ Bindings: Env }>,
-): Promise<Response> {
+export async function handleGraphqlProxy(c: Context<{ Bindings: Env }>): Promise<Response> {
   let body: unknown;
   let bodyStr: string;
   try {
@@ -139,10 +149,20 @@ export async function handleGraphqlProxy(
     return c.json({ error: 'Unknown or missing operation' }, 400);
   }
 
-  const parsed = body as { operationName?: string };
+  const parsed = body as { operationName?: string; query?: string };
   if (!parsed.operationName || parsed.operationName !== operationHint) {
     return c.json({ error: 'operationName must match the query parameter' }, 400);
   }
+
+  if (typeof parsed.query !== 'string' || !parsed.query.trim()) {
+    return c.json({ error: 'Missing query document' }, 400);
+  }
+
+  const docOps = extractOperationNames(parsed.query);
+  if (docOps.length !== 1 || docOps[0] !== operationHint) {
+    return c.json({ error: 'Query document must contain exactly the declared operation' }, 400);
+  }
+
   const isCacheable = Boolean(operationHint && CACHEABLE_OPERATIONS.has(operationHint));
 
   // Check edge cache first — cache hits avoid upstream entirely

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -77,7 +77,7 @@ const app = new Hono<{ Bindings: Env }>();
 app.onError((err, c) => {
   console.error(`[${c.req.method} ${c.req.path}]`, err.message, err.stack);
   const status = 'status' in err && typeof err.status === 'number' ? err.status : 500;
-  const msg = status >= 500 ? 'Internal server error' : (err.message || 'Internal server error');
+  const msg = status >= 500 ? 'Internal server error' : err.message || 'Internal server error';
   return c.json({ error: msg }, status as 500);
 });
 
@@ -93,17 +93,7 @@ function tryDeleteImgBBImage(deleteUrl: string | null): void {
 /** Verify that an encoded payload is valid base64url (no special chars that break URLs). */
 const isValidBase64Url = (s: string): boolean => /^[A-Za-z0-9_-]*=*$/.test(s);
 
-/** Escape HTML entities in user-generated text (defense-in-depth against stored XSS). */
-const escapeHtml = (s: string): string =>
-  s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;');
-
-/** Sanitize and trim a user-provided text field. */
-const sanitize = (s: string): string => escapeHtml(s.trim());
+import { escapeHtml, sanitize } from './sanitize';
 
 /** Validate and sanitize an addon entry. Returns null if invalid. */
 const sanitizeAddonEntry = (a: unknown): RecommendedAddonEntry | null => {
@@ -381,15 +371,10 @@ app.put('/rosters/:id', async (c) => {
     return c.json({ error: 'Invalid JSON' }, 400);
   }
 
-  const {
-    title,
-    description = '',
-    trial_id,
-    roster_data,
-    tags = [],
-    is_anonymous = false,
-    recommended_addons = null,
-  } = body;
+  const { title, description = '', trial_id, roster_data, tags = [] } = body;
+  const is_anonymous = 'is_anonymous' in body ? (body.is_anonymous ?? false) : undefined;
+  const recommended_addons =
+    'recommended_addons' in body ? (body.recommended_addons ?? null) : undefined;
 
   if (!title?.trim()) return c.json({ error: 'title is required' }, 400);
   if (!trial_id?.trim()) return c.json({ error: 'trial_id is required' }, 400);
@@ -429,14 +414,18 @@ app.put('/rosters/:id', async (c) => {
     }
   }
 
+  const existing = await getRosterById(c.env.DB, c.req.param('id'), user.id);
   const updated = await updateRoster(c.env.DB, c.req.param('id'), user.id, {
     title: sanitize(title),
     description: sanitize(description),
     trialId: sanitize(trial_id),
     rosterData: roster_data,
     tags: Array.isArray(tags) ? tags.filter(isValidTag).slice(0, 10).map(sanitize) : [],
-    isAnonymous: !!is_anonymous,
-    recommendedAddons: recommendedAddonsJson,
+    isAnonymous: is_anonymous !== undefined ? !!is_anonymous : !!existing?.is_anonymous,
+    recommendedAddons:
+      recommended_addons !== undefined
+        ? recommendedAddonsJson
+        : ((existing?.recommended_addons as string | null) ?? null),
   });
 
   if (!updated) return c.json({ error: 'Not found or forbidden' }, 404);
@@ -552,7 +541,7 @@ app.post('/rosters/:id/comments', async (c) => {
     rosterId,
     parentId: body.parent_id ?? null,
     authorId: user.id,
-    authorName: user.name,
+    authorName: escapeHtml(user.name),
     body: escapeHtml(body.body.trim()),
   });
 
@@ -837,7 +826,7 @@ app.post('/builds/:id/comments', async (c) => {
     buildId,
     parentId: body.parent_id ?? null,
     authorId: user.id,
-    authorName: user.name,
+    authorName: escapeHtml(user.name),
     body: escapeHtml(body.body.trim()),
   });
 
@@ -976,10 +965,19 @@ app.post('/images/upload', async (c) => {
 
   // Validate image magic numbers (PNG, JPEG, WebP, GIF)
   const isValidImage =
-    (imageBytes[0] === 0x89 && imageBytes[1] === 0x50 && imageBytes[2] === 0x4e && imageBytes[3] === 0x47) || // PNG
+    (imageBytes[0] === 0x89 &&
+      imageBytes[1] === 0x50 &&
+      imageBytes[2] === 0x4e &&
+      imageBytes[3] === 0x47) || // PNG
     (imageBytes[0] === 0xff && imageBytes[1] === 0xd8 && imageBytes[2] === 0xff) || // JPEG
-    (imageBytes[0] === 0x52 && imageBytes[1] === 0x49 && imageBytes[2] === 0x46 && imageBytes[3] === 0x46 &&
-      imageBytes[8] === 0x57 && imageBytes[9] === 0x45 && imageBytes[10] === 0x42 && imageBytes[11] === 0x50) || // WebP
+    (imageBytes[0] === 0x52 &&
+      imageBytes[1] === 0x49 &&
+      imageBytes[2] === 0x46 &&
+      imageBytes[3] === 0x46 &&
+      imageBytes[8] === 0x57 &&
+      imageBytes[9] === 0x45 &&
+      imageBytes[10] === 0x42 &&
+      imageBytes[11] === 0x50) || // WebP
     (imageBytes[0] === 0x47 && imageBytes[1] === 0x49 && imageBytes[2] === 0x46); // GIF
   if (!isValidImage) {
     return c.json({ error: 'Unsupported image format. Use PNG, JPEG, WebP, or GIF.' }, 400);
@@ -1072,8 +1070,9 @@ app.post('/images/:id/report', async (c) => {
   if (!body.reason?.trim()) return c.json({ error: 'reason is required' }, 400);
   if (body.reason.length > 500) return c.json({ error: 'reason must be ≤ 500 characters' }, 400);
 
-  const existing = await c.env.DB
-    .prepare('SELECT id FROM image_reports WHERE image_id = ? AND reporter_id = ?')
+  const existing = await c.env.DB.prepare(
+    'SELECT id FROM image_reports WHERE image_id = ? AND reporter_id = ?',
+  )
     .bind(imageId, user.id)
     .first();
   if (existing) return c.json({ error: 'You have already reported this image' }, 409);
@@ -1227,10 +1226,19 @@ app.put('/users/me/avatar', async (c) => {
 
   // Validate image magic numbers (PNG, JPEG, WebP, GIF)
   const isValidAvatar =
-    (imageBytes[0] === 0x89 && imageBytes[1] === 0x50 && imageBytes[2] === 0x4e && imageBytes[3] === 0x47) || // PNG
+    (imageBytes[0] === 0x89 &&
+      imageBytes[1] === 0x50 &&
+      imageBytes[2] === 0x4e &&
+      imageBytes[3] === 0x47) || // PNG
     (imageBytes[0] === 0xff && imageBytes[1] === 0xd8 && imageBytes[2] === 0xff) || // JPEG
-    (imageBytes[0] === 0x52 && imageBytes[1] === 0x49 && imageBytes[2] === 0x46 && imageBytes[3] === 0x46 &&
-      imageBytes[8] === 0x57 && imageBytes[9] === 0x45 && imageBytes[10] === 0x42 && imageBytes[11] === 0x50) || // WebP
+    (imageBytes[0] === 0x52 &&
+      imageBytes[1] === 0x49 &&
+      imageBytes[2] === 0x46 &&
+      imageBytes[3] === 0x46 &&
+      imageBytes[8] === 0x57 &&
+      imageBytes[9] === 0x45 &&
+      imageBytes[10] === 0x42 &&
+      imageBytes[11] === 0x50) || // WebP
     (imageBytes[0] === 0x47 && imageBytes[1] === 0x49 && imageBytes[2] === 0x46); // GIF
   if (!isValidAvatar) {
     return c.json({ error: 'Unsupported image format. Use PNG, JPEG, WebP, or GIF.' }, 400);
@@ -1289,7 +1297,7 @@ app.put('/users/me/avatar', async (c) => {
   await upsertUserAvatar(
     c.env.DB,
     user.id,
-    user.name,
+    escapeHtml(user.name),
     imgbb.data.url,
     imgbb.data.thumb.url,
     imgbb.data.delete_url,
@@ -1323,7 +1331,7 @@ app.put('/users/me/display-names', async (c) => {
   const na = body.na_display_name?.trim() || null;
   const eu = body.eu_display_name?.trim() || null;
 
-  await updateDisplayNames(c.env.DB, user.id, user.name, na, eu);
+  await updateDisplayNames(c.env.DB, user.id, escapeHtml(user.name), na, eu);
   return c.json({ ok: true });
 });
 
@@ -1681,11 +1689,15 @@ app.post('/admin/sync-leaderboard', async (c) => {
     return c.json({ error: 'Unauthorized' }, 401);
   }
   const enc = new TextEncoder();
-  const a = enc.encode(key);
-  const b = enc.encode(c.env.INTERNAL_API_KEY);
-  if (a.byteLength !== b.byteLength ||
-    !(crypto.subtle as unknown as { timingSafeEqual(a: ArrayBuffer, b: ArrayBuffer): boolean })
-      .timingSafeEqual(a.buffer as ArrayBuffer, b.buffer as ArrayBuffer)) {
+  const [hashA, hashB] = await Promise.all([
+    crypto.subtle.digest('SHA-256', enc.encode(key)),
+    crypto.subtle.digest('SHA-256', enc.encode(c.env.INTERNAL_API_KEY)),
+  ]);
+  if (
+    !(
+      crypto.subtle as unknown as { timingSafeEqual(a: ArrayBuffer, b: ArrayBuffer): boolean }
+    ).timingSafeEqual(hashA, hashB)
+  ) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
   const results = await syncLeaderboardRosters(c.env);

--- a/roster-hub-api/src/leaderboard-sync/roster-encoder.ts
+++ b/roster-hub-api/src/leaderboard-sync/roster-encoder.ts
@@ -6,6 +6,7 @@
  * is available natively in the Workers runtime.
  */
 
+import { escapeHtml } from '../sanitize';
 import type { PlayerDetails, PlayerEntry, RankingEntry } from './esologs-client';
 import { categorizeGear } from './gear-categorizer';
 
@@ -69,7 +70,7 @@ function buildCompactTank(player: PlayerEntry, index: number): CompactTank {
   const gear = categorizeGear(player.combatantInfo?.gear ?? [], false);
   const ct: CompactTank = {};
 
-  if (player.name) ct.pn = player.name;
+  if (player.name) ct.pn = escapeHtml(player.name);
   ct.rl = `T${index + 1}`;
 
   const gs: CompactGear = {};
@@ -92,7 +93,7 @@ function buildCompactHealer(player: PlayerEntry, index: number): CompactHealer {
   const gear = categorizeGear(player.combatantInfo?.gear ?? [], false);
   const ch: CompactHealer = {};
 
-  if (player.name) ch.pn = player.name;
+  if (player.name) ch.pn = escapeHtml(player.name);
   ch.rl = `H${index + 1}`;
 
   if (gear.set1) ch.s1 = gear.set1;
@@ -112,7 +113,7 @@ function buildCompactDPS(player: PlayerEntry, index: number): CompactDPS {
   const gear = categorizeGear(player.combatantInfo?.gear ?? [], true);
   const cd: CompactDPS = { sn: index + 1 };
 
-  if (player.name) cd.pn = player.name;
+  if (player.name) cd.pn = escapeHtml(player.name);
 
   if (gear.set1) cd.s1 = gear.set1;
   if (gear.set2) cd.s2 = gear.set2;
@@ -204,7 +205,7 @@ export async function encodeRoster(roster: CompactRosterV3): Promise<string> {
  * Build a display title for a #1 roster.
  */
 export function buildRosterTitle(ranking: RankingEntry, trialName: string): string {
-  const teamName = ranking.guild?.name ?? 'Unknown';
+  const teamName = escapeHtml(ranking.guild?.name ?? 'Unknown');
   return `${teamName} — ${trialName} #1`;
 }
 
@@ -212,7 +213,7 @@ export function buildRosterTitle(ranking: RankingEntry, trialName: string): stri
  * Build a description for a #1 roster.
  */
 export function buildRosterDescription(ranking: RankingEntry, trialName: string): string {
-  const teamName = ranking.guild?.name ?? 'Unknown';
+  const teamName = escapeHtml(ranking.guild?.name ?? 'Unknown');
   const server = ranking.server?.region?.toUpperCase() ?? '';
   const score = ranking.score ? ` • Score: ${ranking.score.toLocaleString()}` : '';
   return `Auto-imported #1 ${trialName} roster from ${teamName}${server ? ` (${server})` : ''}${score}`;

--- a/roster-hub-api/src/sanitize.ts
+++ b/roster-hub-api/src/sanitize.ts
@@ -1,0 +1,9 @@
+export const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+
+export const sanitize = (s: string): string => escapeHtml(s.trim());

--- a/src/AppAuth.tsx
+++ b/src/AppAuth.tsx
@@ -12,10 +12,10 @@
  * 4. OAuthRedirect detects the app_auth_port flag and sends tokens
  *    to http://localhost:{port}/callback instead of storing them
  */
-import CircularProgress from '@mui/material/CircularProgress';
+import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { startPKCEAuth } from './features/auth/auth';
@@ -26,23 +26,29 @@ export const APP_AUTH_PORT_KEY = 'app_auth_port';
 export const AppAuth: React.FC = () => {
   const [params] = useSearchParams();
   const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
 
-  useEffect(() => {
-    const port = params.get('port');
-    const portNum = port ? parseInt(port, 10) : NaN;
-    if (!port || isNaN(portNum) || portNum < 1 || portNum > 65535) {
-      setError('Missing or invalid port parameter.');
-      return;
-    }
+  const port = params.get('port');
+  const portNum = port ? parseInt(port, 10) : NaN;
+  const validPort = port && !isNaN(portNum) && portNum >= 1 && portNum <= 65535;
 
-    // Store the port so OAuthRedirect knows to send tokens to the app
-    sessionStorage.setItem(APP_AUTH_PORT_KEY, port);
-
-    // Start the normal PKCE OAuth flow (redirects to ESO Logs)
+  const handleConfirm = (): void => {
+    if (!validPort) return;
+    setStarting(true);
+    sessionStorage.setItem(APP_AUTH_PORT_KEY, port!);
     startPKCEAuth().catch(() => {
       setError('Failed to start authentication.');
+      setStarting(false);
     });
-  }, [params]);
+  };
+
+  if (!validPort) {
+    return (
+      <Container maxWidth="sm" style={{ textAlign: 'center', marginTop: '4rem' }}>
+        <Typography color="error">Missing or invalid port parameter.</Typography>
+      </Container>
+    );
+  }
 
   if (error) {
     return (
@@ -54,10 +60,16 @@ export const AppAuth: React.FC = () => {
 
   return (
     <Container maxWidth="sm" style={{ textAlign: 'center', marginTop: '4rem' }}>
-      <CircularProgress />
-      <Typography style={{ marginTop: '1rem' }}>
-        Redirecting to ESO Logs for authentication...
+      <Typography variant="h6" gutterBottom>
+        Desktop App Authentication
       </Typography>
+      <Typography style={{ marginBottom: '1.5rem' }}>
+        A desktop application is requesting ESO Logs authentication via port {portNum}. Click below
+        to continue.
+      </Typography>
+      <Button variant="contained" onClick={handleConfirm} disabled={starting}>
+        {starting ? 'Redirecting…' : 'Continue to ESO Logs'}
+      </Button>
     </Container>
   );
 };

--- a/src/OAuthRedirect.tsx
+++ b/src/OAuthRedirect.tsx
@@ -100,16 +100,10 @@ export const OAuthRedirect: React.FC = () => {
               throw new Error(`Desktop app responded with ${callbackResp.status}`);
             }
           } catch {
-            // CORS not supported or connection refused — fall back to GET redirect
-            // so older Kalpa versions still receive tokens.
-            const tokenPayload = btoa(
-              JSON.stringify({
-                access_token: data.access_token,
-                refresh_token: data.refresh_token || null,
-                expires_in: data.expires_in || 3600,
-              }),
+            setError(
+              'Could not connect to the desktop application. ' +
+                'Please make sure it is running and try again.',
             );
-            window.location.href = `http://localhost:${appPort}/callback?tokens=${encodeURIComponent(tokenPayload)}`;
             return;
           }
           setKalpaSuccess(true);

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -72,9 +72,7 @@ export function clearIntendedDestination(): void {
 const generateCodeVerifier = (): string => {
   const array = new Uint32Array(32);
   window.crypto.getRandomValues(array);
-  const verifier = Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('');
-  localStorage.setItem(PKCE_CODE_VERIFIER_KEY, verifier);
-  return verifier;
+  return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('');
 };
 
 const base64UrlEncode = (str: ArrayBuffer): string => {

--- a/src/features/report_details/ReportFightHeader.tsx
+++ b/src/features/report_details/ReportFightHeader.tsx
@@ -231,7 +231,13 @@ export const ReportFightHeader: React.FC = () => {
           statusIndicator = wasKilled ? '✓' : 'Wipe';
         }
 
-        titleElement.innerHTML = `${fight.name} (<span style="font-weight: 300;">${statusIndicator}</span>)`;
+        titleElement.textContent = '';
+        titleElement.appendChild(document.createTextNode(`${fight.name} (`));
+        const span = document.createElement('span');
+        span.style.fontWeight = '300';
+        span.textContent = statusIndicator;
+        titleElement.appendChild(span);
+        titleElement.appendChild(document.createTextNode(')'));
       }
     }
   }, [fight, isFightLoading, fightId]);

--- a/src/features/report_details/damage/DamageTimelineChart.tsx
+++ b/src/features/report_details/damage/DamageTimelineChart.tsx
@@ -13,6 +13,7 @@ import { useUptimeSeriesForStackedView } from '../../../hooks/useUptimeSeriesFor
 import type { ReportFightContextInput } from '../../../store/contextTypes';
 import { buildPhaseMarkLines } from '../../../utils/echartsAnnotationUtils';
 import { glowLineStyle, gradientAreaStyle, hexToRgb } from '../../../utils/echartsTheme';
+import { escapeHtml } from '../../../utils/escape-html';
 import type {
   DamageOverTimeResult,
   PlayerDamageOverTimeData,
@@ -453,7 +454,7 @@ export const DamageTimelineChart: React.FC<DamageTimelineChartProps> = ({
               (p) =>
                 `<div style="display:flex;align-items:center;gap:6px">` +
                 `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${p.color}"></span>` +
-                `${p.seriesName.split(' (')[0]}: <b>${Math.round(p.value[1]).toLocaleString()} DPS</b></div>`,
+                `${escapeHtml(p.seriesName.split(' (')[0])}: <b>${Math.round(p.value[1]).toLocaleString()} DPS</b></div>`,
             );
           const uptimeLines = showStacked
             ? params
@@ -464,7 +465,7 @@ export const DamageTimelineChart: React.FC<DamageTimelineChartProps> = ({
                   (p) =>
                     `<div style="display:flex;align-items:center;gap:6px">` +
                     `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${p.color}"></span>` +
-                    `${p.seriesName}: <b>Active</b></div>`,
+                    `${escapeHtml(p.seriesName)}: <b>Active</b></div>`,
                 )
             : [];
           const allLines = [

--- a/src/features/report_details/insights/EffectUptimeTimelineModal.tsx
+++ b/src/features/report_details/insights/EffectUptimeTimelineModal.tsx
@@ -18,6 +18,7 @@ import { EChart } from '../../../components/EChart';
 import { useEChartsTheme } from '../../../hooks/useEChartsTheme';
 import type { BuffLookupData } from '../../../utils/BuffLookupUtils';
 import { hexToRgb } from '../../../utils/echartsTheme';
+import { escapeHtml } from '../../../utils/escape-html';
 import { msToSeconds } from '../../../utils/fightDuration';
 
 import type { BuffUptime } from './BuffUptimeProgressBar';
@@ -176,7 +177,7 @@ export const EffectUptimeTimelineModal: React.FC<EffectUptimeTimelineModalProps>
             (p) =>
               `<div style="display:flex;align-items:center;gap:6px">` +
               `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${p.color}"></span>` +
-              `${p.seriesName}: <b>Active</b></div>`,
+              `${escapeHtml(p.seriesName)}: <b>Active</b></div>`,
           );
           return `<div style="font-size:13px"><div style="color:${echartsTheme.mutedColor};margin-bottom:4px">Time: ${time}</div>${lines.join('')}</div>`;
         },

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -70,6 +70,7 @@ import { selectSavedBuilds } from '../store/saved_builds';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
+import { sanitizeYoutubeUrl } from '../utils/sanitize-url';
 import { buildTooltipPropsFromAbilityId } from '../utils/skillTooltipMapper';
 
 // ─── Icon CDNs ────────────────────────────────────────────────────────────────
@@ -2709,12 +2710,12 @@ export const BuildViewPage: React.FC = () => {
                     </Typography>
                   </Box>
                 )}
-                {build.guide.youtubeUrl && (
+                {sanitizeYoutubeUrl(build.guide.youtubeUrl) && (
                   <Button
                     size="small"
                     variant="outlined"
                     startIcon={<YouTubeIcon sx={{ color: '#ef4444' }} />}
-                    href={build.guide.youtubeUrl}
+                    href={sanitizeYoutubeUrl(build.guide.youtubeUrl)!}
                     target="_blank"
                     rel="noopener noreferrer"
                     sx={{

--- a/src/utils/escape-html.ts
+++ b/src/utils/escape-html.ts
@@ -1,0 +1,11 @@
+const ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#039;',
+};
+
+export function escapeHtml(str: string): string {
+  return str.replace(/[&<>"']/g, (ch) => ESCAPE_MAP[ch]);
+}

--- a/src/utils/sanitize-url.ts
+++ b/src/utils/sanitize-url.ts
@@ -1,0 +1,17 @@
+const YOUTUBE_HOST_RE = /(^|\.)youtube\.com$|^youtu\.be$|^m\.youtube\.com$/;
+
+export function sanitizeYoutubeUrl(url: string | undefined | null): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (
+      (parsed.protocol === 'https:' || parsed.protocol === 'http:') &&
+      YOUTUBE_HOST_RE.test(parsed.hostname)
+    ) {
+      return parsed.href;
+    }
+  } catch {
+    // invalid URL
+  }
+  return null;
+}

--- a/tools/mcp/worktree-server/src/index.ts
+++ b/tools/mcp/worktree-server/src/index.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { execFile } from 'node:child_process';
-import { resolve, basename } from 'node:path';
+import { resolve, basename, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
@@ -41,9 +41,7 @@ async function runGit(args: string[], cwd: string): Promise<string> {
 function resolveWorktreePath(worktreePath: string | undefined): string {
   if (worktreePath) return resolve(worktreePath);
   if (activeWorktree) return activeWorktree;
-  throw new Error(
-    'No active worktree. Use worktree_list or worktree_create first.',
-  );
+  throw new Error('No active worktree. Use worktree_list or worktree_create first.');
 }
 
 interface ToolResult {
@@ -59,6 +57,42 @@ function ok(data: unknown): ToolResult {
 
 function fail(message: string): ToolResult {
   return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+const ALLOWED_COMMANDS = new Set([
+  'git',
+  'npm',
+  'npx',
+  'node',
+  'pnpm',
+  'tsc',
+  'eslint',
+  'prettier',
+]);
+
+function parseArgv(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+    } else if ((ch === ' ' || ch === '\t') && !inSingle && !inDouble) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,41 +169,40 @@ server.tool(
   'worktree_create',
   'Create a new worktree for a ticket branch and set it as active',
   {
-    ticket: z
-      .string()
-      .describe('Ticket ID, e.g. "ESO-716"'),
-    description: z
-      .string()
-      .describe('Branch description, e.g. "add-dismiss-button"'),
+    ticket: z.string().describe('Ticket ID, e.g. "ESO-716"'),
+    description: z.string().describe('Branch description, e.g. "add-dismiss-button"'),
   },
   async ({ ticket, description }) => {
     try {
+      if (!/^[A-Za-z0-9_-]+$/.test(ticket)) {
+        return fail('Invalid ticket ID. Use only letters, numbers, hyphens, and underscores.');
+      }
+      if (!/^[a-z0-9-]+$/.test(description)) {
+        return fail('Invalid description. Use only lowercase letters, numbers, and hyphens.');
+      }
+
       const repoRoot = getRepoRoot();
       const worktreeDir = getWorktreeDir();
 
-      const branchName = `${ticket}/${description}`
-        .toLowerCase()
-        .replace(/\s+/g, '-');
+      const branchName = `${ticket}/${description}`.toLowerCase().replace(/\s+/g, '-');
       const wtPath = resolve(worktreeDir, ticket);
+
+      const normalizedWtDir = resolve(worktreeDir) + sep;
+      if (!resolve(wtPath).startsWith(normalizedWtDir)) {
+        return fail('Invalid ticket ID: path escapes worktree directory.');
+      }
 
       // Fetch latest main
       await runGit(['fetch', 'origin', 'main'], repoRoot);
 
       // Create worktree
-      await runGit(
-        ['worktree', 'add', wtPath, '-b', branchName, 'origin/main'],
-        repoRoot,
-      );
+      await runGit(['worktree', 'add', wtPath, '-b', branchName, 'origin/main'], repoRoot);
 
       activeWorktree = wtPath;
 
       // Determine port slot: list worktrees and find next available slot
-      const listRaw = await runGit(
-        ['worktree', 'list', '--porcelain'],
-        repoRoot,
-      );
-      const worktreeCount =
-        listRaw.split(/\n\n+/).filter((b) => b.trim()).length;
+      const listRaw = await runGit(['worktree', 'list', '--porcelain'], repoRoot);
+      const worktreeCount = listRaw.split(/\n\n+/).filter((b) => b.trim()).length;
       // Slot 0 is main, new worktrees get subsequent slots
       const slot = worktreeCount - 1;
       const httpPort = 3000 + slot * 2;
@@ -193,29 +226,34 @@ server.tool(
 
 server.tool(
   'worktree_run',
-  'Run a shell command in a worktree directory (refuses to run in main repo)',
+  'Run a command in a worktree directory (refuses to run in main repo)',
   {
-    command: z.string().describe('Shell command to execute'),
-    worktreePath: z
-      .string()
-      .optional()
-      .describe('Worktree path (defaults to active worktree)'),
+    command: z.string().describe('Command to execute (e.g. "npm install", "git status")'),
+    worktreePath: z.string().optional().describe('Worktree path (defaults to active worktree)'),
   },
   async ({ command, worktreePath }) => {
     try {
       const resolved = resolveWorktreePath(worktreePath);
       const repoRoot = getRepoRoot();
 
-      // Guard: refuse to run in main repo
       if (resolve(resolved) === resolve(repoRoot)) {
+        return fail('Refusing to run command in main repo. Use a worktree path instead.');
+      }
+
+      const argv = parseArgv(command);
+      if (argv.length === 0) {
+        return fail('Empty command.');
+      }
+
+      const executable = basename(argv[0]);
+      if (!ALLOWED_COMMANDS.has(executable)) {
         return fail(
-          'Refusing to run command in main repo. Use a worktree path instead.',
+          `Command "${executable}" is not in the allowlist. Allowed: ${[...ALLOWED_COMMANDS].join(', ')}`,
         );
       }
 
-      const { stdout, stderr } = await execFileAsync(command, [], {
+      const { stdout, stderr } = await execFileAsync(argv[0], argv.slice(1), {
         cwd: resolved,
-        shell: true,
         timeout: 120_000,
         maxBuffer: 10 * 1024 * 1024,
       });
@@ -227,9 +265,7 @@ server.tool(
       return ok(stdout.trim() + (stderr ? `\n\nSTDERR:\n${stderr.trim()}` : ''));
     } catch (err) {
       const error = err as Error & { stderr?: string };
-      return fail(
-        error.stderr?.trim() || error.message,
-      );
+      return fail(error.stderr?.trim() || error.message);
     }
   },
 );
@@ -261,12 +297,8 @@ server.tool(
       }
 
       // Check if worktrees exist (beyond main)
-      const raw = await runGit(
-        ['worktree', 'list', '--porcelain'],
-        repoRoot,
-      );
-      const worktreeCount =
-        raw.split(/\n\n+/).filter((b) => b.trim()).length;
+      const raw = await runGit(['worktree', 'list', '--porcelain'], repoRoot);
+      const worktreeCount = raw.split(/\n\n+/).filter((b) => b.trim()).length;
 
       if (worktreeCount > 1) {
         return ok(
@@ -289,30 +321,22 @@ server.tool(
   'worktree_push',
   'Push the current branch in a worktree to origin (refuses to push main)',
   {
-    worktreePath: z
-      .string()
-      .optional()
-      .describe('Worktree path (defaults to active worktree)'),
-    force: z
-      .boolean()
-      .optional()
-      .default(false)
-      .describe('Use --force-with-lease'),
+    worktreePath: z.string().optional().describe('Worktree path (defaults to active worktree)'),
+    force: z.boolean().optional().default(false).describe('Use --force-with-lease'),
   },
   async ({ worktreePath, force }) => {
     try {
       const resolved = resolveWorktreePath(worktreePath);
 
       // Safety: refuse to push main
-      const branch = await runGit(
-        ['branch', '--show-current'],
-        resolved,
-      );
+      const branch = await runGit(['branch', '--show-current'], resolved);
 
       if (branch === 'main' || branch === 'master') {
-        return fail(
-          `Refusing to push branch "${branch}". Only push feature branches.`,
-        );
+        return fail(`Refusing to push branch "${branch}". Only push feature branches.`);
+      }
+
+      if (!branch || /^-/.test(branch) || !/^[\w./-]+$/.test(branch)) {
+        return fail(`Invalid branch name: "${branch}".`);
       }
 
       const pushArgs = ['push', 'origin', 'HEAD'];
@@ -336,10 +360,7 @@ server.tool(
   'worktree_status',
   'Show git status and recent commits in a worktree',
   {
-    worktreePath: z
-      .string()
-      .optional()
-      .describe('Worktree path (defaults to active worktree)'),
+    worktreePath: z.string().optional().describe('Worktree path (defaults to active worktree)'),
   },
   async ({ worktreePath }) => {
     try {
@@ -350,9 +371,7 @@ server.tool(
         runGit(['log', '--oneline', '-5'], resolved),
       ]);
 
-      return ok(
-        `=== Status ===\n${status || '(clean)'}\n\n=== Recent Commits ===\n${log}`,
-      );
+      return ok(`=== Status ===\n${status || '(clean)'}\n\n=== Recent Commits ===\n${log}`);
     } catch (err) {
       return fail(`Status check failed: ${(err as Error).message}`);
     }
@@ -367,10 +386,7 @@ server.tool(
   'worktree_diff',
   'Show git diff in a worktree (staged or unstaged)',
   {
-    worktreePath: z
-      .string()
-      .optional()
-      .describe('Worktree path (defaults to active worktree)'),
+    worktreePath: z.string().optional().describe('Worktree path (defaults to active worktree)'),
     staged: z
       .boolean()
       .optional()
@@ -391,9 +407,7 @@ server.tool(
       // Truncate at 500KB
       const MAX_SIZE = 500 * 1024;
       if (diff.length > MAX_SIZE) {
-        diff =
-          diff.substring(0, MAX_SIZE) +
-          '\n\n... [truncated at 500KB] ...';
+        diff = diff.substring(0, MAX_SIZE) + '\n\n... [truncated at 500KB] ...';
       }
 
       return ok(diff || '(no changes)');


### PR DESCRIPTION
## Summary

Second comprehensive DeepSec audit. 142 files AI-investigated across eso-toolkit, roster-hub-api, and discord-bot. **30+ fixes** across 22 files.

### CRITICAL + HIGH
- **RCE**: Remove `shell:true` from `worktree_run` MCP tool, add command allowlist + argv parsing
- **Path traversal**: Validate `ticket` param in `worktree_create`
- **GHA injection**: Move `github.head_ref` to `env:` block in jira-sync
- **GraphQL bypass**: Validate query document matches declared operation name
- **Rollbar branch**: Fix trigger `master` → `main`

### XSS (4 fixes)
- Escape `seriesName` in ECharts tooltips (DamageTimelineChart, EffectUptimeTimelineModal)
- Replace `innerHTML` with `textContent` in ReportFightHeader
- Validate `youtubeUrl` scheme+host in BuildViewPage

### HTML Escaping (5 fixes)
- `escapeHtml(user.name)` in createComment, createBuildComment, upsertUserAvatar, updateDisplayNames
- Escape guild/player names in leaderboard sync roster-encoder
- Extract shared `sanitize.ts` module

### OAuth + Auth (4 fixes)
- User confirmation before desktop OAuth flow
- Remove URL token fallback (prevents history leak)
- Remove PKCE verifier from localStorage
- SHA-256 hash before `timingSafeEqual` (fixes length timing leak)

### Discord Bot (8 fixes)
- Validate body.tags, timezone, rolePingIds shape
- KV rate limiting: OAuth exchange, publish-direct, ticket creation
- Guild verification for ticket-setup
- Scope cross-guild refresh to caller's guild
- Fix TOCTOU on ticket close

### Data Integrity
- Fix PUT /rosters/:id silently nullifying recommended_addons/is_anonymous

## Test plan
- [ ] CI: build, lint, format, test, typecheck, playwright-smoke
- [ ] Verify /graphql proxy works
- [ ] Verify desktop OAuth shows confirmation
- [ ] Verify ECharts tooltips render correctly
- [ ] Verify roster PUT preserves recommended_addons