### PR TITLE
fix(a11y): comprehensive responsive audit — touch targets, breakpoints, mobile overflow

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -237,6 +237,9 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
                 textTransform: 'none',
                 borderRadius: 8,
                 fontWeight: 600,
+                '@media (pointer: coarse)': {
+                  minHeight: 44,
+                },
                 '&.MuiButton-containedPrimary': {
                   background: `linear-gradient(135deg, ${tokens.accent}, ${tokens.accent2})`,
                   color: darkMode ? tokens.bg : '#ffffff',
@@ -269,6 +272,16 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
                 '&:hover': {
                   color: tokens.accent,
                   background: darkMode ? 'rgba(56, 189, 248, 0.08)' : 'rgba(3, 105, 161, 0.08)',
+                },
+              },
+            },
+          },
+          MuiIconButton: {
+            styleOverrides: {
+              root: {
+                '@media (pointer: coarse)': {
+                  minWidth: 44,
+                  minHeight: 44,
                 },
               },
             },

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -4177,6 +4177,7 @@ const CalculatorComponent: React.FC = () => {
                         minWidth: 'auto',
                         px: 1,
                         py: 0.4,
+                        minHeight: 44,
                         borderColor: 'rgba(56, 189, 248, 0.4)',
                         color: theme.palette.mode === 'dark' ? '#ffffff' : 'inherit',
                         backgroundColor:
@@ -4217,6 +4218,7 @@ const CalculatorComponent: React.FC = () => {
                         minWidth: 'auto',
                         px: 1,
                         py: 0.4,
+                        minHeight: 44,
                         borderColor: 'rgba(239, 68, 68, 0.4)',
                         color: theme.palette.mode === 'dark' ? '#ffffff' : 'inherit',
                         backgroundColor:
@@ -4249,6 +4251,7 @@ const CalculatorComponent: React.FC = () => {
                         minWidth: 'auto',
                         px: 1,
                         py: 0.4,
+                        minHeight: 44,
                         borderColor: 'rgba(56, 189, 248, 0.4)',
                         color: theme.palette.mode === 'dark' ? '#ffffff' : 'inherit',
                         backgroundColor:
@@ -4317,6 +4320,7 @@ const CalculatorComponent: React.FC = () => {
                         minWidth: 'auto',
                         px: 1,
                         py: 0.4,
+                        minHeight: 44,
                         borderColor: 'rgba(56, 189, 248, 0.4)',
                         color: theme.palette.mode === 'dark' ? '#ffffff' : 'inherit',
                         backgroundColor:
@@ -4345,6 +4349,7 @@ const CalculatorComponent: React.FC = () => {
                         minWidth: 'auto',
                         px: 1,
                         py: 0.4,
+                        minHeight: 44,
                         borderColor: 'rgba(239, 68, 68, 0.4)',
                         color: theme.palette.mode === 'dark' ? '#ffffff' : 'inherit',
                         backgroundColor:
@@ -4402,7 +4407,7 @@ const CalculatorComponent: React.FC = () => {
                             ? '1px solid rgb(128 211 255 / 30%)'
                             : '1px solid rgb(40 145 200 / 25%)',
                         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-                        minHeight: isExtraSmall ? '40px' : isMobile ? '44px' : 'auto',
+                        minHeight: '44px',
                         minWidth: 0,
                         fontSize: isExtraSmall ? '0.75rem' : isMobile ? '0.8rem' : '0.85rem',
                         px: isExtraSmall ? 1 : isMobile ? 1.2 : 1.5,
@@ -4576,6 +4581,7 @@ const CalculatorComponent: React.FC = () => {
                         : 'rgba(248, 250, 252, 0.8)',
                     borderRadius: '10px',
                     border: '1px solid rgba(148, 163, 184, 0.2)',
+                    '& .MuiButton-root': { minHeight: 44 },
                   }}
                 >
                   <motion.div whileTap={{ scale: 0.95 }} style={{ flex: 1 }}>
@@ -5252,6 +5258,7 @@ const CalculatorComponent: React.FC = () => {
                         : 'rgba(248, 250, 252, 0.8)',
                     borderRadius: '10px',
                     border: '1px solid rgba(148, 163, 184, 0.2)',
+                    '& .MuiButton-root': { minHeight: 44 },
                   }}
                 >
                   <motion.div whileTap={{ scale: 0.95 }} style={{ flex: 1 }}>

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -635,7 +635,7 @@ export const DataGrid = <T extends Record<string, unknown>>({
       <TableContainer
         sx={{
           flex: autoHeight ? 'unset' : 1,
-          overflowX: 'hidden',
+          overflowX: { xs: 'auto', md: 'hidden' },
           overflowY: autoHeight ? 'visible' : 'auto',
           scrollbarGutter: 'stable both-edges',
         }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -198,7 +198,7 @@ export const Footer: React.FC = React.memo(() => {
 
       gap: { xs: 0.65, md: 0.85 },
 
-      whiteSpace: 'nowrap',
+      whiteSpace: { xs: 'normal', lg: 'nowrap' },
 
       color: theme.palette.text.secondary,
 
@@ -211,6 +211,8 @@ export const Footer: React.FC = React.memo(() => {
       letterSpacing: '0.01em',
 
       position: 'relative',
+
+      minHeight: 44,
 
       transition: 'color 0.2s ease, transform 0.2s ease',
 
@@ -1102,6 +1104,10 @@ export const Footer: React.FC = React.memo(() => {
                 color: 'inherit',
                 textDecoration: 'none',
                 transition: 'opacity 0.2s ease',
+                minHeight: 44,
+                display: 'inline-flex',
+                alignItems: 'center',
+                px: 1,
                 '&:hover': { opacity: 1, color: accentColor },
               }}
             >
@@ -1119,8 +1125,9 @@ export const Footer: React.FC = React.memo(() => {
                 opacity: 0.6,
                 color: 'inherit',
                 textTransform: 'none',
-                padding: '2px 8px',
+                padding: '8px 12px',
                 minWidth: 0,
+                minHeight: 44,
                 border: 'none',
                 background: 'none',
                 transition: 'opacity 0.2s ease',

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -799,7 +799,7 @@ export const HeaderBar: React.FC = () => {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
               <Button
                 color="inherit"
-                sx={{ p: 0, minWidth: 0, '&:hover': { background: 'transparent' } }}
+                sx={{ p: 0, minWidth: 44, minHeight: 44, '&:hover': { background: 'transparent' } }}
                 onClick={() => navigate('/', { vtType: 'down' })}
               >
                 <Typography
@@ -832,7 +832,7 @@ export const HeaderBar: React.FC = () => {
             <Box
               component="nav"
               aria-label="Main navigation"
-              sx={{ display: { xs: 'none', md: 'flex' }, alignItems: 'center', gap: 1.5 }}
+              sx={{ display: { xs: 'none', lg: 'flex' }, alignItems: 'center', gap: 1.5 }}
             >
               {navItems.map((item) => (
                 <Button
@@ -1044,7 +1044,7 @@ export const HeaderBar: React.FC = () => {
               )}
             </Box>
 
-            <Box sx={{ display: { xs: 'flex', md: 'none' }, alignItems: 'center', gap: 1 }}>
+            <Box sx={{ display: { xs: 'flex', lg: 'none' }, alignItems: 'center', gap: 1 }}>
               <HamburgerButton
                 open={mobileOpen}
                 onClick={handleDrawerToggle}

--- a/src/components/KalpaBanner.tsx
+++ b/src/components/KalpaBanner.tsx
@@ -186,11 +186,13 @@ export const KalpaBanner: React.FC = () => {
         sx={{
           position: 'absolute',
           top: '50%',
-          right: { xs: 4, sm: 8 },
+          right: { xs: 2, sm: 8 },
           transform: 'translateY(-50%)',
           color: 'text.secondary',
           opacity: 0.6,
-          padding: { xs: '4px', sm: '5px' },
+          minWidth: 44,
+          minHeight: 44,
+          padding: '10px',
           '&:hover': { opacity: 1 },
           zIndex: 1,
         }}

--- a/src/components/PanelErrorBoundary.tsx
+++ b/src/components/PanelErrorBoundary.tsx
@@ -16,7 +16,13 @@ const PanelErrorFallback: React.FC<PanelErrorFallbackProps> = ({ panelName, onRe
       icon={<ErrorOutlined />}
       sx={{ width: '100%', maxWidth: 500 }}
       action={
-        <Button color="inherit" size="small" startIcon={<Refresh />} onClick={onRetry} sx={{ minHeight: 44, minWidth: 44 }}>
+        <Button
+          color="inherit"
+          size="small"
+          startIcon={<Refresh />}
+          onClick={onRetry}
+          sx={{ minHeight: 44, minWidth: 44 }}
+        >
           Retry
         </Button>
       }

--- a/src/components/PanelErrorBoundary.tsx
+++ b/src/components/PanelErrorBoundary.tsx
@@ -16,7 +16,7 @@ const PanelErrorFallback: React.FC<PanelErrorFallbackProps> = ({ panelName, onRe
       icon={<ErrorOutlined />}
       sx={{ width: '100%', maxWidth: 500 }}
       action={
-        <Button color="inherit" size="small" startIcon={<Refresh />} onClick={onRetry}>
+        <Button color="inherit" size="small" startIcon={<Refresh />} onClick={onRetry} sx={{ minHeight: 44, minWidth: 44 }}>
           Retry
         </Button>
       }

--- a/src/components/UnauthenticatedLandingSection.tsx
+++ b/src/components/UnauthenticatedLandingSection.tsx
@@ -228,6 +228,7 @@ export const UnauthenticatedLandingSection: React.FC = () => {
             textTransform: 'none',
             fontWeight: 400,
             fontSize: '0.875rem',
+            minHeight: 44,
             color:
               theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.7)' : 'rgba(51, 65, 85, 0.7)',
             '&:hover': {

--- a/src/features/latest_reports/LatestReports.tsx
+++ b/src/features/latest_reports/LatestReports.tsx
@@ -322,7 +322,7 @@ export const LatestReports: React.FC = () => {
                   sx={{
                     borderRadius: 2,
                     mb: 3,
-                    overflowX: 'hidden',
+                    overflowX: 'auto',
                   }}
                 >
                   <Table sx={{ tableLayout: 'fixed', width: '100%' }}>

--- a/src/features/leaderboard/LeaderboardLogsPage.tsx
+++ b/src/features/leaderboard/LeaderboardLogsPage.tsx
@@ -721,7 +721,11 @@ export const LeaderboardLogsPage: React.FC = () => {
             ) : rankingsState.rankings.length === 0 ? (
               <Alert severity="info">No leaderboard entries found for this selection.</Alert>
             ) : (
-              <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 2, overflowX: 'auto' }}>
+              <TableContainer
+                component={Paper}
+                elevation={0}
+                sx={{ borderRadius: 2, overflowX: 'auto' }}
+              >
                 <Table size="small">
                   <TableHead>
                     <TableRow>

--- a/src/features/leaderboard/LeaderboardLogsPage.tsx
+++ b/src/features/leaderboard/LeaderboardLogsPage.tsx
@@ -721,7 +721,7 @@ export const LeaderboardLogsPage: React.FC = () => {
             ) : rankingsState.rankings.length === 0 ? (
               <Alert severity="info">No leaderboard entries found for this selection.</Alert>
             ) : (
-              <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 2 }}>
+              <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 2, overflowX: 'auto' }}>
                 <Table size="small">
                   <TableHead>
                     <TableRow>

--- a/src/features/pack-hub/components/CreatePackDialog.tsx
+++ b/src/features/pack-hub/components/CreatePackDialog.tsx
@@ -841,7 +841,7 @@ export const CreatePackDialog: React.FC<CreatePackDialogProps> = ({
             /* ─── Sortable addon list ─── */
             <Box
               sx={{
-                maxHeight: 240,
+                maxHeight: { xs: 300, sm: 240 },
                 overflowY: 'auto',
                 p: 0.5,
                 '&::-webkit-scrollbar': { width: 5 },

--- a/src/features/pack-hub/components/PackPreviewDialog.tsx
+++ b/src/features/pack-hub/components/PackPreviewDialog.tsx
@@ -399,7 +399,15 @@ export const PackPreviewDialog: React.FC<PackPreviewDialogProps> = ({
         )}
 
         {/* Stats row */}
-        <Box sx={{ display: 'flex', gap: 1, mt: 2.5, flexWrap: 'wrap', '& > *': { minWidth: { xs: 'auto', sm: 72 } } }}>
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1,
+            mt: 2.5,
+            flexWrap: 'wrap',
+            '& > *': { minWidth: { xs: 'auto', sm: 72 } },
+          }}
+        >
           {renderStat('Addons', pack.addons.length, accentColor)}
           {renderStat('Required', requiredCount, '#c4a44a')}
           {renderStat('Optional', optionalCount, '#94a3b8')}

--- a/src/features/pack-hub/components/PackPreviewDialog.tsx
+++ b/src/features/pack-hub/components/PackPreviewDialog.tsx
@@ -163,7 +163,7 @@ export const PackPreviewDialog: React.FC<PackPreviewDialogProps> = ({
         px: 1.5,
         py: 0.85,
         borderRadius: '10px',
-        minWidth: 72,
+        minWidth: { xs: 'auto', sm: 72 },
         background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
         border: isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.06)',
         backdropFilter: 'blur(8px)',
@@ -293,7 +293,7 @@ export const PackPreviewDialog: React.FC<PackPreviewDialogProps> = ({
         sx={{
           position: 'relative',
           zIndex: 1,
-          px: { xs: 2.5, sm: 4 },
+          px: { xs: 1.5, sm: 4 },
           pt: { xs: 3.5, sm: 4 },
           pb: 2.5,
         }}
@@ -360,7 +360,7 @@ export const PackPreviewDialog: React.FC<PackPreviewDialogProps> = ({
             fontSize: { xs: '1.45rem', sm: '1.75rem' },
             letterSpacing: '-0.02em',
             lineHeight: 1.2,
-            pr: 5,
+            pr: { xs: 2, sm: 5 },
             background: isDark
               ? `linear-gradient(135deg, #f8fafc 0%, ${accentColor} 130%)`
               : `linear-gradient(135deg, #0f172a 0%, ${accentColor} 130%)`,
@@ -399,7 +399,7 @@ export const PackPreviewDialog: React.FC<PackPreviewDialogProps> = ({
         )}
 
         {/* Stats row */}
-        <Box sx={{ display: 'flex', gap: 1, mt: 2.5, flexWrap: 'wrap' }}>
+        <Box sx={{ display: 'flex', gap: 1, mt: 2.5, flexWrap: 'wrap', '& > *': { minWidth: { xs: 'auto', sm: 72 } } }}>
           {renderStat('Addons', pack.addons.length, accentColor)}
           {renderStat('Required', requiredCount, '#c4a44a')}
           {renderStat('Optional', optionalCount, '#94a3b8')}

--- a/src/features/report_details/insights/InsightsPanelView.tsx
+++ b/src/features/report_details/insights/InsightsPanelView.tsx
@@ -93,7 +93,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
         }}
       >
         {/* Fight Insights Header - Full Width */}
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{
@@ -341,7 +341,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
         </Box>
         {/* All panels in flexbox with 2 items per row */}
 
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{
@@ -355,7 +355,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
           </Paper>
         </Box>
 
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{
@@ -369,7 +369,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
           </Paper>
         </Box>
 
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{
@@ -383,7 +383,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
           </Paper>
         </Box>
 
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{
@@ -397,7 +397,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
           </Paper>
         </Box>
 
-        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: '300px' }}>
+        <Box sx={{ flex: '1 1 calc(50% - 8px)', minWidth: { xs: '100%', sm: '300px' } }}>
           <Paper
             elevation={2}
             sx={{

--- a/src/features/report_summary/DamageBreakdownSection.tsx
+++ b/src/features/report_summary/DamageBreakdownSection.tsx
@@ -387,7 +387,7 @@ const DamageBreakdownSection: React.FC<DamageBreakdownSectionProps> = ({
                     <TableCell align="right">{formatDamage(player.totalDamage)}</TableCell>
                     <TableCell align="right">{formatNumber(player.dps)}</TableCell>
                     <TableCell align="right">{player.damagePercentage.toFixed(1)}%</TableCell>
-                    <TableCell align="right" sx={{ width: 120 }}>
+                    <TableCell align="right" sx={{ width: { xs: 80, sm: 120 } }}>
                       <LinearProgress
                         variant="determinate"
                         value={(player.totalDamage / highestDamage) * 100}

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,17 @@ code {
   }
 }
 
+/* WCAG 2.2 touch target sizing — ensure 44px minimum on touch devices */
+@media (pointer: coarse) {
+  a,
+  button,
+  [role='button'],
+  [role='tab'],
+  [role='menuitem'] {
+    min-height: 44px;
+  }
+}
+
 /* Pickr theme CSS variables */
 :root {
   --site-bg: #121212;

--- a/src/index.css
+++ b/src/index.css
@@ -116,9 +116,13 @@ code {
   }
 }
 
-/* WCAG 2.2 touch target sizing — ensure 44px minimum on touch devices */
+/* WCAG 2.2 touch target sizing — ensure 44px minimum on touch devices.
+   Scoped to navigation/standalone interactive elements only;
+   inline prose links are excluded to preserve text flow. */
 @media (pointer: coarse) {
-  a,
+  nav a,
+  footer a,
+  [role='navigation'] a,
   button,
   [role='button'],
   [role='tab'],

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-/* Modern Scrollbar Theme for Light and Dark Modes */
+/* Modern scrollbar theme for light and dark modes */
 ::-webkit-scrollbar {
   width: 12px;
   height: 12px;

--- a/src/index.css
+++ b/src/index.css
@@ -116,7 +116,7 @@ code {
   }
 }
 
-/* WCAG 2.2 touch target sizing — ensure 44px minimum on touch devices.
+/* WCAG 2.2 Target Size (Level AA) — 44px minimum on coarse-pointer devices.
    Scoped to navigation/standalone interactive elements only;
    inline prose links are excluded to preserve text flow. */
 @media (pointer: coarse) {

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -1744,7 +1744,7 @@ const ViewStats: React.FC<{ setup: BuildSetup; build: Build }> = ({ setup, build
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(96px, 1fr))',
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(auto-fit, minmax(96px, 1fr))' },
           gap: 2,
           justifyItems: 'center',
           py: 1,

--- a/src/pages/ParseAnalysisPage.tsx
+++ b/src/pages/ParseAnalysisPage.tsx
@@ -1649,7 +1649,7 @@ const ParseAnalysisPageContent: React.FC = () => {
                         },
                       }}
                     >
-                      <Typography variant="caption" sx={{ minWidth: 160, fontWeight: 500 }}>
+                      <Typography variant="caption" sx={{ minWidth: { xs: 80, sm: 160 }, fontWeight: 500 }}>
                         {skill.abilityName}
                       </Typography>
                       <Chip

--- a/src/pages/ParseAnalysisPage.tsx
+++ b/src/pages/ParseAnalysisPage.tsx
@@ -1649,7 +1649,10 @@ const ParseAnalysisPageContent: React.FC = () => {
                         },
                       }}
                     >
-                      <Typography variant="caption" sx={{ minWidth: { xs: 80, sm: 160 }, fontWeight: 500 }}>
+                      <Typography
+                        variant="caption"
+                        sx={{ minWidth: { xs: 80, sm: 160 }, fontWeight: 500 }}
+                      >
                         {skill.abilityName}
                       </Typography>
                       <Chip


### PR DESCRIPTION
## Summary
- Raise header nav desktop/mobile breakpoint from `md` (900px) to `lg` (1200px) to prevent cramped nav text wrapping at 900–1100px
- Add WCAG 2.2 compliant 44px minimum touch targets globally via MUI theme overrides (`MuiButton`, `MuiIconButton`) and scoped CSS for `@media (pointer: coarse)`
- Fix horizontal scroll prevention on data tables (`DataGrid`, `LatestReports`, `LeaderboardLogsPage`)
- Fix responsive layout issues across dialogs, insight panels, build view, parse analysis

## Files changed (17)
**Global**: `ReduxThemeProvider.tsx`, `index.css`  
**Header/footer**: `HeaderBar.tsx`, `Footer.tsx`, `KalpaBanner.tsx`  
**Landing**: `UnauthenticatedLandingSection.tsx`  
**Calculator**: `Calculator.tsx`  
**Error states**: `PanelErrorBoundary.tsx`  
**Data tables**: `DataGrid.tsx`, `LatestReports.tsx`, `LeaderboardLogsPage.tsx`  
**Dialogs**: `PackPreviewDialog.tsx`, `CreatePackDialog.tsx`  
**Report panels**: `InsightsPanelView.tsx`, `DamageBreakdownSection.tsx`  
**Pages**: `BuildViewPage.tsx`, `ParseAnalysisPage.tsx`

## Test plan
- [ ] Mobile (375px): all buttons ≥44px on touch, no horizontal overflow
- [ ] 960–1100px: hamburger menu shown (not cramped nav)
- [ ] 1200px+: full desktop nav
- [ ] Footer links properly sized, "Calculation Knowledge Base" wraps
- [ ] Data tables scroll horizontally on mobile
- [ ] Light mode verified