### PR TITLE
feat(player-card): electric-border effect on top-DPS card

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -760,6 +760,26 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
             '0%': { backgroundPosition: '-200% 0' },
             '100%': { backgroundPosition: '200% 0' },
           },
+          // Electric-border (top DPS): register the angle custom property so it
+          // can interpolate inside the conic-gradient. Without @property the
+          // gradient angle would not animate. Falls back gracefully (static
+          // ring) in engines that don't support @property.
+          '@property --tdps-angle': {
+            syntax: '"<angle>"',
+            initialValue: '0deg',
+            inherits: 'false',
+          },
+          // Sweep the gradient's start angle, NOT the element's transform — that
+          // keeps the rectangular ring in place and moves only the bright
+          // "current" travelling around its edge.
+          '@keyframes electricBorderSpin': {
+            to: { '--tdps-angle': '360deg' },
+          },
+          // Electric-border (top DPS): gentle glow pulse on the outer halo
+          '@keyframes electricBorderPulse': {
+            '0%, 100%': { opacity: 0.55 },
+            '50%': { opacity: 1 },
+          },
           '.u-fade-in': {
             animation: 'tooltipEnter 220ms cubic-bezier(0.26, 0.53, 0.74, 1.48) both',
           },

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -937,8 +937,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                   // painted (both prefixed + standard for cross-browser).
                   background:
                     'conic-gradient(from var(--tdps-angle), transparent 0deg, rgba(251,191,36,0.15) 40deg, rgba(245,158,11,0.85) 80deg, #fde68a 100deg, rgba(245,158,11,0.85) 120deg, rgba(251,191,36,0.15) 160deg, transparent 200deg, transparent 360deg)',
-                  WebkitMask:
-                    'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+                  WebkitMask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
                   mask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
                   WebkitMaskComposite: 'xor',
                   maskComposite: 'exclude',

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -412,6 +412,10 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
             ? '1px solid rgba(255, 255, 255, 0.1)'
             : '1px solid rgba(59, 130, 246, 0.3)',
         ...(isTopDps && {
+          // Allow the electric ring + outer halo (negative insets) to render
+          // beyond the card edge instead of being clipped by MUI's default
+          // overflow:hidden on Card.
+          overflow: 'visible' as const,
           boxShadow:
             theme.palette.mode === 'dark'
               ? '0 0 16px rgba(245,158,11,0.18), 0 0 40px rgba(245,158,11,0.06), inset 0 1px 0 rgba(251,191,36,0.12)'
@@ -910,21 +914,56 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
           data-testid={`player-card-${player.id}`}
         >
           {isTopDps && (
-            <Box
-              aria-hidden="true"
-              sx={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                height: '3px',
-                background:
-                  'linear-gradient(90deg, transparent 0%, rgba(245,158,11,0.5) 20%, rgba(251,191,36,1) 50%, rgba(245,158,11,0.5) 80%, transparent 100%)',
-                borderRadius: '4px 4px 0 0',
-                boxShadow: '0 0 8px rgba(251,191,36,0.7), 0 0 18px rgba(245,158,11,0.35)',
-                zIndex: 2,
-              }}
-            />
+            <>
+              {/* Electric border (top DPS): rotating conic-gradient gold edge.
+                  Adapted from the "electric border" aesthetic to the project's
+                  MUI/token idiom. Scoped to this card via absolute inset so it
+                  cannot bleed into neighbouring cards. Both layers animate via
+                  CSS keyframes, so the global prefers-reduced-motion rule in
+                  ReduxThemeProvider neutralises the motion automatically. */}
+              <Box
+                aria-hidden="true"
+                sx={{
+                  position: 'absolute',
+                  inset: '-1px',
+                  borderRadius: '14px',
+                  padding: '1.5px',
+                  zIndex: 2,
+                  pointerEvents: 'none',
+                  // The conic gradient is the moving "current"; animating its
+                  // start angle (via the --tdps-angle custom property) sweeps the
+                  // bright spot around the edge while the element itself stays
+                  // put. The mask carves out the centre so only the 1.5px ring is
+                  // painted (both prefixed + standard for cross-browser).
+                  background:
+                    'conic-gradient(from var(--tdps-angle), transparent 0deg, rgba(251,191,36,0.15) 40deg, rgba(245,158,11,0.85) 80deg, #fde68a 100deg, rgba(245,158,11,0.85) 120deg, rgba(251,191,36,0.15) 160deg, transparent 200deg, transparent 360deg)',
+                  WebkitMask:
+                    'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+                  mask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+                  WebkitMaskComposite: 'xor',
+                  maskComposite: 'exclude',
+                  animation: 'electricBorderSpin 4s linear infinite',
+                  filter: 'drop-shadow(0 0 4px rgba(245,158,11,0.55))',
+                }}
+              />
+              {/* Soft outer halo that gently pulses, giving the "energised" feel
+                  without the visual noise of a fast crackle. */}
+              <Box
+                aria-hidden="true"
+                sx={{
+                  position: 'absolute',
+                  inset: '-3px',
+                  borderRadius: '16px',
+                  zIndex: 0,
+                  pointerEvents: 'none',
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? '0 0 14px 1px rgba(245,158,11,0.35), 0 0 34px 4px rgba(245,158,11,0.12)'
+                      : '0 0 14px 1px rgba(180,83,9,0.28), 0 0 34px 4px rgba(245,158,11,0.14)',
+                  animation: 'electricBorderPulse 2.8s ease-in-out infinite',
+                }}
+              />
+            </>
           )}
           <CardContent
             sx={{ p: 2, pb: 1, display: 'flex', flexDirection: 'column', height: '100%' }}


### PR DESCRIPTION
## Summary

Adds an animated **electric-border** effect to the **top-DPS player card** on fight-log insights, adapted from the [reactbits electric-border](https://reactbits.dev/animations/electric-border) effect into the project's MUI / theme-token idiom.

The previous static amber top-bar is replaced with:

- A masked **conic-gradient gold ring** (1.5px) whose bright "current" sweeps around the card edge by animating a registered `@property --tdps-angle`. The element stays put (no rotated-rectangle "propeller"), so it never bleeds into neighbouring cards.
- A soft **outer halo** that gently pulses via an opacity keyframe.
- `overflow: visible` on the top-DPS card so the halo isn't clipped.

Design choices: **electric gold** (keeps the trophy / #1-winner semantics the badge already signals) with a **subtle continuous flow** rather than an energetic crackle, so it reads as premium without being noisy in a grid of cards.

### Why
Gives the highest-DPS player a more modern, eye-catching indicator that fits the site's dark-glass aesthetic, while staying contained and non-distracting.

### Accessibility
Both layers animate via CSS keyframes, so the existing global `@media (prefers-reduced-motion: reduce)` rule in `ReduxThemeProvider` neutralises the motion automatically (no per-component guard needed).

### Verification
- `tsc --noEmit`, `npm run build`, and ESLint all pass clean.
- Browser-verified the ring sweeps around the edge and stays in-bounds (doesn't touch neighbouring cards).
- Confirmed via the live dev server that `@property --tdps-angle` registers correctly through the Emotion/stylis render path (`getComputedStyle(...).getPropertyValue('--tdps-angle')` -> `"0deg"`), so the animation is live in the real app rather than silently static.

> Note: per-fight insights panels don't populate in local dev (worker CORS blocks `localhost`), so the populated top-DPS card is best confirmed on production after merge.

### Files changed
- `src/ReduxThemeProvider.tsx` - `@property --tdps-angle` registration + `electricBorderSpin` / `electricBorderPulse` keyframes
- `src/features/report_details/insights/PlayerCard.tsx` - ring + halo overlay (replaces the static amber top-bar)

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`
