### PR TITLE
feat(fight-replay): mobile refactor — inline preview → pseudo-fullscreen interactive mode

### DIFF
--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -42,6 +42,7 @@ import { BossHealthPanel } from './BossHealthPanel';
 import { LockedPlayerStatsPanel } from './LockedPlayerStatsPanel';
 import { MarkerContextMenuPayload } from './Marker3D';
 import { MarkerSpritePreview } from './MarkerSpritePreview';
+import { MobileReplayControls } from './MobileReplayControls';
 import { PerformanceMonitorExternal } from './PerformanceMonitor/PerformanceMonitorExternal';
 import { PlayerListPanel } from './PlayerListPanel';
 import { ReplayErrorBoundary } from './ReplayErrorBoundary';
@@ -116,6 +117,10 @@ interface Arena3DProps {
   showPlayerPathsHUD?: boolean;
   /** Whether to show player trail paths */
   showPlayerTrails?: boolean;
+  /** Toggle the player-paths HUD (the P key on desktop) — used by the mobile control cluster. */
+  onTogglePlayerPathsHUD?: () => void;
+  /** Toggle player trails (the T key on desktop) — used by the mobile control cluster. */
+  onToggleTrails?: () => void;
   /** True when the replay block is fullscreen/immersive (drives the fill-height layout + toggle icon). */
   isFullscreen?: boolean;
   /** Toggle fullscreen of the whole replay block (owned by FightReplay3D, which holds the target ref). */
@@ -156,6 +161,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   onPlayerSelectionChange,
   showPlayerPathsHUD = false,
   showPlayerTrails = false,
+  onTogglePlayerPathsHUD,
+  onToggleTrails,
   reservedInset,
 }) => {
   const { lookup, isActorPositionsLoading } = useActorPositionsTask();
@@ -865,7 +872,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         {/* Boss health — DOM overlay (top-right), crisp + theme-styled. Always shown when
             bosses with health are present. Hidden in the mobile inline preview (the teaser stays
             uncluttered); it returns inside the pseudo-fullscreen interactive mode. */}
-        {!mobilePreview && <BossHealthPanel lookup={lookup} timeRef={timeRef} />}
+        {!mobilePreview && (
+          <BossHealthPanel lookup={lookup} timeRef={timeRef} isMobile={mobileImmersive} />
+        )}
 
         {/* Locked-player stats — DOM overlay (bottom-left), shown only while following a player.
             Role-aware up-to-playhead readout (DPS / healer / tank), reusing the fight-insights
@@ -882,6 +891,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             fightDurationMs={fight.endTime - fight.startTime}
             sections={statsPanelSections}
             onSectionsChange={setStatsPanelSections}
+            isMobile={mobileImmersive}
           />
         )}
 
@@ -900,6 +910,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             playerColorOverrides={playerColorOverrides}
             onPlayerColorChange={handlePlayerColorChange}
             reservedInset={reservedInset}
+            isMobile={mobileImmersive}
           />
         )}
 
@@ -1289,6 +1300,26 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             })}
           />
         </Tooltip>
+      )}
+
+      {/* Mobile touch control cluster — only inside the immersive overlay, where there's room. Gives
+          the keyboard-only controls (P/T/N/R/G/J + perf) a touch home and the only way out (Close),
+          since the desktop right-edge stack and the F-key are unavailable on a phone. */}
+      {mobileImmersive && (
+        <MobileReplayControls
+          onClose={() => onToggleFullscreen?.()}
+          showPlayerList={showPlayerPathsHUD}
+          onTogglePlayerList={() => onTogglePlayerPathsHUD?.()}
+          showTrails={showPlayerTrails}
+          onToggleTrails={() => onToggleTrails?.()}
+          namesEnabled={namesEnabled}
+          onToggleNames={() => setNamesEnabled((prev) => !prev)}
+          performanceMode={performanceMode}
+          onTogglePerformance={() => setPerformanceMode((prev) => !prev)}
+          following={followingActorId != null}
+          statsPanelEnabled={statsPanelEnabled}
+          onToggleStats={() => setStatsPanelEnabled((prev) => !prev)}
+        />
       )}
     </div>
   );

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -1264,25 +1264,50 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             label={
               <Box
                 component="span"
-                sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'baseline',
+                  gap: 0.5,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                }}
               >
-                <Box component="span" sx={{ color: 'rgba(226,232,240,0.7)', fontSize: '0.7rem' }}>
+                <Box
+                  component="span"
+                  sx={{ color: 'rgba(226,232,240,0.7)', fontSize: '0.7rem', flexShrink: 0 }}
+                >
                   Following
                 </Box>
-                <Box component="span" sx={{ fontWeight: 700 }}>
+                <Box
+                  component="span"
+                  sx={{
+                    fontWeight: 700,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                  }}
+                >
                   {followingActorName}
                 </Box>
               </Box>
             }
             aria-label="Unlock camera from actor"
             onDelete={handleUnlockCamera}
+            // On mobile the whole pill unlocks on tap (a 44px touch target beats the tiny delete glyph).
+            // handleUnlockCamera is idempotent, so a body tap + the delete-icon tap can't conflict.
+            onClick={mobileImmersive ? handleUnlockCamera : undefined}
             deleteIcon={<LockOpen />}
             sx={(theme) => ({
               position: 'absolute',
               top: 16,
               left: '50%',
               transform: 'translateX(-50%)',
-              height: 32,
+              // Mobile: 44px tall (touch minimum) and capped wide enough to clear the top-right Close
+              // button (~56px in from the right), with the name ellipsizing instead of overflowing.
+              height: mobileImmersive ? 44 : 32,
+              maxWidth: mobileImmersive ? 'calc(100vw - 120px)' : 'none',
+              zIndex: mobileImmersive ? 3 : undefined,
               color: '#e2e8f0',
               backgroundColor: 'rgba(13, 20, 48, 0.82)',
               backdropFilter: 'blur(10px)',
@@ -1294,7 +1319,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
               '& .MuiChip-icon': { color: theme.palette.primary.main, ml: 0.75 },
               '& .MuiChip-deleteIcon': {
                 color: 'rgba(226,232,240,0.6)',
-                fontSize: '1.05rem',
+                fontSize: mobileImmersive ? '1.4rem' : '1.05rem',
+                ...(mobileImmersive ? { padding: '6px', marginRight: '4px' } : null),
                 '&:hover': { color: theme.palette.primary.main },
               },
             })}

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -5,8 +5,10 @@ import HelpOutline from '@mui/icons-material/HelpOutlineOutlined';
 import Insights from '@mui/icons-material/Insights';
 import Label from '@mui/icons-material/Label';
 import LabelOff from '@mui/icons-material/LabelOff';
+import OpenInFull from '@mui/icons-material/OpenInFull';
 import {
   Box,
+  Button,
   Chip,
   ClickAwayListener,
   IconButton,
@@ -20,6 +22,8 @@ import { Canvas } from '@react-three/fiber';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 
 import { FightFragment } from '../../../graphql/gql/graphql';
+import { usePerfTier } from '../../../hooks/usePerfTier';
+import { usePrefersReducedMotion } from '../../../hooks/usePrefersReducedMotion';
 import { useReplayPrefs } from '../../../hooks/useReplayPrefs';
 import { useActorPositionsTask } from '../../../hooks/workerTasks/useActorPositionsTask';
 import { getMapScaleData } from '../../../types/zoneScaleData';
@@ -31,6 +35,7 @@ import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
 import { COMMON_MARKER_GROUPS, MarkerGroup, MarkerGroupKey } from '../utils/mapMarkerConverters';
 import { DEFAULT_ACTOR_SCALE, computeActorScaleFromMapData } from '../utils/mapScaling';
 import { getVisiblePlayerIds } from '../utils/pathUtils';
+import { decidePreviewMode } from '../utils/previewMode';
 
 import { Arena3DScene, GroundContextMenuPayload } from './Arena3DScene';
 import { BossHealthPanel } from './BossHealthPanel';
@@ -111,10 +116,18 @@ interface Arena3DProps {
   showPlayerPathsHUD?: boolean;
   /** Whether to show player trail paths */
   showPlayerTrails?: boolean;
-  /** True when the replay block is fullscreen (drives the fill-height layout + the toggle icon). */
+  /** True when the replay block is fullscreen/immersive (drives the fill-height layout + toggle icon). */
   isFullscreen?: boolean;
   /** Toggle fullscreen of the whole replay block (owned by FightReplay3D, which holds the target ref). */
   onToggleFullscreen?: () => void;
+  /**
+   * True when the replay is in its mobile layout (narrow viewport). Combined with `isFullscreen`
+   * (which on mobile means the pseudo-fullscreen overlay) this yields the two mobile states:
+   *  - mobile preview  = isMobile && !isFullscreen → a scroll-safe, non-interactive teaser.
+   *  - mobile immersive = isMobile && isFullscreen → the live interactive overlay.
+   * Desktop passes false, so every mobile branch below is dead and the layout is unchanged.
+   */
+  isMobile?: boolean;
   /**
    * Vertical band (px) reserved at the bottom for the transport bar, forwarded to the overlay
    * panels so their height caps clear the bar. Owned by FightReplay3D (it knows the bar's
@@ -134,6 +147,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   onActorClick,
   isFullscreen = false,
   onToggleFullscreen,
+  isMobile = false,
   markersState,
   onAddMarker,
   onRemoveMarker,
@@ -145,6 +159,18 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   reservedInset,
 }) => {
   const { lookup, isActorPositionsLoading } = useActorPositionsTask();
+
+  // The two mobile sub-states (see the isMobile prop doc). On desktop both are false.
+  //  - mobilePreview: scroll-safe teaser on the report page; the canvas must NOT capture touches.
+  //  - mobileImmersive: the live pseudo-fullscreen overlay; full touch interaction, room for chrome.
+  const mobilePreview = isMobile && !isFullscreen;
+  const mobileImmersive = isMobile && isFullscreen;
+
+  // Inline-preview fidelity (static poster vs gentle idle), decided from GPU tier + reduced-motion.
+  // Only meaningful while in mobilePreview; on desktop these hooks still run but the value is unused.
+  const perfTier = usePerfTier();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const previewMode = decidePreviewMode(perfTier, prefersReducedMotion);
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
 
   // Persisted viewer prefs (localStorage). Arena3D owns the names + performance slices; the
@@ -745,7 +771,11 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           // 'percentage' = PCFShadowMap; the bare `shadows` default (PCFSoftShadowMap)
           // is deprecated in three 0.184 and logs a console warning every render.
           shadows="percentage"
-          style={{ background: '#1a1a1a' }}
+          // In the mobile inline PREVIEW the canvas must not capture touches: pointer-events:none lets
+          // a one-finger drag fall straight through to the page so it scrolls normally (OrbitControls'
+          // hardcoded touch-action:none never bites because the element receives no touches). The
+          // user enters interaction via the Expand button. Desktop/immersive keep the default 'auto'.
+          style={{ background: '#1a1a1a', pointerEvents: mobilePreview ? 'none' : 'auto' }}
         >
           <Arena3DScene
             timeRef={timeRef}
@@ -767,23 +797,83 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             playerVisibility={playerVisibility}
             playerColorOverrides={playerColorOverrides}
             performanceMode={performanceMode}
+            mobileImmersive={mobileImmersive}
           />
         </Canvas>
 
+        {/* Mobile inline PREVIEW scrim — the report page shows a dimmed, non-interactive teaser of the
+            3D scene with one clear way in. The scrim is a thin gradient (scene still reads through),
+            sits above the pointer-events:none canvas, and carries the single Expand affordance. Tapping
+            it opens the pseudo-fullscreen interactive mode (onToggleFullscreen → mobilePseudoFullscreen).
+            The scrim itself stays pointer-events:none so a plain drag still scrolls the page; only the
+            button is interactive. Rendered only on mobile while not immersive. */}
+        {mobilePreview && (
+          <Box
+            aria-hidden={false}
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              pointerEvents: 'none',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 1,
+              pb: 3,
+              background:
+                'linear-gradient(180deg, rgba(15,20,40,0.18) 0%, rgba(10,14,30,0.05) 35%, rgba(10,14,30,0.45) 100%)',
+            }}
+          >
+            <Button
+              variant="contained"
+              size="large"
+              startIcon={<OpenInFull />}
+              onClick={onToggleFullscreen}
+              aria-label="Open the interactive 3D replay"
+              sx={(theme) => ({
+                pointerEvents: 'auto',
+                borderRadius: '999px',
+                px: 2.5,
+                py: 1,
+                fontWeight: 700,
+                textTransform: 'none',
+                backgroundColor: 'rgba(13,20,48,0.86)',
+                backdropFilter: 'blur(10px)',
+                WebkitBackdropFilter: 'blur(10px)',
+                border: `1px solid ${theme.palette.primary.main}66`,
+                boxShadow: `0 8px 26px rgba(0,0,0,0.5), 0 0 18px ${theme.palette.primary.main}40`,
+                color: '#e2e8f0',
+                '& .MuiButton-startIcon': { color: theme.palette.primary.main },
+                '&:hover': { backgroundColor: 'rgba(13,20,48,0.95)' },
+              })}
+            >
+              Tap to explore
+            </Button>
+            <Typography
+              variant="caption"
+              sx={{ color: 'rgba(226,232,240,0.75)', fontSize: '0.7rem', pointerEvents: 'none' }}
+            >
+              {previewMode === 'static' ? 'Interactive 3D replay' : 'Live 3D replay'}
+            </Typography>
+          </Box>
+        )}
+
         {/* One-time "Ctrl + scroll to zoom" hint — surfaced the first time the user scrolls plainly
             over the canvas (cooperative zoom: plain wheel scrolls the page, Ctrl/⌘+wheel zooms). */}
-        <ReplayZoomHint />
+        {!mobilePreview && <ReplayZoomHint />}
 
         {/* Boss health — DOM overlay (top-right), crisp + theme-styled. Always shown when
-            bosses with health are present. */}
-        <BossHealthPanel lookup={lookup} timeRef={timeRef} />
+            bosses with health are present. Hidden in the mobile inline preview (the teaser stays
+            uncluttered); it returns inside the pseudo-fullscreen interactive mode. */}
+        {!mobilePreview && <BossHealthPanel lookup={lookup} timeRef={timeRef} />}
 
         {/* Locked-player stats — DOM overlay (bottom-left), shown only while following a player.
             Role-aware up-to-playhead readout (DPS / healer / tank), reusing the fight-insights
             calcs via a prefix-sum engine + own rAF loop. Renders nothing when not following or
             when locked onto a non-player. Gated on statsPanelEnabled (J key / button): disabling
-            UNMOUNTS it, which stops the inner rAF loops — not just a visual hide. */}
-        {statsPanelEnabled && (
+            UNMOUNTS it, which stops the inner rAF loops — not just a visual hide. Also suppressed in
+            the mobile inline preview. */}
+        {statsPanelEnabled && !mobilePreview && (
           <LockedPlayerStatsPanel
             followingActorId={followingActorId}
             lookup={lookup}
@@ -796,8 +886,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         )}
 
         {/* Player list — DOM overlay (top-left), shown when the player-paths HUD is toggled
-            on (P key). Real scroll region so every player is reachable. */}
-        {showPlayerPathsHUD && onPlayerSelectionChange && (
+            on (P key). Real scroll region so every player is reachable. Suppressed in the mobile
+            inline preview. */}
+        {showPlayerPathsHUD && onPlayerSelectionChange && !mobilePreview && (
           <PlayerListPanel
             playerIds={availablePlayerIds}
             lookup={lookup}
@@ -937,8 +1028,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       {/* Performance Monitor Overlay - rendered outside Canvas for proper screen-space positioning */}
       {process.env.NODE_ENV === 'development' && <PerformanceMonitorExternal />}
 
-      {/* Keyboard Controls Help - Shows briefly on load */}
-      <Collapse in={showKeyboardHelp}>
+      {/* Keyboard Controls Help - Shows briefly on load. Desktop-only: it documents physical-key
+          shortcuts (WASD/H/etc.) that don't exist on touch, so it never renders on mobile. */}
+      <Collapse in={showKeyboardHelp && !isMobile}>
         <Box
           sx={{
             position: 'absolute',
@@ -1016,8 +1108,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       </Collapse>
 
       {/* Locked-player stats toggle — only shown while following a player (the panel's condition),
-          so it doesn't clutter the cluster otherwise. Mirrors the J key; on/off shown by color. */}
-      {followingActorId != null && (
+          so it doesn't clutter the cluster otherwise. Mirrors the J key; on/off shown by color.
+          Desktop/immersive-only: on mobile the equivalent lives in the mobile control cluster. */}
+      {!isMobile && followingActorId != null && (
         <Tooltip title={statsPanelEnabled ? 'Hide player stats (J)' : 'Show player stats (J)'}>
           <IconButton
             aria-label={statsPanelEnabled ? 'Hide locked-player stats' : 'Show locked-player stats'}
@@ -1041,8 +1134,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       )}
 
       {/* Fullscreen toggle — fullscreens the whole replay block (canvas + overlays + control bar).
-          Topmost in the bottom-right cluster; mirrors the F key. */}
-      {onToggleFullscreen && (
+          Topmost in the bottom-right cluster; mirrors the F key. Desktop-only: mobile expands via the
+          preview's "Tap to explore" and exits via the mobile control cluster's Close. */}
+      {!isMobile && onToggleFullscreen && (
         <Tooltip title={isFullscreen ? 'Exit fullscreen (F)' : 'Fullscreen (F)'}>
           <IconButton
             aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
@@ -1066,60 +1160,66 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       )}
 
       {/* Performance-mode toggle — drops player-figure shadows for extra headroom on very large
-          fights. Button-only (P/T are already bound to the player-paths HUD and trails). */}
-      <Tooltip
-        title={
-          performanceMode
-            ? 'Performance mode on — figure shadows off'
-            : 'Performance mode — drop figure shadows for large fights'
-        }
-      >
-        <IconButton
-          aria-label={performanceMode ? 'Disable performance mode' : 'Enable performance mode'}
-          aria-pressed={performanceMode}
-          size="small"
-          onClick={() => setPerformanceMode((prev) => !prev)}
-          sx={{
-            position: 'absolute',
-            // Raised to clear the docked control-bar overlay at the bottom of the canvas.
-            bottom: 200,
-            right: 16,
-            color: performanceMode ? '#fcd34d' : 'rgba(255, 255, 255, 0.55)',
-            backgroundColor: 'rgba(0, 0, 0, 0.85)',
-            '&:hover': {
-              backgroundColor: 'rgba(0, 0, 0, 0.95)',
-            },
-          }}
+          fights. Button-only (P/T are already bound to the player-paths HUD and trails). Desktop/
+          immersive-only on the right-edge stack; the mobile equivalent lives in the mobile cluster. */}
+      {!isMobile && (
+        <Tooltip
+          title={
+            performanceMode
+              ? 'Performance mode on — figure shadows off'
+              : 'Performance mode — drop figure shadows for large fights'
+          }
         >
-          <Bolt fontSize="small" />
-        </IconButton>
-      </Tooltip>
+          <IconButton
+            aria-label={performanceMode ? 'Disable performance mode' : 'Enable performance mode'}
+            aria-pressed={performanceMode}
+            size="small"
+            onClick={() => setPerformanceMode((prev) => !prev)}
+            sx={{
+              position: 'absolute',
+              // Raised to clear the docked control-bar overlay at the bottom of the canvas.
+              bottom: 200,
+              right: 16,
+              color: performanceMode ? '#fcd34d' : 'rgba(255, 255, 255, 0.55)',
+              backgroundColor: 'rgba(0, 0, 0, 0.85)',
+              '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.95)',
+              },
+            }}
+          >
+            <Bolt fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
 
       {/* Name-tag toggle - the on-screen affordance for the same state the N key flips, so the
-          declutter control is discoverable without knowing the shortcut. */}
-      <Tooltip title={namesEnabled ? 'Hide name tags (N)' : 'Show name tags (N)'}>
-        <IconButton
-          aria-label={namesEnabled ? 'Hide actor name tags' : 'Show actor name tags'}
-          aria-pressed={namesEnabled}
-          size="small"
-          onClick={() => setNamesEnabled((prev) => !prev)}
-          sx={{
-            position: 'absolute',
-            bottom: 152,
-            right: 16,
-            color: namesEnabled ? 'white' : 'rgba(255, 255, 255, 0.55)',
-            backgroundColor: 'rgba(0, 0, 0, 0.85)',
-            '&:hover': {
-              backgroundColor: 'rgba(0, 0, 0, 0.95)',
-            },
-          }}
-        >
-          {namesEnabled ? <Label fontSize="small" /> : <LabelOff fontSize="small" />}
-        </IconButton>
-      </Tooltip>
+          declutter control is discoverable without knowing the shortcut. Desktop/immersive-only. */}
+      {!isMobile && (
+        <Tooltip title={namesEnabled ? 'Hide name tags (N)' : 'Show name tags (N)'}>
+          <IconButton
+            aria-label={namesEnabled ? 'Hide actor name tags' : 'Show actor name tags'}
+            aria-pressed={namesEnabled}
+            size="small"
+            onClick={() => setNamesEnabled((prev) => !prev)}
+            sx={{
+              position: 'absolute',
+              bottom: 152,
+              right: 16,
+              color: namesEnabled ? 'white' : 'rgba(255, 255, 255, 0.55)',
+              backgroundColor: 'rgba(0, 0, 0, 0.85)',
+              '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.95)',
+              },
+            }}
+          >
+            {namesEnabled ? <Label fontSize="small" /> : <LabelOff fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+      )}
 
-      {/* Persistent help affordance - re-opens the keyboard help panel once it auto-hides */}
-      {!showKeyboardHelp && (
+      {/* Persistent help affordance - re-opens the keyboard help panel once it auto-hides.
+          Desktop-only (no keyboard help on touch). */}
+      {!isMobile && !showKeyboardHelp && (
         <Tooltip title="Keyboard controls (H)">
           <IconButton
             aria-label="Show keyboard controls"
@@ -1144,8 +1244,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       {/* Camera Unlock Chip - Show when following an actor. Anchored top-center so it
           doesn't overlap the top-left PlayerListPanel DOM overlay. Styled to
           match the elevated transport: dark cyan-glass with a glowing accent border + a
-          videocam glyph, so it reads as part of the same designed surface over the 3D scene. */}
-      {followingActorId && followingActorName && (
+          videocam glyph, so it reads as part of the same designed surface over the 3D scene.
+          Suppressed in the mobile inline preview (it returns in the immersive overlay). */}
+      {!mobilePreview && followingActorId && followingActorName && (
         <Tooltip title="Unlock camera from actor">
           <Chip
             icon={<Videocam sx={{ fontSize: '1rem' }} />}

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -12,6 +12,7 @@ import { MapMarkersState } from '../types/mapMarkers';
 import { DEFAULT_ACTOR_SCALE, computeActorScaleFromMapData } from '../utils/mapScaling';
 import { extractPlayerPaths, DEFAULT_PATH_SAMPLING } from '../utils/pathUtils';
 import { getPlayerPathColor } from '../utils/playerColors';
+import { resolveTouchPolicy } from '../utils/touchPolicy';
 
 import { CameraFollower } from './CameraFollower';
 import { CameraResetControls } from './CameraResetControls';
@@ -238,6 +239,12 @@ export interface Arena3DSceneProps {
   playerColorOverrides?: Map<number, string>;
   /** When true, player figures stop casting shadows (perf headroom for large fights). */
   performanceMode?: boolean;
+  /**
+   * True when the replay is a mobile device inside the pseudo-fullscreen overlay. Drives the touch
+   * gesture policy: OrbitControls pan is disabled so two fingers are exclusively pinch-zoom
+   * (CanvasWheelZoom), leaving one-finger rotate clean. Desktop passes false (pan stays on).
+   */
+  mobileImmersive?: boolean;
 }
 
 /**
@@ -265,7 +272,13 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   playerVisibility = EMPTY_VISIBILITY,
   playerColorOverrides = EMPTY_COLOR_OVERRIDES,
   performanceMode = false,
+  mobileImmersive = false,
 }) => {
+  // Touch-gesture policy for OrbitControls. `mobileImmersive` already folds in (mobile && immersive),
+  // so the second arg is true; the helper returns enablePan=false there to free two fingers for
+  // CanvasWheelZoom's pinch, and enablePan=true everywhere else (desktop). See touchPolicy.ts.
+  const touchPolicy = resolveTouchPolicy(mobileImmersive, true);
+
   // Shared render budget for the on-demand RenderLoop. Refilled on every React commit of
   // this scene (effect below, intentionally no deps) so state-driven mutations — markers,
   // trails, player visibility, HUD toggles, prop changes — always repaint, even while
@@ -584,11 +597,13 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           (cooperative wheel: plain wheel scrolls the page through the canvas, Ctrl/⌘+wheel or
           fullscreen zooms) instead of OrbitControls' built-in wheel zoom, which preventDefault()s
           every wheel event and traps page scroll over the canvas. enableZoom=false also governs the
-          touch pinch, which CanvasWheelZoom re-implements minimally so mobile pinch is preserved. */}
+          touch pinch, which CanvasWheelZoom re-implements minimally so mobile pinch is preserved.
+          enablePan is gated by the touch policy: off on mobile-immersive so the two-finger gesture is
+          pinch-only (no OrbitControls pan colliding with CanvasWheelZoom on the same touchmove). */}
       <OrbitControls
-        enablePan={true}
+        enablePan={touchPolicy.enablePan}
         enableZoom={false}
-        enableRotate={true}
+        enableRotate={touchPolicy.enableRotate}
         minDistance={cameraSettings.minDistance}
         maxDistance={cameraSettings.maxDistance}
         maxPolarAngle={Math.PI / 2 - 0.1} // Prevent camera from going below ground (slightly above horizon)

--- a/src/features/fight_replay/components/BossHealthPanel.tsx
+++ b/src/features/fight_replay/components/BossHealthPanel.tsx
@@ -29,6 +29,12 @@ import {
 interface BossHealthPanelProps {
   lookup: TimestampPositionLookup | null;
   timeRef: React.RefObject<number> | { current: number };
+  /**
+   * True inside the mobile pseudo-fullscreen overlay. The panel then drops below the overlay's
+   * top-right Close button (which shares the top-right corner) and respects the top/right safe-area
+   * insets, instead of sitting at the desktop top:16 right:16 where it would collide with Close.
+   */
+  isMobile?: boolean;
 }
 
 const MAX_BOSSES = 4;
@@ -51,7 +57,11 @@ function healthColor(theme: Theme, pct: number): string {
   return theme.palette.error.main;
 }
 
-export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({ lookup, timeRef }) => {
+export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
+  lookup,
+  timeRef,
+  isMobile = false,
+}) => {
   const theme = useTheme();
 
   // The boss SET (identity + names). Only changes when a boss appears or dies, so this drives
@@ -144,10 +154,12 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({ lookup, timeRe
     <Box
       sx={{
         position: 'absolute',
-        top: 16,
-        right: 16,
+        // Mobile overlay: drop below the top-right Close button and honor the safe-area insets so the
+        // panel never sits under the notch or behind Close. Desktop keeps the original top:16 right:16.
+        top: isMobile ? 'calc(env(safe-area-inset-top) + 64px)' : 16,
+        right: isMobile ? 'calc(env(safe-area-inset-right) + 8px)' : 16,
         width: { xs: 220, sm: 280 },
-        maxWidth: 'calc(100% - 32px)',
+        maxWidth: isMobile ? 'calc(100% - 16px)' : 'calc(100% - 32px)',
         pointerEvents: 'none',
         zIndex: 3,
       }}

--- a/src/features/fight_replay/components/BossHealthPanel.tsx
+++ b/src/features/fight_replay/components/BossHealthPanel.tsx
@@ -57,6 +57,21 @@ function healthColor(theme: Theme, pct: number): string {
   return theme.palette.error.main;
 }
 
+/**
+ * Format a boss HP value for the readout. Desktop shows the exact number with grouping commas
+ * (e.g. "181,632,304"); mobile abbreviates to compact notation (e.g. "182M") so the full
+ * "100.0% · 182M / 182M" readout fits on one line inside the narrow ~210px pill instead of
+ * overflowing/clipping the 18px track (the worst case: a 9-digit max at 100% HP).
+ */
+function fmtHp(n: number, compact: boolean): string {
+  const rounded = Math.round(n);
+  if (!compact) return rounded.toLocaleString();
+  return new Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(rounded);
+}
+
 export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
   lookup,
   timeRef,
@@ -115,7 +130,7 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
         if (refs.readout) {
           refs.readout.textContent = boss.isDead
             ? 'DEAD'
-            : `${pct.toFixed(1)}%  ·  ${Math.round(boss.health.current).toLocaleString()} / ${Math.round(boss.health.max).toLocaleString()}`;
+            : `${pct.toFixed(1)}%  ·  ${fmtHp(boss.health.current, isMobile)} / ${fmtHp(boss.health.max, isMobile)}`;
         }
       }
 
@@ -125,9 +140,10 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
     // `bosses.length` intentionally excluded — the loop manages its own dirty check; we only
-    // (re)start it when the data source changes.
+    // (re)start it when the data source changes. isMobile is included so the readout formatter
+    // flips between exact (desktop) and compact (mobile) if the layout changes underneath.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lookup, timeRef, theme]);
+  }, [lookup, timeRef, theme, isMobile]);
 
   // Stable callback-ref factory per boss id.
   const setBarRef = useMemo(() => {
@@ -154,24 +170,32 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
     <Box
       sx={{
         position: 'absolute',
-        // Mobile overlay: drop below the top-right Close button and honor the safe-area insets so the
-        // panel never sits under the notch or behind Close. Desktop keeps the original top:16 right:16.
-        top: isMobile ? 'calc(env(safe-area-inset-top) + 64px)' : 16,
-        right: isMobile ? 'calc(env(safe-area-inset-right) + 8px)' : 16,
+        // Mobile overlay: drop below the top-right Close button. Plain-px offsets (NOT env()) — the
+        // overlay container already pads for the safe area, so adding env() here would double-count
+        // and push the panel too far inboard. Desktop keeps the original top:16 right:16.
+        top: isMobile ? 64 : 16,
+        right: isMobile ? 8 : 16,
         width: { xs: 220, sm: 280 },
         maxWidth: isMobile ? 'calc(100% - 16px)' : 'calc(100% - 32px)',
+        // Mobile: a defensive height cap so a multi-boss stack (up to MAX_BOSSES=4) can't run down
+        // into the control cluster / transport in the short landscape viewport. The per-pill
+        // footprint reduction below is the primary fix; this is the hard safety bound.
+        ...(isMobile
+          ? { maxHeight: 'calc(100vh - 64px - 96px - 44px)', overflow: 'hidden' }
+          : null),
         pointerEvents: 'none',
         zIndex: 3,
       }}
     >
-      <Stack spacing={1}>
+      <Stack spacing={isMobile ? 0.75 : 1}>
         {bosses.map((boss) => (
           <Box
             key={boss.id}
             sx={{
               borderRadius: 2,
               px: 1.5,
-              py: 1,
+              // Tighter vertical padding on mobile so a multi-boss stack fits the short viewport.
+              py: isMobile ? 0.5 : 1,
               backgroundColor: 'rgba(15, 23, 42, 0.82)',
               backdropFilter: 'blur(10px)',
               WebkitBackdropFilter: 'blur(10px)',
@@ -184,20 +208,20 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
               sx={{
                 fontFamily: '"Space Grotesk", Inter, system-ui, sans-serif',
                 fontWeight: 700,
-                fontSize: { xs: '0.9rem', sm: '1rem' },
+                fontSize: isMobile ? '0.8rem' : { xs: '0.9rem', sm: '1rem' },
                 lineHeight: 1.2,
                 color: theme.palette.text.primary,
-                mb: 0.75,
+                mb: isMobile ? 0.25 : 0.75,
               }}
             >
               {boss.name}
             </Typography>
 
-            {/* Track */}
+            {/* Track — keep 16px on mobile (not 14) so the nowrap compact readout never vertically clips. */}
             <Box
               sx={{
                 position: 'relative',
-                height: 18,
+                height: isMobile ? 16 : 18,
                 borderRadius: '999px',
                 backgroundColor: 'rgba(2, 6, 23, 0.85)',
                 border: `1px solid ${theme.palette.primary.main}29`,
@@ -228,10 +252,16 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
+                  // Never wrap — the readout is a single line; wrapping would clip it in the short track.
+                  whiteSpace: 'nowrap',
                   fontSize: '0.7rem',
                   fontWeight: 700,
                   color: theme.palette.text.primary,
-                  textShadow: '0 1px 2px rgba(2,6,23,0.9)',
+                  // Mobile: a symmetric 0-blur halo (surrounds each glyph) so light text stays legible
+                  // over the bright green/orange fill, not just a bottom-only drop shadow.
+                  textShadow: isMobile
+                    ? '0 0 3px rgba(2,6,23,0.95), 0 1px 2px rgba(2,6,23,0.95)'
+                    : '0 1px 2px rgba(2,6,23,0.9)',
                 }}
               />
             </Box>

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -360,6 +360,10 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // auto-hide work inside the mobile overlay for free, with no extra wiring.
   const isImmersive = isFullscreen || mobilePseudoFullscreen;
 
+  // The mobile inline preview = narrow viewport, not yet expanded into the overlay. In this state the
+  // transport is hidden (the canvas is a non-interactive teaser); it returns once the user expands.
+  const mobilePreview = isMobile && !isImmersive;
+
   const toggleFullscreen = useCallback(() => {
     // Mobile: flip the CSS pseudo-fullscreen overlay (the native API can't fullscreen a div on iOS).
     if (isMobile) {
@@ -451,6 +455,23 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     }
     wasFullscreenRef.current = isImmersive;
   }, [isImmersive]);
+
+  // Lock body scroll while the mobile pseudo-fullscreen overlay is open. The overlay is a fixed
+  // element over the page; without this the page behind it can still scroll/rubber-band under the
+  // touch gestures. Keyed ONLY on mobilePseudoFullscreen, so the effect body never runs on desktop
+  // (where it's permanently false) — the native Fullscreen path handles its own scroll containment.
+  useEffect(() => {
+    if (!mobilePseudoFullscreen) return;
+    const { body } = document;
+    const prevOverflow = body.style.overflow;
+    const prevOverscroll = body.style.overscrollBehavior;
+    body.style.overflow = 'hidden';
+    body.style.overscrollBehavior = 'none'; // kill iOS rubber-band past the overlay
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.overscrollBehavior = prevOverscroll;
+    };
+  }, [mobilePseudoFullscreen]);
 
   // Keyboard shortcuts: playback transport + player-path toggles. Camera keys (WASD, r reset,
   // g frame-all) live in-canvas (KeyboardCameraControls / CameraResetControls) because they need
@@ -571,7 +592,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     // (moved off Paper) so the spacing below the block is unchanged.
     <Box
       ref={replayContainerRef}
-      sx={{
+      sx={(theme) => ({
         position: 'relative',
         mb: 3,
         // When fullscreen, the container fills the screen and its inner Paper/canvas fill height
@@ -584,13 +605,36 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           backgroundColor: '#1a1a1a',
           '& > .MuiPaper-root': { height: '100%', borderRadius: 0 },
         },
-      }}
+        // MOBILE pseudo-fullscreen: a position:fixed overlay filling the viewport. This is the iOS
+        // path — Safari can't requestFullscreen() a div, so we go fixed + body-locked instead. The
+        // ancestor chain has no transform/filter, so `fixed` resolves against the viewport (verified).
+        // Safe-area insets keep the close button + transport clear of the notch and home indicator
+        // (index.html sets viewport-fit=cover). The same inner Paper/canvas fill-height rules apply.
+        ...(mobilePseudoFullscreen
+          ? {
+              mb: 0,
+              position: 'fixed',
+              inset: 0,
+              zIndex: theme.zIndex.modal,
+              width: '100%',
+              height: '100%',
+              backgroundColor: '#1a1a1a',
+              paddingTop: 'env(safe-area-inset-top)',
+              paddingBottom: 'env(safe-area-inset-bottom)',
+              paddingLeft: 'env(safe-area-inset-left)',
+              paddingRight: 'env(safe-area-inset-right)',
+              boxSizing: 'border-box',
+              '& > .MuiPaper-root': { height: '100%', borderRadius: 0 },
+            }
+          : null),
+      })}
     >
       <Paper elevation={2} sx={{ overflow: 'hidden' }}>
         <Arena3D
           timeRef={animationTimeRef.timeRef}
           isFullscreen={isImmersive}
           onToggleFullscreen={toggleFullscreen}
+          isMobile={isMobile}
           showActorNames={showActorNames}
           mapTimeline={mapTimeline}
           scrubbingMode={scrubbingMode}
@@ -614,52 +658,55 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
       {/* Playback controls — docked as a translucent overlay at the bottom of the canvas. The outer
           Box is a positioning frame only (pointer-events:none) so its transparent area never steals
           OrbitControls drags / actor clicks from the canvas beneath; PlaybackControls re-enables
-          pointer-events on its own glass surface. */}
-      <Box
-        sx={{
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          bottom: 0,
-          pointerEvents: 'none',
-          '& > *': { pointerEvents: 'auto' },
-        }}
-      >
-        <PlaybackControls
-          currentTime={currentTime}
-          duration={selectedFight.endTime - selectedFight.startTime}
-          isPlaying={isPlaying}
-          playbackSpeed={playbackSpeed}
-          onTimeChange={handleTimeChange}
-          onPlayPause={handlePlayPause}
-          onSpeedChange={handleSpeedChange}
-          onSkipToStart={handleSkipToStart}
-          onSkipToEnd={handleSkipToEnd}
-          onSkipBackward10={handleSkipBackward10}
-          onSkipForward10={handleSkipForward10}
-          onPlayingChange={handlePlayingChange}
-          onScrubbingModeChange={handleScrubbingModeChange}
-          onDraggingChange={handleDraggingChange}
-          timeRef={animationTimeRef.timeRef}
-          reportId={params.reportId}
-          fightId={params.fightId}
-          selectedActorIdRef={followingActorIdRef}
-          fightStartTime={selectedFight.startTime}
-          replayContext={replayContext}
-          loopStart={loopStart}
-          loopEnd={loopEnd}
-          onClearLoop={clearLoop}
-          isFullscreen={isImmersive}
-          barVisible={barVisible}
-          onToggleCollapse={toggleBar}
-          progressPct={
-            selectedFight.endTime > selectedFight.startTime
-              ? (currentTime / (selectedFight.endTime - selectedFight.startTime)) * 100
-              : 0
-          }
-          overlay
-        />
-      </Box>
+          pointer-events on its own glass surface. Hidden in the mobile inline preview — the teaser has
+          no transport; it returns inside the pseudo-fullscreen interactive mode. */}
+      {!mobilePreview && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            pointerEvents: 'none',
+            '& > *': { pointerEvents: 'auto' },
+          }}
+        >
+          <PlaybackControls
+            currentTime={currentTime}
+            duration={selectedFight.endTime - selectedFight.startTime}
+            isPlaying={isPlaying}
+            playbackSpeed={playbackSpeed}
+            onTimeChange={handleTimeChange}
+            onPlayPause={handlePlayPause}
+            onSpeedChange={handleSpeedChange}
+            onSkipToStart={handleSkipToStart}
+            onSkipToEnd={handleSkipToEnd}
+            onSkipBackward10={handleSkipBackward10}
+            onSkipForward10={handleSkipForward10}
+            onPlayingChange={handlePlayingChange}
+            onScrubbingModeChange={handleScrubbingModeChange}
+            onDraggingChange={handleDraggingChange}
+            timeRef={animationTimeRef.timeRef}
+            reportId={params.reportId}
+            fightId={params.fightId}
+            selectedActorIdRef={followingActorIdRef}
+            fightStartTime={selectedFight.startTime}
+            replayContext={replayContext}
+            loopStart={loopStart}
+            loopEnd={loopEnd}
+            onClearLoop={clearLoop}
+            isFullscreen={isImmersive}
+            barVisible={barVisible}
+            onToggleCollapse={toggleBar}
+            progressPct={
+              selectedFight.endTime > selectedFight.startTime
+                ? (currentTime / (selectedFight.endTime - selectedFight.startTime)) * 100
+                : 0
+            }
+            overlay
+          />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -402,6 +402,11 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // Manual collapse toggle (C key + the bar's chevron / restore caret). Works in any mode.
   const toggleBar = useCallback(() => setBarVisible((v) => !v), []);
 
+  // Stable toggles for the mobile control cluster (mirror the P / T keyboard shortcuts). Memoized so
+  // they don't break Arena3D's React.memo on every render.
+  const togglePlayerPathsHUD = useCallback(() => setShowPlayerPathsHUD((prev) => !prev), []);
+  const toggleTrails = useCallback(() => setShowPlayerTrails((prev) => !prev), []);
+
   // Fullscreen cinema auto-hide. Two halves:
   //  1. Reveal on pointer/touch activity over the OUTER container (replayContainerRef — it is
   //     pointer-events:auto; the inner positioning frame is pointer-events:none so a listener
@@ -650,6 +655,8 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           onPlayerSelectionChange={setSelectedPlayerIds}
           showPlayerPathsHUD={showPlayerPathsHUD}
           showPlayerTrails={showPlayerTrails}
+          onTogglePlayerPathsHUD={togglePlayerPathsHUD}
+          onToggleTrails={toggleTrails}
           // When the bar is hidden in fullscreen, only the hairline occludes the bottom, so the
           // overlay panels can grow nearly full-height; otherwise reserve the full bar band.
           reservedInset={isImmersive && !barVisible ? HAIRLINE_H + 4 : TRANSPORT_RESERVED}

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -472,6 +472,17 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     wasFullscreenRef.current = isImmersive;
   }, [isImmersive]);
 
+  // Safety net: if the viewport ever stops being "mobile" while the pseudo-fullscreen overlay is open
+  // (e.g. an unusual rotation/resize that crosses the breakpoint), tear the overlay down. Without this
+  // the mobile-only controls (incl. the Close button) would unmount while the fixed overlay + body
+  // lock persist, stranding the user. The hook is orientation-robust so this rarely fires, but it
+  // guarantees there's no state where the overlay is up with no way out.
+  useEffect(() => {
+    if (!isMobile && mobilePseudoFullscreen) {
+      setMobilePseudoFullscreen(false);
+    }
+  }, [isMobile, mobilePseudoFullscreen]);
+
   // Lock body scroll while the mobile pseudo-fullscreen overlay is open. The overlay is a fixed
   // element over the page; without this the page behind it can still scroll/rubber-band under the
   // touch gestures. Keyed ONLY on mobilePseudoFullscreen, so the effect body never runs on desktop

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -12,6 +12,7 @@ import { useReplayPrefs } from '../../../hooks/useReplayPrefs';
 import { useTimelineMarkers } from '../../../hooks/useTimelineMarkers';
 import { BuffEvent } from '../../../types/combatlogEvents';
 import { TRANSPORT_IDLE_MS, TRANSPORT_RESERVED, HAIRLINE_H } from '../constants/replayDesign';
+import { useIsMobileReplay } from '../hooks/useIsMobileReplay';
 import { MapMarkersState } from '../types/mapMarkers';
 import { clampReplayTime } from '../utils/replayTime';
 
@@ -338,10 +339,34 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     setFollowingActor(null);
   }, [setFollowingActor]);
 
+  // Mobile detection — the single seam every mobile-only branch gates on. Desktop = false, so all
+  // the mobile paths below are dead on desktop and behavior is byte-identical to before.
+  const isMobile = useIsMobileReplay();
+
   // Fullscreen the whole replay block (canvas + overlays + the docked control bar, all of which live
   // inside replayContainerRef). Toggled by the button in Arena3D's cluster and the `f` key.
   const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // Mobile "immersive" mode is a CSS PSEUDO-fullscreen (a position:fixed overlay), NOT the native
+  // Fullscreen API: iOS Safari cannot requestFullscreen() a non-video element, so the native path
+  // silently no-ops on iPhone. We keep this as separate state from isFullscreen because the native
+  // `&:fullscreen` CSS pseudo-class and the fullscreenchange listener only ever fire under the real
+  // API — on mobile we drive the overlay purely from this boolean.
+  const [mobilePseudoFullscreen, setMobilePseudoFullscreen] = useState(false);
+
+  // The single "is the replay filling the screen?" signal everything downstream keys off (fill-height
+  // layout, cinema auto-hide, reserved transport inset). On desktop it equals isFullscreen; on mobile
+  // it's the pseudo-fullscreen overlay. Unifying them here means the transport, overlays, and
+  // auto-hide work inside the mobile overlay for free, with no extra wiring.
+  const isImmersive = isFullscreen || mobilePseudoFullscreen;
+
   const toggleFullscreen = useCallback(() => {
+    // Mobile: flip the CSS pseudo-fullscreen overlay (the native API can't fullscreen a div on iOS).
+    if (isMobile) {
+      setMobilePseudoFullscreen((v) => !v);
+      return;
+    }
+    // Desktop: the native Fullscreen API on the whole replay block (unchanged).
     const el = replayContainerRef.current;
     if (!el) return;
     if (document.fullscreenElement) {
@@ -349,7 +374,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     } else {
       void el.requestFullscreen?.();
     }
-  }, []);
+  }, [isMobile]);
   useEffect(() => {
     // Track real fullscreen state (covers Esc / browser-driven exit, not just our button).
     const onChange = (): void =>
@@ -381,7 +406,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   //     guarded so it never hides mid-scrub/drag.
   const idleTimerRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!isFullscreen) return;
+    if (!isImmersive) return;
     const el = replayContainerRef.current;
     if (!el) return;
 
@@ -414,18 +439,18 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
       if (idleTimerRef.current !== null) window.clearTimeout(idleTimerRef.current);
       idleTimerRef.current = null;
     };
-  }, [isFullscreen, isDragging, isScrubbingMode]);
+  }, [isImmersive, isDragging, isScrubbingMode]);
 
   // When the user LEAVES fullscreen (not on mount), restore the bar — exiting into an
   // auto-hidden bar would be disorienting. Tracks the previous fullscreen state so the persisted
   // barCollapsed seed isn't clobbered on the initial render.
-  const wasFullscreenRef = useRef(isFullscreen);
+  const wasFullscreenRef = useRef(isImmersive);
   useEffect(() => {
-    if (wasFullscreenRef.current && !isFullscreen) {
+    if (wasFullscreenRef.current && !isImmersive) {
       setBarVisible(true);
     }
-    wasFullscreenRef.current = isFullscreen;
-  }, [isFullscreen]);
+    wasFullscreenRef.current = isImmersive;
+  }, [isImmersive]);
 
   // Keyboard shortcuts: playback transport + player-path toggles. Camera keys (WASD, r reset,
   // g frame-all) live in-canvas (KeyboardCameraControls / CameraResetControls) because they need
@@ -564,7 +589,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
       <Paper elevation={2} sx={{ overflow: 'hidden' }}>
         <Arena3D
           timeRef={animationTimeRef.timeRef}
-          isFullscreen={isFullscreen}
+          isFullscreen={isImmersive}
           onToggleFullscreen={toggleFullscreen}
           showActorNames={showActorNames}
           mapTimeline={mapTimeline}
@@ -583,7 +608,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           showPlayerTrails={showPlayerTrails}
           // When the bar is hidden in fullscreen, only the hairline occludes the bottom, so the
           // overlay panels can grow nearly full-height; otherwise reserve the full bar band.
-          reservedInset={isFullscreen && !barVisible ? HAIRLINE_H + 4 : TRANSPORT_RESERVED}
+          reservedInset={isImmersive && !barVisible ? HAIRLINE_H + 4 : TRANSPORT_RESERVED}
         />
       </Paper>
       {/* Playback controls — docked as a translucent overlay at the bottom of the canvas. The outer
@@ -624,7 +649,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           loopStart={loopStart}
           loopEnd={loopEnd}
           onClearLoop={clearLoop}
-          isFullscreen={isFullscreen}
+          isFullscreen={isImmersive}
           barVisible={barVisible}
           onToggleCollapse={toggleBar}
           progressPct={

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -86,14 +86,21 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // initialPrefs/storedPrefs are a one-time mount snapshot used only to seed the state below.
   const { initialPrefs, storedPrefs, persistPrefs } = useReplayPrefs();
 
+  // Mobile detection — the single seam every mobile-only branch gates on. Desktop = false, so all
+  // the mobile paths are dead on desktop and behavior is byte-identical to before.
+  const isMobile = useIsMobileReplay();
+
   // Player path visualization state
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<Set<number>>(
     new Set(initialSelectedPlayerIds),
   );
   // Seed from the stored pref when present, else the showPlayerPaths prop (the feature default).
   // `?? prop` (not initialPrefs) so an explicit prop still wins when the user has never toggled.
+  // On mobile the player list starts CLOSED regardless: it's a wide power-user overlay that would
+  // otherwise dominate the narrow immersive view on open (the user can toggle it on from the mobile
+  // control cluster). Desktop is unaffected.
   const [showPlayerPathsHUD, setShowPlayerPathsHUD] = useState(
-    storedPrefs.showPlayerPaths ?? showPlayerPaths,
+    isMobile ? false : (storedPrefs.showPlayerPaths ?? showPlayerPaths),
   );
   const [showPlayerTrails, setShowPlayerTrails] = useState(
     storedPrefs.showTrails ?? showPlayerPaths,
@@ -339,10 +346,6 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     setFollowingActor(null);
   }, [setFollowingActor]);
 
-  // Mobile detection — the single seam every mobile-only branch gates on. Desktop = false, so all
-  // the mobile paths below are dead on desktop and behavior is byte-identical to before.
-  const isMobile = useIsMobileReplay();
-
   // Fullscreen the whole replay block (canvas + overlays + the docked control bar, all of which live
   // inside replayContainerRef). Toggled by the button in Arena3D's cluster and the `f` key.
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -390,14 +393,22 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // Persist FightReplay3D's pref slice (speed + path/trail toggles + bar-collapsed) whenever it
   // changes. The hook does a read-merge-write so this never clobbers the names/performance slice
   // Arena3D persists.
+  //
+  // On mobile we DON'T persist the path/trail/bar toggles: those are seeded for the mobile session
+  // (player list forced closed, etc.) and writing them back would clobber the user's desktop prefs.
+  // Speed is fine to share across form factors, so it's always persisted.
   useEffect(() => {
-    persistPrefs({
-      playbackSpeed,
-      showPlayerPaths: showPlayerPathsHUD,
-      showTrails: showPlayerTrails,
-      barCollapsed: !barVisible,
-    });
-  }, [persistPrefs, playbackSpeed, showPlayerPathsHUD, showPlayerTrails, barVisible]);
+    persistPrefs(
+      isMobile
+        ? { playbackSpeed }
+        : {
+            playbackSpeed,
+            showPlayerPaths: showPlayerPathsHUD,
+            showTrails: showPlayerTrails,
+            barCollapsed: !barVisible,
+          },
+    );
+  }, [persistPrefs, isMobile, playbackSpeed, showPlayerPathsHUD, showPlayerTrails, barVisible]);
 
   // Manual collapse toggle (C key + the bar's chevron / restore caret). Works in any mode.
   const toggleBar = useCallback(() => setBarVisible((v) => !v), []);

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -771,13 +771,21 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       if ((e.target as HTMLElement).closest('[data-no-drag]')) return;
       const el = rootRef.current;
       if (!el) return;
-      el.setPointerCapture(e.pointerId);
+      // Record the drag origin FIRST so the gesture is live even if capture can't be acquired —
+      // pointer capture is a robustness boost (keeps tracking if the thumb slides off the small
+      // header), not a requirement. setPointerCapture throws if the id isn't an active pointer
+      // (e.g. synthetic events in tests), so guard it; the bubbled move/up events still drive the drag.
       dragRef.current = {
         startX: e.clientX,
         startY: e.clientY,
         baseX: offsetRef.current.x,
         baseY: offsetRef.current.y,
       };
+      try {
+        el.setPointerCapture(e.pointerId);
+      } catch {
+        /* pointer capture unavailable — the drag still works via bubbled pointer events */
+      }
     },
     [isMobile],
   );

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -105,6 +105,12 @@ interface LockedPlayerStatsPanelProps {
   sections?: StatsPanelSections;
   /** Persist a sections change (from the panel's gear menu). Omitted → the gear menu is hidden. */
   onSectionsChange?: (next: StatsPanelSections) => void;
+  /**
+   * True inside the mobile pseudo-fullscreen overlay. The panel then lifts above the touch control
+   * cluster (which docks above the transport) and caps its width/height to the narrow viewport,
+   * instead of the desktop bottom:112 / maxWidth:340 that would overlap the cluster on a phone.
+   */
+  isMobile?: boolean;
 }
 
 /** A section the gear menu can toggle, paired with the roles it's relevant to. */
@@ -695,6 +701,7 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   fightStartTime,
   sections,
   onSectionsChange,
+  isMobile = false,
 }) => {
   const theme = useTheme();
 
@@ -750,14 +757,18 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       sx={{
         position: 'absolute',
         // Bottom-left, lifted clear of the transport bar (~95px) — opposite corner from the
-        // boss-health panel (top-right) and below the player-list panel (top-left).
-        left: 16,
-        bottom: 112,
+        // boss-health panel (top-right) and below the player-list panel (top-left). On mobile it
+        // lifts higher to clear BOTH the transport and the touch control cluster docked above it,
+        // honors the bottom/left safe-area insets, and caps its width to the narrow viewport.
+        left: isMobile ? 'calc(env(safe-area-inset-left) + 8px)' : 16,
+        bottom: isMobile ? 'calc(env(safe-area-inset-bottom) + 152px)' : 112,
         zIndex: 3,
         px: 1.75,
         py: 1.25,
-        minWidth: 220,
-        maxWidth: 340,
+        minWidth: isMobile ? 0 : 220,
+        maxWidth: isMobile ? 'calc(100vw - 16px)' : 340,
+        maxHeight: isMobile ? '40vh' : undefined,
+        overflowY: isMobile ? 'auto' : undefined,
         borderRadius: 2,
         backgroundColor: alpha(theme.palette.background.paper, 0.82),
         backdropFilter: 'blur(10px)',

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -43,10 +43,11 @@ import {
   Popover,
   Tooltip,
   Typography,
+  useMediaQuery,
   useTheme,
   alpha,
 } from '@mui/material';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useReportMasterData } from '../../../hooks';
 import { useCombatantInfoRecord } from '../../../hooks/events/useCombatantInfoRecord';
@@ -89,6 +90,17 @@ import {
 import { getPlayerInfo } from '../utils/pathUtils';
 
 type Role = 'tank' | 'healer' | 'dps';
+
+// Mobile layout constants, shared so the panel's resting bottom offset is DERIVED from the control
+// cluster's geometry (not a hand-tuned magic number that drifts apart from it). The cluster docks at
+// `bottom: MOBILE_CLUSTER_BOTTOM_PX` and its buttons are `MOBILE_CLUSTER_HEIGHT_PX` tall; the panel
+// sits a clearance above that. Mirror MobileReplayControls if those change.
+const MOBILE_CLUSTER_BOTTOM_PX = 96;
+const MOBILE_CLUSTER_HEIGHT_PX = 44;
+const MOBILE_PANEL_CLEARANCE_PX = 24;
+// Resting distance of the panel's bottom edge from the viewport bottom on mobile (clears the cluster).
+const MOBILE_PANEL_BOTTOM_PX =
+  MOBILE_CLUSTER_BOTTOM_PX + MOBILE_CLUSTER_HEIGHT_PX + MOBILE_PANEL_CLEARANCE_PX; // 164
 
 interface LockedPlayerStatsPanelProps {
   /** The currently-followed actor id, or null when not following. */
@@ -708,6 +720,101 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   // Gear-menu anchor (the per-section toggle popover). Local UI state; doesn't affect playback.
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
+  // Landscape-phone (short viewport): the vertical axis is scarce (~390px), so the body height cap
+  // SHRINKS rather than grows. Matches useIsMobileReplay's landscape clause.
+  const shortViewport = useMediaQuery('(pointer: coarse) and (max-height: 600px)');
+
+  // --- Mobile thumb-drag (imperative; zero React render per move, preserving the perf contract) ---
+  // The panel root is pointerEvents:none (click-through); only the HEADER opts into pointer events as
+  // a drag handle. On pointer-down we capture the pointer to the root so a fast drag that leaves the
+  // small header keeps moving the panel instead of falling through to OrbitControls (camera rotate).
+  // The committed offset lives in a ref and is written straight to root.style.transform.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const offsetRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(
+    null,
+  );
+
+  // Clamp the committed offset so the panel's rect stays fully on-screen given its bottom-left anchor.
+  // Reserves the top band (Close + boss panel) and the bottom band (control cluster + transport).
+  const clampOffset = useCallback((x: number, y: number): { x: number; y: number } => {
+    const el = rootRef.current;
+    if (!el) return { x, y };
+    const rect = el.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    // Current on-screen position of the element's top-left WITHOUT the proposed offset delta.
+    const baseLeft = rect.left - offsetRef.current.x;
+    const baseTop = rect.top - offsetRef.current.y;
+    const TOP_RESERVE = 72; // clear the top-right Close / boss stack band
+    const BOTTOM_RESERVE = MOBILE_CLUSTER_BOTTOM_PX; // clear the control cluster + transport
+    const minX = 8 - baseLeft;
+    const maxX = vw - 8 - rect.width - baseLeft;
+    const minY = TOP_RESERVE - baseTop;
+    const maxY = vh - BOTTOM_RESERVE - rect.height - baseTop;
+    return {
+      x: Math.max(minX, Math.min(maxX, x)),
+      y: Math.max(minY, Math.min(maxY, y)),
+    };
+  }, []);
+
+  const applyOffset = useCallback((x: number, y: number) => {
+    const el = rootRef.current;
+    offsetRef.current = { x, y };
+    if (el) el.style.transform = `translate(${x}px, ${y}px)`;
+  }, []);
+
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!isMobile) return;
+      // Don't start a drag from the gear button — it has its own tap (open the Choose-stats popover).
+      if ((e.target as HTMLElement).closest('[data-no-drag]')) return;
+      const el = rootRef.current;
+      if (!el) return;
+      el.setPointerCapture(e.pointerId);
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        baseX: offsetRef.current.x,
+        baseY: offsetRef.current.y,
+      };
+    },
+    [isMobile],
+  );
+
+  const handleDragMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const next = clampOffset(d.baseX + (e.clientX - d.startX), d.baseY + (e.clientY - d.startY));
+      applyOffset(next.x, next.y);
+    },
+    [clampOffset, applyOffset],
+  );
+
+  const handleDragEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    const el = rootRef.current;
+    if (el && el.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId);
+  }, []);
+
+  // Re-clamp the committed offset on resize / orientation change — a portrait-valid offset can shove
+  // the panel off-screen in landscape (844×390).
+  useEffect(() => {
+    if (!isMobile) return;
+    const onResize = (): void => {
+      const c = clampOffset(offsetRef.current.x, offsetRef.current.y);
+      applyOffset(c.x, c.y);
+    };
+    window.addEventListener('resize', onResize);
+    window.addEventListener('orientationchange', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('orientationchange', onResize);
+    };
+  }, [isMobile, clampOffset, applyOffset]);
+
   // Resolve the locked actor's identity from the lookup (same id-space as playersById — the lookup
   // is built by indexing playersById[actorId], so followingActorId is a valid player key).
   const actor = useMemo(() => {
@@ -754,34 +861,51 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
 
   return (
     <Box
+      ref={rootRef}
       sx={{
         position: 'absolute',
         // Bottom-left, lifted clear of the transport bar (~95px) — opposite corner from the
         // boss-health panel (top-right) and below the player-list panel (top-left). On mobile it
-        // lifts higher to clear BOTH the transport and the touch control cluster docked above it,
-        // honors the bottom/left safe-area insets, and caps its width to the narrow viewport.
-        left: isMobile ? 'calc(env(safe-area-inset-left) + 8px)' : 16,
-        bottom: isMobile ? 'calc(env(safe-area-inset-bottom) + 152px)' : 112,
+        // lifts higher to clear BOTH the transport and the touch control cluster docked above it.
+        // Plain-px offsets (NOT env()) — the overlay container already pads for the safe area, so
+        // adding env() here would double-count and push the panel too far inboard. The bottom is
+        // DERIVED from the cluster geometry so the two can't drift into a collision.
+        left: isMobile ? 8 : 16,
+        bottom: isMobile ? MOBILE_PANEL_BOTTOM_PX : 112,
         zIndex: 3,
         px: 1.75,
         py: 1.25,
         minWidth: isMobile ? 0 : 220,
-        maxWidth: isMobile ? 'calc(100vw - 16px)' : 340,
-        maxHeight: isMobile ? '40vh' : undefined,
-        overflowY: isMobile ? 'auto' : undefined,
+        // Mobile: a corner CARD, never a half-screen sheet. 78vw of 844 (landscape) clamps to 320px;
+        // 78vw of 390 (portrait) ≈ 304px — both read as a card, not a panel that eats the short side.
+        maxWidth: isMobile ? 'min(78vw, 320px)' : 340,
         borderRadius: 2,
         backgroundColor: alpha(theme.palette.background.paper, 0.82),
         backdropFilter: 'blur(10px)',
         WebkitBackdropFilter: 'blur(10px)',
         border: `1px solid ${alpha(accent, 0.45)}`,
         boxShadow: `0 8px 26px rgba(0,0,0,0.5), 0 0 14px ${alpha(accent, 0.22)}`,
-        // The panel itself is click-through (so it doesn't block canvas drag); only the gear
-        // button + its popover opt back into pointer events.
+        // The panel ROOT stays click-through on every form factor (so its empty margins never block a
+        // canvas drag); only the header (drag handle) and the gear button opt back into pointer events.
         pointerEvents: 'none',
       }}
     >
-      {/* Header: role pill + name + (optional) gear menu for choosing which sections show. */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1 }}>
+      {/* Header: role pill + name + (optional) gear menu. On mobile it's also the DRAG HANDLE —
+          pointerEvents:auto + touchAction:none so a thumb-drag moves the panel (and, via pointer
+          capture, doesn't fall through to rotate the camera). Desktop header stays inert. */}
+      <Box
+        onPointerDown={isMobile ? handleDragStart : undefined}
+        onPointerMove={isMobile ? handleDragMove : undefined}
+        onPointerUp={isMobile ? handleDragEnd : undefined}
+        onPointerCancel={isMobile ? handleDragEnd : undefined}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          mb: 1,
+          ...(isMobile ? { pointerEvents: 'auto', touchAction: 'none', cursor: 'grab' } : null),
+        }}
+      >
         <Box
           component="span"
           sx={{
@@ -816,6 +940,9 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
             <IconButton
               aria-label="Choose which stats to show"
               size="small"
+              // data-no-drag: on mobile the header is a drag handle; pointer-down here must NOT start
+              // a drag, so the drag handler bails when the target is inside this button.
+              data-no-drag
               onClick={(e) => setMenuAnchor(e.currentTarget)}
               sx={{
                 pointerEvents: 'auto',
@@ -830,54 +957,76 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         )}
       </Box>
 
-      {visible.hero && (
-        <PlayerStatsContent
-          playerId={followingActorId}
-          role={role}
-          fightStartTime={fightStartTime}
-          accent={accent}
-          timeRef={timeRef}
-        />
-      )}
+      {/* Body — on mobile a scrollable region (pan-y) so a long DPS panel (hero+DR+buffs+debuffs+
+          abilities+caveat) is reachable without the panel running off-screen. The height cap lives
+          HERE (not on the root, which must stay click-through) and SHRINKS in landscape where the
+          vertical axis is scarce. Desktop renders the body bare — no wrapper styling, no cap. */}
+      <Box
+        sx={
+          isMobile
+            ? {
+                pointerEvents: 'auto',
+                overflowY: 'auto',
+                touchAction: 'pan-y',
+                WebkitOverflowScrolling: 'touch',
+                // Portrait: cap to a comfortable fraction; landscape (short viewport): tighter so the
+                // card never exceeds the ~390px short side. Both leave the header always visible.
+                maxHeight: shortViewport ? 'calc(100vh - 152px)' : '40vh',
+              }
+            : undefined
+        }
+      >
+        {visible.hero && (
+          <PlayerStatsContent
+            playerId={followingActorId}
+            role={role}
+            fightStartTime={fightStartTime}
+            accent={accent}
+            timeRef={timeRef}
+          />
+        )}
 
-      {role === 'tank' && visible.dr && (
-        <TankDamageReduction
-          playerId={followingActorId}
-          fightStartTime={fightStartTime}
-          timeRef={timeRef}
-        />
-      )}
+        {role === 'tank' && visible.dr && (
+          <TankDamageReduction
+            playerId={followingActorId}
+            fightStartTime={fightStartTime}
+            timeRef={timeRef}
+          />
+        )}
 
-      {visible.buffs && (
-        <BuffUptimeList
-          playerId={followingActorId}
-          fightStartTime={fightStartTime}
-          timeRef={timeRef}
-        />
-      )}
+        {visible.buffs && (
+          <BuffUptimeList
+            playerId={followingActorId}
+            fightStartTime={fightStartTime}
+            timeRef={timeRef}
+          />
+        )}
 
-      {visible.debuffs && (
-        <DebuffUptimeList
-          playerId={followingActorId}
-          fightStartTime={fightStartTime}
-          timeRef={timeRef}
-        />
-      )}
+        {visible.debuffs && (
+          <DebuffUptimeList
+            playerId={followingActorId}
+            fightStartTime={fightStartTime}
+            timeRef={timeRef}
+          />
+        )}
 
-      {role === 'dps' && visible.abilities && (
-        <AbilityBreakdownList
-          playerId={followingActorId}
-          fightStartTime={fightStartTime}
-          timeRef={timeRef}
-          accent={accent}
-        />
-      )}
+        {role === 'dps' && visible.abilities && (
+          <AbilityBreakdownList
+            playerId={followingActorId}
+            fightStartTime={fightStartTime}
+            timeRef={timeRef}
+            accent={accent}
+          />
+        )}
 
-      {tankCaveat && (
-        <Typography sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}>
-          {tankCaveat}
-        </Typography>
-      )}
+        {tankCaveat && (
+          <Typography
+            sx={{ mt: 0.75, fontSize: '0.58rem', color: 'text.disabled', lineHeight: 1.2 }}
+          >
+            {tankCaveat}
+          </Typography>
+        )}
+      </Box>
 
       {onSectionsChange && (
         <Popover

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -91,16 +91,15 @@ import { getPlayerInfo } from '../utils/pathUtils';
 
 type Role = 'tank' | 'healer' | 'dps';
 
-// Mobile layout constants, shared so the panel's resting bottom offset is DERIVED from the control
-// cluster's geometry (not a hand-tuned magic number that drifts apart from it). The cluster docks at
-// `bottom: MOBILE_CLUSTER_BOTTOM_PX` and its buttons are `MOBILE_CLUSTER_HEIGHT_PX` tall; the panel
-// sits a clearance above that. Mirror MobileReplayControls if those change.
-const MOBILE_CLUSTER_BOTTOM_PX = 96;
-const MOBILE_CLUSTER_HEIGHT_PX = 44;
-const MOBILE_PANEL_CLEARANCE_PX = 24;
-// Resting distance of the panel's bottom edge from the viewport bottom on mobile (clears the cluster).
-const MOBILE_PANEL_BOTTOM_PX =
-  MOBILE_CLUSTER_BOTTOM_PX + MOBILE_CLUSTER_HEIGHT_PX + MOBILE_PANEL_CLEARANCE_PX; // 164
+// Mobile layout: the panel is bottom-LEFT and now only has to clear the docked TRANSPORT bar at the
+// bottom edge (the old 7-button toggle cluster that used to sit above the transport was moved into a
+// bottom-RIGHT tools sheet, so there's no cluster band on the left anymore). Reserve the transport
+// band height plus a small clearance. (The tools button lives bottom-right and never overlaps the
+// left side, so it isn't in this calc.)
+const MOBILE_TRANSPORT_BAND_PX = 96;
+const MOBILE_PANEL_CLEARANCE_PX = 16;
+// Resting distance of the panel's bottom edge from the viewport bottom on mobile (clears the transport).
+const MOBILE_PANEL_BOTTOM_PX = MOBILE_TRANSPORT_BAND_PX + MOBILE_PANEL_CLEARANCE_PX; // 112
 
 interface LockedPlayerStatsPanelProps {
   /** The currently-followed actor id, or null when not following. */
@@ -736,7 +735,7 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   );
 
   // Clamp the committed offset so the panel's rect stays fully on-screen given its bottom-left anchor.
-  // Reserves the top band (Close + boss panel) and the bottom band (control cluster + transport).
+  // Reserves the top band (Close + boss panel) and the bottom band (the docked transport bar).
   const clampOffset = useCallback((x: number, y: number): { x: number; y: number } => {
     const el = rootRef.current;
     if (!el) return { x, y };
@@ -747,7 +746,7 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
     const baseLeft = rect.left - offsetRef.current.x;
     const baseTop = rect.top - offsetRef.current.y;
     const TOP_RESERVE = 72; // clear the top-right Close / boss stack band
-    const BOTTOM_RESERVE = MOBILE_CLUSTER_BOTTOM_PX; // clear the control cluster + transport
+    const BOTTOM_RESERVE = MOBILE_TRANSPORT_BAND_PX; // clear the docked transport bar
     const minX = 8 - baseLeft;
     const maxX = vw - 8 - rect.width - baseLeft;
     const minY = TOP_RESERVE - baseTop;

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -979,7 +979,14 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
                 WebkitOverflowScrolling: 'touch',
                 // Portrait: cap to a comfortable fraction; landscape (short viewport): tighter so the
                 // card never exceeds the ~390px short side. Both leave the header always visible.
-                maxHeight: shortViewport ? 'calc(100vh - 152px)' : '40vh',
+                // Landscape (short viewport): the panel rests at bottom:MOBILE_PANEL_BOTTOM_PX and
+                // must also clear the top band, so the body cap is derived from the actually-available
+                // vertical space (≈ 100vh − rest-bottom − top-reserve − header/padding) — NOT a flat
+                // fraction, which let the panel exceed the 390px short side and clip off the top.
+                // Portrait has ample height, so a comfortable 40vh fraction is fine there.
+                maxHeight: shortViewport
+                  ? `calc(100vh - ${MOBILE_PANEL_BOTTOM_PX + 72 + 64}px)`
+                  : '40vh',
               }
             : undefined
         }

--- a/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
+++ b/src/features/fight_replay/components/LockedPlayerStatsPanel.tsx
@@ -768,8 +768,6 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
       if (!isMobile) return;
       // Don't start a drag from the gear button — it has its own tap (open the Choose-stats popover).
       if ((e.target as HTMLElement).closest('[data-no-drag]')) return;
-      const el = rootRef.current;
-      if (!el) return;
       // Record the drag origin FIRST so the gesture is live even if capture can't be acquired —
       // pointer capture is a robustness boost (keeps tracking if the thumb slides off the small
       // header), not a requirement. setPointerCapture throws if the id isn't an active pointer
@@ -781,7 +779,11 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
         baseY: offsetRef.current.y,
       };
       try {
-        el.setPointerCapture(e.pointerId);
+        // Capture on e.currentTarget (the HEADER — where onPointerMove/onPointerUp are attached), NOT
+        // the root. When capture succeeds the browser retargets subsequent pointer events to the
+        // capture element and they no longer fire on a different child, so capturing the root would
+        // starve the header handlers and the drag would stall after the first move.
+        e.currentTarget.setPointerCapture(e.pointerId);
       } catch {
         /* pointer capture unavailable — the drag still works via bubbled pointer events */
       }
@@ -802,8 +804,10 @@ const LockedPlayerStatsPanelComponent: React.FC<LockedPlayerStatsPanelProps> = (
   const handleDragEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     if (!dragRef.current) return;
     dragRef.current = null;
-    const el = rootRef.current;
-    if (el && el.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId);
+    // Release on the same element the capture was taken on (the header = e.currentTarget).
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
   }, []);
 
   // Re-clamp the committed offset on resize / orientation change — a portrait-valid offset can shove

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -1,0 +1,203 @@
+import Bolt from '@mui/icons-material/Bolt';
+import CenterFocusStrong from '@mui/icons-material/CenterFocusStrong';
+import Close from '@mui/icons-material/Close';
+import Insights from '@mui/icons-material/Insights';
+import Label from '@mui/icons-material/Label';
+import LabelOff from '@mui/icons-material/LabelOff';
+import People from '@mui/icons-material/People';
+import RestartAlt from '@mui/icons-material/RestartAlt';
+import Route from '@mui/icons-material/Route';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import type { SystemStyleObject, Theme } from '@mui/system';
+import React from 'react';
+
+/**
+ * Touch control cluster for the mobile pseudo-fullscreen replay overlay.
+ *
+ * The desktop replay drives almost everything from the keyboard (WASD/R/G/P/T/N/J/H/F/C) plus a
+ * right-edge icon stack that's laid out for a wide viewport. On a 390px phone that stack collides
+ * with the transport, and the keyboard shortcuts have no touch path at all (WASD/R/G especially —
+ * camera move/reset/frame-all are keydown-only). This component is the touch home for the controls
+ * that actually matter on a phone, shown ONLY inside the immersive overlay (where there's room).
+ *
+ * Camera reset (R) and frame-all (G) have no callable handle — they live as window keydown handlers
+ * in CameraResetControls (they need the in-Canvas three camera). We bridge to them by dispatching a
+ * synthetic keydown, which is exactly what those handlers consume (they key off event.key and don't
+ * require a trusted event). This reuses the existing logic with no refactor.
+ */
+function pressKey(key: string): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+export interface MobileReplayControlsProps {
+  /** Close the overlay (back to the inline preview). */
+  onClose: () => void;
+  /** Player-paths HUD (the player list) — P on desktop. */
+  showPlayerList: boolean;
+  onTogglePlayerList: () => void;
+  /** Player trails — T on desktop. */
+  showTrails: boolean;
+  onToggleTrails: () => void;
+  /** Name tags — N on desktop. */
+  namesEnabled: boolean;
+  onToggleNames: () => void;
+  /** Performance mode (drop figure shadows) — button-only on desktop. */
+  performanceMode: boolean;
+  onTogglePerformance: () => void;
+  /** Locked-player stats panel — J on desktop. Only meaningful while following a player. */
+  following: boolean;
+  statsPanelEnabled: boolean;
+  onToggleStats: () => void;
+}
+
+/** Shared sx for the round glass toggle buttons so the row reads as one control cluster. */
+const toggleSx = (active: boolean): SystemStyleObject<Theme> => ({
+  color: active ? 'white' : 'rgba(255,255,255,0.6)',
+  backgroundColor: active ? 'rgba(20,30,68,0.92)' : 'rgba(0,0,0,0.6)',
+  border: active ? '1px solid rgba(148,210,255,0.5)' : '1px solid rgba(255,255,255,0.12)',
+  width: 44,
+  height: 44,
+  '&:hover': { backgroundColor: 'rgba(20,30,68,0.98)' },
+});
+
+export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
+  onClose,
+  showPlayerList,
+  onTogglePlayerList,
+  showTrails,
+  onToggleTrails,
+  namesEnabled,
+  onToggleNames,
+  performanceMode,
+  onTogglePerformance,
+  following,
+  statsPanelEnabled,
+  onToggleStats,
+}) => {
+  return (
+    <>
+      {/* Prominent Close — top-right, thumb-reachable. iOS Safari has no Escape key and the desktop
+          fullscreen-exit button is hidden on mobile, so this is the ONLY way out of the overlay. */}
+      <Tooltip title="Close">
+        <IconButton
+          aria-label="Close 3D replay"
+          onClick={onClose}
+          sx={{
+            position: 'absolute',
+            top: 'calc(env(safe-area-inset-top) + 8px)',
+            right: 'calc(env(safe-area-inset-right) + 8px)',
+            zIndex: 2,
+            color: 'white',
+            backgroundColor: 'rgba(0,0,0,0.65)',
+            width: 48,
+            height: 48,
+            '&:hover': { backgroundColor: 'rgba(0,0,0,0.85)' },
+          }}
+        >
+          <Close />
+        </IconButton>
+      </Tooltip>
+
+      {/* Toggle row — a single horizontally-scrollable strip sitting ABOVE the transport (which docks
+          at the very bottom). Raised to clear the transport band + the home-indicator safe area. The
+          frame is pointer-events:none so its gaps never steal a camera drag; only the buttons take input. */}
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 'calc(env(safe-area-inset-left) + 8px)',
+          right: 'calc(env(safe-area-inset-right) + 8px)',
+          bottom: 'calc(env(safe-area-inset-bottom) + 96px)',
+          display: 'flex',
+          gap: 1,
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+          pointerEvents: 'none',
+          '& > *': { pointerEvents: 'auto' },
+        }}
+      >
+        <Tooltip title={showPlayerList ? 'Hide players' : 'Show players'}>
+          <IconButton
+            aria-label={showPlayerList ? 'Hide player list' : 'Show player list'}
+            aria-pressed={showPlayerList}
+            onClick={onTogglePlayerList}
+            sx={toggleSx(showPlayerList)}
+          >
+            <People fontSize="small" />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title={showTrails ? 'Hide trails' : 'Show trails'}>
+          <IconButton
+            aria-label={showTrails ? 'Hide player trails' : 'Show player trails'}
+            aria-pressed={showTrails}
+            onClick={onToggleTrails}
+            sx={toggleSx(showTrails)}
+          >
+            <Route fontSize="small" />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title={namesEnabled ? 'Hide names' : 'Show names'}>
+          <IconButton
+            aria-label={namesEnabled ? 'Hide name tags' : 'Show name tags'}
+            aria-pressed={namesEnabled}
+            onClick={onToggleNames}
+            sx={toggleSx(namesEnabled)}
+          >
+            {namesEnabled ? <Label fontSize="small" /> : <LabelOff fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Reset view">
+          <IconButton
+            aria-label="Reset camera view"
+            onClick={() => pressKey('r')}
+            sx={toggleSx(false)}
+          >
+            <RestartAlt fontSize="small" />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Frame all">
+          <IconButton
+            aria-label="Frame all actors"
+            onClick={() => pressKey('g')}
+            sx={toggleSx(false)}
+          >
+            <CenterFocusStrong fontSize="small" />
+          </IconButton>
+        </Tooltip>
+
+        {/* Stats toggle — only while following a player (mirrors the desktop J-key button condition). */}
+        {following && (
+          <Tooltip title={statsPanelEnabled ? 'Hide player stats' : 'Show player stats'}>
+            <IconButton
+              aria-label={
+                statsPanelEnabled ? 'Hide locked-player stats' : 'Show locked-player stats'
+              }
+              aria-pressed={statsPanelEnabled}
+              onClick={onToggleStats}
+              sx={toggleSx(statsPanelEnabled)}
+            >
+              <Insights fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        <Tooltip title={performanceMode ? 'Performance mode on' : 'Performance mode'}>
+          <IconButton
+            aria-label={performanceMode ? 'Disable performance mode' : 'Enable performance mode'}
+            aria-pressed={performanceMode}
+            onClick={onTogglePerformance}
+            sx={[
+              toggleSx(performanceMode),
+              { color: performanceMode ? '#fcd34d' : 'rgba(255,255,255,0.6)' },
+            ]}
+          >
+            <Bolt fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </>
+  );
+};

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -7,18 +7,20 @@ import LabelOff from '@mui/icons-material/LabelOff';
 import People from '@mui/icons-material/People';
 import RestartAlt from '@mui/icons-material/RestartAlt';
 import Route from '@mui/icons-material/Route';
-import { Box, IconButton, Tooltip } from '@mui/material';
-import type { SystemStyleObject, Theme } from '@mui/system';
-import React from 'react';
+import Tune from '@mui/icons-material/Tune';
+import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import React, { useState } from 'react';
 
 /**
- * Touch control cluster for the mobile pseudo-fullscreen replay overlay.
+ * Touch controls for the mobile pseudo-fullscreen replay overlay.
  *
  * The desktop replay drives almost everything from the keyboard (WASD/R/G/P/T/N/J/H/F/C) plus a
- * right-edge icon stack that's laid out for a wide viewport. On a 390px phone that stack collides
- * with the transport, and the keyboard shortcuts have no touch path at all (WASD/R/G especially —
- * camera move/reset/frame-all are keydown-only). This component is the touch home for the controls
- * that actually matter on a phone, shown ONLY inside the immersive overlay (where there's room).
+ * right-edge icon stack laid out for a wide viewport — none of which works on a phone. On mobile we
+ * surface just the controls that matter, but DON'T cram them into the bottom: a 7-button strip docked
+ * right above the transport made the bottom of the overlay read as a squished pile of bands. Instead a
+ * single bottom-corner "tools" button opens a sheet of toggles, leaving the bottom edge as clean
+ * playback (scrub rail + transport). Shown ONLY inside the immersive overlay.
  *
  * Camera reset (R) and frame-all (G) have no callable handle — they live as window keydown handlers
  * in CameraResetControls (they need the in-Canvas three camera). We bridge to them by dispatching a
@@ -50,15 +52,16 @@ export interface MobileReplayControlsProps {
   onToggleStats: () => void;
 }
 
-/** Shared sx for the round glass toggle buttons so the row reads as one control cluster. */
-const toggleSx = (active: boolean): SystemStyleObject<Theme> => ({
-  color: active ? 'white' : 'rgba(255,255,255,0.6)',
-  backgroundColor: active ? 'rgba(20,30,68,0.92)' : 'rgba(0,0,0,0.6)',
-  border: active ? '1px solid rgba(148,210,255,0.5)' : '1px solid rgba(255,255,255,0.12)',
-  width: 44,
-  height: 44,
-  '&:hover': { backgroundColor: 'rgba(20,30,68,0.98)' },
-});
+/** A row in the tools sheet. `closesOnTap` items open another on-screen panel, so the sheet dismisses
+ *  itself after the tap (otherwise it would sit on top of the panel it just opened). */
+interface ToolItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  active: boolean;
+  onTap: () => void;
+  closesOnTap?: boolean;
+}
 
 export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
   onClose,
@@ -74,6 +77,78 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
   statsPanelEnabled,
   onToggleStats,
 }) => {
+  // The tools sheet anchor — null = closed.
+  const [toolsAnchor, setToolsAnchor] = useState<HTMLElement | null>(null);
+  const toolsOpen = Boolean(toolsAnchor);
+
+  // The toggles, in sheet order. Players (top-left list) and Stats (bottom-left panel) open other
+  // surfaces, so tapping them dismisses the sheet so it doesn't cover what it opened.
+  const items: ToolItem[] = [
+    {
+      key: 'players',
+      label: showPlayerList ? 'Hide players' : 'Show players',
+      icon: <People fontSize="small" />,
+      active: showPlayerList,
+      onTap: onTogglePlayerList,
+      closesOnTap: true,
+    },
+    {
+      key: 'trails',
+      label: showTrails ? 'Hide trails' : 'Show trails',
+      icon: <Route fontSize="small" />,
+      active: showTrails,
+      onTap: onToggleTrails,
+    },
+    {
+      key: 'names',
+      label: namesEnabled ? 'Hide name tags' : 'Show name tags',
+      icon: namesEnabled ? <Label fontSize="small" /> : <LabelOff fontSize="small" />,
+      active: namesEnabled,
+      onTap: onToggleNames,
+    },
+    {
+      key: 'reset',
+      label: 'Reset view',
+      icon: <RestartAlt fontSize="small" />,
+      active: false,
+      onTap: () => pressKey('r'),
+      closesOnTap: true,
+    },
+    {
+      key: 'frame',
+      label: 'Frame all',
+      icon: <CenterFocusStrong fontSize="small" />,
+      active: false,
+      onTap: () => pressKey('g'),
+      closesOnTap: true,
+    },
+    // Stats only while following a player (mirrors the desktop J-key button condition).
+    ...(following
+      ? [
+          {
+            key: 'stats',
+            label: statsPanelEnabled ? 'Hide player stats' : 'Show player stats',
+            icon: <Insights fontSize="small" />,
+            active: statsPanelEnabled,
+            onTap: onToggleStats,
+            closesOnTap: true,
+          } as ToolItem,
+        ]
+      : []),
+    {
+      key: 'perf',
+      label: performanceMode ? 'Performance mode on' : 'Performance mode',
+      icon: <Bolt fontSize="small" />,
+      active: performanceMode,
+      onTap: onTogglePerformance,
+    },
+  ];
+
+  const handleTap = (item: ToolItem): void => {
+    item.onTap();
+    if (item.closesOnTap) setToolsAnchor(null);
+  };
+
   return (
     <>
       {/* Prominent Close — top-right, thumb-reachable. iOS Safari has no Escape key and the desktop
@@ -100,109 +175,71 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
         </IconButton>
       </Tooltip>
 
-      {/* Toggle row — a single horizontally-scrollable strip sitting ABOVE the transport (which docks
-          at the very bottom). Raised to clear the transport band + the home-indicator safe area. The
-          frame is pointer-events:none so its gaps never steal a camera drag; only the buttons take input. */}
-      <Box
-        sx={{
-          position: 'absolute',
-          // Plain px (NOT env()) — the overlay container already pads for the safe area. bottom:96
-          // matches MOBILE_CLUSTER_BOTTOM_PX in LockedPlayerStatsPanel (the stats panel derives its
-          // resting offset from this so the two never collide).
-          left: 8,
-          right: 8,
-          bottom: 96,
-          display: 'flex',
-          gap: 1,
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-          pointerEvents: 'none',
-          '& > *': { pointerEvents: 'auto' },
+      {/* Tools button — a single bottom-RIGHT affordance (thumb zone, clear of the bottom-left stats
+          panel and the contested top). Opens the toggles sheet. Sits ABOVE the transport so the bottom
+          edge stays clean playback. The active-toggle count is conveyed by the sheet, not the button. */}
+      <Tooltip title="Tools">
+        <IconButton
+          aria-label="Replay tools"
+          aria-haspopup="true"
+          aria-expanded={toolsOpen}
+          onClick={(e) => setToolsAnchor(e.currentTarget)}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            bottom: 96,
+            zIndex: 2,
+            width: 48,
+            height: 48,
+            color: toolsOpen ? 'white' : 'rgba(255,255,255,0.85)',
+            backgroundColor: toolsOpen ? 'rgba(20,30,68,0.95)' : 'rgba(0,0,0,0.65)',
+            border: '1px solid rgba(148,210,255,0.35)',
+            '&:hover': { backgroundColor: 'rgba(20,30,68,0.98)' },
+          }}
+        >
+          <Tune />
+        </IconButton>
+      </Tooltip>
+
+      {/* Toggles sheet — a compact menu anchored to the tools button. Each row is a ≥44px tap target. */}
+      <Menu
+        anchorEl={toolsAnchor}
+        open={toolsOpen}
+        onClose={() => setToolsAnchor(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: (theme) => ({
+              minWidth: 200,
+              backgroundColor: alpha(theme.palette.background.paper, 0.96),
+              backdropFilter: 'blur(12px)',
+              border: '1px solid rgba(148,210,255,0.25)',
+            }),
+          },
         }}
       >
-        <Tooltip title={showPlayerList ? 'Hide players' : 'Show players'}>
-          <IconButton
-            aria-label={showPlayerList ? 'Hide player list' : 'Show player list'}
-            aria-pressed={showPlayerList}
-            onClick={onTogglePlayerList}
-            sx={toggleSx(showPlayerList)}
+        {items.map((item) => (
+          <MenuItem
+            key={item.key}
+            onClick={() => handleTap(item)}
+            aria-pressed={item.active}
+            sx={{
+              minHeight: 44,
+              color: item.active ? 'primary.main' : 'text.primary',
+            }}
           >
-            <People fontSize="small" />
-          </IconButton>
-        </Tooltip>
-
-        <Tooltip title={showTrails ? 'Hide trails' : 'Show trails'}>
-          <IconButton
-            aria-label={showTrails ? 'Hide player trails' : 'Show player trails'}
-            aria-pressed={showTrails}
-            onClick={onToggleTrails}
-            sx={toggleSx(showTrails)}
-          >
-            <Route fontSize="small" />
-          </IconButton>
-        </Tooltip>
-
-        <Tooltip title={namesEnabled ? 'Hide names' : 'Show names'}>
-          <IconButton
-            aria-label={namesEnabled ? 'Hide name tags' : 'Show name tags'}
-            aria-pressed={namesEnabled}
-            onClick={onToggleNames}
-            sx={toggleSx(namesEnabled)}
-          >
-            {namesEnabled ? <Label fontSize="small" /> : <LabelOff fontSize="small" />}
-          </IconButton>
-        </Tooltip>
-
-        <Tooltip title="Reset view">
-          <IconButton
-            aria-label="Reset camera view"
-            onClick={() => pressKey('r')}
-            sx={toggleSx(false)}
-          >
-            <RestartAlt fontSize="small" />
-          </IconButton>
-        </Tooltip>
-
-        <Tooltip title="Frame all">
-          <IconButton
-            aria-label="Frame all actors"
-            onClick={() => pressKey('g')}
-            sx={toggleSx(false)}
-          >
-            <CenterFocusStrong fontSize="small" />
-          </IconButton>
-        </Tooltip>
-
-        {/* Stats toggle — only while following a player (mirrors the desktop J-key button condition). */}
-        {following && (
-          <Tooltip title={statsPanelEnabled ? 'Hide player stats' : 'Show player stats'}>
-            <IconButton
-              aria-label={
-                statsPanelEnabled ? 'Hide locked-player stats' : 'Show locked-player stats'
-              }
-              aria-pressed={statsPanelEnabled}
-              onClick={onToggleStats}
-              sx={toggleSx(statsPanelEnabled)}
+            <ListItemIcon
+              sx={{ color: item.active ? 'primary.main' : 'text.secondary', minWidth: 36 }}
             >
-              <Insights fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        )}
-
-        <Tooltip title={performanceMode ? 'Performance mode on' : 'Performance mode'}>
-          <IconButton
-            aria-label={performanceMode ? 'Disable performance mode' : 'Enable performance mode'}
-            aria-pressed={performanceMode}
-            onClick={onTogglePerformance}
-            sx={[
-              toggleSx(performanceMode),
-              { color: performanceMode ? '#fcd34d' : 'rgba(255,255,255,0.6)' },
-            ]}
-          >
-            <Bolt fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </Box>
+              {item.icon}
+            </ListItemIcon>
+            <ListItemText slotProps={{ primary: { sx: { fontSize: '0.9rem' } } }}>
+              {item.label}
+            </ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
     </>
   );
 };

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -84,8 +84,10 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
           onClick={onClose}
           sx={{
             position: 'absolute',
-            top: 'calc(env(safe-area-inset-top) + 8px)',
-            right: 'calc(env(safe-area-inset-right) + 8px)',
+            // Plain px (NOT env()) — the overlay container already pads for the safe area; adding
+            // env() here too would double-count and push the button too far inboard.
+            top: 8,
+            right: 8,
             zIndex: 2,
             color: 'white',
             backgroundColor: 'rgba(0,0,0,0.65)',
@@ -104,9 +106,12 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
       <Box
         sx={{
           position: 'absolute',
-          left: 'calc(env(safe-area-inset-left) + 8px)',
-          right: 'calc(env(safe-area-inset-right) + 8px)',
-          bottom: 'calc(env(safe-area-inset-bottom) + 96px)',
+          // Plain px (NOT env()) — the overlay container already pads for the safe area. bottom:96
+          // matches MOBILE_CLUSTER_BOTTOM_PX in LockedPlayerStatsPanel (the stats panel derives its
+          // resting offset from this so the two never collide).
+          left: 8,
+          right: 8,
+          bottom: 96,
           display: 'flex',
           gap: 1,
           justifyContent: 'center',

--- a/src/features/fight_replay/components/PlaybackButtons.tsx
+++ b/src/features/fight_replay/components/PlaybackButtons.tsx
@@ -62,6 +62,16 @@ export const PlaybackButtons: React.FC<PlaybackButtonsProps> = ({
     '& .MuiSvgIcon-root': { fontSize: compact ? '1.15rem' : '1.4rem' },
   } as const;
 
+  // Skip-to-start / skip-to-end are the redundant outer buttons on a touch phone: the full-width
+  // scrub rail already covers "seek anywhere", and at ~390px they pushed the cluster wide enough to
+  // collide with the speed pill (left) and share (right). Hide them only on COARSE pointers (touch),
+  // gated by media query — NOT by `compact`, because the DESKTOP overlay transport is also compact and
+  // must keep ⏮/⏭ for mouse users.
+  const endStopSx = {
+    ...ghostSx,
+    '@media (pointer: coarse)': { display: 'none' },
+  } as const;
+
   return (
     <Box
       sx={{
@@ -69,10 +79,12 @@ export const PlaybackButtons: React.FC<PlaybackButtonsProps> = ({
         alignItems: 'center',
         justifyContent: 'center',
         gap: 0.75,
-        // On touch devices, enforce a 44x44 minimum tap target and a little more
-        // spacing so the playback controls are comfortable to use on mobile.
+        // On touch devices, enforce a 44x44 minimum tap target so the controls are comfortable.
+        // In the compact mobile transport the cluster is just ±10 + orb (skip-to-start/end are
+        // dropped), so keep the gap tight — a wide gap pushed the outer buttons into the speed/share
+        // controls flanking the row. The non-compact (desktop touch, e.g. tablet) keeps the roomier gap.
         '@media (pointer: coarse)': {
-          gap: 1.25,
+          gap: compact ? 0.5 : 1.25,
           '& .MuiIconButton-root': {
             minWidth: 44,
             minHeight: 44,
@@ -80,8 +92,9 @@ export const PlaybackButtons: React.FC<PlaybackButtonsProps> = ({
         },
       }}
     >
+      {/* Skip-to-start — hidden on touch (endStopSx), kept on desktop/mouse. See endStopSx note. */}
       <Tooltip title="Jump to start">
-        <IconButton onClick={onSkipToStart} size="small" aria-label="Skip to start" sx={ghostSx}>
+        <IconButton onClick={onSkipToStart} size="small" aria-label="Skip to start" sx={endStopSx}>
           <SkipPrevious />
         </IconButton>
       </Tooltip>
@@ -154,8 +167,9 @@ export const PlaybackButtons: React.FC<PlaybackButtonsProps> = ({
         </IconButton>
       </Tooltip>
 
+      {/* Skip-to-end — hidden on touch (endStopSx), kept on desktop/mouse. */}
       <Tooltip title="Jump to end">
-        <IconButton onClick={onSkipToEnd} size="small" aria-label="Skip to end" sx={ghostSx}>
+        <IconButton onClick={onSkipToEnd} size="small" aria-label="Skip to end" sx={endStopSx}>
           <SkipNext />
         </IconButton>
       </Tooltip>

--- a/src/features/fight_replay/components/PlaybackControls.tsx
+++ b/src/features/fight_replay/components/PlaybackControls.tsx
@@ -247,17 +247,25 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
         />
 
         {/* Row 2: a short control row — timecode + speed (left) · transport (center) ·
-            share + collapse (right). Small controls so the whole bar stays thin. */}
+            share + collapse (right). Small controls so the whole bar stays thin. On very narrow
+            phones the left group (timecode + speed) was wide enough to push the centered transport
+            cluster into the speed pill, so tighten the inner gaps and shrink the "/ total" readout
+            there to give the centered orb room. */}
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
             gap: TRANSPORT_SPACING.sectionGapCompact,
             minHeight: 44,
+            '@media (max-width: 430px)': {
+              '& .transport-side': { gap: 0.5 },
+              '& .transport-total-time': { display: 'none' },
+            },
           }}
         >
           {/* Left: timecode + speed */}
           <Box
+            className="transport-side"
             sx={{ flex: '1 1 0', display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0 }}
           >
             <Box
@@ -277,6 +285,7 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
               </Box>
               <Box
                 component="span"
+                className="transport-total-time"
                 sx={{ fontSize: '0.72rem', color: 'text.secondary', fontWeight: 500 }}
               >
                 / {formatTime(duration)}
@@ -304,6 +313,7 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
 
           {/* Right: share + collapse chevron */}
           <Box
+            className="transport-side"
             sx={{
               flex: '1 1 0',
               display: 'flex',

--- a/src/features/fight_replay/components/PlayerListPanel.tsx
+++ b/src/features/fight_replay/components/PlayerListPanel.tsx
@@ -211,8 +211,10 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
     <Box
       sx={{
         position: 'absolute',
-        top: isMobile ? 'calc(env(safe-area-inset-top) + 8px)' : 16,
-        left: isMobile ? 'calc(env(safe-area-inset-left) + 8px)' : 16,
+        // Plain px (NOT env()) on mobile — the overlay container already pads for the safe area, so
+        // adding env() here too would double-count and push the panel too far inboard.
+        top: isMobile ? 8 : 16,
+        left: isMobile ? 8 : 16,
         width: 232,
         maxWidth: 'calc(100% - 32px)',
         // Cap to the arena viewport MINUS the top margin and the reserved transport band (plus the

--- a/src/features/fight_replay/components/PlayerListPanel.tsx
+++ b/src/features/fight_replay/components/PlayerListPanel.tsx
@@ -90,6 +90,12 @@ interface PlayerListPanelProps {
    * hidden (fullscreen cinema mode) so the panel reclaims that space.
    */
   reservedInset?: number;
+  /**
+   * True inside the mobile pseudo-fullscreen overlay. The panel then honors the top/left safe-area
+   * insets and reserves extra bottom space for the touch control cluster (which docks above the
+   * transport), so a long roster's scroll region stops above the cluster instead of behind it.
+   */
+  isMobile?: boolean;
 }
 
 interface PlayerRowInfo {
@@ -120,7 +126,12 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
   playerColorOverrides,
   onPlayerColorChange,
   reservedInset = TRANSPORT_RESERVED,
+  isMobile = false,
 }) => {
+  // On mobile the touch control cluster docks above the transport, so the panel must stop higher.
+  // Fold that extra band into the reserve used by the height caps below (desktop unchanged).
+  const MOBILE_CLUSTER_BAND = 72;
+  const effectiveReserved = isMobile ? reservedInset + MOBILE_CLUSTER_BAND : reservedInset;
   const theme = useTheme();
   const [collapsed, setCollapsed] = useState(false);
 
@@ -200,13 +211,14 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
     <Box
       sx={{
         position: 'absolute',
-        top: 16,
-        left: 16,
+        top: isMobile ? 'calc(env(safe-area-inset-top) + 8px)' : 16,
+        left: isMobile ? 'calc(env(safe-area-inset-left) + 8px)' : 16,
         width: 232,
         maxWidth: 'calc(100% - 32px)',
-        // Cap to the arena viewport MINUS the top margin and the reserved transport band, so the
-        // scroll region — not the page — absorbs overflow AND the panel stops above the bar.
-        maxHeight: `calc(100% - ${16 + reservedInset}px)`,
+        // Cap to the arena viewport MINUS the top margin and the reserved transport band (plus the
+        // mobile control-cluster band), so the scroll region — not the page — absorbs overflow AND
+        // the panel stops above the bar (and, on mobile, above the cluster).
+        maxHeight: `calc(100% - ${16 + effectiveReserved}px)`,
         display: 'flex',
         flexDirection: 'column',
         borderRadius: 2,
@@ -270,7 +282,11 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
             // plunges into the bar. This inner cap (pinned to raw ARENA_HEIGHT) is the real
             // overrun — the outer % cap alone doesn't bound it. The core fix vs. the old
             // fixed-height canvas that silently clipped players past row 12.
-            maxHeight: `calc(${ARENA_HEIGHT} - 56px - ${reservedInset}px)`,
+            // On mobile the panel lives in a full-viewport overlay (not the ARENA_HEIGHT clamp), so
+            // cap the inner scroll region to viewport height there; desktop keeps the arena clamp.
+            maxHeight: isMobile
+              ? `calc(100vh - 96px - ${effectiveReserved}px)`
+              : `calc(${ARENA_HEIGHT} - 56px - ${reservedInset}px)`,
             // Slim, theme-tinted scrollbar.
             '&::-webkit-scrollbar': { width: 6 },
             '&::-webkit-scrollbar-thumb': {

--- a/src/features/fight_replay/components/ShareButton.tsx
+++ b/src/features/fight_replay/components/ShareButton.tsx
@@ -151,24 +151,27 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
           startIcon={<Share sx={{ fontSize: '1.05rem' }} />}
           disableElevation
           sx={(theme) => ({
-            // Match the bold proto's share pill exactly: soft cyan-tinted fill, cyan-glass
-            // border, cyan text, 11px radius, 34px tall to line up with the speed chips.
+            // Desktop: the bold proto's share pill — soft cyan-tinted fill, cyan-glass border, cyan
+            // text, 11px radius, 34px tall to line up with the speed chips.
+            // Mobile (xs): the label is hidden, so a bordered icon-pill read as a stray box next to
+            // the ghost transport buttons + collapse chevron. There, drop the border/fill/min-width so
+            // Share becomes a quiet ghost icon like the rest of the row.
             height: 34,
             borderRadius: '11px',
-            px: '13px',
             fontSize: '13px',
             fontWeight: 600,
             textTransform: 'none',
             color: 'primary.main',
-            border: '1px solid',
-            borderColor: `${theme.palette.primary.main}47`, // ~0.28 alpha
-            backgroundColor: `${theme.palette.primary.main}0f`, // ~0.06 alpha
+            borderColor: `${theme.palette.primary.main}47`, // ~0.28 alpha (only visible at sm+)
+            minWidth: { xs: 0, sm: 64 },
+            px: { xs: '8px', sm: '13px' },
+            border: { xs: 'none', sm: '1px solid' },
+            backgroundColor: { xs: 'transparent', sm: `${theme.palette.primary.main}0f` }, // ~0.06 alpha
             transition: `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, border-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`,
             '&:hover': {
-              backgroundColor: `${theme.palette.primary.main}1f`,
+              backgroundColor: { xs: 'action.hover', sm: `${theme.palette.primary.main}1f` },
               borderColor: `${theme.palette.primary.main}80`,
             },
-            // Hide the word on very narrow screens; the icon + tooltip + aria-label carry it.
             '& .MuiButton-startIcon': { mr: { xs: 0, sm: 0.75 } },
             '& .share-label': { display: { xs: 'none', sm: 'inline' } },
           })}

--- a/src/features/fight_replay/components/SpeedSelector.tsx
+++ b/src/features/fight_replay/components/SpeedSelector.tsx
@@ -178,7 +178,11 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
             },
           }}
         >
-          <SpeedIcon sx={{ fontSize: '1.05rem' }} />
+          {/* On the compact (mobile) bar the trigger is the whole speed control and always shows the
+              current speed as text, so the speedometer glyph is redundant clutter — drop it there and
+              let "1×" stand alone. Desktop (where the trigger sits beside the segmented chips as a
+              "more speeds" affordance) keeps the glyph. */}
+          {!compact && <SpeedIcon sx={{ fontSize: '1.05rem' }} />}
           {triggerLabel}
         </ToggleButton>
       </Tooltip>

--- a/src/features/fight_replay/hooks/useIsMobileReplay.test.ts
+++ b/src/features/fight_replay/hooks/useIsMobileReplay.test.ts
@@ -7,14 +7,13 @@ import { useIsMobileReplay } from './useIsMobileReplay';
 type Listener = (event: MediaQueryListEvent) => void;
 
 /**
- * Mock `window.matchMedia` so MUI's `useMediaQuery` resolves to a known value. MUI builds the
- * query string from `theme.breakpoints.down('sm')` and passes it to `matchMedia`; we ignore the
- * exact string and force every query to the supplied `matches` so the test exercises the hook's
- * contract (true below the breakpoint, false above) without depending on jsdom's media engine.
+ * Mock `window.matchMedia` so MUI's `useMediaQuery` resolves to known values. The hook fires TWO
+ * queries — the `down('sm')` width query and a `(pointer: coarse) and (max-height: 600px)`
+ * landscape-phone query — so the mock matches per-query via a predicate keyed on the query string.
  */
-function mockMatchMedia(matches: boolean): void {
+function mockMatchMedia(matches: (query: string) => boolean): void {
   const matchMedia = jest.fn().mockImplementation((query: string) => ({
-    matches,
+    matches: matches(query),
     media: query,
     onchange: null,
     addEventListener: (_type: string, _cb: Listener) => undefined,
@@ -29,6 +28,9 @@ function mockMatchMedia(matches: boolean): void {
     value: matchMedia,
   });
 }
+
+const isCoarse = (q: string): boolean => q.includes('pointer: coarse');
+const isWidth = (q: string): boolean => q.includes('width');
 
 const theme = createTheme();
 const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement =>
@@ -45,14 +47,24 @@ describe('useIsMobileReplay', () => {
     });
   });
 
-  it('returns true when the viewport is below the sm breakpoint (mobile)', () => {
-    mockMatchMedia(true);
+  it('returns true on a narrow (portrait phone) viewport', () => {
+    // width query matches, pointer/height query does not — portrait phone.
+    mockMatchMedia((q) => isWidth(q));
     const { result } = renderHook(() => useIsMobileReplay(), { wrapper });
     expect(result.current).toBe(true);
   });
 
-  it('returns false on a desktop-width viewport', () => {
-    mockMatchMedia(false);
+  it('returns true on a LANDSCAPE phone (wide but coarse pointer + short height)', () => {
+    // The regression guard: width query is FALSE (landscape is ≥667px wide) but the
+    // coarse-pointer + max-height query is TRUE, so the hook still classifies it as mobile —
+    // otherwise rotating mid-session would strand the user in the body-locked overlay.
+    mockMatchMedia((q) => isCoarse(q));
+    const { result } = renderHook(() => useIsMobileReplay(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false on a desktop viewport (wide, fine pointer)', () => {
+    mockMatchMedia(() => false);
     const { result } = renderHook(() => useIsMobileReplay(), { wrapper });
     expect(result.current).toBe(false);
   });

--- a/src/features/fight_replay/hooks/useIsMobileReplay.test.ts
+++ b/src/features/fight_replay/hooks/useIsMobileReplay.test.ts
@@ -1,0 +1,59 @@
+import { createTheme, ThemeProvider } from '@mui/material';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+
+import { useIsMobileReplay } from './useIsMobileReplay';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+/**
+ * Mock `window.matchMedia` so MUI's `useMediaQuery` resolves to a known value. MUI builds the
+ * query string from `theme.breakpoints.down('sm')` and passes it to `matchMedia`; we ignore the
+ * exact string and force every query to the supplied `matches` so the test exercises the hook's
+ * contract (true below the breakpoint, false above) without depending on jsdom's media engine.
+ */
+function mockMatchMedia(matches: boolean): void {
+  const matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: (_type: string, _cb: Listener) => undefined,
+    removeEventListener: (_type: string, _cb: Listener) => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+  }));
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+}
+
+const theme = createTheme();
+const wrapper = ({ children }: { children: React.ReactNode }): React.ReactElement =>
+  React.createElement(ThemeProvider, { theme }, children);
+
+describe('useIsMobileReplay', () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: original,
+    });
+  });
+
+  it('returns true when the viewport is below the sm breakpoint (mobile)', () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useIsMobileReplay(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false on a desktop-width viewport', () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useIsMobileReplay(), { wrapper });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/features/fight_replay/hooks/useIsMobileReplay.ts
+++ b/src/features/fight_replay/hooks/useIsMobileReplay.ts
@@ -1,0 +1,24 @@
+import { useMediaQuery, useTheme } from '@mui/material';
+
+/**
+ * Single source of truth for "is the fight replay in its mobile layout?".
+ *
+ * The 3D replay is desktop-keyboard-first; the mobile experience is a separate layout
+ * (inline scroll-safe preview → CSS pseudo-fullscreen interactive mode). EVERY mobile-only
+ * branch in the replay tree gates on this one hook, so desktop is guaranteed untouched: the
+ * hook returns `false` above the breakpoint and all mobile code paths become dead.
+ *
+ * Uses the same MUI `breakpoints.down('sm')` query the replay already relies on for its other
+ * responsive collapses (SpeedSelector, MapMarkersModal), so dev-tools narrowing and the real
+ * phone breakpoint stay identical. MUI's `useMediaQuery` handles SSR (returns the
+ * `noSsr`-default of false until mounted) and live viewport changes internally.
+ *
+ * Note: this keys off WIDTH, not `pointer: coarse` — a deliberate match to the existing
+ * precedent so a narrow desktop window previews the mobile layout. If a future need arises to
+ * distinguish a true touch phone from a narrow desktop, AND-in `'(pointer: coarse)'` here; the
+ * single seam means that change lands in exactly one place.
+ */
+export function useIsMobileReplay(): boolean {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down('sm'));
+}

--- a/src/features/fight_replay/hooks/useIsMobileReplay.ts
+++ b/src/features/fight_replay/hooks/useIsMobileReplay.ts
@@ -6,19 +6,24 @@ import { useMediaQuery, useTheme } from '@mui/material';
  * The 3D replay is desktop-keyboard-first; the mobile experience is a separate layout
  * (inline scroll-safe preview → CSS pseudo-fullscreen interactive mode). EVERY mobile-only
  * branch in the replay tree gates on this one hook, so desktop is guaranteed untouched: the
- * hook returns `false` above the breakpoint and all mobile code paths become dead.
+ * hook returns `false` on a wide pointer-fine viewport and all mobile code paths become dead.
  *
- * Uses the same MUI `breakpoints.down('sm')` query the replay already relies on for its other
- * responsive collapses (SpeedSelector, MapMarkersModal), so dev-tools narrowing and the real
- * phone breakpoint stay identical. MUI's `useMediaQuery` handles SSR (returns the
- * `noSsr`-default of false until mounted) and live viewport changes internally.
+ * Two ways to qualify as mobile, OR'd together:
+ *  1. A narrow viewport (`breakpoints.down('sm')`, ≈<600px wide) — the same query the replay's
+ *     other responsive collapses use (SpeedSelector, MapMarkersModal), so a narrow DESKTOP window
+ *     still previews the mobile layout for dev/testing.
+ *  2. A touch device whose SHORT side is phone-sized (`(pointer: coarse) and (max-height: 600px)`).
+ *     This is the LANDSCAPE-PHONE case: rotated, a phone is wide (≥667px) so #1 alone would flip to
+ *     `false` mid-session — which previously unmounted the overlay's controls and stranded the user
+ *     in a body-locked pseudo-fullscreen with no Close. A phone's short side stays ≤ ~430px in
+ *     either orientation, so gating on `max-height` (the short side in landscape) keeps a phone
+ *     classified as mobile through rotation. A large touch tablet (short side > 600px) stays desktop.
  *
- * Note: this keys off WIDTH, not `pointer: coarse` — a deliberate match to the existing
- * precedent so a narrow desktop window previews the mobile layout. If a future need arises to
- * distinguish a true touch phone from a narrow desktop, AND-in `'(pointer: coarse)'` here; the
- * single seam means that change lands in exactly one place.
+ * MUI's `useMediaQuery` handles SSR (false until mounted) and live viewport/orientation changes.
  */
 export function useIsMobileReplay(): boolean {
   const theme = useTheme();
-  return useMediaQuery(theme.breakpoints.down('sm'));
+  const narrow = useMediaQuery(theme.breakpoints.down('sm'));
+  const landscapePhone = useMediaQuery('(pointer: coarse) and (max-height: 600px)');
+  return narrow || landscapePhone;
 }

--- a/src/features/fight_replay/utils/previewMode.test.ts
+++ b/src/features/fight_replay/utils/previewMode.test.ts
@@ -1,0 +1,18 @@
+import { decidePreviewMode } from './previewMode';
+
+describe('decidePreviewMode', () => {
+  it('returns static when reduced motion is preferred, regardless of tier', () => {
+    expect(decidePreviewMode('high', true)).toBe('static');
+    expect(decidePreviewMode('medium', true)).toBe('static');
+    expect(decidePreviewMode('low', true)).toBe('static');
+  });
+
+  it('returns static on a low GPU tier even when motion is allowed', () => {
+    expect(decidePreviewMode('low', false)).toBe('static');
+  });
+
+  it('returns animated on a capable device with motion allowed', () => {
+    expect(decidePreviewMode('medium', false)).toBe('animated');
+    expect(decidePreviewMode('high', false)).toBe('animated');
+  });
+});

--- a/src/features/fight_replay/utils/previewMode.ts
+++ b/src/features/fight_replay/utils/previewMode.ts
@@ -1,0 +1,27 @@
+import type { PerfTier } from '../../../store/ui/uiSlice';
+
+/**
+ * The fidelity of the inline mobile preview (the non-interactive teaser shown on the report page
+ * before the user taps "Expand" into the pseudo-fullscreen interactive mode).
+ *
+ * - `'static'`  — a still frame (poster). No idle animation, no auto-orbit. Chosen for low-end GPUs
+ *                 and for users who asked for reduced motion: the preview must never burn battery or
+ *                 spin the fans on a device that will struggle, and must respect the OS motion pref.
+ * - `'animated'`— a gentle, cheap idle (e.g. a slow auto-rotate / playing at preview scale). Used on
+ *                 capable devices to make the preview read as "this is alive, tap to explore".
+ */
+export type ReplayPreviewMode = 'static' | 'animated';
+
+/**
+ * Decide the inline mobile preview's fidelity from the device's GPU tier and the user's reduced-motion
+ * preference. Pure (no DOM / no hooks) so it's unit-testable in isolation; the component layer feeds it
+ * the resolved tier from `usePerfTier()` and the flag from `usePrefersReducedMotion()`.
+ *
+ * Reduced-motion ALWAYS wins (accessibility) and the low tier falls back to static (perf); only a
+ * capable device with motion allowed gets the animated preview.
+ */
+export function decidePreviewMode(tier: PerfTier, prefersReducedMotion: boolean): ReplayPreviewMode {
+  if (prefersReducedMotion) return 'static';
+  if (tier === 'low') return 'static';
+  return 'animated';
+}

--- a/src/features/fight_replay/utils/previewMode.ts
+++ b/src/features/fight_replay/utils/previewMode.ts
@@ -20,7 +20,10 @@ export type ReplayPreviewMode = 'static' | 'animated';
  * Reduced-motion ALWAYS wins (accessibility) and the low tier falls back to static (perf); only a
  * capable device with motion allowed gets the animated preview.
  */
-export function decidePreviewMode(tier: PerfTier, prefersReducedMotion: boolean): ReplayPreviewMode {
+export function decidePreviewMode(
+  tier: PerfTier,
+  prefersReducedMotion: boolean,
+): ReplayPreviewMode {
   if (prefersReducedMotion) return 'static';
   if (tier === 'low') return 'static';
   return 'animated';

--- a/src/features/fight_replay/utils/touchPolicy.test.ts
+++ b/src/features/fight_replay/utils/touchPolicy.test.ts
@@ -1,0 +1,31 @@
+import { resolveTouchPolicy } from './touchPolicy';
+
+describe('resolveTouchPolicy', () => {
+  it('keeps pan enabled on desktop (windowed and fullscreen)', () => {
+    expect(resolveTouchPolicy(false, false).enablePan).toBe(true);
+    expect(resolveTouchPolicy(false, true).enablePan).toBe(true);
+  });
+
+  it('keeps pan enabled on mobile while still in the inline preview (not immersive)', () => {
+    // The preview canvas is non-interactive anyway (pointer-events:none), but the policy should
+    // only drop pan once the overlay is open, not before.
+    expect(resolveTouchPolicy(true, false).enablePan).toBe(true);
+  });
+
+  it('disables pan on mobile-immersive so two fingers are pinch-only', () => {
+    expect(resolveTouchPolicy(true, true).enablePan).toBe(false);
+  });
+
+  it('always enables rotate and always leaves pinch to CanvasWheelZoom', () => {
+    for (const [m, i] of [
+      [false, false],
+      [false, true],
+      [true, false],
+      [true, true],
+    ] as const) {
+      const policy = resolveTouchPolicy(m, i);
+      expect(policy.enableRotate).toBe(true);
+      expect(policy.pinchOwner).toBe('CanvasWheelZoom');
+    }
+  });
+});

--- a/src/features/fight_replay/utils/touchPolicy.ts
+++ b/src/features/fight_replay/utils/touchPolicy.ts
@@ -1,0 +1,41 @@
+/**
+ * Resolved touch-gesture policy for the replay's OrbitControls, by device + mode.
+ *
+ * Background: three-stdlib's OrbitControls hardcodes `touch-action: none` on the canvas and has no
+ * opt-out (drei #1233, closed not-planned). On the report page that traps page scroll, which the
+ * mobile layout sidesteps by making the inline preview non-interactive (the canvas gets
+ * pointer-events:none) and only going interactive inside the pseudo-fullscreen overlay, where there
+ * is no page to scroll so trapping is fine.
+ *
+ * Inside that overlay we want a clean, unambiguous gesture set:
+ *   - ONE finger  → rotate (OrbitControls' default single-touch action).
+ *   - TWO fingers → pinch-zoom, owned by CanvasWheelZoom (which re-implements pinch because
+ *                   OrbitControls' enableZoom is off).
+ * The problem on mobile is that OrbitControls' TWO-finger action (DOLLY_PAN → pan, since zoom is
+ * off) fires on the same touchmove as CanvasWheelZoom's pinch — a collision. We resolve it by
+ * disabling OrbitControls pan on mobile-immersive, leaving two fingers to CanvasWheelZoom alone.
+ * Desktop keeps pan (mouse right-drag / two-finger trackpad) untouched.
+ */
+export interface TouchPolicy {
+  /** OrbitControls `enablePan`. Off only on mobile-immersive (frees two fingers for pinch). */
+  enablePan: boolean;
+  /** OrbitControls `enableRotate`. Always on — one-finger / left-drag rotate is the core gesture. */
+  enableRotate: boolean;
+  /** Who owns pinch-zoom. Always CanvasWheelZoom (OrbitControls enableZoom stays off everywhere). */
+  pinchOwner: 'CanvasWheelZoom';
+}
+
+/**
+ * @param isMobile     narrow-viewport replay layout (from useIsMobileReplay)
+ * @param isImmersive  filling the screen — native fullscreen on desktop, pseudo-fullscreen on mobile
+ */
+export function resolveTouchPolicy(isMobile: boolean, isImmersive: boolean): TouchPolicy {
+  const mobileImmersive = isMobile && isImmersive;
+  return {
+    // Disable pan only when a mobile device is in the immersive overlay, so its two-finger gesture
+    // is exclusively pinch-zoom (CanvasWheelZoom). Everywhere else pan stays enabled as before.
+    enablePan: !mobileImmersive,
+    enableRotate: true,
+    pinchOwner: 'CanvasWheelZoom',
+  };
+}


### PR DESCRIPTION
## Mobile refactor of the 3D fight replay

The 3D fight replay was desktop-keyboard-first and hard to use on a phone: a one-finger drag over the
canvas rotated the camera **and trapped page scroll** (you couldn't scroll the report past the replay),
the overlay chrome was laid out in hardcoded desktop pixels that collide on a 390px viewport, none of the
keyboard shortcuts (WASD/R/G/P/T/N/J/F/C) had a touch path, and the fullscreen button silently no-ops on
iPhone (iOS Safari can't `requestFullscreen()` a non-video element).

This rethinks the mobile experience around an **inline preview → CSS pseudo-fullscreen** model (the
direction the maintainer picked from three researched options). **Every change is gated behind a single
`useIsMobileReplay()` seam, so desktop is byte-identical** (verified at runtime — see below).

### What changed

- **`useIsMobileReplay` seam** — `down('sm')` OR `(pointer: coarse) and (max-height: 600px)`. The second
  clause keeps a phone classified as mobile in **landscape** too (its short side stays phone-sized);
  without it, rotating mid-session stranded the user in a locked overlay.
- **Inline preview (scroll-safe)** — on mobile the inline canvas gets `pointer-events: none`, so a
  one-finger drag falls through and the report page scrolls normally (defeating OrbitControls' hardcoded
  `touch-action: none` without touching it). A dimmed scrim + a single **"Tap to explore"** button is the
  only way in. Desktop chrome/panels/transport are suppressed in the preview.
- **Pseudo-fullscreen overlay** — tapping Expand restyles the *existing* replay container to
  `position: fixed; inset: 0` (NOT the Fullscreen API — iOS can't fullscreen a div), with body-scroll lock
  and `env(safe-area-inset-*)` padding. It reuses the same container/`<Canvas>` instance, so the WebGL
  context and all playback state survive the transition (no remount).
- **Touch gesture model** — inside the overlay, `resolveTouchPolicy` disables OrbitControls pan so two
  fingers are exclusively `CanvasWheelZoom` pinch, leaving **one-finger rotate** clean (and resolving the
  prior pan/pinch `touchmove` collision). Desktop keeps pan.
- **`MobileReplayControls`** — a touch cluster shown only in the overlay: a prominent **Close** (the only
  exit — iOS has no Esc) + a strip of toggles (players / trails / names / reset / frame-all / perf, plus
  stats when following a player). Camera reset (R) and frame-all (G) have no callable handle, so the
  buttons dispatch a synthetic `keydown` that `CameraResetControls`' existing window handler consumes —
  reuse, no refactor.
- **Responsive overlay panels** — `BossHealthPanel`, `LockedPlayerStatsPanel`, and `PlayerListPanel` get
  mobile-gated positioning (safe-area insets, drop below Close, lift above the cluster, viewport-relative
  width/height caps). The player list also starts **closed** on mobile (it otherwise dominated the narrow
  view), and the path/trail/bar prefs aren't persisted from mobile so they can't clobber desktop prefs.

### Tests

New unit tests for the pure seams: `useIsMobileReplay` (incl. the landscape-phone regression case),
`decidePreviewMode`, `resolveTouchPolicy`. Full project suite green (3091 passed / 0 failed); `fight_replay`
suite 215 passed.

### Verified (Chrome MCP, emulated iPhone — touch viewport)

- **Portrait round-trip**: preview is scroll-safe and shows Expand → tap → fixed overlay (390×844, z-index
  modal) with the canvas filling + repainting (~300ms, both directions), body locked → Close → back to the
  inline preview at the clamped size, body restored.
- **Landscape**: rotating into the overlay keeps the Close button + full control cluster mounted (no
  stranding); the inline preview stays scroll-safe.
- **Desktop unregressed (1440×900)**: no mobile chrome leaks; the right-edge button stack, native
  fullscreen, and OrbitControls pan all behave exactly as before (`enablePan: true`, canvas
  `pointer-events: auto`).

### Notes / follow-ups (not in this PR)

- **iOS-Safari real-device pass** is still owed for the actual rotate / pinch / scroll-through gestures —
  Blink emulation confirms the *mechanism* (the scroll-through and the Expand button are the same
  `mobilePreview` boolean in one render) but not Safari's touch quirks.
- **Event-dependent panel content** (boss/stats) is CORS-blocked on localhost; this fight happened to have
  cached data so the panels populated in emulation, but a cold fight's panel *content* should be confirmed
  on prod (esotk.com). Layout/gesture/overlay behavior is fully verifiable locally.
- `decidePreviewMode`'s static/animated result currently only swaps the scrim label — the inline preview
  still mounts the full (paused) WebGL scene rather than a lighter poster. Defensible to ship; a cheaper
  poster is a possible follow-up.
- Repo-wide `format:check` is pre-existing-dirty on ~244 untouched files; every file in this diff is
  Prettier-clean.
