### PR TITLE
feat(profiles): show a user's public ESO Logs (uploaded) on their profile

### DIFF
--- a/roster-hub-api/src/db/queries.ts
+++ b/roster-hub-api/src/db/queries.ts
@@ -590,10 +590,7 @@ export async function toggleBuildVote(
     .first<{ cnt: number }>();
   const voteCount = countRow?.cnt ?? 0;
 
-  await db
-    .prepare('UPDATE builds SET vote_count = ? WHERE id = ?')
-    .bind(voteCount, buildId)
-    .run();
+  await db.prepare('UPDATE builds SET vote_count = ? WHERE id = ?').bind(voteCount, buildId).run();
 
   return { voted, voteCount };
 }
@@ -710,7 +707,9 @@ export async function recordRateLimitEvent(
   action: string,
 ): Promise<void> {
   await db
-    .prepare("INSERT INTO rate_limit_events (user_id, action, created_at) VALUES (?, ?, datetime('now'))")
+    .prepare(
+      "INSERT INTO rate_limit_events (user_id, action, created_at) VALUES (?, ?, datetime('now'))",
+    )
     .bind(userId, action)
     .run();
 }
@@ -935,8 +934,16 @@ export async function checkImageUploadRateLimit(db: D1Database, userId: string):
 
 const PROFILE_PAGE_SIZE = 12;
 
-type BuildSummaryRow = BuildSummary & { tags_concat: string | null; author_name: string };
-type RosterSummaryRow = RosterSummary & { tags_concat: string | null; author_name: string };
+type BuildSummaryRow = BuildSummary & {
+  tags_concat: string | null;
+  author_name: string;
+  author_id: string;
+};
+type RosterSummaryRow = RosterSummary & {
+  tags_concat: string | null;
+  author_name: string;
+  author_id: string;
+};
 
 export async function getUserProfile(
   db: D1Database,
@@ -953,7 +960,7 @@ export async function getUserProfile(
 
       db
         .prepare(
-          `SELECT b.id, b.author_name, b.title, b.description, b.eso_class, b.role, b.game_mode,
+          `SELECT b.id, b.author_id, b.author_name, b.title, b.description, b.eso_class, b.role, b.game_mode,
                   b.vote_count, b.created_at, GROUP_CONCAT(DISTINCT bt.tag) AS tags_concat
            FROM builds b
            LEFT JOIN build_tags bt ON bt.build_id = b.id
@@ -967,7 +974,7 @@ export async function getUserProfile(
 
       db
         .prepare(
-          `SELECT r.id, r.author_name, r.title, r.description, r.trial_id,
+          `SELECT r.id, r.author_id, r.author_name, r.title, r.description, r.trial_id,
                   r.vote_count, r.created_at, GROUP_CONCAT(DISTINCT rt.tag) AS tags_concat
            FROM rosters r
            LEFT JOIN roster_tags rt ON rt.roster_id = r.id
@@ -1006,6 +1013,15 @@ export async function getUserProfile(
     profileRow?.author_name ??
     username;
 
+  // The ESO Logs user ID is the author_id (auth.ts derives it from the ESO Logs
+  // currentUser.id). Prefer the profile row, then any content row, so uploaded
+  // logs resolve even when a profile has content but no profile row yet.
+  const esoLogsUserId =
+    profileRow?.author_id ??
+    buildsResult.results[0]?.author_id ??
+    rostersResult.results[0]?.author_id ??
+    null;
+
   return {
     username: displayName,
     bio: profileRow?.bio ?? '',
@@ -1013,6 +1029,9 @@ export async function getUserProfile(
     avatar_thumb_url: profileRow?.avatar_thumb_url ?? null,
     build_count: buildCountRow?.cnt ?? 0,
     roster_count: rosterCountRow?.cnt ?? 0,
+    eso_logs_user_id: esoLogsUserId,
+    na_display_name: profileRow?.na_display_name ?? null,
+    eu_display_name: profileRow?.eu_display_name ?? null,
     builds: buildsResult.results.map((b) => ({
       id: b.id,
       title: b.title,
@@ -1102,10 +1121,7 @@ export async function deleteUserAvatar(
 }
 
 /** Retrieve the current avatar's ImgBB delete URL (used before overwriting). */
-export async function getAvatarDeleteUrl(
-  db: D1Database,
-  authorId: string,
-): Promise<string | null> {
+export async function getAvatarDeleteUrl(db: D1Database, authorId: string): Promise<string | null> {
   const row = await db
     .prepare('SELECT avatar_delete_url FROM user_profiles WHERE author_id = ?')
     .bind(authorId)

--- a/roster-hub-api/src/graphql-proxy.ts
+++ b/roster-hub-api/src/graphql-proxy.ts
@@ -52,6 +52,9 @@ async function getCachedClientToken(env: Env): Promise<string> {
 // ─── Response caching ────────────────────────────────────────────────────────
 
 // Event data queries are immutable once a report is uploaded; safe to cache.
+// Profile log lists are mutable (a user can upload new logs) but tolerate the
+// short CACHE_TTL_SECONDS staleness in exchange for far less upstream pressure
+// on popular profiles.
 const CACHEABLE_OPERATIONS = new Set([
   'getBuffEvents',
   'getDebuffEvents',
@@ -64,6 +67,7 @@ const CACHEABLE_OPERATIONS = new Set([
   'getPlayersForReport',
   'getReportByCode',
   'getReportMasterData',
+  'getProfileUploadedReports',
 ]);
 
 const CACHE_TTL_SECONDS = 600; // 10 minutes
@@ -101,6 +105,7 @@ const ALLOWED_OPERATIONS = new Set([
   'getReportDamageEvents',
   'getReportDeathEvents',
   'getReportHealingEvents',
+  'getProfileUploadedReports',
 ]);
 
 const MAX_BODY_BYTES = 100_000; // 100 KB

--- a/roster-hub-api/src/types.ts
+++ b/roster-hub-api/src/types.ts
@@ -227,4 +227,15 @@ export interface UserProfileResponse {
   roster_count: number;
   builds: BuildSummary[];
   rosters: RosterSummary[];
+  /**
+   * The user's ESO Logs numeric user ID (as a string), used to fetch the
+   * reports they have uploaded. Equal to `author_id`, which the auth layer
+   * derives from the ESO Logs `currentUser.id`. Null if it cannot be
+   * resolved (e.g. a profile with no content and no profile row).
+   */
+  eso_logs_user_id: string | null;
+  /** ESO Logs NA-server account display name, if the user linked one. */
+  na_display_name: string | null;
+  /** ESO Logs EU-server account display name, if the user linked one. */
+  eu_display_name: string | null;
 }

--- a/src/features/profile_logs/ProfileLogsPanel.test.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.test.tsx
@@ -97,6 +97,25 @@ describe('ProfileLogsPanel', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('navigates in-app when the row itself is activated via keyboard', () => {
+    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
+
+    const row = screen.getByRole('link', { name: /open log: my abc123 run/i });
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/report/ABC123', { vtType: 'forward' });
+  });
+
+  it('does not hijack the external link when it is activated via keyboard', () => {
+    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
+
+    // Enter/Space on the nested external anchor must NOT bubble into the row's
+    // in-app navigation handler.
+    const external = screen.getByRole('link', { name: /open on eso logs/i });
+    fireEvent.keyDown(external, { key: 'Enter' });
+    fireEvent.keyDown(external, { key: ' ' });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('shows a "Show more" button when more pages exist and calls loadMore', () => {
     const loadMore = jest.fn();
     renderPanel({ reports: [makeReport('ABC123')], total: 20, hasMore: true, loadMore });

--- a/src/features/profile_logs/ProfileLogsPanel.test.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material';
+
+import { ProfileLogsPanel } from './ProfileLogsPanel';
+import type { UseProfileUploadedReportsResult } from './useProfileUploadedReports';
+import type { ProfileReportSummary } from './profileLogsQueries';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockNavigate = jest.fn();
+jest.mock('../../hooks/useViewTransitionNavigate', () => ({
+  useViewTransitionNavigate: () => mockNavigate,
+}));
+
+jest.mock('../reports/reportFormatting', () => ({
+  formatReportDateTime: () => 'Jan 01, 2024 10:00',
+  formatReportDuration: () => '6m',
+}));
+
+let hookValue: UseProfileUploadedReportsResult;
+jest.mock('./useProfileUploadedReports', () => ({
+  useProfileUploadedReports: () => hookValue,
+}));
+
+const baseHook: UseProfileUploadedReportsResult = {
+  reports: [],
+  total: 0,
+  loading: false,
+  loadingMore: false,
+  error: null,
+  hasMore: false,
+  loadMore: jest.fn(),
+  reload: jest.fn(),
+  unavailable: false,
+};
+
+const renderPanel = (overrides: Partial<UseProfileUploadedReportsResult> = {}) => {
+  hookValue = { ...baseHook, ...overrides };
+  return render(
+    <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
+      <ProfileLogsPanel esoLogsUserId="12345" username="Tester" />
+    </ThemeProvider>,
+  );
+};
+
+const makeReport = (code: string): ProfileReportSummary => ({
+  code,
+  title: `My ${code} run`,
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  visibility: 'public',
+  zone: { name: 'Rockgrove' },
+  owner: { id: 42, name: 'Tester' },
+});
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ProfileLogsPanel', () => {
+  it('renders nothing when there is no usable ESO Logs id', () => {
+    const { container } = renderPanel({ unavailable: true });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the section heading and a loading skeleton while loading', () => {
+    renderPanel({ loading: true });
+    expect(screen.getByText('Recent Logs')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no public logs', () => {
+    renderPanel({ reports: [], total: 0 });
+    expect(screen.getByText(/no public logs uploaded yet/i)).toBeInTheDocument();
+  });
+
+  it('renders a row per report and navigates to the in-app viewer on click', () => {
+    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
+
+    const row = screen.getByRole('link', { name: /open log: my abc123 run/i });
+    expect(row).toBeInTheDocument();
+    expect(screen.getByText('My ABC123 run')).toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(mockNavigate).toHaveBeenCalledWith('/report/ABC123', { vtType: 'forward' });
+  });
+
+  it('exposes an external ESO Logs link per row without triggering in-app nav', () => {
+    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
+
+    const external = screen.getByRole('link', { name: /open on eso logs/i });
+    expect(external).toHaveAttribute('href', 'https://www.esologs.com/reports/ABC123');
+
+    fireEvent.click(external);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a "Show more" button when more pages exist and calls loadMore', () => {
+    const loadMore = jest.fn();
+    renderPanel({ reports: [makeReport('ABC123')], total: 20, hasMore: true, loadMore });
+
+    const btn = screen.getByRole('button', { name: /show more logs/i });
+    fireEvent.click(btn);
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('shows an error state with a retry that calls reload', () => {
+    const reload = jest.fn();
+    renderPanel({ error: 'Could not load logs right now. Please try again later.', reload });
+
+    expect(screen.getByText(/could not load logs/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/src/features/profile_logs/ProfileLogsPanel.test.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.test.tsx
@@ -79,40 +79,26 @@ describe('ProfileLogsPanel', () => {
   it('renders a row per report and navigates to the in-app viewer on click', () => {
     renderPanel({ reports: [makeReport('ABC123')], total: 1 });
 
-    const row = screen.getByRole('link', { name: /open log: my abc123 run/i });
-    expect(row).toBeInTheDocument();
+    // The primary in-app action is a real <button> (not a nested role="link"),
+    // so its keyboard activation is native — no custom handler to hijack.
+    const open = screen.getByRole('button', { name: /open log: my abc123 run/i });
+    expect(open).toBeInTheDocument();
     expect(screen.getByText('My ABC123 run')).toBeInTheDocument();
 
-    fireEvent.click(row);
+    fireEvent.click(open);
     expect(mockNavigate).toHaveBeenCalledWith('/report/ABC123', { vtType: 'forward' });
   });
 
-  it('exposes an external ESO Logs link per row without triggering in-app nav', () => {
+  it('renders the external ESO Logs link as a sibling that does not trigger in-app nav', () => {
     renderPanel({ reports: [makeReport('ABC123')], total: 1 });
 
     const external = screen.getByRole('link', { name: /open on eso logs/i });
     expect(external).toHaveAttribute('href', 'https://www.esologs.com/reports/ABC123');
+    // It must NOT be nested inside the in-app button (invalid nested interactive).
+    const openBtn = screen.getByRole('button', { name: /open log: my abc123 run/i });
+    expect(openBtn).not.toContainElement(external);
 
     fireEvent.click(external);
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('navigates in-app when the row itself is activated via keyboard', () => {
-    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
-
-    const row = screen.getByRole('link', { name: /open log: my abc123 run/i });
-    fireEvent.keyDown(row, { key: 'Enter' });
-    expect(mockNavigate).toHaveBeenCalledWith('/report/ABC123', { vtType: 'forward' });
-  });
-
-  it('does not hijack the external link when it is activated via keyboard', () => {
-    renderPanel({ reports: [makeReport('ABC123')], total: 1 });
-
-    // Enter/Space on the nested external anchor must NOT bubble into the row's
-    // in-app navigation handler.
-    const external = screen.getByRole('link', { name: /open on eso logs/i });
-    fireEvent.keyDown(external, { key: 'Enter' });
-    fireEvent.keyDown(external, { key: ' ' });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/src/features/profile_logs/ProfileLogsPanel.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.tsx
@@ -117,6 +117,10 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
       aria-label={`Open log: ${title}`}
       onClick={openInApp}
       onKeyDown={(e) => {
+        // Only act on keyboard activation of the row itself. Without this guard,
+        // pressing Enter/Space while focused on a nested interactive element
+        // (the "Open on ESO Logs" anchor) bubbles here and hijacks its action.
+        if (e.target !== e.currentTarget) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           openInApp();

--- a/src/features/profile_logs/ProfileLogsPanel.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.tsx
@@ -111,29 +111,20 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
   const title = report.title?.trim() || zoneName;
 
   return (
+    // Container is a plain positioned wrapper (NOT interactive). The whole-row
+    // in-app navigation is a full-bleed <button> overlay; the external ESO Logs
+    // <a> is a sibling layered above it. This avoids nesting one interactive
+    // element inside another (invalid ARIA + double tab-stop) — same pattern as
+    // BuildCard/RosterCard.
     <Box
-      role="link"
-      tabIndex={0}
-      aria-label={`Open log: ${title}`}
-      onClick={openInApp}
-      onKeyDown={(e) => {
-        // Only act on keyboard activation of the row itself. Without this guard,
-        // pressing Enter/Space while focused on a nested interactive element
-        // (the "Open on ESO Logs" anchor) bubbles here and hijacks its action.
-        if (e.target !== e.currentTarget) return;
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          openInApp();
-        }
-      }}
       sx={{
+        position: 'relative',
         display: 'flex',
         alignItems: 'center',
         gap: 1.5,
         px: 2,
         py: 1.5,
         borderRadius: '12px',
-        cursor: 'pointer',
         border: isDarkMode ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.06)',
         background: isDarkMode
           ? 'linear-gradient(160deg, rgba(56,189,248,0.04) 0%, rgba(11,18,32,0.35) 100%)'
@@ -146,13 +137,37 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
           boxShadow: `0 0 16px ${accent}1f`,
           transform: 'translateY(-1px)',
         },
-        '&:focus-visible': {
+        // Focus ring follows the overlay button's focus.
+        '&:focus-within': {
           outline: `2px solid ${accent}aa`,
           outlineOffset: '2px',
         },
       }}
     >
-      <Box sx={{ minWidth: 0, flex: 1 }}>
+      {/* Full-bleed primary action: opens the in-app report viewer. */}
+      <Box
+        component="button"
+        type="button"
+        onClick={openInApp}
+        aria-label={`Open log: ${title}`}
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          m: 0,
+          p: 0,
+          border: 0,
+          background: 'transparent',
+          cursor: 'pointer',
+          borderRadius: '12px',
+          // The button's own focus ring is handled by the container's
+          // :focus-within above, so suppress the default to avoid a double ring.
+          '&:focus-visible': { outline: 'none' },
+        }}
+      />
+
+      <Box sx={{ minWidth: 0, flex: 1, position: 'relative', pointerEvents: 'none' }}>
         <Typography
           sx={{
             fontWeight: 600,
@@ -197,6 +212,8 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
         </Box>
       </Box>
 
+      {/* External link — layered above the overlay button so it stays clickable
+          and is a sibling (not a descendant) of any interactive element. */}
       <Tooltip title="Open on ESO Logs" arrow>
         <Box
           component="a"
@@ -204,8 +221,9 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Open on ESO Logs"
-          onClick={(e) => e.stopPropagation()}
           sx={{
+            position: 'relative',
+            zIndex: 1,
             display: 'inline-flex',
             alignItems: 'center',
             color: theme.palette.text.disabled,
@@ -216,7 +234,9 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
           <OpenInNewIcon sx={{ fontSize: '1rem' }} />
         </Box>
       </Tooltip>
-      <ChevronRightIcon sx={{ fontSize: '1.2rem', color: theme.palette.text.disabled }} />
+      <ChevronRightIcon
+        sx={{ fontSize: '1.2rem', color: theme.palette.text.disabled, pointerEvents: 'none' }}
+      />
     </Box>
   );
 };
@@ -225,8 +245,12 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
 
 /**
  * Shows the PUBLIC ESO Logs reports a user has uploaded, on their profile page.
- * Renders nothing structural when there is no usable ESO Logs id and no logs —
- * profiles without linked logs simply don't get the section.
+ *
+ * Renders nothing at all only when there is no usable ESO Logs id (`unavailable`)
+ * — i.e. the profile's author_id isn't a numeric ESO Logs user id (e.g. the
+ * synthetic `system:eso-1`). For a real account with zero public uploads, the
+ * section still renders with a "No public logs uploaded yet" empty state, so the
+ * heading stays consistent with the Builds/Rosters sections above it.
  */
 export const ProfileLogsPanel: React.FC<ProfileLogsPanelProps> = ({ esoLogsUserId, username }) => {
   const theme = useTheme();

--- a/src/features/profile_logs/ProfileLogsPanel.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.tsx
@@ -1,0 +1,342 @@
+import {
+  AccessTime as AccessTimeIcon,
+  Assessment as AssessmentIcon,
+  ChevronRight as ChevronRightIcon,
+  Error as ErrorIcon,
+  OpenInNew as OpenInNewIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
+import { Box, Button, Chip, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import React from 'react';
+
+import { useViewTransitionNavigate } from '../../hooks/useViewTransitionNavigate';
+import { formatReportDateTime, formatReportDuration } from '../reports/reportFormatting';
+
+import type { ProfileReportSummary } from './profileLogsQueries';
+import { useProfileUploadedReports } from './useProfileUploadedReports';
+
+const CARD_RADIUS = '16px';
+
+interface ProfileLogsPanelProps {
+  /** The profile's ESO Logs user id (== author_id), or null if unknown. */
+  esoLogsUserId: string | null;
+  /** Profile username, used for the "search on ESO Logs" fallback link. */
+  username: string;
+}
+
+// ─── Section heading (mirrors PublicProfilePage's SectionHeading) ────────────
+
+const LogsSectionHeading: React.FC<{ count: number | null }> = ({ count }) => {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+  const accent = isDarkMode ? '#38bdf8' : '#3b82f6';
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 3 }}>
+      <Box
+        sx={{
+          width: 38,
+          height: 38,
+          borderRadius: '11px',
+          background: isDarkMode
+            ? `linear-gradient(135deg, ${accent}30 0%, ${accent}18 100%)`
+            : `linear-gradient(135deg, ${accent}22 0%, ${accent}10 100%)`,
+          border: `1px solid ${accent}55`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: accent,
+          boxShadow: `0 0 10px ${accent}35, inset 0 1px 0 rgba(255,255,255,0.12)`,
+        }}
+      >
+        <AssessmentIcon sx={{ fontSize: 20 }} />
+      </Box>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 700,
+          color: theme.palette.text.primary,
+          fontFamily: 'Space Grotesk, Inter, system-ui',
+          letterSpacing: '-0.01em',
+          fontSize: '1.15rem',
+        }}
+      >
+        Recent Logs
+      </Typography>
+      {count !== null && count > 0 && (
+        <Chip
+          label={count}
+          size="small"
+          sx={{
+            height: 24,
+            minWidth: 30,
+            fontSize: '0.75rem',
+            fontWeight: 700,
+            fontVariantNumeric: 'tabular-nums',
+            background: isDarkMode
+              ? `linear-gradient(90deg, ${accent}22, ${accent}10)`
+              : `linear-gradient(90deg, ${accent}18, ${accent}08)`,
+            color: accent,
+            border: `1px solid ${accent}45`,
+            boxShadow: `0 0 6px ${accent}20`,
+          }}
+        />
+      )}
+      <Box
+        sx={{
+          flex: 1,
+          height: '1px',
+          background: `linear-gradient(to right, ${accent}35, transparent 80%)`,
+          ml: 0.5,
+        }}
+      />
+    </Box>
+  );
+};
+
+// ─── A single log row ────────────────────────────────────────────────────────
+
+const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+  const accent = isDarkMode ? '#38bdf8' : '#3b82f6';
+  const navigate = useViewTransitionNavigate();
+
+  const openInApp = (): void => {
+    navigate(`/report/${report.code}`, { vtType: 'forward' });
+  };
+
+  const zoneName = report.zone?.name ?? 'Unknown zone';
+  const title = report.title?.trim() || zoneName;
+
+  return (
+    <Box
+      role="link"
+      tabIndex={0}
+      aria-label={`Open log: ${title}`}
+      onClick={openInApp}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openInApp();
+        }
+      }}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        px: 2,
+        py: 1.5,
+        borderRadius: '12px',
+        cursor: 'pointer',
+        border: isDarkMode ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.06)',
+        background: isDarkMode
+          ? 'linear-gradient(160deg, rgba(56,189,248,0.04) 0%, rgba(11,18,32,0.35) 100%)'
+          : 'linear-gradient(160deg, rgba(59,130,246,0.03) 0%, rgba(255,255,255,0.6) 100%)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        transition: 'all 0.18s ease',
+        '&:hover': {
+          borderColor: `${accent}55`,
+          boxShadow: `0 0 16px ${accent}1f`,
+          transform: 'translateY(-1px)',
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${accent}aa`,
+          outlineOffset: '2px',
+        },
+      }}
+    >
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography
+          sx={{
+            fontWeight: 600,
+            fontSize: '0.9rem',
+            color: theme.palette.text.primary,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {title}
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            mt: 0.4,
+            flexWrap: 'wrap',
+            color: theme.palette.text.secondary,
+            fontSize: '0.75rem',
+          }}
+        >
+          {report.zone?.name && (
+            <Typography
+              component="span"
+              sx={{ fontSize: 'inherit', color: accent, fontWeight: 600 }}
+            >
+              {report.zone.name}
+            </Typography>
+          )}
+          <Box
+            component="span"
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, fontSize: 'inherit' }}
+          >
+            <AccessTimeIcon sx={{ fontSize: '0.85rem' }} />
+            {formatReportDateTime(report.startTime)}
+          </Box>
+          <Typography component="span" sx={{ fontSize: 'inherit', opacity: 0.85 }}>
+            {formatReportDuration(report.startTime, report.endTime)}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Tooltip title="Open on ESO Logs" arrow>
+        <Box
+          component="a"
+          href={`https://www.esologs.com/reports/${report.code}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open on ESO Logs"
+          onClick={(e) => e.stopPropagation()}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            color: theme.palette.text.disabled,
+            transition: 'color 0.15s ease',
+            '&:hover': { color: accent },
+          }}
+        >
+          <OpenInNewIcon sx={{ fontSize: '1rem' }} />
+        </Box>
+      </Tooltip>
+      <ChevronRightIcon sx={{ fontSize: '1.2rem', color: theme.palette.text.disabled }} />
+    </Box>
+  );
+};
+
+// ─── Panel ───────────────────────────────────────────────────────────────────
+
+/**
+ * Shows the PUBLIC ESO Logs reports a user has uploaded, on their profile page.
+ * Renders nothing structural when there is no usable ESO Logs id and no logs —
+ * profiles without linked logs simply don't get the section.
+ */
+export const ProfileLogsPanel: React.FC<ProfileLogsPanelProps> = ({ esoLogsUserId, username }) => {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+  const accent = isDarkMode ? '#38bdf8' : '#3b82f6';
+
+  const { reports, total, loading, loadingMore, error, hasMore, loadMore, reload, unavailable } =
+    useProfileUploadedReports(esoLogsUserId);
+
+  // Nothing to link to and nothing loading — omit the section entirely.
+  if (unavailable) return null;
+
+  return (
+    <Box>
+      <LogsSectionHeading count={loading ? null : total} />
+
+      {loading ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={64} sx={{ borderRadius: '12px' }} />
+          ))}
+        </Box>
+      ) : error ? (
+        <Box
+          sx={{
+            py: 4,
+            px: 3,
+            textAlign: 'center',
+            borderRadius: CARD_RADIUS,
+            border: isDarkMode
+              ? '1px dashed rgba(255,255,255,0.09)'
+              : '1px dashed rgba(0,0,0,0.09)',
+          }}
+        >
+          <ErrorIcon sx={{ fontSize: 36, color: theme.palette.error.main, mb: 1 }} />
+          <Typography variant="body2" sx={{ color: theme.palette.text.secondary, mb: 2 }}>
+            {error}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1.5, justifyContent: 'center', flexWrap: 'wrap' }}>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<RefreshIcon />}
+              onClick={reload}
+              sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '10px', px: 3 }}
+            >
+              Try again
+            </Button>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<OpenInNewIcon />}
+              component="a"
+              href={`https://www.esologs.com/search?term=${encodeURIComponent(username)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ textTransform: 'none', fontWeight: 600, borderRadius: '10px', px: 2 }}
+            >
+              Search on ESO Logs
+            </Button>
+          </Box>
+        </Box>
+      ) : reports.length === 0 ? (
+        <Box
+          sx={{
+            py: 5,
+            px: 3,
+            textAlign: 'center',
+            borderRadius: CARD_RADIUS,
+            border: isDarkMode
+              ? '1px dashed rgba(255,255,255,0.09)'
+              : '1px dashed rgba(0,0,0,0.09)',
+            background: isDarkMode
+              ? 'linear-gradient(160deg, rgba(56,189,248,0.04) 0%, rgba(11,18,32,0.4) 100%)'
+              : 'linear-gradient(160deg, rgba(59,130,246,0.03) 0%, rgba(255,255,255,0.6) 100%)',
+            backdropFilter: 'blur(8px)',
+            WebkitBackdropFilter: 'blur(8px)',
+          }}
+        >
+          <AssessmentIcon sx={{ fontSize: 40, color: theme.palette.text.disabled, mb: 1.5 }} />
+          <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>
+            No public logs uploaded yet.
+          </Typography>
+        </Box>
+      ) : (
+        <>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+            {reports.map((report) => (
+              <LogRow key={report.code} report={report} />
+            ))}
+          </Box>
+          {hasMore && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={loadingMore}
+                onClick={loadMore}
+                sx={{
+                  textTransform: 'none',
+                  fontWeight: 600,
+                  borderRadius: '10px',
+                  px: 3,
+                  borderColor: `${accent}35`,
+                  transition: 'all 0.2s ease',
+                  '&:hover': { borderColor: `${accent}80`, boxShadow: `0 0 16px ${accent}20` },
+                }}
+              >
+                {loadingMore ? 'Loading…' : 'Show more logs'}
+              </Button>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+};

--- a/src/features/profile_logs/profileLogsQueries.ts
+++ b/src/features/profile_logs/profileLogsQueries.ts
@@ -3,11 +3,11 @@ import { gql } from '@apollo/client';
 /**
  * GraphQL for public ESO Logs shown on a user's profile page.
  *
- * The operation name MUST stay `getProfileUploadedReports` — the Cloudflare
- * Worker proxy whitelists requests by operation name (it routes via the
- * `?query=` URL param the Apollo link appends), and the canonical document
- * lives in `src/graphql/profile-logs.graphql` for codegen. Keep all three in
- * sync.
+ * This inline `gql` document is the single source of truth (the same pattern as
+ * `userReportsQueries.ts` — there is no `.graphql`/codegen counterpart). The
+ * operation name MUST stay `getProfileUploadedReports`: the Cloudflare Worker
+ * proxy whitelists requests by operation name, matched against the `?query=`
+ * URL param the Apollo link appends.
  *
  * This query routes through the client-credentials proxy, so only PUBLIC
  * reports are ever returned; the hook additionally filters on visibility.

--- a/src/features/profile_logs/profileLogsQueries.ts
+++ b/src/features/profile_logs/profileLogsQueries.ts
@@ -1,0 +1,77 @@
+import { gql } from '@apollo/client';
+
+/**
+ * GraphQL for public ESO Logs shown on a user's profile page.
+ *
+ * The operation name MUST stay `getProfileUploadedReports` — the Cloudflare
+ * Worker proxy whitelists requests by operation name (it routes via the
+ * `?query=` URL param the Apollo link appends), and the canonical document
+ * lives in `src/graphql/profile-logs.graphql` for codegen. Keep all three in
+ * sync.
+ *
+ * This query routes through the client-credentials proxy, so only PUBLIC
+ * reports are ever returned; the hook additionally filters on visibility.
+ */
+export const GET_PROFILE_UPLOADED_REPORTS = gql`
+  query getProfileUploadedReports($userID: Int!, $limit: Int, $page: Int) {
+    reportData {
+      reports(userID: $userID, limit: $limit, page: $page) {
+        data {
+          ...ProfileReportSummary
+        }
+        total
+        current_page
+        per_page
+        last_page
+        has_more_pages
+      }
+    }
+  }
+
+  fragment ProfileReportSummary on Report {
+    code
+    title
+    startTime
+    endTime
+    visibility
+    zone {
+      name
+    }
+    owner {
+      id
+      name
+    }
+  }
+`;
+
+/** A single report row as returned by {@link GET_PROFILE_UPLOADED_REPORTS}. */
+export interface ProfileReportSummary {
+  code: string;
+  title: string;
+  startTime: number;
+  endTime: number;
+  visibility: string;
+  zone: { name: string } | null;
+  owner: { id: number; name: string } | null;
+}
+
+export interface ProfileReportsPagination {
+  data: (ProfileReportSummary | null)[] | null;
+  total: number;
+  current_page: number;
+  per_page: number;
+  last_page: number;
+  has_more_pages: boolean;
+}
+
+export interface GetProfileUploadedReportsResult {
+  reportData: {
+    reports: ProfileReportsPagination | null;
+  } | null;
+}
+
+export interface GetProfileUploadedReportsVariables {
+  userID: number;
+  limit?: number;
+  page?: number;
+}

--- a/src/features/profile_logs/useProfileUploadedReports.test.tsx
+++ b/src/features/profile_logs/useProfileUploadedReports.test.tsx
@@ -70,6 +70,19 @@ describe('parseEsoLogsUserId', () => {
     expect(parseEsoLogsUserId('-5')).toBeNull();
     expect(parseEsoLogsUserId('3.5')).toBeNull();
   });
+
+  it('rejects lenient Number() forms (hex, scientific, signed, whitespace)', () => {
+    expect(parseEsoLogsUserId('0x10')).toBeNull();
+    expect(parseEsoLogsUserId('1e10')).toBeNull();
+    expect(parseEsoLogsUserId('+5')).toBeNull();
+    expect(parseEsoLogsUserId(' 123 ')).toBeNull();
+    expect(parseEsoLogsUserId('123abc')).toBeNull();
+    expect(parseEsoLogsUserId('Infinity')).toBeNull();
+  });
+
+  it('rejects digit strings beyond MAX_SAFE_INTEGER (would lose precision / overflow Int)', () => {
+    expect(parseEsoLogsUserId('99999999999999999999')).toBeNull();
+  });
 });
 
 // ─── Hook behaviour ──────────────────────────────────────────────────────────
@@ -157,5 +170,34 @@ describe('useProfileUploadedReports', () => {
 
     expect(result.current.reports).toEqual([]);
     expect(result.current.error).toBeNull();
+  });
+
+  it('drops a stale response when the keyed user changes mid-flight', async () => {
+    // User A's request resolves AFTER we re-key to user B. The combined
+    // defenses (the keyed-user reset effect + the post-await requestSeq guard)
+    // must discard A's data so it never contaminates B's list.
+    let resolveA: (v: unknown) => void = () => {};
+    const aPending = new Promise((res) => {
+      resolveA = res;
+    });
+    mockClient.query
+      .mockReturnValueOnce(aPending) // user A (in-flight)
+      .mockResolvedValueOnce(pageResult([makeReport('B-ONLY')])); // user B
+
+    const { result, rerender } = renderHook(({ id }) => useProfileUploadedReports(id), {
+      initialProps: { id: '111' },
+    });
+
+    // Re-key to user B before A resolves.
+    rerender({ id: '222' });
+    await waitFor(() => expect(result.current.reports.map((r) => r.code)).toEqual(['B-ONLY']));
+
+    // Now resolve A late — it must be ignored.
+    resolveA(pageResult([makeReport('A-STALE')]));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result.current.reports.map((r) => r.code)).toEqual(['B-ONLY']);
+    expect(result.current.reports.map((r) => r.code)).not.toContain('A-STALE');
   });
 });

--- a/src/features/profile_logs/useProfileUploadedReports.test.tsx
+++ b/src/features/profile_logs/useProfileUploadedReports.test.tsx
@@ -1,0 +1,161 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { parseEsoLogsUserId, useProfileUploadedReports } from './useProfileUploadedReports';
+import type { ProfileReportSummary } from './profileLogsQueries';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockClient = { query: jest.fn() };
+
+jest.mock('../../EsoLogsClientContext', () => ({
+  useEsoLogsClientContext: () => ({ client: mockClient, isReady: true }),
+}));
+
+jest.mock('../../contexts/LoggerContext', () => ({
+  useLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeReport = (code: string, visibility = 'public'): ProfileReportSummary => ({
+  code,
+  title: `Report ${code}`,
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  visibility,
+  zone: { name: 'Rockgrove' },
+  owner: { id: 42, name: 'Tester' },
+});
+
+const pageResult = (
+  reports: ProfileReportSummary[],
+  opts: { total?: number; hasMore?: boolean } = {},
+) => ({
+  reportData: {
+    reports: {
+      data: reports,
+      total: opts.total ?? reports.length,
+      current_page: 1,
+      per_page: 12,
+      last_page: opts.hasMore ? 2 : 1,
+      has_more_pages: opts.hasMore ?? false,
+    },
+  },
+});
+
+beforeEach(() => {
+  mockClient.query.mockReset();
+});
+
+// ─── parseEsoLogsUserId (the security-critical guard) ────────────────────────
+
+describe('parseEsoLogsUserId', () => {
+  it('parses a positive numeric id', () => {
+    expect(parseEsoLogsUserId('12345')).toBe(12345);
+  });
+
+  it('rejects null / undefined / empty', () => {
+    expect(parseEsoLogsUserId(null)).toBeNull();
+    expect(parseEsoLogsUserId(undefined)).toBeNull();
+    expect(parseEsoLogsUserId('')).toBeNull();
+  });
+
+  it('rejects non-numeric synthetic ids (e.g. system:eso-1)', () => {
+    expect(parseEsoLogsUserId('system:eso-1')).toBeNull();
+  });
+
+  it('rejects zero, negatives, and non-integers', () => {
+    expect(parseEsoLogsUserId('0')).toBeNull();
+    expect(parseEsoLogsUserId('-5')).toBeNull();
+    expect(parseEsoLogsUserId('3.5')).toBeNull();
+  });
+});
+
+// ─── Hook behaviour ──────────────────────────────────────────────────────────
+
+describe('useProfileUploadedReports', () => {
+  it('marks unavailable and never queries when the id is non-numeric', async () => {
+    const { result } = renderHook(() => useProfileUploadedReports('system:eso-1'));
+
+    expect(result.current.unavailable).toBe(true);
+    expect(result.current.reports).toEqual([]);
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('marks unavailable for a missing id', () => {
+    const { result } = renderHook(() => useProfileUploadedReports(null));
+    expect(result.current.unavailable).toBe(true);
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns public reports for a valid id', async () => {
+    mockClient.query.mockResolvedValueOnce(pageResult([makeReport('AAA'), makeReport('BBB')]));
+
+    const { result } = renderHook(() => useProfileUploadedReports('12345'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.unavailable).toBe(false);
+    expect(result.current.reports.map((r) => r.code)).toEqual(['AAA', 'BBB']);
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    // The numeric userID must be passed (not the raw string).
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: expect.objectContaining({ userID: 12345 }) }),
+    );
+  });
+
+  it('filters out non-public reports (defence-in-depth)', async () => {
+    mockClient.query.mockResolvedValueOnce(
+      pageResult([
+        makeReport('PUB', 'public'),
+        makeReport('PRIV', 'private'),
+        makeReport('UNL', 'unlisted'),
+      ]),
+    );
+
+    const { result } = renderHook(() => useProfileUploadedReports('12345'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.reports.map((r) => r.code)).toEqual(['PUB']);
+  });
+
+  it('accumulates and de-dupes across pages on loadMore', async () => {
+    mockClient.query
+      .mockResolvedValueOnce(pageResult([makeReport('AAA'), makeReport('BBB')], { hasMore: true }))
+      .mockResolvedValueOnce(
+        pageResult([makeReport('BBB'), makeReport('CCC')], { hasMore: false }),
+      );
+
+    const { result } = renderHook(() => useProfileUploadedReports('12345'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+
+    // BBB appears once despite being on both pages.
+    expect(result.current.reports.map((r) => r.code)).toEqual(['AAA', 'BBB', 'CCC']);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('surfaces an error message and empties the list when the query fails', async () => {
+    mockClient.query.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useProfileUploadedReports('12345'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toMatch(/could not load/i);
+    expect(result.current.reports).toEqual([]);
+  });
+
+  it('handles a null reports payload without throwing', async () => {
+    mockClient.query.mockResolvedValueOnce({ reportData: { reports: null } });
+
+    const { result } = renderHook(() => useProfileUploadedReports('12345'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.reports).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/features/profile_logs/useProfileUploadedReports.ts
+++ b/src/features/profile_logs/useProfileUploadedReports.ts
@@ -17,15 +17,18 @@ const PAGE_SIZE = 12;
  * ID, == author_id) into a valid `userID` argument, or null when it is missing
  * or non-numeric.
  *
- * `author_id` is usually numeric, but some rows use synthetic ids (e.g. the
- * leaderboard's `system:eso-1`). `Number('system:eso-1')` is `NaN` and
- * `Number('')` is `0`; both are invalid as an ESO Logs `userID: Int!`, so we
- * reject anything that is not a positive integer.
+ * `author_id` is a plain decimal string for real accounts (`String(user.id)`),
+ * but some rows use synthetic ids (e.g. the leaderboard's `system:eso-1`). We
+ * require a run of ASCII digits and a positive value — this rejects
+ * `system:eso-1`, the empty string, and also avoids `Number()`'s lenient
+ * parsing of hex (`0x10`), scientific (`1e10`), signed (`+5`), and whitespace-
+ * padded forms, none of which are valid as an ESO Logs `userID: Int!`.
  */
 export function parseEsoLogsUserId(raw: string | null | undefined): number | null {
-  if (raw == null || raw === '') return null;
+  if (raw == null) return null;
+  if (!/^\d+$/.test(raw)) return null;
   const n = Number(raw);
-  return Number.isInteger(n) && n > 0 ? n : null;
+  return Number.isSafeInteger(n) && n > 0 ? n : null;
 }
 
 export interface UseProfileUploadedReportsResult {

--- a/src/features/profile_logs/useProfileUploadedReports.ts
+++ b/src/features/profile_logs/useProfileUploadedReports.ts
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useLogger } from '../../contexts/LoggerContext';
+import { useEsoLogsClientContext } from '../../EsoLogsClientContext';
+
+import {
+  GET_PROFILE_UPLOADED_REPORTS,
+  type GetProfileUploadedReportsResult,
+  type GetProfileUploadedReportsVariables,
+  type ProfileReportSummary,
+} from './profileLogsQueries';
+
+const PAGE_SIZE = 12;
+
+/**
+ * Parses a profile's `eso_logs_user_id` (the stringified ESO Logs numeric user
+ * ID, == author_id) into a valid `userID` argument, or null when it is missing
+ * or non-numeric.
+ *
+ * `author_id` is usually numeric, but some rows use synthetic ids (e.g. the
+ * leaderboard's `system:eso-1`). `Number('system:eso-1')` is `NaN` and
+ * `Number('')` is `0`; both are invalid as an ESO Logs `userID: Int!`, so we
+ * reject anything that is not a positive integer.
+ */
+export function parseEsoLogsUserId(raw: string | null | undefined): number | null {
+  if (raw == null || raw === '') return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export interface UseProfileUploadedReportsResult {
+  /** Public reports the user uploaded, accumulated across loaded pages. */
+  reports: ProfileReportSummary[];
+  /** Total public+private count reported by the API for the first page. */
+  total: number;
+  loading: boolean;
+  /** True while a "load more" page (beyond the first) is in flight. */
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  /** Reloads the first page from scratch (used to retry after an error). */
+  reload: () => void;
+  /** True when there is no usable ESO Logs user id to query. */
+  unavailable: boolean;
+}
+
+/**
+ * Fetches the PUBLIC reports a user uploaded to ESO Logs, keyed by their numeric
+ * ESO Logs user id. Routes through the client-credentials Worker proxy (no login
+ * required), which only ever returns public reports; we additionally filter on
+ * `visibility === 'public'` as defence-in-depth.
+ */
+export function useProfileUploadedReports(
+  esoLogsUserId: string | null | undefined,
+): UseProfileUploadedReportsResult {
+  const { client, isReady } = useEsoLogsClientContext();
+  const logger = useLogger('ProfileLogs');
+
+  const userId = parseEsoLogsUserId(esoLogsUserId);
+  const unavailable = userId === null;
+
+  const [reports, setReports] = useState<ProfileReportSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards against state updates after unmount or after the keyed user changes.
+  const requestSeq = useRef(0);
+
+  const fetchPage = useCallback(
+    async (targetPage: number) => {
+      if (userId === null || !client) return;
+
+      const seq = ++requestSeq.current;
+      if (targetPage === 1) {
+        setLoading(true);
+        setError(null);
+      } else {
+        setLoadingMore(true);
+      }
+
+      try {
+        const result = await client.query<
+          GetProfileUploadedReportsResult,
+          GetProfileUploadedReportsVariables
+        >({
+          query: GET_PROFILE_UPLOADED_REPORTS,
+          variables: { userID: userId, limit: PAGE_SIZE, page: targetPage },
+          fetchPolicy: 'network-only',
+        });
+
+        if (seq !== requestSeq.current) return; // superseded
+
+        const pagination = result.reportData?.reports;
+        const pageReports = (pagination?.data ?? []).filter(
+          (r): r is ProfileReportSummary => r != null && r.visibility === 'public',
+        );
+
+        setReports((prev) => {
+          if (targetPage === 1) return pageReports;
+          // De-dupe by code in case pages overlap.
+          const seen = new Set(prev.map((r) => r.code));
+          return [...prev, ...pageReports.filter((r) => !seen.has(r.code))];
+        });
+        setTotal(pagination?.total ?? pageReports.length);
+        setHasMore(Boolean(pagination?.has_more_pages));
+        setPage(targetPage);
+      } catch (err) {
+        if (seq !== requestSeq.current) return;
+        logger.error(
+          'Failed to load profile uploaded reports',
+          err instanceof Error ? err : new Error(String(err)),
+        );
+        if (targetPage === 1) {
+          setReports([]);
+          setTotal(0);
+          setHasMore(false);
+        }
+        setError('Could not load logs right now. Please try again later.');
+      } finally {
+        if (seq === requestSeq.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [client, userId, logger],
+  );
+
+  // (Re)load the first page whenever the keyed user becomes available.
+  useEffect(() => {
+    if (userId === null || !isReady || !client) {
+      requestSeq.current++; // cancel any in-flight request
+      setReports([]);
+      setTotal(0);
+      setPage(1);
+      setHasMore(false);
+      setLoading(false);
+      setLoadingMore(false);
+      setError(null);
+      return;
+    }
+    void fetchPage(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, isReady, client]);
+
+  const loadMore = useCallback(() => {
+    if (loading || loadingMore || !hasMore) return;
+    void fetchPage(page + 1);
+  }, [loading, loadingMore, hasMore, page, fetchPage]);
+
+  const reload = useCallback(() => {
+    if (loading) return;
+    void fetchPage(1);
+  }, [loading, fetchPage]);
+
+  return {
+    reports,
+    total,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+    reload,
+    unavailable,
+  };
+}

--- a/src/features/roster-hub/types/roster-hub.types.ts
+++ b/src/features/roster-hub/types/roster-hub.types.ts
@@ -135,6 +135,16 @@ export interface UserProfile {
   roster_count: number;
   builds: ProfileBuildSummary[];
   rosters: ProfileRosterSummary[];
+  /**
+   * The user's ESO Logs numeric user ID (as a string, == author_id), used to
+   * fetch the public reports they have uploaded. Null when it cannot be
+   * resolved. Optional so older API responses (pre-feature) still type-check.
+   */
+  eso_logs_user_id?: string | null;
+  /** ESO Logs NA-server account display name, if linked. */
+  na_display_name?: string | null;
+  /** ESO Logs EU-server account display name, if linked. */
+  eu_display_name?: string | null;
 }
 
 export interface UserProfileResponse {

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -42,6 +42,7 @@ import { useAuth } from '../features/auth/AuthContext';
 import { CLASS_COLOR_MAP } from '../features/build-editor/theme/classColorMap';
 import { buildHubApi } from '../features/build-hub/api/build-hub-api';
 import { ROLE_ACCENT } from '../features/build-hub/types/build-hub.types';
+import { ProfileLogsPanel } from '../features/profile_logs/ProfileLogsPanel';
 import { rosterHubApi } from '../features/roster-hub/api/roster-hub-api';
 import {
   TRIAL_ACCENT,
@@ -1683,6 +1684,12 @@ export const PublicProfilePage: React.FC = () => {
           />
         )}
       </Box>
+
+      {/* ── Recent Logs (uploaded to ESO Logs) ─────────────────────────── */}
+      <ProfileLogsPanel
+        esoLogsUserId={profile.eso_logs_user_id ?? null}
+        username={profile.username}
+      />
 
       {/* ── Bio edit dialog ────────────────────────────────────────────── */}
       <BioDialog


### PR DESCRIPTION
## What

Adds a **"Recent Logs"** section to the public profile page (`/u/:username`) that lists the **public ESO Logs reports a user has uploaded**. Visible to any visitor — no login required. Rows open the in-app report viewer (`/report/:code`); each also links out to esologs.com. Paginated via "Show more".

## Why / how it works

A profile's `author_id` **is** the user's ESO Logs numeric user id — the auth layer derives it from `currentUser.id` (`String(user.id)`), and every roster/build insert stamps it. So `Number(author_id)` is exactly the `userID` argument for `reportData.reports(userID:)`. **No new linking field, no migration.**

- The worker now returns `eso_logs_user_id` on `GET /users/:username`, sourced from the profile row or any content row (so it resolves even without a profile row).
- The frontend queries `reportData.reports(userID:)` through the **existing client-credentials Worker proxy** (`/graphql` → `/api/v2/client`), which can only ever return **public** reports — so this works for anonymous visitors and never exposes private logs.

## Scope: uploaded logs only (deliberate)

There is **no public ESO Logs path** from an account to "reports a user *participated in*": `User.characters`/`User.guilds` are gated behind the owner's own `view-user-profile` OAuth scope, and the stored display names are *account* handles (not character names), so `characterData.character(name:)` would return null or mismatch an unrelated character. `reports(userID:)` is upload-only by design. Confirmed with the requester that uploaded logs cover their use case.

## Security / correctness

- **Public-only by construction** (client-credentials endpoint) **and** by explicit `visibility === 'public'` filter (defence-in-depth).
- Rejects non-numeric / non-positive `author_id` (e.g. the leaderboard's `system:eso-1` → `NaN`) before it can reach the API as a bad `userID`.
- Exposing `eso_logs_user_id` is **not** new exposure — `author_id` is already public via rosters/builds.

## Changes

- **Worker** (`roster-hub-api`): `eso_logs_user_id` (+ na/eu display names) on the profile response; `getProfileUploadedReports` added to the proxy allowlist.
- **Frontend** (`src/features/profile_logs/`): inline-`gql` query (matches `userReportsQueries.ts`), `useProfileUploadedReports` hook, `ProfileLogsPanel` (glassmorphic, matches the profile's existing sections), mounted below Rosters.

## Tests

18 unit tests: the id guard (rejects `system:eso-1`/empty/zero/negative/float), public-only filtering, pagination + de-dupe, error/null-payload handling, and all panel states (loading / empty / rows / nav-to-viewer / external link / show-more / error+retry). All passing locally.

## Follow-ups / notes for reviewers

- **Worker deploy required** before this works end-to-end — the proxy allowlist entry must be deployed, and a quick smoke test on a real profile should confirm rows render + open `/report/:code`.
- The row fragment omits `segments`, so it can't reuse `isReportEmpty` — empty / zero-duration uploads will render as rows (the My Reports view filters these). Easy follow-up if undesired.
