### PR TITLE
fix(sample-reports): resolve bundled sample URL against base path

### DIFF
--- a/src/utils/sampleReports.ts
+++ b/src/utils/sampleReports.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from './envUtils';
+
 /**
  * Curated sample report codes whose report metadata is bundled as static JSON
  * in `public/sample-reports/<code>/report.json`.
@@ -27,7 +29,11 @@ export const SAMPLE_REPORT_LIST: ReadonlyArray<string> = [...SAMPLE_REPORT_CODES
 /**
  * Build the URL for a bundled sample report JSON file served from `public/`.
  *
- * Uses a root-relative path (`/sample-reports/…`) which works for both the Vite
- * dev server and the production deployment (base URL defaults to `"/"`).
+ * Resolves against Vite's base URL (`getBaseUrl()`) so the file is fetched from
+ * `<base>/sample-reports/…` rather than the origin root. A root-relative path
+ * would 404 on any non-root deployment — e.g. the GitHub Pages PR previews
+ * served under `/dev-previews/pr-<n>/` — which surfaced the bundled sample as
+ * an empty log. `getBaseUrl()` always returns a value ending in `/`.
  */
-export const getSampleReportUrl = (code: string): string => `/sample-reports/${code}/report.json`;
+export const getSampleReportUrl = (code: string): string =>
+  `${getBaseUrl()}sample-reports/${code}/report.json`;


### PR DESCRIPTION
## Problem

Bundled sample reports load as an **empty log** on non-root deployments. Reproduced on the PR-1158 preview: <https://eso-toolkit.github.io/dev-previews/pr-1158/report/F4f2bMwWtgVKxjB9> shows *"No fights available — Empty Log."*

## Root cause

`getSampleReportUrl()` built a **root-relative** URL:

```ts
`/sample-reports/${code}/report.json`
```

That ignores Vite's configured `base`. On a non-root deploy (GitHub Pages PR previews are served under `/dev-previews/pr-<n>/`) the browser resolves it against the origin root, so the fetch hits `…github.io/sample-reports/…` → **404**. `fetchReportData` then rejects, the report has no fights, and `ReportFightsView` renders its "Empty Log" card.

The bundled JSON *is* deployed correctly under the base — only the fetch URL was wrong. (Confirmed: base-prefixed URL → `200`; root-relative → `404`.)

## Fix

Build the URL from `getBaseUrl()` (the same `envUtils` helper `App.tsx` already uses to derive the router `basename`), so it resolves to `<base>/sample-reports/<code>/report.json`. `getBaseUrl()` always returns a value ending in `/`.

```ts
`${getBaseUrl()}sample-reports/${code}/report.json`
```

Behavior at the default root base (`/`) is unchanged.

## Verification

- Reproduced the deploy condition locally (`VITE_BASE_URL=/dev-previews/pr-1158/`, port 3001) and loaded `…/dev-previews/pr-1158/report/F4f2bMwWtgVKxjB9` — all fights render, no Empty Log. Network tab shows the sample JSON fetched `200` from the base-prefixed path.
- Report/sample test suites pass (14 suites, 140 tests); `import.meta.env.BASE_URL` transforms fine under ts-jest, no new mock needed.
- Typecheck + ESLint clean on the changed file.