### PR TITLE
ci(security): add supply-chain guard + harden cla.yml against injection

### DIFF
--- a/.github/workflows/ci-supply-chain-guard.yml
+++ b/.github/workflows/ci-supply-chain-guard.yml
@@ -1,0 +1,69 @@
+# Blocks the class of CI-backdoor payloads seen in the May 2026 GitHub Actions
+# mass-injection wave (e.g. the "Megalodon" campaign): download/decode piped
+# straight into a shell, reverse shells, and a known C2 indicator. Patterns are
+# deliberately narrow so legitimate CI (e.g. `base64 -d | python3` in cla.yml)
+# is never flagged. This catches a malicious workflow the moment it lands in a PR.
+name: Supply-Chain Guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan-ci-payloads:
+    name: Scan workflow definitions for CI-backdoor payloads
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Scan
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          targets=(.github/workflows/*.yml .github/workflows/*.yaml .github/actions/*/action.yml)
+          if [ ${#targets[@]} -eq 0 ]; then
+            echo "No workflow definitions found; nothing to scan."
+            exit 0
+          fi
+
+          # IOC literals are assembled from fragments so this guard never matches
+          # its own definitions while scanning the file set (which includes itself).
+          c2_ip="216.126.225"".129"
+          dev_tcp="/dev/""tcp/"
+
+          fail=0
+
+          # 1. Remote payload piped directly into a shell (curl/wget | sh|bash)
+          if grep -nHE '(curl|wget)[^|]*\|[[:space:]]*(ba)?sh([[:space:]]|$)' "${targets[@]}"; then
+            echo "::error::Remote download piped into a shell"
+            fail=1
+          fi
+
+          # 2. Decoded blob piped into a shell (the Megalodon payload shape)
+          if grep -nHE 'base64[^|]*(-d|--decode|-D)[^|]*\|[[:space:]]*(ba)?sh([[:space:]]|$)' "${targets[@]}"; then
+            echo "::error::Encoded blob piped into a shell"
+            fail=1
+          fi
+
+          # 3. Reverse-shell primitives
+          if grep -nHE "${dev_tcp}|[^a-zA-Z]nc[[:space:]]+-e|bash[[:space:]]+-i" "${targets[@]}"; then
+            echo "::error::Reverse-shell primitive"
+            fail=1
+          fi
+
+          # 4. Known Megalodon C2 indicator
+          if grep -nHF "$c2_ip" "${targets[@]}"; then
+            echo "::error::Known C2 indicator"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Supply-Chain Guard FAILED — a workflow contains a known CI-backdoor pattern. Review the flagged lines above."
+            exit 1
+          fi
+          echo "Supply-Chain Guard passed: no known CI-backdoor payload patterns found."

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,11 +48,12 @@ jobs:
         if: (github.event_name == 'issue_comment' && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || (github.event_name == 'pull_request_target' && github.event.action != 'closed')
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         run: |
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             PR_AUTHOR=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.user.login')
           else
-            PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+            PR_AUTHOR="$PR_AUTHOR_LOGIN"
           fi
 
           echo "Checking CLA for PR author: $PR_AUTHOR"


### PR DESCRIPTION
## Summary

Following a verification sweep against the May 2026 mass GitHub Actions injection wave (the "Megalodon" campaign), this repo was confirmed **clean and not affected**. This PR adds two low-risk, defense-in-depth measures so a future injection attempt is caught automatically — without changing any existing behavior or end-user experience.

### 1. New `Supply-Chain Guard` workflow (`.github/workflows/ci-supply-chain-guard.yml`)
Runs on every PR and on push to `main`. Fails CI if any workflow/action definition contains a known CI-backdoor payload shape:
- remote download piped directly into a shell (`curl|wget … | sh`)
- encoded blob piped into a shell (`base64 -d … | sh` — the Megalodon payload shape)
- reverse-shell primitives (`/dev/tcp/`, `nc -e`, `bash -i`)
- the campaign's known C2 indicator

Patterns are deliberately narrow so legitimate CI is never flagged (e.g. the existing `base64 -d | python3` in `cla.yml` passes). IOC literals are assembled from fragments so the guard does not match its own definitions while scanning the file set (which includes itself). Verified locally: passes clean on the current tree and correctly detects an injected payload. Permissions are `contents: read` only.

### 2. Harden `cla.yml` against expression injection
Move the user-controlled PR author login out of inline `${{ … }}` interpolation and into an `env:` var consumed as `$PR_AUTHOR_LOGIN`. This is defense-in-depth for the `pull_request_target` context. No behavior change.

## What this intentionally does NOT do
- No branch-protection / required-signed-commit changes (would disrupt contributor push workflow; needs admin).
- No SHA-pinning of GitHub-owned `actions/*` (breakage risk + disables auto-patching; marginal benefit since GitHub controls them).

## Test plan
- [x] Guard logic passes clean against the current repo (scanning all 18 workflow/action files, including itself)
- [x] Guard correctly fails on an injected `curl|sh` / `base64|bash` workflow (negative control)
- [x] Both YAML files parse (PyYAML `safe_load`)
- [ ] Confirm the `Supply-Chain Guard` check runs green on this PR

https://claude.ai/code/session_01MTJtAxePyReucwF6WesWc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTJtAxePyReucwF6WesWc8)_