### PR TITLE
fix: remove overly-broad 44px min-height rules breaking mobile layouts

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -276,16 +276,6 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
               },
             },
           },
-          MuiIconButton: {
-            styleOverrides: {
-              root: {
-                '@media (pointer: coarse)': {
-                  minWidth: 44,
-                  minHeight: 44,
-                },
-              },
-            },
-          },
           MuiChip: {
             styleOverrides: {
               root: {

--- a/src/index.css
+++ b/src/index.css
@@ -116,20 +116,6 @@ code {
   }
 }
 
-/* WCAG 2.2 Target Size (Level AA) — 44px minimum on coarse-pointer devices.
-   Scoped to navigation/standalone interactive elements only;
-   inline prose links are excluded to preserve text flow. */
-@media (pointer: coarse) {
-  nav a,
-  footer a,
-  [role='navigation'] a,
-  button,
-  [role='button'],
-  [role='tab'],
-  [role='menuitem'] {
-    min-height: 44px;
-  }
-}
 
 /* Pickr theme CSS variables */
 :root {

--- a/src/index.css
+++ b/src/index.css
@@ -116,7 +116,6 @@ code {
   }
 }
 
-
 /* Pickr theme CSS variables */
 :root {
   --site-bg: #121212;


### PR DESCRIPTION
## Summary
- Removes the global `@media (pointer: coarse)` CSS rule in `index.css` that applied `min-height: 44px` to every `button`, `[role='tab']`, `[role='button']`, and `[role='menuitem']` — this overrode explicit compact sizing on role stepper buttons (26x26), Simple/Full tabs, picker tabs, and setup tab delete icons
- Removes the `MuiIconButton` theme override in `ReduxThemeProvider.tsx` that forced `minWidth/minHeight: 44px` on all icon buttons on touch devices

All targeted per-component `minHeight: 44` additions from #1148 (Calculator, Footer, HeaderBar, KalpaBanner, PanelErrorBoundary, etc.) remain in place. Only the two overly-broad global rules are removed.

Fixes regression introduced in #1148.

## Test plan
- [x] Verified Roster Builder Simple/Full tabs are centered and compact on mobile
- [x] Verified Tank/Healer/DPS role counter +/- buttons are 26x26 on mobile
- [x] Verified Calculator, Build Editor, Pack Hub, Roster Hub, Build Hub, Gear Sets, Parse Analysis, Text Editor, Latest Reports, Footer all render correctly on 375x812 mobile viewport
- [x] TypeScript compilation passes