### PR TITLE
fix(Footer): stop decorative gradient overflowing rounded panel corners

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -127,7 +127,6 @@ export const Footer: React.FC = React.memo(() => {
           theme.palette.mode === 'dark'
             ? `radial-gradient(circle, ${alpha(secondaryAccent, 0.28)} 0%, transparent 65%)`
             : `radial-gradient(circle, ${alpha(secondaryAccent, 0.18)} 0%, transparent 65%)`,
-        filter: 'blur(6px)',
         pointerEvents: 'none',
       },
       '& > *': { position: 'relative', zIndex: 1 },
@@ -178,7 +177,6 @@ export const Footer: React.FC = React.memo(() => {
           theme.palette.mode === 'dark'
             ? `radial-gradient(circle, ${alpha(secondaryAccent, 0.25)} 0%, transparent 60%)`
             : `radial-gradient(circle, ${alpha(secondaryAccent, 0.16)} 0%, transparent 60%)`,
-        filter: 'blur(8px)',
         pointerEvents: 'none',
       },
       '& > *': { position: 'relative', zIndex: 1 },


### PR DESCRIPTION
## Problem

On iOS/Safari, the purple decorative gradient glow in the footer's "Quick Links" (and Overview) panels bled **past the rounded bottom corners** instead of being clipped by them.

## Root cause

Each panel (`overviewPanelSx`, `linksPanelSx`) has `overflow: 'hidden'` + `borderRadius` and a decorative `::after` radial-gradient glow positioned just outside the box (negative offsets). Those pseudo-elements also carried a `filter: blur(...)`.

WebKit/Safari does **not** clip a `filter`ed descendant against a parent's rounded `overflow: hidden` corner — a well-known browser bug. As a result the blurred glow escaped the rounded corner.

## Fix

Removed the `filter: blur(6px)` / `filter: blur(8px)` from the two decorative `::after` pseudo-elements. The radial gradients already fade to `transparent` (soft edges), so the extra blur was visually redundant. Without the filter, `overflow: hidden` clips the glow against the rounded corners correctly — fixing the overflow while keeping the same glow look.

## Notes

- CSS-only change (two object-literal properties removed); no logic or type changes.
- The project's lint/typecheck harness could not be run in this environment because dev dependencies (`@eslint/js`, `@types/node`) are not installed here.

https://claude.ai/code/session_01Ey7BgKjwYEN3BQeuXRFXGL