### PR TITLE
fix(skill-icons): repair broken skill-line icons (Magma Fist +12) + add CI guard

### DIFF
--- a/scripts/check-skill-line-icons.cjs
+++ b/scripts/check-skill-line-icons.cjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Skill-line icon validator (offline, deterministic).
+ *
+ * Asserts that every `icon:` string in the skill-line data resolves to a real
+ * ESO ability/UI icon. This is the offline oracle that would have caught the
+ * broken Magma Fist icon (ability_dragonknight_013_stonefist_b), which 403s on
+ * the rpglogs CDN and left the skill with no icon in the UI.
+ *
+ * Oracle: the union of the two bundled icon datasets —
+ *   - data/abilities.json     (ability id -> { icon })
+ *   - data/abilityIcons.json  (ability id -> icon filename)
+ * plus KNOWN_GOOD_PREFIXES for verified real icon families that ship with the
+ * game but appear in neither dataset (e.g. the Antiquities excavation icons
+ * "u26_ability_digging_*", referenced by real, working skills and present only
+ * in abilityIcons.json's value set... which is why both datasets are unioned).
+ *
+ * The CDN is intentionally NOT queried: it rate-limits scripted probes (its
+ * HTTP codes flap between 200/401/403) and CI must run offline. The bundled
+ * datasets are what the app itself ships, so they are the source of truth for
+ * "will this icon resolve".
+ *
+ * Scope: files under src/data/skill-lines, excluding
+ *   - the unreferenced duplicate trees (templar/, warden/, sorcerer/,
+ *     nightblade/, weapons/, Alliance/) that nothing in the app imports, and
+ *   - the decorative SkillsetData files (class/dragonknight.ts etc.) and
+ *     global-abilites.ts, which use emoji/placeholder icons and feed only the
+ *     damage-calc utilities, not icon rendering.
+ *
+ * Usage:
+ *   node scripts/check-skill-line-icons.cjs          # exit 1 on any unknown icon
+ *   node scripts/check-skill-line-icons.cjs --list   # print every icon + status
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SKILL_DIR = path.join(ROOT, 'src', 'data', 'skill-lines');
+
+// Skill-line subtrees / files that are not part of icon rendering.
+const EXCLUDED_DIRS = new Set([
+  'templar',
+  'warden',
+  'sorcerer',
+  'nightblade',
+  'weapons',
+  'Alliance',
+]);
+const EXCLUDED_FILES = new Set([
+  'global-abilites.ts', // decorative emoji headers, damage-calc only
+]);
+// class/*.ts that are SkillsetData (emoji icons), not SkillLineData. These are
+// consumed by damage-calc utils, never rendered as icons.
+const EXCLUDED_CLASS_SKILLSET_FILES = new Set([
+  'dragonknight.ts',
+  'sorcerer.ts',
+  'nightblade.ts',
+  'templar.ts',
+  'warden.ts',
+  'necromancer.ts',
+  'arcanist.ts',
+]);
+
+// Verified real icon families absent from both bundled datasets.
+const KNOWN_GOOD_PREFIXES = ['u26_ability_digging_'];
+
+function buildValidIconSet() {
+  const set = new Set();
+  const abilities = JSON.parse(fs.readFileSync(path.join(ROOT, 'data', 'abilities.json'), 'utf8'));
+  for (const id of Object.keys(abilities)) {
+    const icon = abilities[id] && abilities[id].icon;
+    if (icon && icon !== 'icon_missing') set.add(icon);
+  }
+  const iconMap = JSON.parse(fs.readFileSync(path.join(ROOT, 'data', 'abilityIcons.json'), 'utf8'));
+  for (const icon of Object.values(iconMap)) {
+    if (icon && icon !== 'icon_missing') set.add(icon);
+  }
+  return set;
+}
+
+function isKnownGood(icon, validIcons) {
+  if (validIcons.has(icon)) return true;
+  return KNOWN_GOOD_PREFIXES.some((p) => icon.startsWith(p));
+}
+
+function walk(dir, rel) {
+  let out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (EXCLUDED_DIRS.has(e.name)) continue;
+      out = out.concat(walk(path.join(dir, e.name), rel ? `${rel}/${e.name}` : e.name));
+    } else if (e.isFile() && e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) {
+      if (EXCLUDED_FILES.has(e.name)) continue;
+      if (rel === 'class' && EXCLUDED_CLASS_SKILLSET_FILES.has(e.name)) continue;
+      out.push(path.join(dir, e.name));
+    }
+  }
+  return out;
+}
+
+function collectIcons(files) {
+  const refs = [];
+  for (const f of files) {
+    const lines = fs.readFileSync(f, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      const m = /icon:\s*'([^']+)'/.exec(line);
+      if (m) refs.push({ icon: m[1], where: `${path.relative(ROOT, f)}:${i + 1}` });
+    });
+  }
+  return refs;
+}
+
+function main() {
+  const list = process.argv.includes('--list');
+  const validIcons = buildValidIconSet();
+  const files = walk(SKILL_DIR, '');
+  const refs = collectIcons(files);
+
+  const unknown = [];
+  for (const ref of refs) {
+    const ok = isKnownGood(ref.icon, validIcons);
+    if (list) console.log(`${ok ? 'OK  ' : 'BAD '} ${ref.icon}  (${ref.where})`);
+    if (!ok) unknown.push(ref);
+  }
+
+  const unique = new Set(refs.map((r) => r.icon)).size;
+  console.log(
+    `Checked ${refs.length} icon references (${unique} unique) across ${files.length} skill-line files.`,
+  );
+
+  if (unknown.length) {
+    console.error(`\n${unknown.length} icon(s) not found in the bundled icon datasets:`);
+    for (const u of unknown) console.error(`  ${u.icon}  ->  ${u.where}`);
+    console.error(
+      '\nFix: replace with the icon that abilities.json / abilityIcons.json maps for ' +
+        "the skill's ability id, or, if it is a verified real icon family missing from " +
+        'both datasets, add its prefix to KNOWN_GOOD_PREFIXES.',
+    );
+    process.exit(1);
+  }
+
+  console.log('All skill-line icons resolve to known game icons.');
+}
+
+main();

--- a/src/data/skill-lines/alliance-war/support.ts
+++ b/src/data/skill-lines/alliance-war/support.ts
@@ -6,7 +6,7 @@ export const support: SkillLineData = {
   name: 'Support',
   class: 'alliance-war',
   category: 'alliance',
-  icon: 'ability_ava_010',
+  icon: 'ability_ava_005',
   sourceUrl: 'https://eso-hub.com/en/skills/alliance-war/support',
   skills: [
     // Ultimate abilities

--- a/src/data/skill-lines/class/earthenHeart.ts
+++ b/src/data/skill-lines/class/earthenHeart.ts
@@ -58,7 +58,7 @@ export const earthenHeart: SkillLineData = {
       id: ClassSkillId.DRAGONKNIGHT_MAGMA_FIST,
       name: 'Magma Fist',
       type: 'active',
-      icon: 'ability_dragonknight_013_stonefist_b',
+      icon: 'ability_dragonknight_013_a',
       description:
         "Draw forth magma from below to hurl at an enemy, dealing 2399 Flame Damage while applying a stack of Heat Shock, which increases the enemy's damage taken by 66 for 7 seconds per stack, up to 3 times. Hitting an enemy at max stacks of Heat Shock with this ability increases the damage done of the next cast of this ability within 6 seconds by 66%, up to once every 6 seconds.",
       baseSkillId: ClassSkillId.DRAGONKNIGHT_SUPERHEATED_WARD,

--- a/src/data/skill-lines/guild/darkBrotherhood.ts
+++ b/src/data/skill-lines/guild/darkBrotherhood.ts
@@ -6,7 +6,7 @@ export const darkBrotherhood: SkillLineData = {
   name: 'Dark Brotherhood',
   class: 'guild',
   category: 'guild',
-  icon: 'passive_guild_32.webp',
+  icon: 'ability_darkbrotherhood_passive_002',
   sourceUrl: 'https://eso-hub.com/en/skills/guild/dark-brotherhood',
   skills: [
     {

--- a/src/data/skill-lines/guild/fightersGuild.ts
+++ b/src/data/skill-lines/guild/fightersGuild.ts
@@ -6,7 +6,7 @@ export const fightersGuild: SkillLineData = {
   name: 'Fighters Guild',
   class: 'guild',
   category: 'guild',
-  icon: 'class_003',
+  icon: 'ability_fightersguild_005',
   sourceUrl: 'https://eso-hub.com/en/skills/guild/fighters-guild',
   skills: [
     // Ultimate abilities

--- a/src/data/skill-lines/guild/magesGuild.ts
+++ b/src/data/skill-lines/guild/magesGuild.ts
@@ -6,7 +6,7 @@ export const magesGuild: SkillLineData = {
   name: 'Mages Guild',
   class: 'guild',
   category: 'guild',
-  icon: 'class_003',
+  icon: 'ability_mageguild_005',
   sourceUrl: 'https://eso-hub.com/en/skills/guild/mages-guild',
   skills: [
     // Ultimate abilities

--- a/src/data/skill-lines/guild/thievesGuild.ts
+++ b/src/data/skill-lines/guild/thievesGuild.ts
@@ -6,7 +6,7 @@ export const thievesGuild: SkillLineData = {
   name: 'Thieves Guild',
   class: 'guild',
   category: 'guild',
-  icon: 'passive_guild_32.webp',
+  icon: 'ability_thievesguild_passive_001',
   sourceUrl: 'https://eso-hub.com/en/skills/guild/thieves-guild',
   skills: [
     {

--- a/src/data/skill-lines/skill-line-icons.test.ts
+++ b/src/data/skill-lines/skill-line-icons.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Guard: every `icon:` in the skill-line data must resolve to a real ESO icon.
+ *
+ * Regression origin: the Magma Fist skill referenced
+ * `ability_dragonknight_013_stonefist_b`, which exists in neither bundled icon
+ * dataset and 403s on the rpglogs CDN, so the skill rendered with no icon.
+ * abilities.json maps its ability ids (31816 / 133027) to
+ * `ability_dragonknight_013_a`.
+ *
+ * This test runs scripts/check-skill-line-icons.cjs — the same offline
+ * validator usable standalone in CI — and asserts a clean exit, so the script
+ * and this guard can never drift apart.
+ */
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+describe('skill-line icons', () => {
+  it('all skill-line icons resolve to a known game icon', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..');
+    const script = path.join(repoRoot, 'scripts', 'check-skill-line-icons.cjs');
+
+    const result = spawnSync(process.execPath, [script], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+
+    if (result.status !== 0) {
+      // Surface the validator's report (lists each offending icon + location).
+      throw new Error(
+        `Skill-line icon validator failed:\n${result.stdout ?? ''}${result.stderr ?? ''}`,
+      );
+    }
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/src/data/skill-lines/weapon/restorationStaff.ts
+++ b/src/data/skill-lines/weapon/restorationStaff.ts
@@ -6,7 +6,7 @@ export const restorationStaff: SkillLineData = {
   name: 'Restoration Staff',
   class: 'Weapon',
   category: 'weapon',
-  icon: 'restoration-staff-icon.png',
+  icon: 'ability_restorationstaff_002',
   sourceUrl: 'https://eso-hub.com/en/skills/weapon/restoration-staff',
   skills: [
     // Ultimate abilities

--- a/src/data/skill-lines/world/excavation.ts
+++ b/src/data/skill-lines/world/excavation.ts
@@ -12,7 +12,7 @@ export const excavation: SkillLineData = {
   name: 'Excavation',
   class: 'world',
   category: 'world',
-  icon: 'ability_world_excavation_001',
+  icon: 'u26_ability_digging_01',
   sourceUrl: 'https://eso-hub.com/en/skills/world/excavation',
   skills: [
     {

--- a/src/data/skill-lines/world/legerdemain.ts
+++ b/src/data/skill-lines/world/legerdemain.ts
@@ -16,7 +16,7 @@ export const legerdemain: SkillLineData = {
   name: 'Legerdemain',
   class: 'world',
   category: 'world',
-  icon: 'ability_world_legerdemain_001',
+  icon: 'ability_legerdemain_lockpick',
   sourceUrl: 'https://eso-hub.com/en/skills/world/legerdemain',
   skills: [
     // Passive Skill 1: Improved Hiding - Stealth efficiency

--- a/src/data/skill-lines/world/scrying.ts
+++ b/src/data/skill-lines/world/scrying.ts
@@ -6,7 +6,7 @@ export const scrying: SkillLineData = {
   name: 'Scrying',
   class: 'world',
   category: 'world',
-  icon: 'ability_world_scrying_001',
+  icon: 'ability_scrying_01',
   sourceUrl: 'https://eso-hub.com/en/skills/world/scrying',
   skills: [
     {

--- a/src/data/skill-lines/world/soul-magic.ts
+++ b/src/data/skill-lines/world/soul-magic.ts
@@ -6,7 +6,7 @@ export const soulMagic: SkillLineData = {
   name: 'Soul Magic',
   class: 'world',
   category: 'world',
-  icon: 'ability_soul_magic_soul_strike',
+  icon: 'ability_otherclass_002',
   sourceUrl: 'https://eso-hub.com/en/skills/world/soul-magic',
   skills: [
     {
@@ -24,7 +24,7 @@ export const soulMagic: SkillLineData = {
       name: 'Shatter Soul',
       description:
         'Burn an enemy from the inside with soulfire, dealing 14814 Magic Damage over 5 seconds. Upon completion, the soulfire overflows and explodes from the enemy, dealing 2399 Magic Damage to all enemies near them. While channeling this ability, you gain immunity to all disabling effects. Enemies affected by this ability are revealed for 3 seconds and may not enter stealth or invisibility. This ability is considered direct damage. Upon completion, deals damage to all enemies near your target.',
-      icon: 'ability_soul_magic_shatter_soul',
+      icon: 'ability_otherclass_002_a',
       isUltimate: true,
       isPassive: false,
       maxRank: 4,

--- a/src/data/skill-lines/world/vampire.ts
+++ b/src/data/skill-lines/world/vampire.ts
@@ -6,7 +6,7 @@ export const vampire: SkillLineData = {
   name: 'Vampire',
   class: 'world',
   category: 'world',
-  icon: 'ability_u26_vampire_blood_scion',
+  icon: 'ability_u26_vampire_06',
   sourceUrl: 'https://eso-hub.com/en/skills/world/vampire',
   skills: [
     // Ultimate abilities

--- a/src/data/skill-lines/world/werewolf.ts
+++ b/src/data/skill-lines/world/werewolf.ts
@@ -6,7 +6,7 @@ export const werewolf: SkillLineData = {
   name: 'Werewolf',
   class: 'world',
   category: 'world',
-  icon: 'ability_werewolf_werewolf_transformation',
+  icon: 'ability_werewolf_001',
   sourceUrl: 'https://eso-hub.com/en/skills/world/werewolf',
   skills: [
     // Ultimate Abilities


### PR DESCRIPTION
## Summary

Several skill-line `icon:` strings referenced filenames that exist on neither bundled icon dataset and **403 on the rpglogs CDN**, so those skills/lines render with **no icon** in the Loadout/Build manager UI. The most visible was **Magma Fist**, which used the bogus `ability_dragonknight_013_stonefist_b`.

Audited *every* icon referenced by the skill-line data against `data/abilities.json` + `data/abilityIcons.json` and replaced each broken value with the icon the corresponding ability id actually resolves to.

> **Scope:** these strings feed the in-progress Loadout/Build manager UI. The live report views resolve icons by game id and were **not** affected — nothing user-facing was broken in production, but the data is now correct for when that UI ships.

## Icons fixed (13)

| Skill line | Before | After |
|---|---|---|
| Earthen Heart — **Magma Fist** | `ability_dragonknight_013_stonefist_b` | `ability_dragonknight_013_a` |
| Alliance War / Support | `ability_ava_010` | `ability_ava_005` |
| Mages Guild | `class_003` | `ability_mageguild_005` |
| Fighters Guild | `class_003` | `ability_fightersguild_005` |
| Dark Brotherhood | `passive_guild_32.webp` | `ability_darkbrotherhood_passive_002` |
| Thieves Guild | `passive_guild_32.webp` | `ability_thievesguild_passive_001` |
| Restoration Staff | `restoration-staff-icon.png` | `ability_restorationstaff_002` |
| Excavation | `ability_world_excavation_001` | `u26_ability_digging_01` |
| Legerdemain | `ability_world_legerdemain_001` | `ability_legerdemain_lockpick` |
| Scrying | `ability_world_scrying_001` | `ability_scrying_01` |
| Soul Magic (header) | `ability_soul_magic_soul_strike` | `ability_otherclass_002` |
| Soul Magic — Shatter Soul | `ability_soul_magic_shatter_soul` | `ability_otherclass_002_a` |
| Vampire | `ability_u26_vampire_blood_scion` | `ability_u26_vampire_06` |
| Werewolf | `ability_werewolf_werewolf_transformation` | `ability_werewolf_001` |

## Regression guard

- **`scripts/check-skill-line-icons.cjs`** — offline validator asserting every icon in the live skill-line data exists in `abilities.json`/`abilityIcons.json` (plus a small allowlist of real icon families absent from both, e.g. the Antiquities `u26_ability_digging_*` set). It excludes the unreferenced duplicate skill-line trees and the decorative emoji `SkillsetData` files.
- **`src/data/skill-lines/skill-line-icons.test.ts`** — jest test that runs the validator so the suite fails on any future broken icon.

The CDN is intentionally **not** queried — it rate-limits scripted probes (flapping 200/401/403) and CI runs offline; the bundled datasets the app ships are the source of truth.

## Testing

- `node scripts/check-skill-line-icons.cjs` → passes clean across all icon references (exit 0); negative test (reintroducing a broken icon) correctly exits 1.
- `tsc --noEmit` → clean.
- The jest guard runs in CI/top-level checkouts. (Note: jest is configured to ignore `.claude/worktrees/`, so it doesn't execute from this worktree — the validator was run directly to verify the same logic.)
