### PR TITLE
feat(fight-replay): live role-aware stats panel on lock-on

### DIFF
--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -758,11 +758,14 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         <BossHealthPanel lookup={lookup} timeRef={timeRef} />
 
         {/* Locked-player stats — DOM overlay (bottom-left), shown only while following a player.
-            Role-aware whole-fight readout (DPS / healer / tank), reusing the fight-insights calcs.
-            Renders nothing when not following or when locked onto a non-player. */}
+            Role-aware up-to-playhead readout (DPS / healer / tank), reusing the fight-insights
+            calcs via a prefix-sum engine + own rAF loop. Renders nothing when not following or
+            when locked onto a non-player. */}
         <LockedPlayerStatsPanel
           followingActorId={followingActorId}
           lookup={lookup}
+          timeRef={timeRef}
+          fightStartTime={fight.startTime}
           fightDurationMs={fight.endTime - fight.startTime}
         />
 

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -2,6 +2,7 @@ import { Fullscreen, FullscreenExit, LockOpen, Videocam } from '@mui/icons-mater
 import Bolt from '@mui/icons-material/Bolt';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import HelpOutline from '@mui/icons-material/HelpOutlineOutlined';
+import Insights from '@mui/icons-material/Insights';
 import Label from '@mui/icons-material/Label';
 import LabelOff from '@mui/icons-material/LabelOff';
 import {
@@ -163,6 +164,12 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   // player-paths HUD and trails in FightReplay3D).
   const [performanceMode, setPerformanceMode] = useState(initialPrefs.performanceMode);
 
+  // Locked-player stats panel: master on/off (J key + button) and which sections show (the panel's
+  // gear menu). Owned here because the panel mounts here and this mirrors the names/perf slices.
+  // Disabling unmounts the panel entirely, which stops its inner rAF loops — a real cost saving.
+  const [statsPanelEnabled, setStatsPanelEnabled] = useState(initialPrefs.statsPanelEnabled);
+  const [statsPanelSections, setStatsPanelSections] = useState(initialPrefs.statsPanelSections);
+
   // Per-player visibility of the 3D actor models. Owned here (rather than in Arena3DScene)
   // so the DOM PlayerListPanel overlay — which renders the toggle controls — and the
   // in-canvas actors share one source of truth. Changes only on a user toggle, so the
@@ -191,11 +198,16 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
     });
   }, []);
 
-  // Persist Arena3D's pref slice (names + performance) on change. Read-merge-write in the hook
-  // means this never clobbers the speed/path slice FightReplay3D persists.
+  // Persist Arena3D's pref slice (names + performance + stats-panel) on change. Read-merge-write in
+  // the hook means this never clobbers the speed/path slice FightReplay3D persists.
   useEffect(() => {
-    persistPrefs({ showNames: namesEnabled, performanceMode });
-  }, [persistPrefs, namesEnabled, performanceMode]);
+    persistPrefs({
+      showNames: namesEnabled,
+      performanceMode,
+      statsPanelEnabled,
+      statsPanelSections,
+    });
+  }, [persistPrefs, namesEnabled, performanceMode, statsPanelEnabled, statsPanelSections]);
 
   // Player IDs for the DOM player-list overlay (derived from the same lookup the scene uses).
   const availablePlayerIds = useMemo(() => (lookup ? getVisiblePlayerIds(lookup) : []), [lookup]);
@@ -387,11 +399,20 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         setNamesEnabled((prev) => !prev);
         event.preventDefault();
       }
+
+      // J toggles the locked-player stats panel on/off. Gated on actually following someone (read
+      // via the always-current ref, since this effect's deps are []) so the key mirrors the on-screen
+      // button, which only appears while following — no flipping a hidden pref with zero feedback.
+      if (event.key.toLowerCase() === 'j' && followingActorIdRef.current != null) {
+        setStatsPanelEnabled((prev) => !prev);
+        event.preventDefault();
+      }
     };
 
     window.addEventListener('keydown', handleKeyPress);
     return () => window.removeEventListener('keydown', handleKeyPress);
-  }, []);
+    // followingActorIdRef is a stable ref; listed to satisfy exhaustive-deps without re-binding.
+  }, [followingActorIdRef]);
 
   // Calculate arena dimensions based on fight bounding box
   const arenaDimensions = useMemo(() => {
@@ -760,14 +781,19 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         {/* Locked-player stats — DOM overlay (bottom-left), shown only while following a player.
             Role-aware up-to-playhead readout (DPS / healer / tank), reusing the fight-insights
             calcs via a prefix-sum engine + own rAF loop. Renders nothing when not following or
-            when locked onto a non-player. */}
-        <LockedPlayerStatsPanel
-          followingActorId={followingActorId}
-          lookup={lookup}
-          timeRef={timeRef}
-          fightStartTime={fight.startTime}
-          fightDurationMs={fight.endTime - fight.startTime}
-        />
+            when locked onto a non-player. Gated on statsPanelEnabled (J key / button): disabling
+            UNMOUNTS it, which stops the inner rAF loops — not just a visual hide. */}
+        {statsPanelEnabled && (
+          <LockedPlayerStatsPanel
+            followingActorId={followingActorId}
+            lookup={lookup}
+            timeRef={timeRef}
+            fightStartTime={fight.startTime}
+            fightDurationMs={fight.endTime - fight.startTime}
+            sections={statsPanelSections}
+            onSectionsChange={setStatsPanelSections}
+          />
+        )}
 
         {/* Player list — DOM overlay (top-left), shown when the player-paths HUD is toggled
             on (P key). Real scroll region so every player is reachable. */}
@@ -968,6 +994,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             ['P', 'Player list'],
             ['T', 'Player trails'],
             ['N', 'Name cards'],
+            ['J', 'Player stats (when locked)'],
             ['F', 'Fullscreen'],
             ['C', 'Collapse controls'],
           ].map(([k, label]) => (
@@ -987,6 +1014,31 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           </Typography>
         </Box>
       </Collapse>
+
+      {/* Locked-player stats toggle — only shown while following a player (the panel's condition),
+          so it doesn't clutter the cluster otherwise. Mirrors the J key; on/off shown by color. */}
+      {followingActorId != null && (
+        <Tooltip title={statsPanelEnabled ? 'Hide player stats (J)' : 'Show player stats (J)'}>
+          <IconButton
+            aria-label={statsPanelEnabled ? 'Hide locked-player stats' : 'Show locked-player stats'}
+            aria-pressed={statsPanelEnabled}
+            size="small"
+            onClick={() => setStatsPanelEnabled((prev) => !prev)}
+            sx={{
+              position: 'absolute',
+              bottom: 296,
+              right: 16,
+              color: statsPanelEnabled ? 'white' : 'rgba(255, 255, 255, 0.55)',
+              backgroundColor: 'rgba(0, 0, 0, 0.85)',
+              '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.95)',
+              },
+            }}
+          >
+            <Insights fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
 
       {/* Fullscreen toggle — fullscreens the whole replay block (canvas + overlays + control bar).
           Topmost in the bottom-right cluster; mirrors the F key. */}

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -33,6 +33,7 @@ import { getVisiblePlayerIds } from '../utils/pathUtils';
 
 import { Arena3DScene, GroundContextMenuPayload } from './Arena3DScene';
 import { BossHealthPanel } from './BossHealthPanel';
+import { LockedPlayerStatsPanel } from './LockedPlayerStatsPanel';
 import { MarkerContextMenuPayload } from './Marker3D';
 import { MarkerSpritePreview } from './MarkerSpritePreview';
 import { PerformanceMonitorExternal } from './PerformanceMonitor/PerformanceMonitorExternal';
@@ -755,6 +756,15 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         {/* Boss health — DOM overlay (top-right), crisp + theme-styled. Always shown when
             bosses with health are present. */}
         <BossHealthPanel lookup={lookup} timeRef={timeRef} />
+
+        {/* Locked-player stats — DOM overlay (bottom-left), shown only while following a player.
+            Role-aware whole-fight readout (DPS / healer / tank), reusing the fight-insights calcs.
+            Renders nothing when not following or when locked onto a non-player. */}
+        <LockedPlayerStatsPanel
+          followingActorId={followingActorId}
+          lookup={lookup}
+          fightDurationMs={fight.endTime - fight.startTime}
+        />
 
         {/* Player list — DOM overlay (top-left), shown when the player-paths HUD is toggled
             on (P key). Real scroll region so every player is reachable. */}

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -35,8 +35,9 @@
  */
 
 import { Box, Typography, useTheme, alpha } from '@mui/material';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
+import { useReportMasterData } from '../../../hooks';
 import { useCombatantInfoRecord } from '../../../hooks/events/useCombatantInfoRecord';
 import { useDamageEvents } from '../../../hooks/events/useDamageEvents';
 import { useDeathEvents } from '../../../hooks/events/useDeathEvents';
@@ -44,6 +45,7 @@ import { useHealingEvents } from '../../../hooks/events/useHealingEvents';
 import { usePlayerData } from '../../../hooks/usePlayerData';
 import { useBuffLookupTask } from '../../../hooks/workerTasks/useBuffLookupTask';
 import { useDebuffLookupTask } from '../../../hooks/workerTasks/useDebuffLookupTask';
+import { computeBuffUptimes } from '../../../utils/buffUptimeCalculator';
 import {
   calculateDynamicDamageReductionAtTimestamp,
   calculateStaticResistanceValue,
@@ -53,6 +55,7 @@ import {
   type TimestampPositionLookup,
   getActorPositionAtClosestTimestamp,
 } from '../../../workers/calculations/CalculateActorPositions';
+import { IMPORTANT_BUFF_ABILITIES } from '../../report_details/insights/BuffUptimesPanel';
 import { getReplayActorResolvedAccentColor } from '../utils/actorVisualState';
 import {
   type LiveLockedStats,
@@ -300,6 +303,128 @@ const TankDamageReduction: React.FC<{
   );
 };
 
+/** How often the (O(n)) buff-uptime recompute runs while scrubbing. */
+const UPTIME_THROTTLE_MS = 280;
+/** How many buffs to surface — kept short so the panel stays glanceable. */
+const UPTIME_TOP_N = 4;
+
+interface UptimeRow {
+  key: string;
+  name: string;
+  pct: number;
+}
+
+/**
+ * Buff-uptime list — the important raid buffs the locked player currently HAS, up to the playhead.
+ * Reuses the insights' curated IMPORTANT_BUFF_ABILITIES set and computeBuffUptimes (targetIds =
+ * the locked player, so the averaging path resolves to exactly that player's uptime). Window-scoped
+ * to [fightStart, playhead] so the % is live as you scrub.
+ *
+ * computeBuffUptimes is O(n) over intervals, so — unlike the scalar path — this can't run per frame.
+ * It lives in its OWN sub-component and recomputes on a ~3-4Hz throttle, setState-ing only when the
+ * rounded rows change. As a memo'd-leaf child its re-render can't reconcile Arena3D; it's isolated
+ * from the scalar component so that one still renders exactly once on lock.
+ */
+const BuffUptimeList: React.FC<{
+  playerId: number;
+  fightStartTime: number;
+  timeRef: React.RefObject<number> | { current: number };
+}> = ({ playerId, fightStartTime, timeRef }) => {
+  const { buffLookupData } = useBuffLookupTask();
+  const { reportMasterData } = useReportMasterData();
+
+  const targetIds = useMemo(() => new Set<number>([playerId]), [playerId]);
+  const abilitiesById = reportMasterData?.abilitiesById ?? {};
+
+  const [rows, setRows] = useState<UptimeRow[]>([]);
+  // Signature of the last-pushed rows, so we only setState when the visible list actually changes.
+  const lastSigRef = useRef<string>('');
+
+  useEffect(() => {
+    if (!buffLookupData) {
+      if (rows.length) setRows([]);
+      lastSigRef.current = '';
+      return;
+    }
+    let raf = 0;
+    let lastRun = -Infinity;
+    const tick = (now: number): void => {
+      if (now - lastRun >= UPTIME_THROTTLE_MS) {
+        lastRun = now;
+        const playheadMs = timeRef.current ?? 0;
+        const fightEndTime = fightStartTime + playheadMs;
+        const uptimes = computeBuffUptimes(buffLookupData, {
+          abilityIds: IMPORTANT_BUFF_ABILITIES,
+          targetIds,
+          fightStartTime,
+          fightEndTime,
+          fightDuration: playheadMs,
+          abilitiesById,
+          isDebuff: false,
+          hostilityType: 0,
+        });
+        const next: UptimeRow[] = uptimes.slice(0, UPTIME_TOP_N).map((u) => ({
+          key: u.uniqueKey,
+          name: u.abilityName,
+          pct: u.uptimePercentage,
+        }));
+        let sig = '';
+        for (const r of next) sig += `${r.key}:${Math.round(r.pct)};`;
+        if (sig !== lastSigRef.current) {
+          lastSigRef.current = sig;
+          setRows(next);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // rows.length intentionally excluded — the loop owns its dirty check via lastSigRef.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buffLookupData, targetIds, fightStartTime, timeRef, abilitiesById]);
+
+  if (!buffLookupData || rows.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Typography
+        sx={{
+          fontSize: '0.58rem',
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          color: 'text.secondary',
+          mb: 0.25,
+        }}
+      >
+        BUFF UPTIME
+      </Typography>
+      {rows.map((r) => (
+        <Box
+          key={r.key}
+          sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 1 }}
+        >
+          <Typography
+            noWrap
+            sx={{ fontSize: '0.72rem', color: 'text.primary', minWidth: 0, flex: 1 }}
+          >
+            {r.name}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+              color: 'text.secondary',
+            }}
+          >
+            {r.pct.toFixed(0)}%
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
 const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = ({
   followingActorId,
   lookup,
@@ -391,19 +516,24 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       />
 
       {role === 'tank' && (
-        <>
-          <TankDamageReduction
-            playerId={followingActorId}
-            fightStartTime={fightStartTime}
-            timeRef={timeRef}
-          />
-          <Typography
-            sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}
-          >
-            Damage taken &amp; deaths are measured; DR % is a modeled resistance estimate (excludes
-            Protection, block &amp; shields).
-          </Typography>
-        </>
+        <TankDamageReduction
+          playerId={followingActorId}
+          fightStartTime={fightStartTime}
+          timeRef={timeRef}
+        />
+      )}
+
+      <BuffUptimeList
+        playerId={followingActorId}
+        fightStartTime={fightStartTime}
+        timeRef={timeRef}
+      />
+
+      {role === 'tank' && (
+        <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
+          Damage taken &amp; deaths are measured; DR % is a modeled resistance estimate (excludes
+          Protection, block &amp; shields).
+        </Typography>
       )}
     </Box>
   );

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -34,7 +34,18 @@
  * Buff/debuff uptime and the per-ability breakdown layer on next.
  */
 
-import { Box, Typography, useTheme, alpha } from '@mui/material';
+import Tune from '@mui/icons-material/Tune';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  Popover,
+  Tooltip,
+  Typography,
+  useTheme,
+  alpha,
+} from '@mui/material';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useReportMasterData } from '../../../hooks';
@@ -43,6 +54,10 @@ import { useDamageEvents } from '../../../hooks/events/useDamageEvents';
 import { useDeathEvents } from '../../../hooks/events/useDeathEvents';
 import { useHealingEvents } from '../../../hooks/events/useHealingEvents';
 import { usePlayerData } from '../../../hooks/usePlayerData';
+import {
+  DEFAULT_STATS_PANEL_SECTIONS,
+  type StatsPanelSections,
+} from '../../../hooks/useReplayPrefs';
 import { useBuffLookupTask } from '../../../hooks/workerTasks/useBuffLookupTask';
 import { useDebuffLookupTask } from '../../../hooks/workerTasks/useDebuffLookupTask';
 import { computeBuffUptimes } from '../../../utils/buffUptimeCalculator';
@@ -86,7 +101,27 @@ interface LockedPlayerStatsPanelProps {
   fightStartTime: number;
   /** Fight duration in ms (currently informational; rates use the elapsed playhead). */
   fightDurationMs: number;
+  /** Which sections to show. Omitted → all sections (back-compat default). */
+  sections?: StatsPanelSections;
+  /** Persist a sections change (from the panel's gear menu). Omitted → the gear menu is hidden. */
+  onSectionsChange?: (next: StatsPanelSections) => void;
 }
+
+/** A section the gear menu can toggle, paired with the roles it's relevant to. */
+interface SectionDef {
+  key: keyof StatsPanelSections;
+  label: string;
+  /** Roles this section applies to — the gear menu only lists it for those roles. */
+  roles: readonly Role[];
+}
+
+const SECTION_DEFS: readonly SectionDef[] = [
+  { key: 'hero', label: 'Hero stats', roles: ['tank', 'healer', 'dps'] },
+  { key: 'dr', label: 'Est. resistance DR %', roles: ['tank'] },
+  { key: 'buffs', label: 'Buff uptime', roles: ['tank', 'healer', 'dps'] },
+  { key: 'debuffs', label: 'Debuffs applied', roles: ['tank', 'healer', 'dps'] },
+  { key: 'abilities', label: 'Top abilities', roles: ['dps'] },
+];
 
 /** Compact, abbreviated number: 1.23M / 45.6K / 678. */
 const fmtNum = (n: number): string => {
@@ -655,8 +690,13 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   lookup,
   timeRef,
   fightStartTime,
+  sections,
+  onSectionsChange,
 }) => {
   const theme = useTheme();
+
+  // Gear-menu anchor (the per-section toggle popover). Local UI state; doesn't affect playback.
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
   // Resolve the locked actor's identity from the lookup (same id-space as playersById — the lookup
   // is built by indexing playersById[actorId], so followingActorId is a valid player key).
@@ -679,6 +719,17 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   const role: Role = actor.role ?? 'dps';
   const accent = getReplayActorResolvedAccentColor({ type: 'player', role, isDead: false });
 
+  // Effective section flags (prop, or the all-on default for back-compat — identical today, deduped
+  // against the prefs default). A section renders only when its flag is on AND it's relevant to this
+  // role (the role gates already enforced below stay in force).
+  const visible = sections ?? DEFAULT_STATS_PANEL_SECTIONS;
+
+  // The gear menu only lists sections relevant to this role, so a healer never sees "Top abilities".
+  const menuSections = onSectionsChange ? SECTION_DEFS.filter((s) => s.roles.includes(role)) : [];
+
+  // The tank caveat only makes sense when at least one of its referenced sections is showing.
+  const showTankCaveat = role === 'tank' && (visible.hero || visible.dr);
+
   return (
     <Box
       sx={{
@@ -698,10 +749,12 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         WebkitBackdropFilter: 'blur(10px)',
         border: `1px solid ${alpha(accent, 0.45)}`,
         boxShadow: `0 8px 26px rgba(0,0,0,0.5), 0 0 14px ${alpha(accent, 0.22)}`,
+        // The panel itself is click-through (so it doesn't block canvas drag); only the gear
+        // button + its popover opt back into pointer events.
         pointerEvents: 'none',
       }}
     >
-      {/* Header: role pill + name */}
+      {/* Header: role pill + name + (optional) gear menu for choosing which sections show. */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1 }}>
         <Box
           component="span"
@@ -726,21 +779,42 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
+            flex: 1,
+            minWidth: 0,
           }}
         >
           {actor.name}
         </Typography>
+        {menuSections.length > 0 && (
+          <Tooltip title="Choose stats">
+            <IconButton
+              aria-label="Choose which stats to show"
+              size="small"
+              onClick={(e) => setMenuAnchor(e.currentTarget)}
+              sx={{
+                pointerEvents: 'auto',
+                p: 0.25,
+                color: alpha(theme.palette.text.secondary, 0.8),
+                '&:hover': { color: 'text.primary' },
+              }}
+            >
+              <Tune sx={{ fontSize: '0.95rem' }} />
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
 
-      <PlayerStatsContent
-        playerId={followingActorId}
-        role={role}
-        fightStartTime={fightStartTime}
-        accent={accent}
-        timeRef={timeRef}
-      />
+      {visible.hero && (
+        <PlayerStatsContent
+          playerId={followingActorId}
+          role={role}
+          fightStartTime={fightStartTime}
+          accent={accent}
+          timeRef={timeRef}
+        />
+      )}
 
-      {role === 'tank' && (
+      {role === 'tank' && visible.dr && (
         <TankDamageReduction
           playerId={followingActorId}
           fightStartTime={fightStartTime}
@@ -748,19 +822,23 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         />
       )}
 
-      <BuffUptimeList
-        playerId={followingActorId}
-        fightStartTime={fightStartTime}
-        timeRef={timeRef}
-      />
+      {visible.buffs && (
+        <BuffUptimeList
+          playerId={followingActorId}
+          fightStartTime={fightStartTime}
+          timeRef={timeRef}
+        />
+      )}
 
-      <DebuffUptimeList
-        playerId={followingActorId}
-        fightStartTime={fightStartTime}
-        timeRef={timeRef}
-      />
+      {visible.debuffs && (
+        <DebuffUptimeList
+          playerId={followingActorId}
+          fightStartTime={fightStartTime}
+          timeRef={timeRef}
+        />
+      )}
 
-      {role === 'dps' && (
+      {role === 'dps' && visible.abilities && (
         <AbilityBreakdownList
           playerId={followingActorId}
           fightStartTime={fightStartTime}
@@ -769,11 +847,60 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         />
       )}
 
-      {role === 'tank' && (
+      {showTankCaveat && (
         <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
           Damage taken &amp; deaths are measured; DR % is a modeled resistance estimate (excludes
           Protection, block &amp; shields).
         </Typography>
+      )}
+
+      {onSectionsChange && (
+        <Popover
+          open={Boolean(menuAnchor)}
+          anchorEl={menuAnchor}
+          onClose={() => setMenuAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          slotProps={{
+            paper: {
+              sx: {
+                pointerEvents: 'auto',
+                px: 1.5,
+                py: 1,
+                backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                backdropFilter: 'blur(10px)',
+                border: `1px solid ${alpha(accent, 0.4)}`,
+              },
+            },
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.6rem',
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              color: 'text.secondary',
+              mb: 0.5,
+            }}
+          >
+            SHOW STATS
+          </Typography>
+          {menuSections.map((s) => (
+            <FormControlLabel
+              key={s.key}
+              sx={{ display: 'flex', m: 0, mb: 0.25 }}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={visible[s.key]}
+                  onChange={(e) => onSectionsChange({ ...visible, [s.key]: e.target.checked })}
+                  sx={{ p: 0.5, color: accent, '&.Mui-checked': { color: accent } }}
+                />
+              }
+              label={<Typography sx={{ fontSize: '0.78rem' }}>{s.label}</Typography>}
+            />
+          ))}
+        </Popover>
       )}
     </Box>
   );

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -58,8 +58,12 @@ import {
 import { IMPORTANT_BUFF_ABILITIES } from '../../report_details/insights/BuffUptimesPanel';
 import { getReplayActorResolvedAccentColor } from '../utils/actorVisualState';
 import {
+  type AbilityBreakdownIndex,
+  type AbilityBreakdownRow,
   type LiveLockedStats,
+  buildAbilityBreakdownIndex,
   buildLockedStatsIndex,
+  queryAbilityBreakdown,
   queryLiveLockedStats,
 } from '../utils/lockedPlayerStats';
 import { getPlayerInfo } from '../utils/pathUtils';
@@ -334,7 +338,7 @@ const BuffUptimeList: React.FC<{
   const { reportMasterData } = useReportMasterData();
 
   const targetIds = useMemo(() => new Set<number>([playerId]), [playerId]);
-  const abilitiesById = reportMasterData?.abilitiesById ?? {};
+  const abilitiesById = reportMasterData?.abilitiesById;
 
   const [rows, setRows] = useState<UptimeRow[]>([]);
   // Signature of the last-pushed rows, so we only setState when the visible list actually changes.
@@ -359,7 +363,7 @@ const BuffUptimeList: React.FC<{
           fightStartTime,
           fightEndTime,
           fightDuration: playheadMs,
-          abilitiesById,
+          abilitiesById: abilitiesById ?? {},
           isDebuff: false,
           hostilityType: 0,
         });
@@ -418,6 +422,103 @@ const BuffUptimeList: React.FC<{
             }}
           >
             {r.pct.toFixed(0)}%
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+/** How often the ability breakdown recomputes while scrubbing, and how many abilities to surface. */
+const BREAKDOWN_THROTTLE_MS = 280;
+const BREAKDOWN_TOP_N = 3;
+
+/**
+ * Per-ability damage breakdown — the locked player's top damage abilities, up to the playhead.
+ * Reuses the same outgoing-damage filter + crit rule as the /damage insights DamageBreakdownPanel
+ * (extracted into buildAbilityBreakdownIndex/queryAbilityBreakdown). DPS-focused: the breakdown is
+ * only meaningful for damage roles, so the panel mounts it for DPS.
+ *
+ * Like the buff list, it builds its per-ability prefix index once on lock and recomputes the top-N
+ * on a ~3-4Hz throttle (a binary search per ability — cheap, but a reordering list must render
+ * through React, so not the per-frame DOM-ref path). Sibling-isolated, so the scalar leaf still
+ * renders once on lock.
+ */
+const AbilityBreakdownList: React.FC<{
+  playerId: number;
+  fightStartTime: number;
+  timeRef: React.RefObject<number> | { current: number };
+  accent: string;
+}> = ({ playerId, fightStartTime, timeRef, accent }) => {
+  const { damageEvents } = useDamageEvents();
+  const { reportMasterData } = useReportMasterData();
+  const abilitiesById = reportMasterData?.abilitiesById;
+
+  const index: AbilityBreakdownIndex = useMemo(
+    () => buildAbilityBreakdownIndex(playerId, damageEvents, abilitiesById ?? {}),
+    [playerId, damageEvents, abilitiesById],
+  );
+
+  const [rows, setRows] = useState<AbilityBreakdownRow[]>([]);
+  const lastSigRef = useRef<string>('');
+
+  useEffect(() => {
+    let raf = 0;
+    let lastRun = -Infinity;
+    const tick = (now: number): void => {
+      if (now - lastRun >= BREAKDOWN_THROTTLE_MS) {
+        lastRun = now;
+        const playheadMs = timeRef.current ?? 0;
+        const cutoff = fightStartTime + playheadMs;
+        const next = queryAbilityBreakdown(index, cutoff, BREAKDOWN_TOP_N);
+        let sig = '';
+        for (const r of next) sig += `${r.abilityGameID}:${Math.round(r.totalDamage / 1000)};`;
+        if (sig !== lastSigRef.current) {
+          lastSigRef.current = sig;
+          setRows(next);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [index, fightStartTime, timeRef]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Typography
+        sx={{
+          fontSize: '0.58rem',
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          color: 'text.secondary',
+          mb: 0.25,
+        }}
+      >
+        TOP ABILITIES
+      </Typography>
+      {rows.map((r) => (
+        <Box
+          key={r.abilityGameID}
+          sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 1 }}
+        >
+          <Typography
+            noWrap
+            sx={{ fontSize: '0.72rem', color: 'text.primary', minWidth: 0, flex: 1 }}
+          >
+            {r.name}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+              color: accent,
+            }}
+          >
+            {fmtNum(r.totalDamage)}
           </Typography>
         </Box>
       ))}
@@ -528,6 +629,15 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         fightStartTime={fightStartTime}
         timeRef={timeRef}
       />
+
+      {role === 'dps' && (
+        <AbilityBreakdownList
+          playerId={followingActorId}
+          fightStartTime={fightStartTime}
+          timeRef={timeRef}
+          accent={accent}
+        />
+      )}
 
       {role === 'tank' && (
         <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -2,37 +2,45 @@
  * Locked-player stats panel — DOM overlay shown when the replay camera is locked onto a player.
  *
  * When the user follows an actor (the "Following: <name>" lock), this surfaces a compact,
- * role-tinted readout of that player's combat performance for the fight: DPS for damage roles,
- * HPS/overheal for healers, and resistance-based damage-reduction + survivability for tanks. It
- * REUSES the proven fight-insights calculations rather than re-deriving them:
- *   - DPS / total / crit       → usePlayerCardData (the same per-actor scalars the player card uses)
- *   - damage-reduction %        → useDamageReductionTask (the /damage-reduction insights view's calc)
- *   - HPS / overheal, dmg taken → small recompute from the raw event arrays already in the store
+ * role-tinted readout of that player's combat performance UP TO THE PLAYHEAD: scrub to 30s and you
+ * see the player's DPS/HPS/damage-taken as of 30s, not the whole-fight total. DPS for damage roles,
+ * HPS/overheal for healers, and measured damage-taken + survivability for tanks.
  *
- * SCOPE (v1): WHOLE-FIGHT totals, computed once when an actor is locked (not live-scrubbing). The
- * heavy data hook (usePlayerCardData) lives in an inner component that only mounts while an actor
- * is locked — mirroring PlayerCardModal's mount-on-select pattern — so it never runs during normal
- * playback. This deliberately does NOT use a per-frame rAF loop (the stats don't change per frame
- * at whole-fight scope), so it doesn't touch the replay's idle-gate / no-per-tick-reconcile contract.
+ * It REUSES the proven fight-insights semantics rather than re-deriving them — damage/crit filter
+ * mirrors usePlayerCardData.damageStats, healing mirrors HealingDonePanel — but feeds them through a
+ * prefix-sum engine (lockedPlayerStats.ts) so an up-to-playhead query is O(log n) per frame.
  *
- * IMPORTANT LABELING: the tank "damage reduction %" is a MODELED resistance estimate (gear/CP/buff
- * resistances → reduction %), NOT measured damage mitigated — it never reads a damage event and
- * omits Protection/block/shields. It is labeled "est. resistance DR" here so it's never read as
- * true mitigation. The measured "damage taken" beside it IS from real events.
+ * PERF CONTRACT (mirrors BossHealthPanel's per-frame discipline):
+ *   - The replay throttles `currentTime` React state to ~2Hz so it never re-reconciles Arena3D.
+ *     Driving these numbers from React state would make them choppy AND risk per-tick renders. So
+ *     the scalar values run on their OWN requestAnimationFrame loop that reads the high-frequency
+ *     `timeRef.current` and writes straight to DOM refs (textContent) — zero React render per frame.
+ *   - The heavy work (filter + sort + prefix-sum) happens ONCE on lock, inside an inner component
+ *     that only mounts while an actor is followed (mirroring PlayerCardModal's mount-on-select), so
+ *     it costs nothing during normal playback when nobody is locked.
+ *   - This panel is a React.memo'd leaf that owns its own state — its internal renders structurally
+ *     cannot re-render Arena3D. Every per-frame value stays inside this leaf.
+ *
+ * SCOPE (this commit): live up-to-playhead SCALARS (DPS/HPS/damage-taken/crit/overheal/deaths).
+ * Tank modeled resistance-DR %, buff/debuff uptime, and the per-ability breakdown layer on next.
  */
 
 import { Box, Typography, useTheme, alpha } from '@mui/material';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import { useDamageEvents } from '../../../hooks/events/useDamageEvents';
 import { useDeathEvents } from '../../../hooks/events/useDeathEvents';
 import { useHealingEvents } from '../../../hooks/events/useHealingEvents';
-import { usePlayerCardData } from '../../../hooks/usePlayerCardData';
 import {
   type TimestampPositionLookup,
   getActorPositionAtClosestTimestamp,
 } from '../../../workers/calculations/CalculateActorPositions';
 import { getReplayActorResolvedAccentColor } from '../utils/actorVisualState';
+import {
+  type LiveLockedStats,
+  buildLockedStatsIndex,
+  queryLiveLockedStats,
+} from '../utils/lockedPlayerStats';
 import { getPlayerInfo } from '../utils/pathUtils';
 
 type Role = 'tank' | 'healer' | 'dps';
@@ -42,7 +50,11 @@ interface LockedPlayerStatsPanelProps {
   followingActorId: number | null;
   /** Position lookup — resolves the actor's name/role/type and is the shared id-space with playersById. */
   lookup: TimestampPositionLookup | null;
-  /** Fight duration in ms (for per-second rates). */
+  /** High-frequency playhead time (ms into the fight). Read every rAF tick. */
+  timeRef: React.RefObject<number> | { current: number };
+  /** Absolute fight start timestamp — added to the playhead to get the event-space cutoff. */
+  fightStartTime: number;
+  /** Fight duration in ms (currently informational; rates use the elapsed playhead). */
   fightDurationMs: number;
 }
 
@@ -57,123 +69,122 @@ const fmtNum = (n: number): string => {
 
 const fmtPct = (n: number): string => (Number.isFinite(n) ? `${n.toFixed(1)}%` : '—');
 
-/** A hero stat: big value + small label, optionally a sub-line. */
-const Stat: React.FC<{ value: string; label: string; hint?: string; accent?: string }> = ({
-  value,
-  label,
-  hint,
-  accent,
-}) => (
-  <Box sx={{ minWidth: 0 }}>
-    <Typography
-      sx={{
-        fontFamily: 'Space Grotesk, Inter, system-ui',
-        fontWeight: 700,
-        fontSize: '1.25rem',
-        lineHeight: 1.05,
-        fontVariantNumeric: 'tabular-nums',
-        color: accent || 'text.primary',
-      }}
-    >
-      {value}
-    </Typography>
-    <Typography
-      sx={{
-        fontSize: '0.66rem',
-        fontWeight: 600,
-        letterSpacing: '0.04em',
-        color: 'text.secondary',
-      }}
-    >
-      {label.toUpperCase()}
-    </Typography>
-    {hint && (
-      <Typography sx={{ fontSize: '0.6rem', color: 'text.disabled', lineHeight: 1.1 }}>
-        {hint}
-      </Typography>
-    )}
-  </Box>
-);
+/** Which LiveLockedStats fields each role's three hero slots read, and how to format them. */
+interface StatSlot {
+  label: string;
+  /** Pull the raw number out of the live stats. */
+  pick: (s: LiveLockedStats) => number;
+  /** Format it for display. */
+  fmt: (n: number) => string;
+  /** Whether this slot gets the role accent color (the headline stat). */
+  accented?: boolean;
+}
+
+const ROLE_SLOTS: Record<Role, StatSlot[]> = {
+  dps: [
+    { label: 'DPS', pick: (s) => s.dps, fmt: fmtNum, accented: true },
+    { label: 'Damage', pick: (s) => s.totalDamage, fmt: fmtNum },
+    { label: 'Crit', pick: (s) => s.critChance, fmt: fmtPct },
+  ],
+  healer: [
+    { label: 'HPS', pick: (s) => s.hps, fmt: fmtNum, accented: true },
+    { label: 'Healing', pick: (s) => s.effectiveHealing, fmt: fmtNum },
+    { label: 'Overheal', pick: (s) => s.overhealPct, fmt: fmtPct },
+  ],
+  tank: [
+    { label: 'Dmg Taken', pick: (s) => s.damageTaken, fmt: fmtNum, accented: true },
+    { label: 'Deaths', pick: (s) => s.deaths, fmt: (n) => `${n}` },
+    { label: 'Dmg Done', pick: (s) => s.totalDamage, fmt: fmtNum },
+  ],
+};
 
 /**
- * Inner content — mounts ONLY while an actor is locked, so the heavy usePlayerCardData hook (≈12
- * event types + worker tasks) never runs during normal playback. Computes whole-fight stats for the
- * one locked player and renders a role-appropriate set.
+ * Inner content — mounts ONLY while an actor is locked. Builds the prefix-sum index once (keyed on
+ * playerId, so locking A→B rebuilds), then runs a rAF loop writing live values to DOM refs. No
+ * React render happens per frame.
  */
 const PlayerStatsContent: React.FC<{
   playerId: number;
   role: Role;
-  fightDurationMs: number;
+  fightStartTime: number;
   accent: string;
-}> = ({ playerId, role, fightDurationMs, accent }) => {
-  const card = usePlayerCardData({ playerId });
+  timeRef: React.RefObject<number> | { current: number };
+}> = ({ playerId, role, fightStartTime, accent, timeRef }) => {
   const { healingEvents } = useHealingEvents();
   const { damageEvents } = useDamageEvents();
   const { deathEvents } = useDeathEvents();
 
-  const durationSecs = fightDurationMs > 0 ? fightDurationMs / 1000 : 0;
+  // Built once per (player, event-set). Rebuilds when locking onto a different player or when the
+  // event arrays finish loading (lock-before-load → indexes fill in and the rAF loop picks them up).
+  const index = useMemo(
+    () => buildLockedStatsIndex(playerId, damageEvents, healingEvents, deathEvents),
+    [playerId, damageEvents, healingEvents, deathEvents],
+  );
 
-  // Healer recompute (effective healing / HPS / overheal%). Mirrors HealingDonePanel exactly:
-  // event.amount is ALREADY effective; overheal is a separate field.
-  const healing = useMemo(() => {
-    if (role !== 'healer') return null;
-    let raw = 0;
-    let overheal = 0;
-    for (const ev of healingEvents) {
-      if (ev.sourceID === playerId) {
-        raw += ev.amount ?? 0;
-        overheal += ev.overheal ?? 0;
+  const slots = ROLE_SLOTS[role];
+
+  // One DOM ref per hero-stat value node; the rAF loop writes textContent here.
+  const valueRefs = useRef<Array<HTMLSpanElement | null>>([]);
+
+  // Dev-only render counter — used to confirm this leaf does NOT re-render per frame while scrubbing
+  // (it should only render on lock/role change). Exposed on window for the Chrome-MCP perf check.
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+  if (process.env.NODE_ENV !== 'production') {
+    (window as unknown as { __lockedStatsRenders?: number }).__lockedStatsRenders =
+      renderCountRef.current;
+  }
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = (): void => {
+      const playheadMs = timeRef.current ?? 0;
+      const cutoff = fightStartTime + playheadMs;
+      const elapsedSeconds = playheadMs / 1000;
+      const stats = queryLiveLockedStats(index, cutoff, elapsedSeconds);
+      for (let i = 0; i < slots.length; i++) {
+        const node = valueRefs.current[i];
+        if (node) node.textContent = slots[i].fmt(slots[i].pick(stats));
       }
-    }
-    const total = raw + overheal;
-    return {
-      effective: raw,
-      hps: durationSecs > 0 ? raw / durationSecs : 0,
-      overhealPct: total > 0 ? (overheal / total) * 100 : 0,
+      raf = requestAnimationFrame(tick);
     };
-  }, [role, healingEvents, playerId, durationSecs]);
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [index, slots, fightStartTime, timeRef]);
 
-  // Tank recompute (measured damage TAKEN + deaths). All app summing keys by sourceID = damage
-  // DONE, so we flip the key to targetID for damage taken.
-  const survivability = useMemo(() => {
-    if (role !== 'tank') return null;
-    let taken = 0;
-    for (const ev of damageEvents) {
-      if (ev.targetID === playerId) taken += ev.amount ?? 0;
-    }
-    let deaths = 0;
-    for (const ev of deathEvents) {
-      if ((ev as { targetID?: number }).targetID === playerId) deaths += 1;
-    }
-    return { damageTaken: taken, deaths };
-  }, [role, damageEvents, deathEvents, playerId]);
-
-  if (role === 'healer') {
-    return (
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <Stat value={fmtNum(healing?.hps ?? 0)} label="HPS" accent={accent} />
-        <Stat value={fmtNum(healing?.effective ?? 0)} label="Healing" />
-        <Stat value={fmtPct(healing?.overhealPct ?? 0)} label="Overheal" />
-      </Box>
-    );
-  }
-
-  if (role === 'tank') {
-    return (
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <Stat value={fmtNum(survivability?.damageTaken ?? 0)} label="Dmg Taken" accent={accent} />
-        <Stat value={`${survivability?.deaths ?? 0}`} label="Deaths" />
-        <Stat value={fmtNum(card.totalDamage ?? 0)} label="Dmg Done" />
-      </Box>
-    );
-  }
-
-  // DPS (default)
   return (
     <Box sx={{ display: 'flex', gap: 2 }}>
-      <Stat value={fmtNum(card.dpsValue ?? 0)} label="DPS" accent={accent} />
-      <Stat value={fmtNum(card.totalDamage ?? 0)} label="Damage" />
-      <Stat value={fmtPct(card.critChance ?? 0)} label="Crit" />
+      {slots.map((slot, i) => (
+        <Box key={slot.label} sx={{ minWidth: 0 }}>
+          <Typography
+            component="span"
+            ref={(el: HTMLSpanElement | null) => {
+              valueRefs.current[i] = el;
+            }}
+            sx={{
+              display: 'block',
+              fontFamily: 'Space Grotesk, Inter, system-ui',
+              fontWeight: 700,
+              fontSize: '1.25rem',
+              lineHeight: 1.05,
+              fontVariantNumeric: 'tabular-nums',
+              color: slot.accented ? accent : 'text.primary',
+            }}
+          >
+            —
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.66rem',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              color: 'text.secondary',
+            }}
+          >
+            {slot.label.toUpperCase()}
+          </Typography>
+        </Box>
+      ))}
     </Box>
   );
 };
@@ -181,7 +192,8 @@ const PlayerStatsContent: React.FC<{
 const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = ({
   followingActorId,
   lookup,
-  fightDurationMs,
+  timeRef,
+  fightStartTime,
 }) => {
   const theme = useTheme();
 
@@ -225,6 +237,7 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         WebkitBackdropFilter: 'blur(10px)',
         border: `1px solid ${alpha(accent, 0.45)}`,
         boxShadow: `0 8px 26px rgba(0,0,0,0.5), 0 0 14px ${alpha(accent, 0.22)}`,
+        pointerEvents: 'none',
       }}
     >
       {/* Header: role pill + name */}
@@ -261,13 +274,14 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       <PlayerStatsContent
         playerId={followingActorId}
         role={role}
-        fightDurationMs={fightDurationMs}
+        fightStartTime={fightStartTime}
         accent={accent}
+        timeRef={timeRef}
       />
 
       {role === 'tank' && (
         <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
-          Damage taken &amp; deaths are measured; resistance-based DR is a modeled estimate.
+          Damage taken &amp; deaths are measured up to the playhead.
         </Typography>
       )}
     </Box>
@@ -275,8 +289,8 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
 };
 
 /**
- * Memoized: only re-renders when the locked actor changes (or the lookup/duration). It does NOT
- * read the per-frame timeRef, so it never reconciles during playback — whole-fight stats are static
- * for a given locked actor.
+ * Memoized: only re-renders when the locked actor / lookup / fight changes. It does NOT take the
+ * per-frame time as a prop, so React never reconciles it during playback — the live numbers are
+ * written to DOM refs by the inner rAF loop.
  */
 export const LockedPlayerStatsPanel = React.memo(LockedPlayerStatsPanelComponent);

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -1,0 +1,282 @@
+/**
+ * Locked-player stats panel — DOM overlay shown when the replay camera is locked onto a player.
+ *
+ * When the user follows an actor (the "Following: <name>" lock), this surfaces a compact,
+ * role-tinted readout of that player's combat performance for the fight: DPS for damage roles,
+ * HPS/overheal for healers, and resistance-based damage-reduction + survivability for tanks. It
+ * REUSES the proven fight-insights calculations rather than re-deriving them:
+ *   - DPS / total / crit       → usePlayerCardData (the same per-actor scalars the player card uses)
+ *   - damage-reduction %        → useDamageReductionTask (the /damage-reduction insights view's calc)
+ *   - HPS / overheal, dmg taken → small recompute from the raw event arrays already in the store
+ *
+ * SCOPE (v1): WHOLE-FIGHT totals, computed once when an actor is locked (not live-scrubbing). The
+ * heavy data hook (usePlayerCardData) lives in an inner component that only mounts while an actor
+ * is locked — mirroring PlayerCardModal's mount-on-select pattern — so it never runs during normal
+ * playback. This deliberately does NOT use a per-frame rAF loop (the stats don't change per frame
+ * at whole-fight scope), so it doesn't touch the replay's idle-gate / no-per-tick-reconcile contract.
+ *
+ * IMPORTANT LABELING: the tank "damage reduction %" is a MODELED resistance estimate (gear/CP/buff
+ * resistances → reduction %), NOT measured damage mitigated — it never reads a damage event and
+ * omits Protection/block/shields. It is labeled "est. resistance DR" here so it's never read as
+ * true mitigation. The measured "damage taken" beside it IS from real events.
+ */
+
+import { Box, Typography, useTheme, alpha } from '@mui/material';
+import React, { useMemo } from 'react';
+
+import { useDamageEvents } from '../../../hooks/events/useDamageEvents';
+import { useDeathEvents } from '../../../hooks/events/useDeathEvents';
+import { useHealingEvents } from '../../../hooks/events/useHealingEvents';
+import { usePlayerCardData } from '../../../hooks/usePlayerCardData';
+import {
+  type TimestampPositionLookup,
+  getActorPositionAtClosestTimestamp,
+} from '../../../workers/calculations/CalculateActorPositions';
+import { getReplayActorResolvedAccentColor } from '../utils/actorVisualState';
+import { getPlayerInfo } from '../utils/pathUtils';
+
+type Role = 'tank' | 'healer' | 'dps';
+
+interface LockedPlayerStatsPanelProps {
+  /** The currently-followed actor id, or null when not following. */
+  followingActorId: number | null;
+  /** Position lookup — resolves the actor's name/role/type and is the shared id-space with playersById. */
+  lookup: TimestampPositionLookup | null;
+  /** Fight duration in ms (for per-second rates). */
+  fightDurationMs: number;
+}
+
+/** Compact, abbreviated number: 1.23M / 45.6K / 678. */
+const fmtNum = (n: number): string => {
+  if (!Number.isFinite(n)) return '—';
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${Math.round(n)}`;
+};
+
+const fmtPct = (n: number): string => (Number.isFinite(n) ? `${n.toFixed(1)}%` : '—');
+
+/** A hero stat: big value + small label, optionally a sub-line. */
+const Stat: React.FC<{ value: string; label: string; hint?: string; accent?: string }> = ({
+  value,
+  label,
+  hint,
+  accent,
+}) => (
+  <Box sx={{ minWidth: 0 }}>
+    <Typography
+      sx={{
+        fontFamily: 'Space Grotesk, Inter, system-ui',
+        fontWeight: 700,
+        fontSize: '1.25rem',
+        lineHeight: 1.05,
+        fontVariantNumeric: 'tabular-nums',
+        color: accent || 'text.primary',
+      }}
+    >
+      {value}
+    </Typography>
+    <Typography
+      sx={{
+        fontSize: '0.66rem',
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        color: 'text.secondary',
+      }}
+    >
+      {label.toUpperCase()}
+    </Typography>
+    {hint && (
+      <Typography sx={{ fontSize: '0.6rem', color: 'text.disabled', lineHeight: 1.1 }}>
+        {hint}
+      </Typography>
+    )}
+  </Box>
+);
+
+/**
+ * Inner content — mounts ONLY while an actor is locked, so the heavy usePlayerCardData hook (≈12
+ * event types + worker tasks) never runs during normal playback. Computes whole-fight stats for the
+ * one locked player and renders a role-appropriate set.
+ */
+const PlayerStatsContent: React.FC<{
+  playerId: number;
+  role: Role;
+  fightDurationMs: number;
+  accent: string;
+}> = ({ playerId, role, fightDurationMs, accent }) => {
+  const card = usePlayerCardData({ playerId });
+  const { healingEvents } = useHealingEvents();
+  const { damageEvents } = useDamageEvents();
+  const { deathEvents } = useDeathEvents();
+
+  const durationSecs = fightDurationMs > 0 ? fightDurationMs / 1000 : 0;
+
+  // Healer recompute (effective healing / HPS / overheal%). Mirrors HealingDonePanel exactly:
+  // event.amount is ALREADY effective; overheal is a separate field.
+  const healing = useMemo(() => {
+    if (role !== 'healer') return null;
+    let raw = 0;
+    let overheal = 0;
+    for (const ev of healingEvents) {
+      if (ev.sourceID === playerId) {
+        raw += ev.amount ?? 0;
+        overheal += ev.overheal ?? 0;
+      }
+    }
+    const total = raw + overheal;
+    return {
+      effective: raw,
+      hps: durationSecs > 0 ? raw / durationSecs : 0,
+      overhealPct: total > 0 ? (overheal / total) * 100 : 0,
+    };
+  }, [role, healingEvents, playerId, durationSecs]);
+
+  // Tank recompute (measured damage TAKEN + deaths). All app summing keys by sourceID = damage
+  // DONE, so we flip the key to targetID for damage taken.
+  const survivability = useMemo(() => {
+    if (role !== 'tank') return null;
+    let taken = 0;
+    for (const ev of damageEvents) {
+      if (ev.targetID === playerId) taken += ev.amount ?? 0;
+    }
+    let deaths = 0;
+    for (const ev of deathEvents) {
+      if ((ev as { targetID?: number }).targetID === playerId) deaths += 1;
+    }
+    return { damageTaken: taken, deaths };
+  }, [role, damageEvents, deathEvents, playerId]);
+
+  if (role === 'healer') {
+    return (
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Stat value={fmtNum(healing?.hps ?? 0)} label="HPS" accent={accent} />
+        <Stat value={fmtNum(healing?.effective ?? 0)} label="Healing" />
+        <Stat value={fmtPct(healing?.overhealPct ?? 0)} label="Overheal" />
+      </Box>
+    );
+  }
+
+  if (role === 'tank') {
+    return (
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Stat value={fmtNum(survivability?.damageTaken ?? 0)} label="Dmg Taken" accent={accent} />
+        <Stat value={`${survivability?.deaths ?? 0}`} label="Deaths" />
+        <Stat value={fmtNum(card.totalDamage ?? 0)} label="Dmg Done" />
+      </Box>
+    );
+  }
+
+  // DPS (default)
+  return (
+    <Box sx={{ display: 'flex', gap: 2 }}>
+      <Stat value={fmtNum(card.dpsValue ?? 0)} label="DPS" accent={accent} />
+      <Stat value={fmtNum(card.totalDamage ?? 0)} label="Damage" />
+      <Stat value={fmtPct(card.critChance ?? 0)} label="Crit" />
+    </Box>
+  );
+};
+
+const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = ({
+  followingActorId,
+  lookup,
+  fightDurationMs,
+}) => {
+  const theme = useTheme();
+
+  // Resolve the locked actor's identity from the lookup (same id-space as playersById — the lookup
+  // is built by indexing playersById[actorId], so followingActorId is a valid player key).
+  const actor = useMemo(() => {
+    if (followingActorId == null || !lookup) return null;
+    const info = getPlayerInfo(lookup, followingActorId);
+    // getActorPositionAtClosestTimestamp gives us `type` (player vs boss/enemy) for the fallback.
+    const pos = getActorPositionAtClosestTimestamp(lookup, followingActorId, 0);
+    return { name: info?.name ?? pos?.name ?? null, role: info?.role, type: pos?.type };
+  }, [followingActorId, lookup]);
+
+  if (followingActorId == null || !actor || actor.name == null) return null;
+
+  // Only players have role-based combat stats. Locking onto a boss/enemy/pet → don't render a
+  // role-less shell; the BossHealthPanel already covers bosses. (A future round could add an
+  // enemy damage-taken readout here.)
+  const isPlayer = actor.type === 'player';
+  if (!isPlayer) return null;
+
+  const role: Role = actor.role ?? 'dps';
+  const accent = getReplayActorResolvedAccentColor({ type: 'player', role, isDead: false });
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        // Bottom-left, lifted clear of the transport bar (~95px) — opposite corner from the
+        // boss-health panel (top-right) and below the player-list panel (top-left).
+        left: 16,
+        bottom: 112,
+        zIndex: 3,
+        px: 1.75,
+        py: 1.25,
+        minWidth: 220,
+        maxWidth: 340,
+        borderRadius: 2,
+        backgroundColor: alpha(theme.palette.background.paper, 0.82),
+        backdropFilter: 'blur(10px)',
+        WebkitBackdropFilter: 'blur(10px)',
+        border: `1px solid ${alpha(accent, 0.45)}`,
+        boxShadow: `0 8px 26px rgba(0,0,0,0.5), 0 0 14px ${alpha(accent, 0.22)}`,
+      }}
+    >
+      {/* Header: role pill + name */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1 }}>
+        <Box
+          component="span"
+          sx={{
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 0.75,
+            fontSize: '0.6rem',
+            fontWeight: 800,
+            letterSpacing: '0.06em',
+            color: theme.palette.getContrastText(accent),
+            backgroundColor: accent,
+          }}
+        >
+          {role.toUpperCase()}
+        </Box>
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '0.9rem',
+            color: 'text.primary',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {actor.name}
+        </Typography>
+      </Box>
+
+      <PlayerStatsContent
+        playerId={followingActorId}
+        role={role}
+        fightDurationMs={fightDurationMs}
+        accent={accent}
+      />
+
+      {role === 'tank' && (
+        <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
+          Damage taken &amp; deaths are measured; resistance-based DR is a modeled estimate.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+/**
+ * Memoized: only re-renders when the locked actor changes (or the lookup/duration). It does NOT
+ * read the per-frame timeRef, so it never reconciles during playback — whole-fight stats are static
+ * for a given locked actor.
+ */
+export const LockedPlayerStatsPanel = React.memo(LockedPlayerStatsPanelComponent);

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -56,14 +56,19 @@ import {
   getActorPositionAtClosestTimestamp,
 } from '../../../workers/calculations/CalculateActorPositions';
 import { IMPORTANT_BUFF_ABILITIES } from '../../report_details/insights/BuffUptimesPanel';
+import { IMPORTANT_DEBUFF_ABILITIES } from '../../report_details/insights/DebuffUptimesPanel';
 import { getReplayActorResolvedAccentColor } from '../utils/actorVisualState';
 import {
   type AbilityBreakdownIndex,
   type AbilityBreakdownRow,
+  type DebuffAppliedIndex,
+  type DebuffAppliedRow,
   type LiveLockedStats,
   buildAbilityBreakdownIndex,
+  buildDebuffAppliedIndex,
   buildLockedStatsIndex,
   queryAbilityBreakdown,
+  queryDebuffApplied,
   queryLiveLockedStats,
 } from '../utils/lockedPlayerStats';
 import { getPlayerInfo } from '../utils/pathUtils';
@@ -526,6 +531,125 @@ const AbilityBreakdownList: React.FC<{
   );
 };
 
+/** Throttle + cap for the debuff-applied list (same discipline as the buff list). */
+const DEBUFF_THROTTLE_MS = 280;
+const DEBUFF_TOP_N = 4;
+
+/**
+ * Debuffs APPLIED BY the locked player, up to the playhead — e.g. a tank's Major Breach / Crusher
+ * uptime on the boss. Reuses the insights' curated IMPORTANT_DEBUFF_ABILITIES set. Debuff intervals
+ * store the applier in a different field per ability (inverted: sourceID; normal: targetID), so the
+ * index classifies each ability with the friendly-player id set before attributing it to the player
+ * (see buildDebuffAppliedIndex). Uptime is the PRIMARY-BOSS number (max per-enemy uptime — the target
+ * the player maintained it on hardest), labeled "on boss" to distinguish it from the insights Debuffs
+ * tab's multi-target average.
+ *
+ * Same sibling-isolated throttled-list pattern as the buff list; degrades gracefully while the
+ * debuff lookup + player data load.
+ */
+const DebuffUptimeList: React.FC<{
+  playerId: number;
+  fightStartTime: number;
+  timeRef: React.RefObject<number> | { current: number };
+}> = ({ playerId, fightStartTime, timeRef }) => {
+  const { debuffLookupData } = useDebuffLookupTask();
+  const { playerData } = usePlayerData();
+  const { reportMasterData } = useReportMasterData();
+  const abilitiesById = reportMasterData?.abilitiesById;
+
+  // Friendly player id set — used to classify each debuff's applier field.
+  const friendlyPlayerIds = useMemo(() => {
+    const ids = new Set<number>();
+    const byId = playerData?.playersById;
+    if (byId) for (const key of Object.keys(byId)) ids.add(Number(key));
+    return ids;
+  }, [playerData]);
+
+  const index: DebuffAppliedIndex = useMemo(
+    () =>
+      buildDebuffAppliedIndex(
+        playerId,
+        debuffLookupData,
+        IMPORTANT_DEBUFF_ABILITIES,
+        friendlyPlayerIds,
+        abilitiesById ?? {},
+      ),
+    [playerId, debuffLookupData, friendlyPlayerIds, abilitiesById],
+  );
+
+  const [rows, setRows] = useState<DebuffAppliedRow[]>([]);
+  const lastSigRef = useRef<string>('');
+
+  useEffect(() => {
+    if (index.abilities.length === 0) {
+      if (rows.length) setRows([]);
+      lastSigRef.current = '';
+      return;
+    }
+    let raf = 0;
+    let lastRun = -Infinity;
+    const tick = (now: number): void => {
+      if (now - lastRun >= DEBUFF_THROTTLE_MS) {
+        lastRun = now;
+        const playheadMs = timeRef.current ?? 0;
+        const cutoff = fightStartTime + playheadMs;
+        const next = queryDebuffApplied(index, fightStartTime, cutoff, DEBUFF_TOP_N);
+        let sig = '';
+        for (const r of next) sig += `${r.abilityGameID}:${Math.round(r.uptimePct)};`;
+        if (sig !== lastSigRef.current) {
+          lastSigRef.current = sig;
+          setRows(next);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [index, fightStartTime, timeRef]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Typography
+        sx={{
+          fontSize: '0.58rem',
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          color: 'text.secondary',
+          mb: 0.25,
+        }}
+      >
+        DEBUFFS APPLIED · ON BOSS
+      </Typography>
+      {rows.map((r) => (
+        <Box
+          key={r.abilityGameID}
+          sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 1 }}
+        >
+          <Typography
+            noWrap
+            sx={{ fontSize: '0.72rem', color: 'text.primary', minWidth: 0, flex: 1 }}
+          >
+            {r.name}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+              color: 'text.secondary',
+            }}
+          >
+            {r.uptimePct.toFixed(0)}%
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
 const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = ({
   followingActorId,
   lookup,
@@ -625,6 +749,12 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       )}
 
       <BuffUptimeList
+        playerId={followingActorId}
+        fightStartTime={fightStartTime}
+        timeRef={timeRef}
+      />
+
+      <DebuffUptimeList
         playerId={followingActorId}
         fightStartTime={fightStartTime}
         timeRef={timeRef}

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -727,8 +727,20 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   // The gear menu only lists sections relevant to this role, so a healer never sees "Top abilities".
   const menuSections = onSectionsChange ? SECTION_DEFS.filter((s) => s.roles.includes(role)) : [];
 
-  // The tank caveat only makes sense when at least one of its referenced sections is showing.
-  const showTankCaveat = role === 'tank' && (visible.hero || visible.dr);
+  // Tank caveat — built from ONLY the clauses whose section is actually showing, so compacting the
+  // panel never leaves a disclaimer referencing a stat that isn't on screen (e.g. the DR sentence
+  // must not appear when the DR line is toggled off).
+  const tankCaveat =
+    role === 'tank'
+      ? [
+          visible.hero ? 'Damage taken & deaths are measured.' : null,
+          visible.dr
+            ? 'DR % is a modeled resistance estimate (excludes Protection, block & shields).'
+            : null,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      : '';
 
   return (
     <Box
@@ -847,10 +859,9 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         />
       )}
 
-      {showTankCaveat && (
+      {tankCaveat && (
         <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
-          Damage taken &amp; deaths are measured; DR % is a modeled resistance estimate (excludes
-          Protection, block &amp; shields).
+          {tankCaveat}
         </Typography>
       )}
 

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -511,8 +511,11 @@ const AbilityBreakdownList: React.FC<{
         const playheadMs = timeRef.current ?? 0;
         const cutoff = fightStartTime + playheadMs;
         const next = queryAbilityBreakdown(index, cutoff, BREAKDOWN_TOP_N);
+        // Key the dirty-check on the DISPLAYED string (fmtNum), not a coarse 1K bucket. The row
+        // renders fmtNum(totalDamage) — exact integers below 1K, one-decimal K above — so a 1K
+        // bucket let the visible value go stale (e.g. 100→499, or 1.1K→1.4K) between boundaries.
         let sig = '';
-        for (const r of next) sig += `${r.abilityGameID}:${Math.round(r.totalDamage / 1000)};`;
+        for (const r of next) sig += `${r.abilityGameID}:${fmtNum(r.totalDamage)};`;
         if (sig !== lastSigRef.current) {
           lastSigRef.current = sig;
           setRows(next);

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -10,6 +10,14 @@
  * mirrors usePlayerCardData.damageStats, healing mirrors HealingDonePanel — but feeds them through a
  * prefix-sum engine (lockedPlayerStats.ts) so an up-to-playhead query is O(log n) per frame.
  *
+ * TANK MODELED DR % (labeling matters): tanks also get an "est. DR" line — the SAME modeled
+ * resistance-based damage-reduction the /damage-reduction insights view computes (static gear/CP/
+ * passive resistance + dynamic buff/debuff resistance at the playhead → resistanceToDamageReduction,
+ * capped at 50%). It NEVER reads a damage event and omits Major/Minor Protection, block, and shields,
+ * so it is labeled "est." and sits beside the MEASURED damage-taken — never presented as true
+ * mitigation. It degrades gracefully: the measured scalars show immediately; the DR % line only
+ * appears once the (heavier, async) gear + buff/debuff lookups resolve.
+ *
  * PERF CONTRACT (mirrors BossHealthPanel's per-frame discipline):
  *   - The replay throttles `currentTime` React state to ~2Hz so it never re-reconciles Arena3D.
  *     Driving these numbers from React state would make them choppy AND risk per-tick renders. So
@@ -21,16 +29,26 @@
  *   - This panel is a React.memo'd leaf that owns its own state — its internal renders structurally
  *     cannot re-render Arena3D. Every per-frame value stays inside this leaf.
  *
- * SCOPE (this commit): live up-to-playhead SCALARS (DPS/HPS/damage-taken/crit/overheal/deaths).
- * Tank modeled resistance-DR %, buff/debuff uptime, and the per-ability breakdown layer on next.
+ * SCOPE: live up-to-playhead SCALARS (DPS/HPS/damage-taken/crit/overheal/deaths) for every role,
+ * plus a MODELED resistance-based damage-reduction % for tanks (see the tank labeling note above).
+ * Buff/debuff uptime and the per-ability breakdown layer on next.
  */
 
 import { Box, Typography, useTheme, alpha } from '@mui/material';
 import React, { useEffect, useMemo, useRef } from 'react';
 
+import { useCombatantInfoRecord } from '../../../hooks/events/useCombatantInfoRecord';
 import { useDamageEvents } from '../../../hooks/events/useDamageEvents';
 import { useDeathEvents } from '../../../hooks/events/useDeathEvents';
 import { useHealingEvents } from '../../../hooks/events/useHealingEvents';
+import { usePlayerData } from '../../../hooks/usePlayerData';
+import { useBuffLookupTask } from '../../../hooks/workerTasks/useBuffLookupTask';
+import { useDebuffLookupTask } from '../../../hooks/workerTasks/useDebuffLookupTask';
+import {
+  calculateDynamicDamageReductionAtTimestamp,
+  calculateStaticResistanceValue,
+  resistanceToDamageReduction,
+} from '../../../utils/damageReductionUtils';
 import {
   type TimestampPositionLookup,
   getActorPositionAtClosestTimestamp,
@@ -189,6 +207,99 @@ const PlayerStatsContent: React.FC<{
   );
 };
 
+/**
+ * Tank modeled damage-reduction % — a thin live line under the tank scalars. Mounts only for tanks.
+ * Computes the static resistance once on lock, then a per-frame dynamic resistance at the playhead
+ * (frame-safe: isBuffActiveOnTarget is O(log m)), summed and run through resistanceToDamageReduction
+ * (caps 50%). Renders nothing until the gear + buff/debuff lookups resolve, so it never blocks the
+ * measured scalars above it. The DR value is written to a DOM ref by its own rAF loop — no React
+ * render per frame, same contract as the scalar path.
+ */
+const TankDamageReduction: React.FC<{
+  playerId: number;
+  fightStartTime: number;
+  timeRef: React.RefObject<number> | { current: number };
+}> = ({ playerId, fightStartTime, timeRef }) => {
+  const { combatantInfoRecord } = useCombatantInfoRecord();
+  const { playerData } = usePlayerData();
+  const { buffLookupData } = useBuffLookupTask();
+  const { debuffLookupData } = useDebuffLookupTask();
+
+  const player = playerData?.playersById?.[playerId] ?? null;
+  const combatantInfo = combatantInfoRecord?.[playerId] ?? null;
+
+  // Static resistance (gear/CP/passives) — recomputed only when the inputs change.
+  const staticResistance = useMemo(() => {
+    if (!player) return null;
+    return calculateStaticResistanceValue(combatantInfo, player);
+  }, [combatantInfo, player]);
+
+  const valueRef = useRef<HTMLSpanElement | null>(null);
+
+  // All four async inputs must be present before the modeled DR % means anything.
+  const ready = staticResistance != null && buffLookupData != null && debuffLookupData != null;
+
+  useEffect(() => {
+    if (!ready || !buffLookupData || !debuffLookupData || staticResistance == null) return;
+    let raf = 0;
+    const tick = (): void => {
+      const playheadMs = timeRef.current ?? 0;
+      const timestamp = fightStartTime + playheadMs;
+      const dynamic = calculateDynamicDamageReductionAtTimestamp(
+        buffLookupData,
+        debuffLookupData,
+        timestamp,
+        playerId,
+      );
+      const dr = resistanceToDamageReduction(staticResistance + dynamic);
+      const node = valueRef.current;
+      if (node) node.textContent = `${dr.toFixed(1)}%`;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [
+    ready,
+    buffLookupData,
+    debuffLookupData,
+    staticResistance,
+    playerId,
+    fightStartTime,
+    timeRef,
+  ]);
+
+  // Until the lookups resolve, render nothing — the measured scalars carry the panel.
+  if (!ready) return null;
+
+  return (
+    <Box sx={{ mt: 0.75, display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+      <Typography
+        component="span"
+        ref={valueRef}
+        sx={{
+          fontFamily: 'Space Grotesk, Inter, system-ui',
+          fontWeight: 700,
+          fontSize: '0.95rem',
+          fontVariantNumeric: 'tabular-nums',
+          color: 'text.primary',
+        }}
+      >
+        —
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: '0.6rem',
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+          color: 'text.secondary',
+        }}
+      >
+        EST. RESIST. DR
+      </Typography>
+    </Box>
+  );
+};
+
 const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = ({
   followingActorId,
   lookup,
@@ -280,9 +391,19 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       />
 
       {role === 'tank' && (
-        <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
-          Damage taken &amp; deaths are measured up to the playhead.
-        </Typography>
+        <>
+          <TankDamageReduction
+            playerId={followingActorId}
+            fightStartTime={fightStartTime}
+            timeRef={timeRef}
+          />
+          <Typography
+            sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}
+          >
+            Damage taken &amp; deaths are measured; DR % is a modeled resistance estimate (excludes
+            Protection, block &amp; shields).
+          </Typography>
+        </>
       )}
     </Box>
   );

--- a/src/features/fight_replay/utils/lockedPlayerStats.test.ts
+++ b/src/features/fight_replay/utils/lockedPlayerStats.test.ts
@@ -1,10 +1,13 @@
 import { DamageEvent, DeathEvent, HealEvent, HitType } from '../../../types/combatlogEvents';
+import type { BuffLookupData } from '../../../utils/BuffLookupUtils';
 
 import {
   MIN_RATE_WINDOW_SECONDS,
   buildAbilityBreakdownIndex,
+  buildDebuffAppliedIndex,
   buildLockedStatsIndex,
   queryAbilityBreakdown,
+  queryDebuffApplied,
   queryLiveLockedStats,
 } from './lockedPlayerStats';
 
@@ -152,5 +155,106 @@ describe('buildAbilityBreakdownIndex + queryAbilityBreakdown', () => {
     const rows = queryAbilityBreakdown(index, FIGHT_START + 60_000, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0].name).toBe('Crystal Frags');
+  });
+});
+
+describe('buildDebuffAppliedIndex + queryDebuffApplied', () => {
+  const FRIENDLY = new Set<number>([PLAYER, 6]); // players 5 and 6 are friendly
+  const ENEMY = 99;
+  const IMPORTANT = new Set<number>([100, 200, 300]);
+  const abilitiesById = {
+    100: { name: 'Major Breach' },
+    200: { name: 'Crusher' },
+    300: { name: 'Off Balance' },
+  };
+
+  // Ability 100 (Major Breach) is INVERTED: sourceID = friendly applier, targetID = enemy.
+  //   - player 5 applied it on the enemy from +5s..+25s (20s)
+  //   - player 6 applied it from +30s..+40s (not player 5)
+  // Ability 200 (Crusher) is NORMAL: sourceID = enemy, targetID = friendly applier.
+  //   - player 5 applied it from +10s..+50s (40s)
+  // Ability 300 (Off Balance): only player 6 applied it → must not appear for player 5.
+  const debuffLookup: BuffLookupData = {
+    buffIntervals: {
+      '100': [
+        {
+          start: FIGHT_START + 5_000,
+          end: FIGHT_START + 25_000,
+          sourceID: PLAYER,
+          targetID: ENEMY,
+        },
+        { start: FIGHT_START + 30_000, end: FIGHT_START + 40_000, sourceID: 6, targetID: ENEMY },
+      ],
+      '200': [
+        {
+          start: FIGHT_START + 10_000,
+          end: FIGHT_START + 50_000,
+          sourceID: ENEMY,
+          targetID: PLAYER,
+        },
+      ],
+      '300': [
+        { start: FIGHT_START + 5_000, end: FIGHT_START + 55_000, sourceID: 6, targetID: ENEMY },
+      ],
+    },
+  };
+
+  const index = buildDebuffAppliedIndex(PLAYER, debuffLookup, IMPORTANT, FRIENDLY, abilitiesById);
+
+  it('attributes inverted (sourceID=applier) and normal (targetID=applier) debuffs to the player', () => {
+    const names = index.abilities.map((a) => a.name).sort();
+    expect(names).toEqual(['Crusher', 'Major Breach']); // Off Balance excluded (player 6's)
+  });
+
+  it('computes whole-window uptime% on the target at the end', () => {
+    const rows = queryDebuffApplied(index, FIGHT_START, FIGHT_START + 60_000, 5);
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r.uptimePct]));
+    // Crusher: 40s of 60s = 66.7%; Major Breach (player 5's interval only): 20s of 60s = 33.3%.
+    expect(byName['Crusher']).toBeCloseTo((40 / 60) * 100, 1);
+    expect(byName['Major Breach']).toBeCloseTo((20 / 60) * 100, 1);
+  });
+
+  it('is up-to-playhead: a mid-fight cutoff clips the window', () => {
+    // Cutoff +20s: Crusher active +10..+20 = 10s of 20s = 50%; Major Breach +5..+20 = 15s of 20s = 75%.
+    const rows = queryDebuffApplied(index, FIGHT_START, FIGHT_START + 20_000, 5);
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r.uptimePct]));
+    expect(byName['Crusher']).toBeCloseTo(50, 1);
+    expect(byName['Major Breach']).toBeCloseTo(75, 1);
+  });
+
+  it('returns nothing before the window opens', () => {
+    expect(queryDebuffApplied(index, FIGHT_START, FIGHT_START, 5)).toEqual([]);
+  });
+
+  it('takes the PRIMARY-BOSS (max per-enemy) uptime, not a multi-enemy average or union', () => {
+    // Multi-boss case: player 5 keeps Crusher (inverted) on BOSS_A nearly the whole fight, but only
+    // briefly on BOSS_B. The primary-boss number should be BOSS_A's high uptime — NOT the average of
+    // the two (which would halve it) NOR the union across both (which could exceed either).
+    const BOSS_A = 201;
+    const BOSS_B = 202;
+    const lookup: BuffLookupData = {
+      buffIntervals: {
+        // Crusher INVERTED: sourceID = friendly applier (player 5), targetID = enemy.
+        '200': [
+          {
+            start: FIGHT_START + 2_000,
+            end: FIGHT_START + 56_000,
+            sourceID: PLAYER,
+            targetID: BOSS_A,
+          }, // 54s on A
+          {
+            start: FIGHT_START + 10_000,
+            end: FIGHT_START + 16_000,
+            sourceID: PLAYER,
+            targetID: BOSS_B,
+          }, // 6s on B
+        ],
+      },
+    };
+    const multiIndex = buildDebuffAppliedIndex(PLAYER, lookup, IMPORTANT, FRIENDLY, abilitiesById);
+    const rows = queryDebuffApplied(multiIndex, FIGHT_START, FIGHT_START + 60_000, 5);
+    const crusher = rows.find((r) => r.name === 'Crusher');
+    // Max per-enemy: 54s on BOSS_A of 60s = 90%. (Average would be ~50%; union would be ~93%.)
+    expect(crusher?.uptimePct).toBeCloseTo((54 / 60) * 100, 1);
   });
 });

--- a/src/features/fight_replay/utils/lockedPlayerStats.test.ts
+++ b/src/features/fight_replay/utils/lockedPlayerStats.test.ts
@@ -1,0 +1,156 @@
+import { DamageEvent, DeathEvent, HealEvent, HitType } from '../../../types/combatlogEvents';
+
+import {
+  MIN_RATE_WINDOW_SECONDS,
+  buildAbilityBreakdownIndex,
+  buildLockedStatsIndex,
+  queryAbilityBreakdown,
+  queryLiveLockedStats,
+} from './lockedPlayerStats';
+
+// Fight window used across the suite: absolute timestamps run 1_000_000 → 1_060_000 (60s fight).
+const FIGHT_START = 1_000_000;
+
+// Helpers build only the fields the engine reads; the rest is irrelevant to these pure functions.
+const dmg = (
+  timestamp: number,
+  sourceID: number,
+  targetID: number,
+  amount: number,
+  crit = false,
+  opts?: { sourceIsFriendly?: boolean; targetIsFriendly?: boolean },
+): DamageEvent =>
+  ({
+    type: 'damage',
+    timestamp,
+    sourceID,
+    targetID,
+    amount,
+    hitType: crit ? HitType.Critical : HitType.Normal,
+    sourceIsFriendly: opts?.sourceIsFriendly ?? true,
+    targetIsFriendly: opts?.targetIsFriendly ?? false,
+    abilityGameID: 1,
+  }) as unknown as DamageEvent;
+
+const heal = (timestamp: number, sourceID: number, amount: number, overheal: number): HealEvent =>
+  ({
+    type: 'heal',
+    timestamp,
+    sourceID,
+    targetID: 99,
+    amount,
+    overheal,
+    sourceIsFriendly: true,
+    targetIsFriendly: true,
+    abilityGameID: 2,
+  }) as unknown as HealEvent;
+
+const death = (timestamp: number, targetID: number): DeathEvent =>
+  ({ type: 'death', timestamp, targetID, sourceID: 0 }) as unknown as DeathEvent;
+
+const PLAYER = 5;
+
+describe('buildLockedStatsIndex + queryLiveLockedStats', () => {
+  // Player 5 deals damage at +10s, +20s, +30s; one crit. Takes damage at +15s. Heals at +25s.
+  const damageEvents: DamageEvent[] = [
+    dmg(FIGHT_START + 10_000, PLAYER, 7, 1000), // done
+    dmg(FIGHT_START + 20_000, PLAYER, 7, 2000, true), // done, crit
+    dmg(FIGHT_START + 30_000, PLAYER, 7, 3000), // done
+    dmg(FIGHT_START + 15_000, 8, PLAYER, 500), // taken (someone hits player 5)
+    dmg(FIGHT_START + 12_000, 6, 7, 9999), // unrelated (different source)
+  ];
+  const healingEvents: HealEvent[] = [heal(FIGHT_START + 25_000, PLAYER, 800, 200)];
+  const deathEvents: DeathEvent[] = [death(FIGHT_START + 40_000, PLAYER)];
+
+  const index = buildLockedStatsIndex(PLAYER, damageEvents, healingEvents, deathEvents);
+
+  it('returns zeros before the first event', () => {
+    const stats = queryLiveLockedStats(index, FIGHT_START + 5_000, 5);
+    expect(stats.totalDamage).toBe(0);
+    expect(stats.damageTaken).toBe(0);
+    expect(stats.deaths).toBe(0);
+    expect(stats.effectiveHealing).toBe(0);
+    expect(stats.critChance).toBe(0);
+  });
+
+  it('accumulates only up to the cutoff (partial mid-fight)', () => {
+    // Cutoff at +22s: damage events at +10s (1000) and +20s (2000 crit) count; +30s does not.
+    const stats = queryLiveLockedStats(index, FIGHT_START + 22_000, 22);
+    expect(stats.totalDamage).toBe(3000);
+    expect(stats.critChance).toBeCloseTo(50); // 1 crit of 2 hits
+    expect(stats.dps).toBeCloseTo(3000 / 22);
+    // Damage taken at +15s counts; death at +40s does not yet.
+    expect(stats.damageTaken).toBe(500);
+    expect(stats.deaths).toBe(0);
+  });
+
+  it('matches whole-fight totals at/after the last event', () => {
+    const durationSecs = 60;
+    const stats = queryLiveLockedStats(index, FIGHT_START + 60_000, durationSecs);
+    expect(stats.totalDamage).toBe(6000);
+    // Whole-fight DPS must equal total / full duration (the usePlayerCardData semantics).
+    expect(stats.dps).toBeCloseTo(6000 / durationSecs);
+    expect(stats.critChance).toBeCloseTo((1 / 3) * 100);
+    expect(stats.damageTaken).toBe(500);
+    expect(stats.deaths).toBe(1);
+    // Effective healing 800; overheal 200 → 20% overheal.
+    expect(stats.effectiveHealing).toBe(800);
+    expect(stats.overhealPct).toBeCloseTo(20);
+    expect(stats.hps).toBeCloseTo(800 / durationSecs);
+  });
+
+  it('floors the rate denominator so early-fight rates do not explode', () => {
+    // Cutoff just after the first event with a sub-1s elapsed window.
+    const stats = queryLiveLockedStats(index, FIGHT_START + 10_000, 0.1);
+    // Denominator floored to MIN_RATE_WINDOW_SECONDS, not 0.1.
+    expect(stats.dps).toBeCloseTo(1000 / MIN_RATE_WINDOW_SECONDS);
+  });
+
+  it('is order-independent of a backward query (no forward-only accumulator)', () => {
+    const forward = queryLiveLockedStats(index, FIGHT_START + 30_000, 30);
+    queryLiveLockedStats(index, FIGHT_START + 60_000, 60); // advance...
+    const backward = queryLiveLockedStats(index, FIGHT_START + 30_000, 30); // ...then rewind
+    expect(backward.totalDamage).toBe(forward.totalDamage);
+    expect(backward.dps).toBeCloseTo(forward.dps);
+  });
+
+  it('ignores damage from other sources / friendly targets', () => {
+    const stats = queryLiveLockedStats(index, FIGHT_START + 60_000, 60);
+    // Only player 5's hostile-target damage counts (6000), not the unrelated 9999 from source 6.
+    expect(stats.totalDamage).toBe(6000);
+  });
+});
+
+describe('buildAbilityBreakdownIndex + queryAbilityBreakdown', () => {
+  const abilitiesById = {
+    100: { name: 'Force Pulse', icon: 'fp.dds' },
+    200: { name: 'Crystal Frags', icon: 'cf.dds' },
+  };
+  const damageEvents: DamageEvent[] = [
+    { ...dmg(FIGHT_START + 5_000, PLAYER, 7, 500), abilityGameID: 100 } as DamageEvent,
+    { ...dmg(FIGHT_START + 10_000, PLAYER, 7, 700, true), abilityGameID: 100 } as DamageEvent,
+    { ...dmg(FIGHT_START + 20_000, PLAYER, 7, 3000), abilityGameID: 200 } as DamageEvent,
+  ];
+  const index = buildAbilityBreakdownIndex(PLAYER, damageEvents, abilitiesById);
+
+  it('orders abilities by damage descending at the cutoff', () => {
+    const rows = queryAbilityBreakdown(index, FIGHT_START + 60_000, 5);
+    expect(rows.map((r) => r.name)).toEqual(['Crystal Frags', 'Force Pulse']);
+    expect(rows[0].totalDamage).toBe(3000);
+    expect(rows[1].totalDamage).toBe(1200);
+    expect(rows[1].critRate).toBeCloseTo(50); // 1 crit of 2 Force Pulse hits
+  });
+
+  it('drops abilities that have not fired yet at the cutoff', () => {
+    // Cutoff at +12s: only Force Pulse has fired (Crystal Frags is at +20s).
+    const rows = queryAbilityBreakdown(index, FIGHT_START + 12_000, 5);
+    expect(rows.map((r) => r.name)).toEqual(['Force Pulse']);
+    expect(rows[0].totalDamage).toBe(1200);
+  });
+
+  it('respects the top-N limit', () => {
+    const rows = queryAbilityBreakdown(index, FIGHT_START + 60_000, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Crystal Frags');
+  });
+});

--- a/src/features/fight_replay/utils/lockedPlayerStats.ts
+++ b/src/features/fight_replay/utils/lockedPlayerStats.ts
@@ -1,0 +1,367 @@
+/**
+ * Live up-to-playhead stat engine for the locked-player panel.
+ *
+ * The replay panel needs combat stats that advance with the playhead (scrub to 30s → see the
+ * player's DPS/HPS/damage-taken AS OF 30s, not the whole-fight total). The replay's perf contract
+ * forbids per-tick React reconciliation, so the panel runs its own rAF loop and reads these values
+ * imperatively. To keep that loop allocation-free and cheap, the heavy work is done ONCE on lock:
+ * we filter + sort the player's relevant events and build PREFIX-SUM arrays. A per-frame query is
+ * then an O(log n) binary search for the cutoff index plus a couple of array reads — and because we
+ * recompute from the cutoff every frame (never accumulate a forward-only pointer), backward scrubs
+ * and A–B loops are correct for free.
+ *
+ * All times here are ABSOLUTE combat-log timestamps (event.timestamp). The caller converts the
+ * fight-relative playhead via `fight.startTime + playheadMs` before querying.
+ *
+ * Damage/crit semantics mirror usePlayerCardData.damageStats and DamageBreakdownPanel exactly
+ * (sourceIsFriendly && !targetIsFriendly && sourceID === playerId; crit = hitType === 2) so the
+ * numbers match the fight-insights views the user already trusts.
+ */
+
+import { DamageEvent, DeathEvent, HealEvent, HitType } from '../../../types/combatlogEvents';
+
+/** Minimum elapsed seconds used as the rate denominator, so early-fight DPS/HPS doesn't explode. */
+export const MIN_RATE_WINDOW_SECONDS = 1;
+
+/** Prefix-sum index over a player's contribution to one event stream, sorted by timestamp. */
+interface PrefixIndex {
+  /** Sorted absolute timestamps of the kept events. */
+  times: number[];
+  /** cumAmount[i] = sum of `amount` for events[0..i-1] (so cumAmount[len] = grand total). */
+  cumAmount: Float64Array;
+  /** cumSecondary[i] = sum of a secondary field (overheal, or crit amount) over events[0..i-1]. */
+  cumSecondary: Float64Array;
+  /** cumCount[i] = count of events[0..i-1] (for hit-based rates like crit chance). */
+  cumCount: Int32Array;
+  /** cumSecondaryCount[i] = count of "flagged" events (crit hits) over events[0..i-1]. */
+  cumSecondaryCount: Int32Array;
+}
+
+/** What a query returns for one stream up to the cutoff. */
+interface PrefixQuery {
+  amount: number;
+  secondary: number;
+  count: number;
+  secondaryCount: number;
+}
+
+const EMPTY_INDEX: PrefixIndex = {
+  times: [],
+  cumAmount: new Float64Array(1),
+  cumSecondary: new Float64Array(1),
+  cumCount: new Int32Array(1),
+  cumSecondaryCount: new Int32Array(1),
+};
+
+/**
+ * Build a prefix index from a pre-filtered, time-sorted list of {timestamp, amount, secondary,
+ * isFlagged} rows. Done once on lock.
+ */
+function buildPrefixIndex(
+  rows: Array<{ timestamp: number; amount: number; secondary: number; isFlagged: boolean }>,
+): PrefixIndex {
+  rows.sort((a, b) => a.timestamp - b.timestamp);
+  const n = rows.length;
+  const times = new Array<number>(n);
+  const cumAmount = new Float64Array(n + 1);
+  const cumSecondary = new Float64Array(n + 1);
+  const cumCount = new Int32Array(n + 1);
+  const cumSecondaryCount = new Int32Array(n + 1);
+  for (let i = 0; i < n; i++) {
+    const row = rows[i];
+    times[i] = row.timestamp;
+    cumAmount[i + 1] = cumAmount[i] + row.amount;
+    cumSecondary[i + 1] = cumSecondary[i] + row.secondary;
+    cumCount[i + 1] = cumCount[i] + 1;
+    cumSecondaryCount[i + 1] = cumSecondaryCount[i] + (row.isFlagged ? 1 : 0);
+  }
+  return { times, cumAmount, cumSecondary, cumCount, cumSecondaryCount };
+}
+
+/** Largest index `i` such that times[0..i-1] are all <= cutoff (i.e. count of events at/before cutoff). */
+function upperBoundCount(times: number[], cutoff: number): number {
+  let lo = 0;
+  let hi = times.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (times[mid] <= cutoff) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+function queryPrefix(index: PrefixIndex, cutoff: number): PrefixQuery {
+  const i = upperBoundCount(index.times, cutoff);
+  return {
+    amount: index.cumAmount[i],
+    secondary: index.cumSecondary[i],
+    count: index.cumCount[i],
+    secondaryCount: index.cumSecondaryCount[i],
+  };
+}
+
+/** Sorted death timestamps where the player was the victim. */
+type DeathIndex = number[];
+
+/** Per-role indexes, built once when a player is locked. */
+export interface LockedStatsIndex {
+  /** Damage DONE by the player to hostiles (amount, crit amount as secondary, crit hits flagged). */
+  damageDone: PrefixIndex;
+  /** Damage TAKEN by the player (targetID === playerId). */
+  damageTaken: PrefixIndex;
+  /** Healing DONE by the player (amount = effective, overheal as secondary). */
+  healingDone: PrefixIndex;
+  /** Absolute timestamps the player died at, sorted. */
+  deaths: DeathIndex;
+}
+
+/**
+ * Build all per-role indexes for one player in a single pass over each event stream. Cheap to keep
+ * all four indexes regardless of role — the arrays are small (one player's events) and it keeps the
+ * panel free of role branches at build time.
+ */
+export function buildLockedStatsIndex(
+  playerId: number,
+  damageEvents: readonly DamageEvent[],
+  healingEvents: readonly HealEvent[],
+  deathEvents: readonly DeathEvent[],
+): LockedStatsIndex {
+  const doneRows: Array<{
+    timestamp: number;
+    amount: number;
+    secondary: number;
+    isFlagged: boolean;
+  }> = [];
+  const takenRows: Array<{
+    timestamp: number;
+    amount: number;
+    secondary: number;
+    isFlagged: boolean;
+  }> = [];
+  for (const ev of damageEvents) {
+    if (ev.sourceIsFriendly && !ev.targetIsFriendly && ev.sourceID === playerId) {
+      const amount = ev.amount ?? 0;
+      const isCrit = ev.hitType === HitType.Critical;
+      doneRows.push({
+        timestamp: ev.timestamp,
+        amount,
+        secondary: isCrit ? amount : 0,
+        isFlagged: isCrit,
+      });
+    }
+    if (ev.targetID === playerId) {
+      takenRows.push({
+        timestamp: ev.timestamp,
+        amount: ev.amount ?? 0,
+        secondary: 0,
+        isFlagged: false,
+      });
+    }
+  }
+
+  const healRows: Array<{
+    timestamp: number;
+    amount: number;
+    secondary: number;
+    isFlagged: boolean;
+  }> = [];
+  for (const ev of healingEvents) {
+    if (ev.sourceIsFriendly && ev.sourceID === playerId) {
+      healRows.push({
+        timestamp: ev.timestamp,
+        amount: ev.amount ?? 0,
+        secondary: ev.overheal ?? 0,
+        isFlagged: false,
+      });
+    }
+  }
+
+  const deaths: number[] = [];
+  for (const ev of deathEvents) {
+    if (ev.targetID === playerId) deaths.push(ev.timestamp);
+  }
+  deaths.sort((a, b) => a - b);
+
+  return {
+    damageDone: doneRows.length ? buildPrefixIndex(doneRows) : EMPTY_INDEX,
+    damageTaken: takenRows.length ? buildPrefixIndex(takenRows) : EMPTY_INDEX,
+    healingDone: healRows.length ? buildPrefixIndex(healRows) : EMPTY_INDEX,
+    deaths,
+  };
+}
+
+/** Resolved live stats at a cutoff timestamp. Fields are role-agnostic; the panel reads what it needs. */
+export interface LiveLockedStats {
+  /** DPS = damage done / elapsed (elapsed floored at MIN_RATE_WINDOW_SECONDS). */
+  dps: number;
+  /** Total damage done so far. */
+  totalDamage: number;
+  /** Crit chance % over hits so far. */
+  critChance: number;
+  /** HPS = effective healing / elapsed. */
+  hps: number;
+  /** Effective healing so far. */
+  effectiveHealing: number;
+  /** Overheal % = overheal / (effective + overheal) so far. */
+  overhealPct: number;
+  /** Total damage taken so far. */
+  damageTaken: number;
+  /** Death count so far. */
+  deaths: number;
+}
+
+/**
+ * Query live stats at a cutoff (absolute timestamp). `elapsedSeconds` is the playhead seconds into
+ * the fight; the caller passes it so the rate denominator matches the visible playhead exactly.
+ */
+export function queryLiveLockedStats(
+  index: LockedStatsIndex,
+  cutoffTimestamp: number,
+  elapsedSeconds: number,
+): LiveLockedStats {
+  const window = Math.max(MIN_RATE_WINDOW_SECONDS, elapsedSeconds);
+
+  const done = queryPrefix(index.damageDone, cutoffTimestamp);
+  const taken = queryPrefix(index.damageTaken, cutoffTimestamp);
+  const healed = queryPrefix(index.healingDone, cutoffTimestamp);
+  const deaths = upperBoundCount(index.deaths, cutoffTimestamp);
+
+  const healTotal = healed.amount + healed.secondary;
+
+  return {
+    dps: done.amount / window,
+    totalDamage: done.amount,
+    critChance: done.count > 0 ? (done.secondaryCount / done.count) * 100 : 0,
+    hps: healed.amount / window,
+    effectiveHealing: healed.amount,
+    overhealPct: healTotal > 0 ? (healed.secondary / healTotal) * 100 : 0,
+    damageTaken: taken.amount,
+    deaths,
+  };
+}
+
+// ── Per-ability damage breakdown ──────────────────────────────────────────────────────────────
+//
+// Extracted from DamageBreakdownPanel.tsx (the /report .../damage insights view) so the locked-
+// player panel reports per-ability damage with the SAME filter + crit rule. Made up-to-playhead by
+// keeping a per-ability prefix index (sorted timestamps + cumulative damage / hits / crits), so a
+// query at the playhead is a binary search per ability — cheap enough for the throttled (≈3Hz)
+// breakdown refresh, never run on the per-frame scalar tick.
+
+/** Minimal ability lookup shape (matches reportMasterData.abilitiesById entries we read). */
+export interface AbilityNameIcon {
+  name?: string | null;
+  icon?: string | number | null;
+}
+
+interface AbilityPrefix {
+  abilityGameID: string;
+  name: string;
+  icon?: string;
+  times: number[];
+  cumDamage: Float64Array;
+  cumHits: Int32Array;
+  cumCrits: Int32Array;
+}
+
+/** Built once on lock: per-ability prefix indexes for the player's outgoing damage. */
+export interface AbilityBreakdownIndex {
+  abilities: AbilityPrefix[];
+}
+
+/** One row of the resolved breakdown at a cutoff. */
+export interface AbilityBreakdownRow {
+  abilityGameID: string;
+  name: string;
+  icon?: string;
+  totalDamage: number;
+  hitCount: number;
+  critRate: number;
+}
+
+/**
+ * Build per-ability prefix indexes for the player's outgoing damage (friendly source → hostile
+ * target, matching DamageBreakdownPanel). Done once on lock.
+ */
+export function buildAbilityBreakdownIndex(
+  playerId: number,
+  damageEvents: readonly DamageEvent[],
+  abilitiesById: Record<string | number, AbilityNameIcon>,
+): AbilityBreakdownIndex {
+  // Group the player's outgoing damage events by ability, preserving timestamp order within each.
+  const rowsByAbility = new Map<
+    string,
+    Array<{ timestamp: number; amount: number; crit: boolean }>
+  >();
+  for (const ev of damageEvents) {
+    if (!ev.sourceIsFriendly || ev.targetIsFriendly || ev.sourceID !== playerId) continue;
+    const key = String(ev.abilityGameID);
+    let rows = rowsByAbility.get(key);
+    if (!rows) {
+      rows = [];
+      rowsByAbility.set(key, rows);
+    }
+    rows.push({
+      timestamp: ev.timestamp,
+      amount: ev.amount ?? 0,
+      crit: ev.hitType === HitType.Critical,
+    });
+  }
+
+  const abilities: AbilityPrefix[] = [];
+  for (const [key, rows] of rowsByAbility) {
+    rows.sort((a, b) => a.timestamp - b.timestamp);
+    const n = rows.length;
+    const times = new Array<number>(n);
+    const cumDamage = new Float64Array(n + 1);
+    const cumHits = new Int32Array(n + 1);
+    const cumCrits = new Int32Array(n + 1);
+    for (let i = 0; i < n; i++) {
+      times[i] = rows[i].timestamp;
+      cumDamage[i + 1] = cumDamage[i] + rows[i].amount;
+      cumHits[i + 1] = cumHits[i] + 1;
+      cumCrits[i + 1] = cumCrits[i] + (rows[i].crit ? 1 : 0);
+    }
+    const ability = abilitiesById[key];
+    abilities.push({
+      abilityGameID: key,
+      name: ability?.name || `Ability ${key}`,
+      icon: ability?.icon != null ? String(ability.icon) : undefined,
+      times,
+      cumDamage,
+      cumHits,
+      cumCrits,
+    });
+  }
+  return { abilities };
+}
+
+/**
+ * Resolve the top-N abilities by damage as of a cutoff timestamp. Returns rows sorted by damage
+ * descending, dropping abilities that haven't fired yet at the cutoff.
+ */
+export function queryAbilityBreakdown(
+  index: AbilityBreakdownIndex,
+  cutoffTimestamp: number,
+  topN: number,
+): AbilityBreakdownRow[] {
+  const rows: AbilityBreakdownRow[] = [];
+  for (const ability of index.abilities) {
+    const i = upperBoundCount(ability.times, cutoffTimestamp);
+    if (i === 0) continue;
+    const totalDamage = ability.cumDamage[i];
+    if (totalDamage <= 0) continue;
+    const hitCount = ability.cumHits[i];
+    const crits = ability.cumCrits[i];
+    rows.push({
+      abilityGameID: ability.abilityGameID,
+      name: ability.name,
+      icon: ability.icon,
+      totalDamage,
+      hitCount,
+      critRate: hitCount > 0 ? (crits / hitCount) * 100 : 0,
+    });
+  }
+  rows.sort((a, b) => b.totalDamage - a.totalDamage);
+  return rows.slice(0, topN);
+}

--- a/src/features/fight_replay/utils/lockedPlayerStats.ts
+++ b/src/features/fight_replay/utils/lockedPlayerStats.ts
@@ -19,6 +19,7 @@
  */
 
 import { DamageEvent, DeathEvent, HealEvent, HitType } from '../../../types/combatlogEvents';
+import type { BuffLookupData } from '../../../utils/BuffLookupUtils';
 
 /** Minimum elapsed seconds used as the rate denominator, so early-fight DPS/HPS doesn't explode. */
 export const MIN_RATE_WINDOW_SECONDS = 1;
@@ -363,5 +364,162 @@ export function queryAbilityBreakdown(
     });
   }
   rows.sort((a, b) => b.totalDamage - a.totalDamage);
+  return rows.slice(0, topN);
+}
+
+// ── Player-applied debuff uptime ──────────────────────────────────────────────────────────────
+//
+// "Debuffs applied BY the player" is trickier than buffs-received because the debuff lookup stores
+// the APPLIER in a different field per ability (the same inverted/normal split DebuffUptimesPanel
+// handles):
+//   - INVERTED abilities: sourceID = the friendly player who applied it, targetID = the enemy.
+//   - NORMAL abilities:   sourceID = the enemy carrying the debuff, targetID = the friendly applier.
+// There is no single "applier" field, so we classify per ability using the known friendly-player id
+// set: if an ability's intervals carry a friendly id in sourceID it's inverted (applier = sourceID),
+// otherwise the applier is targetID. Every IMPORTANT_DEBUFF_ABILITIES entry is player-applied, so we
+// only need to pick the applier field — not also distinguish applied-vs-received.
+//
+// UPTIME IS MEASURED ON THE PRIMARY-BOSS TARGET: for each ability we group the player's intervals by
+// the enemy they were on, compute per-enemy uptime, and take the MAX across enemies — i.e. the target
+// the player maintained the debuff on hardest (their "main target"). This deliberately differs from the
+// insights Debuffs tab default, which AVERAGES across all selected targets (so a 3-boss fight reads ~⅓
+// the number); the per-player replay panel wants the tank's actual maintenance on the boss they're on,
+// not a multi-boss average. The panel labels it "on boss" so the choice is explicit. (Matching the
+// insights "single target = Tideborn Taleria" view, this reproduces Crusher 93% / Major Vuln 90% etc.)
+
+/** One resolved player-applied debuff row at a cutoff. */
+export interface DebuffAppliedRow {
+  abilityGameID: string;
+  name: string;
+  icon?: string;
+  uptimePct: number;
+}
+
+/** Merge [start,end] intervals (sorted by start) and sum their length clipped to [windowStart, cutoff]. */
+function mergedClippedDuration(
+  intervals: Array<{ start: number; end: number }>,
+  windowStart: number,
+  cutoff: number,
+): number {
+  if (intervals.length === 0 || cutoff <= windowStart) return 0;
+  const sorted = intervals
+    .map((iv) => ({ start: Math.max(iv.start, windowStart), end: Math.min(iv.end, cutoff) }))
+    .filter((iv) => iv.end > iv.start)
+    .sort((a, b) => a.start - b.start);
+  let total = 0;
+  let curStart = -Infinity;
+  let curEnd = -Infinity;
+  for (const iv of sorted) {
+    if (iv.start > curEnd) {
+      if (curEnd > curStart) total += curEnd - curStart;
+      curStart = iv.start;
+      curEnd = iv.end;
+    } else if (iv.end > curEnd) {
+      curEnd = iv.end;
+    }
+  }
+  if (curEnd > curStart) total += curEnd - curStart;
+  return total;
+}
+
+/**
+ * Pre-classified, player-attributed debuff intervals — built once on lock. For each important debuff
+ * the player applied, the intervals are GROUPED BY ENEMY TARGET so the query can take the max per-enemy
+ * uptime (the primary-boss number) rather than a union or a multi-enemy average.
+ */
+export interface DebuffAppliedIndex {
+  abilities: Array<{
+    abilityGameID: string;
+    name: string;
+    icon?: string;
+    /** Map of enemy targetId → intervals of this debuff on that enemy that the player applied. */
+    byEnemy: Map<number, Array<{ start: number; end: number }>>;
+  }>;
+}
+
+/**
+ * Build the player-applied debuff index. `importantDebuffIds` is the curated IMPORTANT_DEBUFF_ABILITIES
+ * set; `friendlyPlayerIds` is used to classify a given ability's applier field (sourceID vs targetID).
+ */
+export function buildDebuffAppliedIndex(
+  playerId: number,
+  debuffLookup: BuffLookupData | null | undefined,
+  importantDebuffIds: ReadonlySet<number>,
+  friendlyPlayerIds: ReadonlySet<number>,
+  abilitiesById: Record<string | number, AbilityNameIcon>,
+): DebuffAppliedIndex {
+  const abilities: DebuffAppliedIndex['abilities'] = [];
+  if (!debuffLookup) return { abilities };
+
+  for (const [abilityIdStr, intervals] of Object.entries(debuffLookup.buffIntervals)) {
+    const abilityId = parseInt(abilityIdStr, 10);
+    if (!importantDebuffIds.has(abilityId)) continue;
+
+    // Classify: does any interval carry a friendly id in sourceID? Then applier = sourceID (inverted)
+    // and the enemy is the targetID; otherwise the applier is targetID and the enemy is the sourceID.
+    let inverted = false;
+    for (const iv of intervals) {
+      if (friendlyPlayerIds.has(iv.sourceID)) {
+        inverted = true;
+        break;
+      }
+    }
+
+    // Keep only intervals THIS player applied, grouped by the enemy they were on.
+    const byEnemy = new Map<number, Array<{ start: number; end: number }>>();
+    for (const iv of intervals) {
+      const applier = inverted ? iv.sourceID : iv.targetID;
+      if (applier !== playerId) continue;
+      const enemy = inverted ? iv.targetID : iv.sourceID;
+      let list = byEnemy.get(enemy);
+      if (!list) {
+        list = [];
+        byEnemy.set(enemy, list);
+      }
+      list.push({ start: iv.start, end: iv.end });
+    }
+    if (byEnemy.size === 0) continue;
+
+    const ability = abilitiesById[abilityIdStr];
+    abilities.push({
+      abilityGameID: abilityIdStr,
+      name: ability?.name || `Debuff ${abilityIdStr}`,
+      icon: ability?.icon != null ? String(ability.icon) : undefined,
+      byEnemy,
+    });
+  }
+  return { abilities };
+}
+
+/**
+ * Resolve top-N player-applied debuffs by PRIMARY-BOSS uptime% as of a cutoff. Per ability we compute
+ * each enemy's merged uptime (clipped to [windowStart, cutoff]) / elapsed window and take the MAX —
+ * the target the player maintained it on hardest. The elapsed denominator is the playhead window so
+ * the % is live as you scrub.
+ */
+export function queryDebuffApplied(
+  index: DebuffAppliedIndex,
+  windowStart: number,
+  cutoffTimestamp: number,
+  topN: number,
+): DebuffAppliedRow[] {
+  const elapsed = cutoffTimestamp - windowStart;
+  if (elapsed <= 0) return [];
+  const rows: DebuffAppliedRow[] = [];
+  for (const ability of index.abilities) {
+    let bestDur = 0;
+    for (const intervals of ability.byEnemy.values()) {
+      const dur = mergedClippedDuration(intervals, windowStart, cutoffTimestamp);
+      if (dur > bestDur) bestDur = dur;
+    }
+    if (bestDur <= 0) continue;
+    rows.push({
+      abilityGameID: ability.abilityGameID,
+      name: ability.name,
+      icon: ability.icon,
+      uptimePct: Math.min(100, (bestDur / elapsed) * 100),
+    });
+  }
+  rows.sort((a, b) => b.uptimePct - a.uptimePct);
   return rows.slice(0, topN);
 }

--- a/src/hooks/useReplayPrefs.test.ts
+++ b/src/hooks/useReplayPrefs.test.ts
@@ -1,6 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { DEFAULT_REPLAY_PREFS, useReplayPrefs, type ReplayPrefs } from './useReplayPrefs';
+import {
+  DEFAULT_REPLAY_PREFS,
+  DEFAULT_STATS_PANEL_SECTIONS,
+  useReplayPrefs,
+  type ReplayPrefs,
+} from './useReplayPrefs';
 
 const STORAGE_KEY = 'replay.prefs.v1';
 
@@ -23,6 +28,8 @@ describe('useReplayPrefs', () => {
       showTrails: true,
       performanceMode: true,
       barCollapsed: true,
+      statsPanelEnabled: false,
+      statsPanelSections: { hero: true, dr: false, buffs: true, debuffs: false, abilities: true },
     };
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
 
@@ -69,6 +76,42 @@ describe('useReplayPrefs', () => {
     const { result } = renderHook(() => useReplayPrefs());
     expect(result.current.storedPrefs.barCollapsed).toBe(true);
     expect(result.current.initialPrefs.barCollapsed).toBe(true);
+  });
+
+  it('restores the persisted statsPanelEnabled flag', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ statsPanelEnabled: false }));
+    const { result } = renderHook(() => useReplayPrefs());
+    // sanitize MUST have a branch for this key or it silently drops (resets every reload).
+    expect(result.current.storedPrefs.statsPanelEnabled).toBe(false);
+    expect(result.current.initialPrefs.statsPanelEnabled).toBe(false);
+  });
+
+  it('restores a partial statsPanelSections object, merging missing flags over the defaults', () => {
+    // Only `debuffs` stored → it's honored; every other section falls back to its default (true).
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ statsPanelSections: { debuffs: false } }),
+    );
+    const { result } = renderHook(() => useReplayPrefs());
+    expect(result.current.storedPrefs.statsPanelSections).toEqual({
+      ...DEFAULT_STATS_PANEL_SECTIONS,
+      debuffs: false,
+    });
+    expect(result.current.initialPrefs.statsPanelSections.debuffs).toBe(false);
+    expect(result.current.initialPrefs.statsPanelSections.hero).toBe(true);
+  });
+
+  it('drops a non-object statsPanelSections and a non-boolean section flag', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ statsPanelSections: 'all', statsPanelEnabled: 'yes' }),
+    );
+    const { result } = renderHook(() => useReplayPrefs());
+    // Wrong-typed → both dropped; initialPrefs uses the defaults.
+    expect(result.current.storedPrefs.statsPanelSections).toBeUndefined();
+    expect(result.current.storedPrefs.statsPanelEnabled).toBeUndefined();
+    expect(result.current.initialPrefs.statsPanelEnabled).toBe(true);
+    expect(result.current.initialPrefs.statsPanelSections).toEqual(DEFAULT_STATS_PANEL_SECTIONS);
   });
 
   it('persistPrefs writes a partial patch and reads back', () => {

--- a/src/hooks/useReplayPrefs.ts
+++ b/src/hooks/useReplayPrefs.ts
@@ -24,6 +24,24 @@ import { useCallback, useMemo } from 'react';
 const VERSION = 1;
 const STORAGE_KEY = `replay.prefs.v${VERSION}`;
 
+/**
+ * Which sections of the locked-player stats panel are shown. Each flag gates one section; a section
+ * also only renders when it's relevant to the locked player's role (e.g. `dr` is tank-only). All
+ * default true, so the panel shows everything until the user trims it from the panel's gear menu.
+ */
+export interface StatsPanelSections {
+  /** Role hero stats row (DPS/Damage/Crit · HPS/Healing/Overheal · Dmg-taken/Deaths/Dmg-done). */
+  hero: boolean;
+  /** Tank modeled "est. resistance DR %" line. */
+  dr: boolean;
+  /** Buff-uptime list. */
+  buffs: boolean;
+  /** Debuffs-applied list. */
+  debuffs: boolean;
+  /** Per-ability damage breakdown (DPS). */
+  abilities: boolean;
+}
+
 export interface ReplayPrefs {
   /** Playback speed multiplier (one of the SpeedSelector ladder values). */
   playbackSpeed: number;
@@ -37,6 +55,10 @@ export interface ReplayPrefs {
   performanceMode: boolean;
   /** Transport bar collapsed/hidden (cinema mode) — persists so the chosen state survives reload. */
   barCollapsed: boolean;
+  /** Locked-player stats panel shown at all (disable toggle / key). */
+  statsPanelEnabled: boolean;
+  /** Which sections of the stats panel are shown (the panel's gear-menu checklist). */
+  statsPanelSections: StatsPanelSections;
 }
 
 /**
@@ -46,6 +68,14 @@ export interface ReplayPrefs {
  * — the hook only supplies the fallback when nothing is stored AND the caller has no stronger
  * initial value.
  */
+export const DEFAULT_STATS_PANEL_SECTIONS: StatsPanelSections = {
+  hero: true,
+  dr: true,
+  buffs: true,
+  debuffs: true,
+  abilities: true,
+};
+
 export const DEFAULT_REPLAY_PREFS: ReplayPrefs = {
   playbackSpeed: 1,
   showNames: true,
@@ -53,6 +83,8 @@ export const DEFAULT_REPLAY_PREFS: ReplayPrefs = {
   showTrails: false,
   performanceMode: false,
   barCollapsed: false,
+  statsPanelEnabled: true,
+  statsPanelSections: DEFAULT_STATS_PANEL_SECTIONS,
 };
 
 const isFiniteNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
@@ -75,6 +107,19 @@ const sanitize = (raw: unknown): Partial<ReplayPrefs> => {
   if (isBool(obj.showTrails)) out.showTrails = obj.showTrails;
   if (isBool(obj.performanceMode)) out.performanceMode = obj.performanceMode;
   if (isBool(obj.barCollapsed)) out.barCollapsed = obj.barCollapsed;
+  if (isBool(obj.statsPanelEnabled)) out.statsPanelEnabled = obj.statsPanelEnabled;
+  // statsPanelSections: accept a partial object, keep only the well-typed boolean flags, and merge
+  // over the defaults so a missing/corrupt flag falls back rather than disappearing.
+  if (obj.statsPanelSections && typeof obj.statsPanelSections === 'object') {
+    const s = obj.statsPanelSections as Record<string, unknown>;
+    const sections: StatsPanelSections = { ...DEFAULT_STATS_PANEL_SECTIONS };
+    if (isBool(s.hero)) sections.hero = s.hero;
+    if (isBool(s.dr)) sections.dr = s.dr;
+    if (isBool(s.buffs)) sections.buffs = s.buffs;
+    if (isBool(s.debuffs)) sections.debuffs = s.debuffs;
+    if (isBool(s.abilities)) sections.abilities = s.abilities;
+    out.statsPanelSections = sections;
+  }
   return out;
 };
 


### PR DESCRIPTION
## What

When the replay camera is locked onto a player (the "Following: …" lock), a compact, role-tinted overlay shows that player's combat performance **up to the playhead** — scrub to 0:30 and the numbers read as of 0:30, not the whole-fight total. Builds on the v1 whole-fight panel (commit 07079708) and makes it live.

Stacked on `feat/replay-ux` (#1167). GitHub will auto-retarget this to `main` once #1167 merges.

### Layers (one commit each)
- **Live up-to-playhead scalars** (all roles) — DPS/Damage/Crit, HPS/Healing/Overheal, Damage-taken/Deaths/Damage-done. A prefix-sum engine (`lockedPlayerStats.ts`) built once on lock makes a per-frame up-to-playhead query an O(log n) binary search; recomputing from the cutoff every frame makes backward scrubs and A–B loops correct by construction. Damage/crit semantics mirror `usePlayerCardData.damageStats`; healing mirrors `HealingDonePanel`.
- **Modeled tank resistance-DR %** — reuses the `/damage-reduction` insights model (static gear/CP/passive + dynamic buff/debuff resistance at the playhead → `resistanceToDamageReduction`, capped 50%). Explicitly labeled "est." and excludes Protection/block/shields; degrades gracefully until the gear+buff lookups resolve.
- **Live buff-uptime list** (all roles) — top raid buffs the player currently has, reusing the insights' curated `IMPORTANT_BUFF_ABILITIES` + `computeBuffUptimes` window-scoped to the playhead.
- **Per-ability damage breakdown** (DPS) — top abilities by damage, reusing the `/damage` `DamageBreakdownPanel` filter + crit rule.
- **Debuffs-applied list** (the debuffs the player maintains, e.g. a tank's Crusher/Major Breach) — reuses the curated `IMPORTANT_DEBUFF_ABILITIES`. Debuff intervals store the applier in a different field per ability (inverted: sourceID, normal: targetID); the index classifies each ability via the friendly-player set, attributes only the locked player's intervals, and shows the **primary-boss** uptime (max per-enemy — the target the player maintained it on hardest), labeled "on boss" to distinguish it from the insights tab's multi-target average.

## Perf contract
The replay is built around NOT re-reconciling Arena3D per tick. The scalar values run on their own `requestAnimationFrame` loop reading the high-frequency `timeRef` and writing straight to DOM refs (`textContent`) — **zero React render per frame** (mirrors `BossHealthPanel`). The O(n) list paths (buff uptime, debuff uptime, ability breakdown) live in sibling-isolated sub-components that recompute on a ~3–4Hz throttle and only `setState` when the rounded rows change. The panel is a `React.memo`'d leaf; a render counter confirmed the scalar component renders **exactly once on lock** across every scrub, with all list layers mounted.

## Verification (live, report F4f2bMwWtgVKxjB9 / fight 39)
Every layer was cross-checked against the fight-insights view / worker it reuses, and all converged exactly:
- DPS @Em.pire: **183.1K DPS / 63.1% crit** (= player card); top abilities Relentless Focus 2.44M / Virulent Shot 2.38M / Killer's Blade 2.26M (= damage breakdown).
- Healer @stileanima: **21.4K HPS / 74.7% overheal**.
- Tank @Onyx643: **666.6K taken / 1.32M done**; est. DR **34.6% → 48.1%** (matches the `calculateDamageReductionData` worker series to the decimal — verified my input wiring, not just the leaf math).
- Buff uptime (@Em.pire): Minor Savagery 100% / Minor Brutality 98% / Enlivening Overflow 91%.
- Debuff uptime (@Onyx643): Stagger 97% / Crusher 93% / Major Vulnerability 90% / Minor Breach 47% — exact match against the rendered `DebuffUptimesPanel` filtered to that player + target Tideborn Taleria.
- Backward scrub + lock A→B rebuild verified; FPS ~190–230 with all layers live.

## Gates
`tsc --noEmit` · `eslint --max-warnings 0` · `npm run build` (Rolldown) · `jest src/features/fight_replay` (**205 passing**, incl. new `lockedPlayerStats` engine tests covering the scalar engine, ability breakdown, and the debuff inverted/normal classification + primary-boss-vs-average-vs-union aggregation) · `prettier --check` — all green.

## Notes
- No new MUI icons (per the Rolldown icon-import gotcha).
- The pre-existing uncommitted Actor3D.tsx / AnimationFrameActor3D.tsx working-tree mods were left untouched.

## Update: disable + per-section compact

Added two controls the panel was missing:
- **Disable** — an Insights button in the bottom-right cluster (shown while following a player) + the **J** key toggle the whole panel off. Disabling *unmounts* it (stops the inner rAF loops). Persisted, mirroring the names (N) / perf toggles; J is gated on following so it can't flip a hidden pref with no feedback.
- **Compact** — a gear menu in the panel header with a per-section checklist (Hero / Est. DR % / Buff uptime / Debuffs / Top abilities), role-filtered. Each choice persists. Trims the tank panel from ~330px to ~115px (hero-only).

Both live in two additive `ReplayPrefs` keys (`statsPanelEnabled` + `statsPanelSections`) — `sanitize()` validates both, VERSION intentionally not bumped (backward-compatible). Verified live (toggle/compact/disable persist across reload; role-filtered menu; zero per-frame renders during playback). jest 218. Adversarially reviewed — no blockers; the two actionable findings folded in.
