### PR TITLE
fix: filter zeroed gear items to prevent empty Gear section on player cards

### DIFF
--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -476,7 +476,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
         const build = playerToBuild({
           playerName: resolveActorName(player),
           role: broadRole,
-          gear,
+          gear: player?.combatantInfo?.gear ?? [],
           talents,
           mundusBuffs,
           championPoints,
@@ -498,7 +498,6 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       }
     }, [
       player,
-      gear,
       talents,
       mundusBuffs,
       championPoints,

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -271,7 +271,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       [player?.combatantInfo?.talents],
     );
     const gear = React.useMemo(
-      () => player?.combatantInfo?.gear ?? [],
+      () => (player?.combatantInfo?.gear ?? []).filter((g) => g.id !== 0),
       [player?.combatantInfo?.gear],
     );
     const armorWeights = getArmorWeightCounts(gear);

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -957,7 +957,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       if (!player?.id) return;
 
       const playerId = String(player.id);
-      const gear = player?.combatantInfo?.gear ?? [];
+      const gear = (player?.combatantInfo?.gear ?? []).filter((g) => g.id !== 0);
       const resourceSnapshot = maxResourcesByPlayer[playerId];
       const playerResourceProfile = resourceSnapshot
         ? { stamina: resourceSnapshot.stamina, magicka: resourceSnapshot.magicka }


### PR DESCRIPTION
## Summary

- Filter out zeroed gear items (`id === 0`) in `PlayerCard.tsx` and `PlayersPanel.tsx` to prevent the Gear section from rendering when no real gear data exists
- The ESO Logs API returns 16 gear entries for all players, but non-uploading players have zeroed-out items (id: 0, no name/setName) — this caused an empty "Gear" heading with no chips, and `detectBuildIssues` processing empty gear
- Matches the existing `id !== 0` filtering pattern already used in `GearDetailsPanel.tsx:446` and `armorUtils.ts:22`
- The filter is intentionally NOT applied in the `playerGear` set computation because `isDoubleSetCount` relies on positional array indexing via `GearSlot` enum values

## Test plan

- [ ] Verify player cards for non-uploading players no longer show an empty "Gear" section
- [ ] Verify the log uploader's player card still shows gear sets correctly (with proper set piece counts for two-handed weapons)
- [ ] Verify `detectBuildIssues` no longer produces false-positive gear warnings for players with zeroed gear
- [ ] Run existing test suites: `armorUtils`, `gearUtilities`, `detectBuildIssues`, `PlayersPanel` (88 tests, all passing)