### PR TITLE
chore(security): remove invisible Unicode chars from source (scanner false positives)

### DIFF
--- a/scripts/refresh-class-skills.mjs
+++ b/scripts/refresh-class-skills.mjs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * refresh-class-skills.mjs
  *
  * Fetches all class skill descriptions and icons from the ESO-Hub API and

--- a/src/components/BugReportDialog.tsx
+++ b/src/components/BugReportDialog.tsx
@@ -1,4 +1,4 @@
-﻿import { BugReport, Send, Feedback, CheckCircleOutlined, Close } from '@mui/icons-material';
+import { BugReport, Send, Feedback, CheckCircleOutlined, Close } from '@mui/icons-material';
 import {
   Alert,
   Dialog,

--- a/src/data/Gear Sets/shared.ts
+++ b/src/data/Gear Sets/shared.ts
@@ -1,4 +1,4 @@
-﻿import { GearSetData } from '../../types/gearSet';
+import { GearSetData } from '../../types/gearSet';
 
 export const agility: GearSetData = {
   name: 'Agility',

--- a/src/features/loadout-manager/components/ItemPickerDialog.tsx
+++ b/src/features/loadout-manager/components/ItemPickerDialog.tsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Item Picker Dialog Component
  * Provides a typeahead experience for selecting gear items per slot.
  */

--- a/src/utils/rosterDiscordFormat.test.ts
+++ b/src/utils/rosterDiscordFormat.test.ts
@@ -24,7 +24,7 @@ import {
 } from './rosterDiscordFormat';
 
 // Zero-width space used by escapeDiscord to break Discord mention triggers.
-const ZWSP = '​';
+const ZWSP = '\u200B';
 
 describe('groupArrow', () => {
   it("maps a 'Left'-containing group name to the left arrow", () => {

--- a/src/utils/rosterDiscordFormat.ts
+++ b/src/utils/rosterDiscordFormat.ts
@@ -12,7 +12,7 @@ import { getSetDisplayName } from './setNameUtils';
  * escaped via {@link escapeDiscord} to prevent unwanted mentions / markdown injection.
  */
 
-const ZERO_WIDTH_SPACE = '​';
+const ZERO_WIDTH_SPACE = '\u200B';
 
 /**
  * Neutralize Discord mentions and escape markdown control characters in a

--- a/tests/utils/api-mocking.ts
+++ b/tests/utils/api-mocking.ts
@@ -1,4 +1,4 @@
-﻿import { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 


### PR DESCRIPTION
## Summary

A third-party security scan via **[wewatchyourwebsite.com](https://wewatchyourwebsite.com)** (reported framework: "vite", 2015 files scanned) flagged **8 CRITICAL** findings. Each was investigated against the actual codebase. **None is an exploitable vulnerability** — all 8 are false positives. This PR makes the safe, behavior-preserving hygiene changes that clear the *invisible-character* findings, and documents why the rest require no code change.

## Findings triage

### A08:2025 / CWE-506 — "invisible Unicode characters / steganographic payload" (4 findings)

The scanner's per-file counts (19/32/35/31) did not match the codebase; an exhaustive scan found only single invisible characters per file, in two benign categories:

| Location | Char | Verdict |
|---|---|---|
| `src/utils/rosterDiscordFormat.ts:15`, `...test.ts:27` | `U+200B` ZWSP | **Intentional security control.** The zero-width space is inserted after `@` and `<` to neutralize Discord `@everyone` / `@here` / `<@id>` **mention-injection** from user-supplied roster text. Removing it would *reintroduce* a real vulnerability. |
| `BugReportDialog.tsx`, `ItemPickerDialog.tsx`, `Gear Sets/shared.ts`, `tests/utils/api-mocking.ts`, `scripts/refresh-class-skills.mjs` (all line 1) | `U+FEFF` BOM | Harmless editor artifact. |
| `src/assets/localhost.har` | `U+200B` ×5 | Recorded network-capture data — left untouched (editing it would corrupt the capture). |

**Changes made (no runtime behavior change):**
- Replaced the literal `U+200B` with the explicit `''` escape in the two `rosterDiscordFormat` files. Proven equivalent: `'' === String.fromCharCode(0x200B)`. This keeps the mention-injection defense while removing the invisible character from source so it's visible to reviewers and quiet to scanners.
- Stripped the leading UTF-8 BOM from the 5 affected files.

### A07:2025 / CWE-798 — "hardcoded fallback for a secret env var" (4 findings)

These match variable **names** containing "TOKEN", not actual secrets:
- `ESOLOGS_TOKEN_URL || 'https://www.esologs.com/oauth/token'` (×3, test setup) — the fallback is a **public OAuth endpoint URL**, not a credential.
- `ERROR_TRACKING_TOKEN` in `src/Constants.ts` — a Rollbar **client-side post token**, public by design and documented as such in `.env.example`. Client-side error-reporting tokens are meant to ship in the bundle and can only post items, not read data.

No code change is warranted; these are intentional, public values. Genuine backend secrets (`discord-bot/src/auth.ts`, `roster-hub-api`) already guard correctly (e.g. `if (!env.WEBHOOK_SECRET) return false;`) with **no** hardcoded fallbacks.

## Verification
- Exhaustive re-scan of `src`, `tests`, `scripts`, `discord-bot`, `roster-hub-api`, `tools`: **zero** invisible characters remain in source (the `.har` recorded data is intentionally excluded).
- `''` escape confirmed byte-for-byte equivalent to the original literal at runtime.
- Edited files now begin with real content (no BOM); `node --check` passes on the `.mjs`.

> Note: `node_modules` was not installed in this fresh container, so the full Jest/typecheck suite was not run locally — CI covers it. The changes are limited to a literal→escape swap (identical string) and BOM removal, neither of which alters parsing or behavior.
