### PR TITLE
feat(fight-replay): declutter 3D player name tags when actors stack

### DIFF
--- a/src/features/fight_replay/components/BatchedActorNames3D.tsx
+++ b/src/features/fight_replay/components/BatchedActorNames3D.tsx
@@ -170,6 +170,11 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
   const lastCamQuat = useRef(new THREE.Quaternion(NaN, NaN, NaN, NaN));
   const lastTime = useRef(NaN);
   const lastSize = useRef({ w: 0, h: 0 });
+  // Selection also gates the pass: lock-on usually starts the follow-camera lerp (camera moves →
+  // the gate fires anyway), but a selection change while the camera and playhead are static would
+  // otherwise be skipped, leaving the newly-followed name faded. The whole promise of the feature
+  // is "the followed name is always legible", so the gate must react to selection directly.
+  const lastSelected = useRef<number | null | undefined>(undefined);
 
   // Scratch objects reused every frame (no per-frame allocation in the hot loop).
   const scratchWorld = useRef(new THREE.Vector3());
@@ -181,20 +186,21 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
     if (!lookup || handles.size === 0) return;
 
     const currentTime = timeRef ? timeRef.current : 0;
+    const selectedActorId = selectedActorRef ? selectedActorRef.current : null;
 
     // --- Idle gate ---------------------------------------------------------------------------
     const camMoved =
       !lastCamPos.current.equals(camera.position) || !lastCamQuat.current.equals(camera.quaternion);
     const timeMoved = lastTime.current !== currentTime;
     const sizeChanged = lastSize.current.w !== size.width || lastSize.current.h !== size.height;
-    if (!camMoved && !timeMoved && !sizeChanged) return;
+    const selectionChanged = lastSelected.current !== selectedActorId;
+    if (!camMoved && !timeMoved && !sizeChanged && !selectionChanged) return;
     lastCamPos.current.copy(camera.position);
     lastCamQuat.current.copy(camera.quaternion);
     lastTime.current = currentTime;
     lastSize.current.w = size.width;
     lastSize.current.h = size.height;
-
-    const selectedActorId = selectedActorRef ? selectedActorRef.current : null;
+    lastSelected.current = selectedActorId;
 
     // --- Pass 1: position / orient / scale / text every name; collect on-screen rectangles ----
     const items = screenItems.current;

--- a/src/features/fight_replay/components/BatchedActorNames3D.tsx
+++ b/src/features/fight_replay/components/BatchedActorNames3D.tsx
@@ -1,14 +1,21 @@
 import { Text } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
-import { useMemo, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 
 import {
+  ActorPosition,
   TimestampPositionLookup,
   getActorPositionAtClosestTimestamp,
 } from '../../../workers/calculations/CalculateActorPositions';
 import { RenderPriority } from '../constants/renderPriorities';
 import { getReplayActorLabelColor } from '../utils/actorVisualState';
+import {
+  NamePriority,
+  NamePriorityValue,
+  NameScreenItem,
+  resolveNameVisibility,
+} from '../utils/resolveNameVisibility';
 
 /**
  * SDF-based actor name layer (Phase 2), replacing the per-actor CanvasTexture billboards in
@@ -16,12 +23,21 @@ import { getReplayActorLabelColor } from '../utils/actorVisualState';
  * CanvasTexture + material per actor. The win isn't fewer draw calls (troika renders one mesh per
  * Text, so it stays ~N) — it's removing the per-actor canvas/texture/material churn: all names now
  * share ONE SDF glyph atlas, with no per-actor canvas raster and no per-actor CanvasTexture upload.
- * Live-measured this drops names-ON render-time well below the CanvasTexture baseline.
  *
  * Behavior preserved from ActorNameBillboard: per-name text, per-actor color (getReplayActorLabelColor),
  * dead dimming, distance-based screen-size scaling, always-camera-facing, the stable per-actor
  * renderOrder (1000 + actorId) + depthTest:false flicker fix, and the N-key visibility toggle
  * (driven by the parent passing/omitting this layer).
+ *
+ * SCREEN-SPACE DECLUTTER: when actors stack tightly (the melee ball on a boss) the tags pile up
+ * into an unreadable blob. Distance-fade can't fix a close stack — every name sits at nearly the
+ * same camera distance. So ONE coordinator useFrame (here, NOT per-name) projects every name to the
+ * viewport, runs a greedy overlap pass (`resolveNameVisibility`) that keeps the followed player and
+ * bosses as priority anchors and fades lower-priority overlappers, then writes the resulting opacity
+ * to each <Text>. Doing it in a single coordinator (instead of a useFrame per name) keeps the cost
+ * O(N) projection + one O(N²) overlap pass per frame — NOT O(N²) closures — and the coordinator
+ * early-returns when neither the camera nor the playhead moved, so idle frames stay render-free
+ * (the on-demand render gate only throttles gl.render, not useFrame).
  */
 interface BatchedActorNames3DProps {
   lookup: TimestampPositionLookup | null;
@@ -29,6 +45,8 @@ interface BatchedActorNames3DProps {
   scale?: number;
   actorIds: number[];
   playerVisibility?: Map<number, boolean>;
+  /** The followed/locked-on actor — always kept legible and used as a declutter priority anchor. */
+  selectedActorRef?: React.RefObject<number | null>;
 }
 
 const GROUND_LEVEL = 0.05;
@@ -36,71 +54,54 @@ const BILLBOARD_HEIGHT_OFFSET = 0.35;
 const BASE_DISTANCE = 24;
 const FONT_SIZE = 0.42;
 const EMPTY_VISIBILITY: Map<number, boolean> = new Map();
+const DEAD_FILL_OPACITY = 0.62;
+// Faded overlappers keep a faint ghost rather than vanishing — enough to hint presence without
+// rejoining the blob. Outline fades proportionally so the dark halo doesn't outlive the fill.
+const FADED_OPACITY = 0.1;
+// Rough on-screen label box, in world units before distance-scale, used only to size the
+// collision rectangle for the overlap pass. troika's true bounds aren't known until an async sync,
+// so we approximate width from glyph count; the declutter only needs the boxes to be in the right
+// ballpark, not pixel-exact.
+const CHAR_WIDTH_FACTOR = 0.55; // average glyph advance as a fraction of font size
+const LABEL_WORLD_HEIGHT = FONT_SIZE * 1.2;
+
+type NameTextMesh = THREE.Mesh & {
+  text?: string;
+  color?: unknown;
+  fillOpacity?: number;
+  outlineOpacity?: number;
+};
+
+interface NameHandle {
+  group: THREE.Group | null;
+  text: NameTextMesh | null;
+}
 
 interface SingleNameProps {
   actorId: number;
-  lookup: TimestampPositionLookup | null;
-  timeRef?: React.RefObject<number> | { current: number };
-  scale: number;
 }
 
-const SingleName: React.FC<SingleNameProps> = ({ actorId, lookup, timeRef, scale }) => {
-  const { camera } = useThree();
+/**
+ * A single name tag. Deliberately dumb: it owns NO useFrame. All per-frame work (position,
+ * camera-facing, scale, text, color, opacity, declutter) is driven by the parent coordinator via
+ * the imperative handle below, so there is exactly one useFrame for the whole layer.
+ */
+const SingleName = forwardRef<NameHandle, SingleNameProps>(({ actorId }, ref) => {
   const groupRef = useRef<THREE.Group>(null);
-  const textRef = useRef<THREE.Mesh & { text?: string; color?: unknown; fillOpacity?: number }>(
-    null,
+  const textRef = useRef<NameTextMesh>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      get group() {
+        return groupRef.current;
+      },
+      get text() {
+        return textRef.current;
+      },
+    }),
+    [],
   );
-  const visibleRef = useRef(true);
-  const worldPos = useRef(new THREE.Vector3());
-  const lastData = useRef<{ name: string; color: string; alive: boolean } | null>(null);
-
-  // Damp actor scale so oversized arenas don't create huge labels (matches ActorNameBillboard).
-  const adjustedActorScale = 0.4 + scale * 0.6;
-
-  useFrame(() => {
-    const group = groupRef.current;
-    const text = textRef.current;
-    if (!lookup || !group || !text) return;
-
-    const currentTime = timeRef ? timeRef.current : 0;
-    const actor = getActorPositionAtClosestTimestamp(lookup, actorId, currentTime);
-
-    if (!actor) {
-      if (visibleRef.current) {
-        group.visible = false;
-        visibleRef.current = false;
-      }
-      return;
-    }
-    if (!visibleRef.current) {
-      group.visible = true;
-      visibleRef.current = true;
-    }
-
-    // World-anchored position above the actor.
-    const [x, y, z] = actor.position;
-    group.position.set(x, y + GROUND_LEVEL + BILLBOARD_HEIGHT_OFFSET * scale, z);
-    // Always face the camera (copy camera orientation — the group is a scene child, no parent
-    // rotation to counteract, mirroring ActorNameBillboard's anchorMode="world").
-    group.quaternion.copy(camera.quaternion);
-
-    // Distance-based screen-size scaling, identical curve to ActorNameBillboard.
-    group.getWorldPosition(worldPos.current);
-    const distanceToCamera = camera.position.distanceTo(worldPos.current);
-    const distanceScale = Math.max(0.4, Math.min(1.4, distanceToCamera / BASE_DISTANCE));
-    group.scale.setScalar(distanceScale * adjustedActorScale);
-
-    // Update text content/color/opacity only when the underlying data changes.
-    const color = getReplayActorLabelColor(actor);
-    const alive = !actor.isDead;
-    const prev = lastData.current;
-    if (!prev || prev.name !== actor.name || prev.color !== color || prev.alive !== alive) {
-      text.text = actor.name;
-      (text as unknown as { color: string }).color = color;
-      text.fillOpacity = alive ? 1 : 0.62;
-      lastData.current = { name: actor.name, color, alive };
-    }
-  }, RenderPriority.HUD);
 
   return (
     <group ref={groupRef}>
@@ -128,7 +129,14 @@ const SingleName: React.FC<SingleNameProps> = ({ actorId, lookup, timeRef, scale
       </Text>
     </group>
   );
-};
+});
+SingleName.displayName = 'SingleName';
+
+function priorityForActor(actor: ActorPosition, selectedActorId: number | null): NamePriorityValue {
+  if (selectedActorId != null && actor.id === selectedActorId) return NamePriority.FOLLOWED;
+  if (actor.type === 'boss') return NamePriority.BOSS;
+  return NamePriority.NORMAL;
+}
 
 export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
   lookup,
@@ -136,11 +144,150 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
   scale = 1,
   actorIds,
   playerVisibility = EMPTY_VISIBILITY,
+  selectedActorRef,
 }) => {
+  const { camera, size } = useThree();
+
   const visibleActorIds = useMemo(
     () => actorIds.filter((id) => playerVisibility.get(id) ?? true),
     [actorIds, playerVisibility],
   );
+
+  // Damp actor scale so oversized arenas don't create huge labels (matches ActorNameBillboard).
+  const adjustedActorScale = 0.4 + scale * 0.6;
+
+  // One handle per name; the coordinator writes through these refs.
+  const handlesRef = useRef<Map<number, NameHandle>>(new Map());
+
+  // Per-name presentation cache so we only touch troika's text/color/opacity when they change.
+  const lastData = useRef<Map<number, { name: string; color: string; alive: boolean }>>(new Map());
+  const lastVisible = useRef<Map<number, boolean>>(new Map());
+
+  // Idle gate: skip the entire pass (no ref writes, no projection, no render trigger) when neither
+  // the camera nor the playhead moved since last frame. The on-demand render gate throttles
+  // gl.render but NOT useFrame, so this guard is what keeps an idle, paused scene render-free.
+  const lastCamPos = useRef(new THREE.Vector3(NaN, NaN, NaN));
+  const lastCamQuat = useRef(new THREE.Quaternion(NaN, NaN, NaN, NaN));
+  const lastTime = useRef(NaN);
+  const lastSize = useRef({ w: 0, h: 0 });
+
+  // Scratch objects reused every frame (no per-frame allocation in the hot loop).
+  const scratchWorld = useRef(new THREE.Vector3());
+  const scratchProjected = useRef(new THREE.Vector3());
+  const screenItems = useRef<NameScreenItem[]>([]);
+
+  useFrame(() => {
+    const handles = handlesRef.current;
+    if (!lookup || handles.size === 0) return;
+
+    const currentTime = timeRef ? timeRef.current : 0;
+
+    // --- Idle gate ---------------------------------------------------------------------------
+    const camMoved =
+      !lastCamPos.current.equals(camera.position) || !lastCamQuat.current.equals(camera.quaternion);
+    const timeMoved = lastTime.current !== currentTime;
+    const sizeChanged = lastSize.current.w !== size.width || lastSize.current.h !== size.height;
+    if (!camMoved && !timeMoved && !sizeChanged) return;
+    lastCamPos.current.copy(camera.position);
+    lastCamQuat.current.copy(camera.quaternion);
+    lastTime.current = currentTime;
+    lastSize.current.w = size.width;
+    lastSize.current.h = size.height;
+
+    const selectedActorId = selectedActorRef ? selectedActorRef.current : null;
+
+    // --- Pass 1: position / orient / scale / text every name; collect on-screen rectangles ----
+    const items = screenItems.current;
+    items.length = 0;
+
+    handles.forEach((handle, actorId) => {
+      const group = handle.group;
+      const text = handle.text;
+      if (!group || !text) return;
+
+      const actor = getActorPositionAtClosestTimestamp(lookup, actorId, currentTime);
+
+      const wasVisible = lastVisible.current.get(actorId);
+      if (!actor) {
+        if (wasVisible !== false) {
+          group.visible = false;
+          lastVisible.current.set(actorId, false);
+        }
+        return;
+      }
+      if (wasVisible === false || wasVisible === undefined) {
+        group.visible = true;
+        lastVisible.current.set(actorId, true);
+      }
+
+      // World-anchored position above the actor.
+      const [x, y, z] = actor.position;
+      group.position.set(x, y + GROUND_LEVEL + BILLBOARD_HEIGHT_OFFSET * scale, z);
+      // Always face the camera (copy camera orientation — the group is a scene child, no parent
+      // rotation to counteract, mirroring ActorNameBillboard's anchorMode="world").
+      group.quaternion.copy(camera.quaternion);
+
+      // Distance-based screen-size scaling, identical curve to ActorNameBillboard.
+      group.getWorldPosition(scratchWorld.current);
+      const distanceToCamera = camera.position.distanceTo(scratchWorld.current);
+      const distanceScale = Math.max(0.4, Math.min(1.4, distanceToCamera / BASE_DISTANCE));
+      const finalScale = distanceScale * adjustedActorScale;
+      group.scale.setScalar(finalScale);
+
+      // Update text content/color only when the underlying data changes (opacity is set below,
+      // every frame the pass runs, because the declutter result can change without the data).
+      const color = getReplayActorLabelColor(actor);
+      const alive = !actor.isDead;
+      const prev = lastData.current.get(actorId);
+      if (!prev || prev.name !== actor.name || prev.color !== color || prev.alive !== alive) {
+        text.text = actor.name;
+        (text as unknown as { color: string }).color = color;
+        lastData.current.set(actorId, { name: actor.name, color, alive });
+      }
+
+      // Project the anchor to screen pixels and size an approximate collision box.
+      scratchProjected.current.copy(scratchWorld.current).project(camera);
+      // Behind the camera → treat as off-screen (don't let it occupy declutter space).
+      if (scratchProjected.current.z > 1) return;
+      const screenX = (scratchProjected.current.x * 0.5 + 0.5) * size.width;
+      const screenY = (-scratchProjected.current.y * 0.5 + 0.5) * size.height;
+
+      // World→pixel scale: a 1-unit segment at this depth spans this many vertical pixels.
+      // Derived from the perspective frustum half-height at this distance (h = 2·d·tan(fov/2)).
+      const fovRad = ((camera as THREE.PerspectiveCamera).fov ?? 50) * (Math.PI / 180);
+      const frustumHeight = 2 * Math.max(distanceToCamera, 0.001) * Math.tan(fovRad / 2);
+      const worldToPixel = size.height / frustumHeight;
+      const charCount = Math.max(actor.name.length, 1);
+      const labelWorldW = charCount * FONT_SIZE * CHAR_WIDTH_FACTOR * finalScale;
+      const labelWorldH = LABEL_WORLD_HEIGHT * finalScale;
+      const halfW = (labelWorldW * worldToPixel) / 2;
+      const halfH = (labelWorldH * worldToPixel) / 2;
+
+      items.push({
+        id: actorId,
+        screenX,
+        screenY,
+        halfW,
+        halfH,
+        priority: priorityForActor(actor, selectedActorId),
+      });
+    });
+
+    // --- Pass 2: resolve overlap once, then write opacity through the refs --------------------
+    const visibility = resolveNameVisibility(items, { fadedOpacity: FADED_OPACITY });
+
+    handles.forEach((handle, actorId) => {
+      const text = handle.text;
+      if (!text) return;
+      const data = lastData.current.get(actorId);
+      const declutter = visibility.get(actorId);
+      if (declutter === undefined) return; // off-screen / no actor this frame
+      const deadDim = data && !data.alive ? DEAD_FILL_OPACITY : 1;
+      const fill = deadDim * declutter;
+      text.fillOpacity = fill;
+      text.outlineOpacity = 0.95 * declutter;
+    });
+  }, RenderPriority.HUD);
 
   return (
     <>
@@ -148,9 +295,10 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
         <SingleName
           key={actorId}
           actorId={actorId}
-          lookup={lookup}
-          timeRef={timeRef}
-          scale={scale}
+          ref={(handle) => {
+            if (handle) handlesRef.current.set(actorId, handle);
+            else handlesRef.current.delete(actorId);
+          }}
         />
       ))}
     </>

--- a/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
+++ b/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
@@ -1323,6 +1323,7 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
           scale={scale}
           actorIds={actorIds}
           playerVisibility={playerVisibility}
+          selectedActorRef={selectedActorRef}
         />
       )}
     </>

--- a/src/features/fight_replay/utils/resolveNameVisibility.test.ts
+++ b/src/features/fight_replay/utils/resolveNameVisibility.test.ts
@@ -1,0 +1,120 @@
+import { NamePriority, NameScreenItem, resolveNameVisibility } from './resolveNameVisibility';
+
+/**
+ * resolveNameVisibility is the pure overlap-resolution core behind the 3D name-tag declutter.
+ * These tests pin the contract the coordinator relies on: priority names stay full-opacity, equal
+ * names disambiguate by a STABLE id tiebreak (never camera distance — that would flicker on orbit),
+ * and lower-priority names that collide with a kept name fade.
+ */
+
+// A label box centered at (x, y) with default half-extents — tweak per case.
+function item(
+  id: number,
+  x: number,
+  y: number,
+  priority: NameScreenItem['priority'] = NamePriority.NORMAL,
+  halfW = 40,
+  halfH = 10,
+): NameScreenItem {
+  return { id, screenX: x, screenY: y, halfW, halfH, priority };
+}
+
+describe('resolveNameVisibility', () => {
+  it('returns an empty map for no items', () => {
+    expect(resolveNameVisibility([]).size).toBe(0);
+  });
+
+  it('keeps every name at full opacity when none overlap', () => {
+    const result = resolveNameVisibility([item(1, 0, 0), item(2, 500, 0), item(3, 0, 500)]);
+    expect(result.get(1)).toBe(1);
+    expect(result.get(2)).toBe(1);
+    expect(result.get(3)).toBe(1);
+  });
+
+  it('fades the lower-priority loser of a normal/normal collision and keeps the stable winner', () => {
+    // Two boxes at the same point — they collide. Lower id wins the stable tiebreak.
+    const result = resolveNameVisibility([item(7, 100, 100), item(3, 100, 100)]);
+    expect(result.get(3)).toBe(1); // lower id kept
+    expect(result.get(7)).toBeLessThan(1); // higher id faded
+  });
+
+  it('uses id order, NOT input order, for the tiebreak (input reversed gives same result)', () => {
+    const a = resolveNameVisibility([item(3, 0, 0), item(7, 0, 0)]);
+    const b = resolveNameVisibility([item(7, 0, 0), item(3, 0, 0)]);
+    expect(a.get(3)).toBe(1);
+    expect(a.get(7)).toBeLessThan(1);
+    expect(b.get(3)).toBe(a.get(3));
+    expect(b.get(7)).toBe(a.get(7));
+  });
+
+  it('keeps the followed player at full opacity even when buried in a stack', () => {
+    const stack = [
+      item(1, 0, 0),
+      item(2, 0, 0),
+      item(3, 0, 0),
+      item(9, 0, 0, NamePriority.FOLLOWED),
+    ];
+    const result = resolveNameVisibility(stack);
+    expect(result.get(9)).toBe(1); // followed always legible
+    // The followed name occupies space; normal names in the same spot fade.
+    expect(result.get(2)).toBeLessThan(1);
+    expect(result.get(3)).toBeLessThan(1);
+  });
+
+  it('keeps a boss at full opacity even when overlapped by players', () => {
+    const result = resolveNameVisibility([
+      item(1, 50, 50),
+      item(2, 50, 50),
+      item(5, 50, 50, NamePriority.BOSS),
+    ]);
+    expect(result.get(5)).toBe(1);
+  });
+
+  it('keeps BOTH a boss and the followed player legible when they overlap each other', () => {
+    const result = resolveNameVisibility([
+      item(5, 0, 0, NamePriority.BOSS),
+      item(9, 0, 0, NamePriority.FOLLOWED),
+    ]);
+    expect(result.get(5)).toBe(1);
+    expect(result.get(9)).toBe(1);
+  });
+
+  it('lets a normal name survive if it only overlaps a faded (not kept) name', () => {
+    // Chain: A and B overlap; B and C overlap; A and C do NOT.
+    // A (id 1) kept. B (id 2) overlaps A → faded, NOT placed. C (id 3) overlaps only B → C kept.
+    const A = item(1, 0, 0);
+    const B = item(2, 60, 0); // overlaps A (40+40=80 > 60)
+    const C = item(3, 120, 0); // overlaps B but not A (dist 120 > 80)
+    const result = resolveNameVisibility([A, B, C]);
+    expect(result.get(1)).toBe(1);
+    expect(result.get(2)).toBeLessThan(1); // faded by A
+    expect(result.get(3)).toBe(1); // C only overlapped the faded B, so it survives
+  });
+
+  it('respects a custom fadedOpacity', () => {
+    const result = resolveNameVisibility([item(1, 0, 0), item(2, 0, 0)], {
+      fadedOpacity: 0.3,
+    });
+    expect(result.get(2)).toBe(0.3);
+  });
+
+  it('fades a normal name buried under multiple priority anchors', () => {
+    const result = resolveNameVisibility([
+      item(5, 0, 0, NamePriority.BOSS),
+      item(9, 5, 0, NamePriority.FOLLOWED),
+      item(1, 2, 0, NamePriority.NORMAL),
+    ]);
+    expect(result.get(5)).toBe(1);
+    expect(result.get(9)).toBe(1);
+    expect(result.get(1)).toBeLessThan(1);
+  });
+
+  it('overlapSlack requires more overlap before colliding', () => {
+    // Boxes 70px apart, half-widths 40 each → sum 80 > 70 so they collide with slack 0.
+    const a = item(1, 0, 0);
+    const b = item(2, 70, 0);
+    expect(resolveNameVisibility([a, b]).get(2)).toBeLessThan(1);
+    // With slack 0.2, the collision threshold shrinks to 80*0.8 = 64 < 70 → no collision.
+    expect(resolveNameVisibility([a, b], { overlapSlack: 0.2 }).get(2)).toBe(1);
+  });
+});

--- a/src/features/fight_replay/utils/resolveNameVisibility.ts
+++ b/src/features/fight_replay/utils/resolveNameVisibility.ts
@@ -1,0 +1,127 @@
+/**
+ * Screen-space overlap resolution for the 3D actor name tags.
+ *
+ * When actors stack tightly (the melee ball on a boss), their floating name tags pile up into an
+ * unreadable blob. Distance-fade alone can't fix a close stack — every name in the pile sits at
+ * nearly the same camera distance, so they all stay bright and overlap. This resolves overlap in
+ * SCREEN space instead: project each name to the viewport, then greedily keep high-priority names
+ * (the followed player and bosses) and fade the lower-priority names that would collide with an
+ * already-placed one.
+ *
+ * Pure and three-free: it takes already-projected screen rectangles + a priority tier and returns a
+ * target opacity multiplier per id. The caller (the names coordinator) does the three.js projection
+ * and applies the multiplier on top of the existing dead-dim. Keeping it pure makes the
+ * place-or-fade logic unit-testable without a WebGL context.
+ */
+
+/** Priority tiers. Higher wins when two names collide. */
+export const NamePriority = {
+  /** Ordinary players / enemies — fade first when crowded. */
+  NORMAL: 0,
+  /** Bosses — always kept legible. */
+  BOSS: 1,
+  /** The followed/locked-on player — always kept legible. */
+  FOLLOWED: 2,
+} as const;
+
+export type NamePriorityValue = (typeof NamePriority)[keyof typeof NamePriority];
+
+export interface NameScreenItem {
+  /** Stable actor id — also the tiebreak key for equal-priority collisions. */
+  id: number;
+  /** Screen-space center, in pixels (origin top-left). Off-screen items should be omitted. */
+  screenX: number;
+  screenY: number;
+  /** Half the on-screen label width / height, in pixels (the collision box half-extents). */
+  halfW: number;
+  halfH: number;
+  /** Priority tier — see {@link NamePriority}. */
+  priority: NamePriorityValue;
+}
+
+export interface ResolveNameVisibilityOptions {
+  /**
+   * Opacity a fully-overlapped lower-priority name fades to. 0 hides it entirely; a small positive
+   * value keeps a faint ghost. Defaults to 0.12 — enough to hint presence without adding to the
+   * blob.
+   */
+  fadedOpacity?: number;
+  /**
+   * Fraction of the collision box that must overlap (on each axis) before two names count as
+   * colliding. 0 = any touch collides; larger = names must overlap more before one fades. Defaults
+   * to 0 (axis-aligned box intersection) — kept as a knob for tuning density.
+   */
+  overlapSlack?: number;
+}
+
+const DEFAULT_FADED_OPACITY = 0.12;
+
+/**
+ * Returns a Map of actor id → target opacity multiplier in [0, 1]. Priority names (followed player,
+ * bosses) are always 1. Lower-priority names that would overlap an already-kept name fade toward
+ * {@link ResolveNameVisibilityOptions.fadedOpacity}.
+ *
+ * Algorithm: sort by priority DESC, then by id ASC (a STABLE tiebreak — never camera distance,
+ * which would re-rank as the orbit camera moves and reintroduce the exact flicker the per-actor
+ * renderOrder fix was built to kill). Walk the sorted list, keeping each name that does not collide
+ * with any already-kept name and fading each one that does. Priority names are always kept (and
+ * still occupy space, so they push lower names out), but are never themselves faded even if two
+ * priority names overlap — both bosses and the followed player must stay legible.
+ *
+ * O(N²) in the worst case (each kept name checked against the placed set). At N ≈ 23–50 names this
+ * runs once per frame in the coordinator and is far cheaper than the per-name three.js work around
+ * it; a spatial grid would be premature.
+ */
+export function resolveNameVisibility(
+  items: NameScreenItem[],
+  options: ResolveNameVisibilityOptions = {},
+): Map<number, number> {
+  const fadedOpacity = options.fadedOpacity ?? DEFAULT_FADED_OPACITY;
+  const overlapSlack = options.overlapSlack ?? 0;
+
+  const result = new Map<number, number>();
+  if (items.length === 0) return result;
+
+  // Sort by priority DESC, then id ASC. Stable key only — no distance term.
+  const ordered = [...items].sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    return a.id - b.id;
+  });
+
+  // Names already kept this frame; later (lower-priority) names fade if they overlap any of these.
+  const placed: NameScreenItem[] = [];
+
+  for (const item of ordered) {
+    const isPriority = item.priority > NamePriority.NORMAL;
+
+    if (isPriority) {
+      // Priority names always stay legible and always occupy space.
+      result.set(item.id, 1);
+      placed.push(item);
+      continue;
+    }
+
+    const collides = placed.some((other) => overlaps(item, other, overlapSlack));
+    if (collides) {
+      result.set(item.id, fadedOpacity);
+    } else {
+      result.set(item.id, 1);
+      placed.push(item);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Axis-aligned box intersection between two name rectangles. `slack` shrinks each box by that
+ * fraction of its half-extent before testing, so names must overlap a bit more before colliding.
+ */
+function overlaps(a: NameScreenItem, b: NameScreenItem, slack: number): boolean {
+  const dx = Math.abs(a.screenX - b.screenX);
+  const dy = Math.abs(a.screenY - b.screenY);
+  const shrink = 1 - slack;
+  const overlapX = (a.halfW + b.halfW) * shrink;
+  const overlapY = (a.halfH + b.halfH) * shrink;
+  return dx < overlapX && dy < overlapY;
+}


### PR DESCRIPTION
When actors crowd together — the melee ball on the boss — the floating 3D name tags piled up into an unreadable blob. This resolves overlap in screen space so the tags read cleanly: the followed player and bosses always stay legible while the surrounding pile thins out.

## What changed

- **`utils/resolveNameVisibility.ts`** — a pure, three-free overlap resolver (unit-tested). It takes already-projected screen rectangles + a priority tier and returns a target opacity per actor. Greedy place-or-fade: priority anchors (the followed player, bosses) are always kept and occupy space; lower-priority names that collide with a kept name fade to a faint ghost (`0.1`).
- **`components/BatchedActorNames3D.tsx`** — `SingleName` is now a dumb `forwardRef`'d `<Text>` with no `useFrame`. A single coordinator `useFrame` does all per-actor work (position / camera-facing / distance-scale / text / color), then one screen-space projection + one overlap pass, then writes the resulting opacity through refs.
- **`components/InstancedReplayFigures3D.tsx`** — threads `selectedActorRef` into the names layer so the followed player can be a priority anchor.

## Why screen-space, not distance-fade

Distance-fade can't fix a close stack — every name in the pile sits at nearly the same camera distance, so they all stay bright and overlap. Resolving overlap in screen space is the only thing that thins a tight cluster while keeping the names you care about.

## Notes for review

- **Stable tiebreak (load-bearing):** equal-priority collisions are broken by actor id, never by camera distance. A distance tiebreak would re-rank names as the orbit camera moves and reintroduce the exact flicker the existing `renderOrder = 1000 + actorId` / `depthTest:false` fix was built to kill. That flicker fix, plus per-actor color, dead-dim, camera-facing, and the N-key toggle, are all preserved.
- **Perf — the trap this avoids:** the on-demand render gate throttles `gl.render`, not `useFrame`. The coordinator runs every idle frame, so it early-returns when neither the camera, the playhead, the viewport size, nor the selected actor changed — it mutates refs only and never touches the render budget. Verified idle frame-delta = 0 (patched `gl.render` probe, 0 renders over 3s while paused; renders resume on camera move). Collapsing N per-name `useFrame` closures into one is also the larger of the two wins.
- The second commit gates the recompute on `selectedActorId` too: lock-on usually starts the follow-camera lerp (camera moves → the gate fires), but a selection change while the camera and playhead are static would otherwise leave the newly-followed name faded.

## Verification

This is a scene-level change affecting desktop and mobile equally (no mobile gate). Verified live on `/report/F4f2bMwWtgVKxjB9/fight/39/replay` (Dreadsail Reef / Tideborn Taleria) at 1440×900 plus an emulated phone, by reading actual mesh `fillOpacity` at the boss melee stack:

- Bosses (Tideborn Taleria, Sea Behemoth) and spatially-separated players: `1.0`.
- Crowded overlappers: exactly `0.1` (the declutter fade — distinct from the `0.62` dead-dim, confirming the resolver is doing the work).
- Locking onto a player buried in the pile flips that name `0.1 → 1.0` while its neighbors stay faded.

Gates: `tsc` clean, `eslint` clean, `jest` 216/216 in `src/features/fight_replay` (including 11 new tests for the pure helper).