### PR TITLE
fix(discord-bot): repair roster bot defects found in audit

### DIFF
--- a/.github/workflows/discord-bot-ci.yml
+++ b/.github/workflows/discord-bot-ci.yml
@@ -1,0 +1,43 @@
+name: Discord Bot CI
+
+# Typechecks and tests the Cloudflare Worker in discord-bot/. This package is
+# separate from the root React app (its own package.json/tsconfig/vitest), so
+# the root PR Checks never covered it — which let typecheck errors reach main.
+# Runs only when discord-bot/ changes.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'discord-bot/**'
+      - '.github/workflows/discord-bot-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'discord-bot/**'
+      - '.github/workflows/discord-bot-ci.yml'
+
+jobs:
+  discord-bot:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: discord-bot
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: discord-bot/package-lock.json
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test

--- a/discord-bot/package-lock.json
+++ b/discord-bot/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.0.0",
         "typescript": "^5.0.0",
+        "vitest": "^3.0.0",
         "wrangler": "^4.75.0"
       }
     },
@@ -1144,6 +1145,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -1164,12 +1515,199 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -1183,6 +1721,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1204,6 +1770,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1247,6 +1820,44 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1262,6 +1873,13 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1270,6 +1888,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/miniflare": {
@@ -1293,6 +1928,32 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -1306,6 +1967,110 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -1365,6 +2130,50 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -1376,6 +2185,67 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1418,6 +2288,194 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/discord-bot/src/buttons/roster-refresh.ts
+++ b/discord-bot/src/buttons/roster-refresh.ts
@@ -9,7 +9,7 @@ import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
 import { getMappingByChannelId, getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
 import { refreshRoster } from '../roster/publish.js';
-import { InteractionResponseType, MessageFlags } from '../types.js';
+import { InteractionResponseType, MessageFlags, RosterButtonId } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
 
 export async function handleRosterRefreshButton(
@@ -50,18 +50,29 @@ export async function handleRosterRefreshButton(
     };
   }
 
+  // The button encodes its own roster ID (roster_refresh:<rosterId>), so refresh
+  // that exact roster even when several rosters share one channel. Fall back to
+  // the channel→roster lookup for any older buttons without an encoded ID.
+  const customId = interaction.data?.custom_id ?? '';
+  const prefix = `${RosterButtonId.REFRESH}:`;
+  const encodedRosterId = customId.startsWith(prefix) ? customId.slice(prefix.length) : '';
+
   ctx.waitUntil(
     (async () => {
-      const mapping = await getMappingByChannelId(env, channelId);
-      if (!mapping) {
-        await sendFollowup(env, interaction.token, {
-          content: '❌ No roster is linked to this channel.',
-          flags: MessageFlags.EPHEMERAL,
-        });
-        return;
+      let rosterId = encodedRosterId;
+      if (!rosterId) {
+        const mapping = await getMappingByChannelId(env, channelId);
+        if (!mapping) {
+          await sendFollowup(env, interaction.token, {
+            content: '❌ No roster is linked to this channel.',
+            flags: MessageFlags.EPHEMERAL,
+          });
+          return;
+        }
+        rosterId = mapping.rosterId;
       }
 
-      const result = await refreshRoster(env, mapping.rosterId);
+      const result = await refreshRoster(env, rosterId, guildId);
       if (result.ok) {
         await sendFollowup(env, interaction.token, {
           content: '✅ Roster refreshed!',

--- a/discord-bot/src/buttons/roster-refresh.ts
+++ b/discord-bot/src/buttons/roster-refresh.ts
@@ -73,9 +73,17 @@ export async function handleRosterRefreshButton(
       }
 
       const result = await refreshRoster(env, rosterId, guildId);
-      if (result.ok) {
+      if (result.ok && (result.refreshedCount ?? 0) > 0) {
         await sendFollowup(env, interaction.token, {
           content: '✅ Roster refreshed!',
+          flags: MessageFlags.EPHEMERAL,
+        });
+      } else if (result.ok) {
+        // ok but nothing refreshed → this roster has no live post in this server
+        // (mapping removed/expired). Don't claim success.
+        await sendFollowup(env, interaction.token, {
+          content:
+            "⚠️ Couldn't find this roster's post to refresh — it may have been removed. Try re-publishing it.",
           flags: MessageFlags.EPHEMERAL,
         });
       } else {

--- a/discord-bot/src/buttons/roster-refresh.ts
+++ b/discord-bot/src/buttons/roster-refresh.ts
@@ -7,7 +7,12 @@
 
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
-import { getMappingByChannelId, getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
+import {
+  getMappingByChannelId,
+  getGuildConfig,
+  getDefaultGuildConfig,
+  checkRosterRateLimit,
+} from '../roster/kv.js';
 import { refreshRoster } from '../roster/publish.js';
 import { InteractionResponseType, MessageFlags, RosterButtonId } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
@@ -45,6 +50,18 @@ export async function handleRosterRefreshButton(
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content: '❌ Could not determine channel.',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
+  const userId = interaction.member?.user?.id ?? 'unknown';
+  const allowed = await checkRosterRateLimit(env, `refresh:${guildId}:${userId}`, 10, 60);
+  if (!allowed) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "⏳ You're refreshing too quickly. Please wait a minute and try again.",
         flags: MessageFlags.EPHEMERAL,
       },
     };

--- a/discord-bot/src/commands/roster-config.ts
+++ b/discord-bot/src/commands/roster-config.ts
@@ -192,6 +192,26 @@ async function handleSetRolePings(
   const healer = options.find((o) => o.name === 'healer-role')?.value as string | undefined;
   const dd = options.find((o) => o.name === 'dd-role')?.value as string | undefined;
 
+  // Defense-in-depth: option values come from Discord role pickers (already
+  // snowflakes), but reject anything malformed so we never store junk that
+  // would later be skipped silently at ping time.
+  const snowflake = /^\d{17,20}$/;
+  for (const [label, value] of [
+    ['tank', tank],
+    ['healer', healer],
+    ['dd', dd],
+  ] as const) {
+    if (value !== undefined && !snowflake.test(value)) {
+      return {
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: `❌ Invalid ${label} role. Please pick a role from the list.`,
+          flags: MessageFlags.EPHEMERAL,
+        },
+      };
+    }
+  }
+
   const config = (await getGuildConfig(env, guildId)) ?? getDefaultGuildConfig(guildId);
   config.rolePingIds = {
     ...config.rolePingIds,

--- a/discord-bot/src/commands/roster-config.ts
+++ b/discord-bot/src/commands/roster-config.ts
@@ -117,13 +117,25 @@ async function handleSetNamePattern(
   guildId: string,
   options: DiscordInteractionOption[],
 ): Promise<InteractionResponse> {
-  const pattern = options.find((o) => o.name === 'pattern')?.value as string | undefined;
+  const rawPattern = options.find((o) => o.name === 'pattern')?.value as string | undefined;
+  const pattern = rawPattern?.trim();
   if (!pattern) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content:
           '❌ Please provide a pattern. Tokens: `{day-short}`, `{day}`, `{time}`, `{trial}`, `{difficulty}`',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
+  // Match the HTTP API's cap (Discord channel names are capped at 100 chars).
+  if (pattern.length > 100) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '❌ Pattern is too long. Keep it to 100 characters or fewer.',
         flags: MessageFlags.EPHEMERAL,
       },
     };

--- a/discord-bot/src/commands/roster-link.ts
+++ b/discord-bot/src/commands/roster-link.ts
@@ -8,7 +8,7 @@
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
 import { publishRoster } from '../roster/publish.js';
-import { getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
+import { getGuildConfig, getDefaultGuildConfig, checkRosterRateLimit } from '../roster/kv.js';
 import { InteractionResponseType, MessageFlags } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
 
@@ -77,10 +77,22 @@ export async function handleRosterLink(
     };
   }
 
+  // Throttle channel/ping creation per user (5 / minute).
+  const userId = interaction.member?.user?.id ?? 'unknown';
+  const allowed = await checkRosterRateLimit(env, `publish:${guildId}:${userId}`, 5, 60);
+  if (!allowed) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "⏳ You're publishing too quickly. Please wait a minute and try again.",
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
   // Defer the response since publish involves multiple API calls
   ctx.waitUntil(
     (async () => {
-      const userId = interaction.member?.user?.id ?? '';
       const result = await publishRoster(env, {
         guildId,
         rosterId,

--- a/discord-bot/src/commands/roster-publish.ts
+++ b/discord-bot/src/commands/roster-publish.ts
@@ -7,7 +7,7 @@
 
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
-import { getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
+import { getGuildConfig, getDefaultGuildConfig, checkRosterRateLimit } from '../roster/kv.js';
 import { publishRoster } from '../roster/publish.js';
 import { InteractionResponseType, MessageFlags } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
@@ -54,9 +54,21 @@ export async function handleRosterPublish(
     };
   }
 
+  // Throttle channel/ping creation per publisher (5 / minute).
+  const userId = interaction.member?.user?.id ?? 'unknown';
+  const allowed = await checkRosterRateLimit(env, `publish:${guildId}:${userId}`, 5, 60);
+  if (!allowed) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "⏳ You're publishing too quickly. Please wait a minute and try again.",
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
   ctx.waitUntil(
     (async () => {
-      const userId = interaction.member?.user?.id ?? '';
       const result = await publishRoster(env, {
         guildId,
         rosterId,

--- a/discord-bot/src/commands/roster-refresh.ts
+++ b/discord-bot/src/commands/roster-refresh.ts
@@ -7,7 +7,12 @@
 
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
-import { listMappingsForGuild, getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
+import {
+  listMappingsForGuild,
+  getGuildConfig,
+  getDefaultGuildConfig,
+  checkRosterRateLimit,
+} from '../roster/kv.js';
 import { refreshRoster } from '../roster/publish.js';
 import { InteractionResponseType, MessageFlags } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
@@ -45,6 +50,18 @@ export async function handleRosterRefresh(
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content: '❌ Could not determine channel.',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
+  const userId = interaction.member?.user?.id ?? 'unknown';
+  const allowed = await checkRosterRateLimit(env, `refresh:${guildId}:${userId}`, 10, 60);
+  if (!allowed) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "⏳ You're refreshing too quickly. Please wait a minute and try again.",
         flags: MessageFlags.EPHEMERAL,
       },
     };

--- a/discord-bot/src/commands/roster-refresh.ts
+++ b/discord-bot/src/commands/roster-refresh.ts
@@ -69,8 +69,8 @@ export async function handleRosterRefresh(
       let lastError: string | undefined;
       for (const mapping of mappings) {
         const result = await refreshRoster(env, mapping.rosterId, guildId);
-        if (result.ok) okCount++;
-        else lastError = result.error;
+        if (result.ok && (result.refreshedCount ?? 0) > 0) okCount++;
+        else if (!result.ok) lastError = result.error;
       }
 
       if (okCount > 0) {
@@ -79,9 +79,14 @@ export async function handleRosterRefresh(
           content: `✅ Roster refreshed from ESO Toolkit!${suffix}`,
           flags: MessageFlags.EPHEMERAL,
         });
+      } else if (lastError) {
+        await sendFollowup(env, interaction.token, {
+          content: `❌ Refresh failed: ${lastError}`,
+          flags: MessageFlags.EPHEMERAL,
+        });
       } else {
         await sendFollowup(env, interaction.token, {
-          content: `❌ Refresh failed: ${lastError ?? 'Unknown error'}`,
+          content: '⚠️ Nothing to refresh — this channel has no live roster posts anymore.',
           flags: MessageFlags.EPHEMERAL,
         });
       }

--- a/discord-bot/src/commands/roster-refresh.ts
+++ b/discord-bot/src/commands/roster-refresh.ts
@@ -7,7 +7,7 @@
 
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
-import { getMappingByChannelId, getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
+import { listMappingsForGuild, getGuildConfig, getDefaultGuildConfig } from '../roster/kv.js';
 import { refreshRoster } from '../roster/publish.js';
 import { InteractionResponseType, MessageFlags } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
@@ -52,8 +52,12 @@ export async function handleRosterRefresh(
 
   ctx.waitUntil(
     (async () => {
-      const mapping = await getMappingByChannelId(env, channelId);
-      if (!mapping) {
+      // A channel may host more than one roster (when a default posting channel
+      // is configured), so refresh every roster mapped to this channel.
+      const mappings = (await listMappingsForGuild(env, guildId)).filter(
+        (m) => m.channelId === channelId,
+      );
+      if (mappings.length === 0) {
         await sendFollowup(env, interaction.token, {
           content: '❌ No roster is linked to this channel. Use `/roster link` first.',
           flags: MessageFlags.EPHEMERAL,
@@ -61,15 +65,23 @@ export async function handleRosterRefresh(
         return;
       }
 
-      const result = await refreshRoster(env, mapping.rosterId);
-      if (result.ok) {
+      let okCount = 0;
+      let lastError: string | undefined;
+      for (const mapping of mappings) {
+        const result = await refreshRoster(env, mapping.rosterId, guildId);
+        if (result.ok) okCount++;
+        else lastError = result.error;
+      }
+
+      if (okCount > 0) {
+        const suffix = mappings.length > 1 ? ` (${okCount}/${mappings.length})` : '';
         await sendFollowup(env, interaction.token, {
-          content: '✅ Roster refreshed from ESO Toolkit!',
+          content: `✅ Roster refreshed from ESO Toolkit!${suffix}`,
           flags: MessageFlags.EPHEMERAL,
         });
       } else {
         await sendFollowup(env, interaction.token, {
-          content: `❌ Refresh failed: ${result.error}`,
+          content: `❌ Refresh failed: ${lastError ?? 'Unknown error'}`,
           flags: MessageFlags.EPHEMERAL,
         });
       }

--- a/discord-bot/src/discord.ts
+++ b/discord-bot/src/discord.ts
@@ -253,6 +253,8 @@ export interface DiscordRole {
   id: string;
   name: string;
   permissions: string;
+  color?: number;
+  managed?: boolean;
 }
 
 export function getGuildRoles(env: Env, guildId: string): Promise<DiscordRole[]> {

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -528,10 +528,8 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
     const roles = await getGuildRoles(env, guildId);
     // Filter out @everyone (id === guildId) and managed/bot roles
     const filtered = roles
-      .filter(
-        (r) => r.id !== guildId && !('managed' in r && (r as Record<string, unknown>).managed),
-      )
-      .map((r) => ({ id: r.id, name: r.name, color: (r as Record<string, unknown>).color ?? 0 }));
+      .filter((r) => r.id !== guildId && !r.managed)
+      .map((r) => ({ id: r.id, name: r.name, color: r.color ?? 0 }));
     return jsonResponse({ roles: filtered });
   }
 

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -432,7 +432,9 @@ async function handleRefresh(
     scopeGuildId = guildId;
   }
 
-  const result = await refreshRoster(env, rosterId, scopeGuildId);
+  // Webhook (server-to-server) refreshes must not resurrect channels that staff
+  // deleted on purpose; user-initiated HTTP refreshes may recreate.
+  const result = await refreshRoster(env, rosterId, scopeGuildId, { allowRecreate: !isWebhook });
   if (!result.ok) {
     return jsonResponse({ error: result.error }, 400);
   }

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -550,7 +550,8 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
     const updated = {
       ...existing,
       guildId,
-      ...(typeof body.defaultChannelId === 'string' && { defaultChannelId: body.defaultChannelId }),
+      ...(typeof body.defaultChannelId === 'string' &&
+        /^\d{17,20}$/.test(body.defaultChannelId) && { defaultChannelId: body.defaultChannelId }),
       ...(typeof body.defaultCategoryId === 'string' && {
         defaultCategoryId: body.defaultCategoryId,
       }),
@@ -581,6 +582,9 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
           }
         })() && { timezone: body.timezone }),
     };
+
+    // An explicit empty string clears the default posting channel.
+    if (body.defaultChannelId === '') delete (updated as GuildConfig).defaultChannelId;
 
     await upsertGuildConfig(env, updated);
     return jsonResponse({ ok: true, config: updated });

--- a/discord-bot/src/roster/decoder.test.ts
+++ b/discord-bot/src/roster/decoder.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { decodeRosterData } from './decoder';
+
+/**
+ * Encode an object the same way the frontend does: JSON → deflate-raw → base64url.
+ * Mirrors the wire format the decoder consumes.
+ */
+async function encodeRoster(obj: unknown): Promise<string> {
+  const json = JSON.stringify(obj);
+  const cs = new CompressionStream('deflate-raw');
+  const writer = cs.writable.getWriter();
+  void writer.write(new TextEncoder().encode(json));
+  void writer.close();
+  const compressed = new Uint8Array(await new Response(cs.readable).arrayBuffer());
+  let bin = '';
+  for (const b of compressed) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+describe('decodeRosterData — composition', () => {
+  it('defaults a blank v3 roster to 2/2/8 even with no filled slots', async () => {
+    // The encoder omits `co` when it equals the default and omits empty slot
+    // arrays — exactly the "seeking signups" payload.
+    const data = await encodeRoster({ v: 3 });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.composition).toEqual({ tanks: 2, healers: 2, dps: 8 });
+    expect(decoded.tanks).toHaveLength(0);
+    expect(decoded.healers).toHaveLength(0);
+    expect(decoded.dps).toHaveLength(0);
+  });
+
+  it('reads an explicit v3 composition that excludes a role', async () => {
+    const data = await encodeRoster({ v: 3, co: [2, 0, 8] });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.composition).toEqual({ tanks: 2, healers: 0, dps: 8 });
+  });
+
+  it('clamps an out-of-range composition to the hard caps', async () => {
+    const data = await encodeRoster({ v: 3, co: [9, 9, 99] });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.composition).toEqual({ tanks: 4, healers: 4, dps: 24 });
+  });
+
+  it('defaults a legacy v2 roster to 2/2/8', async () => {
+    const data = await encodeRoster({ v: 2, t1: { pn: 'Tanky' } });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.composition).toEqual({ tanks: 2, healers: 2, dps: 8 });
+    expect(decoded.tanks[0]?.playerName).toBe('Tanky');
+  });
+
+  it('rejects unsupported roster versions', async () => {
+    const data = await encodeRoster({ v: 99 });
+    await expect(decodeRosterData(data)).rejects.toThrow(/Unsupported roster version/);
+  });
+});

--- a/discord-bot/src/roster/decoder.ts
+++ b/discord-bot/src/roster/decoder.ts
@@ -120,10 +120,21 @@ interface CompactTrialOverrides { ti: string; }
 
 interface CompactRoster {
   v: number; n?: string; no?: string;
+  /** Composition tuple [tanks, healers, dps] (v3 only). Omitted when default 2/2/8. */
+  co?: [number, number, number];
   ts?: CompactTank[]; hs?: CompactHealer[]; dp?: CompactDPS[];
   to?: CompactTrialOverrides;
   t1?: CompactTank; t2?: CompactTank; h1?: CompactHealer; h2?: CompactHealer;
 }
+
+// Composition defaults/clamps — mirror the frontend's rosterEncoding.ts so the
+// ping logic knows how many slots a roster *wants*, not just how many are filled.
+const DEFAULT_COMPOSITION = { tanks: 2, healers: 2, dps: 8 } as const;
+const MAX_TANKS = 4;
+const MAX_HEALERS = 4;
+const MAX_DPS = 24;
+
+const clampCount = (n: number, max: number): number => Math.min(Math.max(0, n), max);
 
 // ── Decode helpers ──────────────────────────────────────────────────────────
 
@@ -279,10 +290,22 @@ export async function decodeRosterData(rosterData: string): Promise<DecodedRoste
     if (compact.dp) dps.push(...compact.dp.map(decodeDPS));
   }
 
+  // Composition reflects the slots the roster *asks for*. v3 carries it in `co`
+  // (default 2/2/8 when omitted); v2 is always the legacy 2/2/8 trial layout.
+  const composition =
+    compact.v === 3 && compact.co
+      ? {
+          tanks: clampCount(compact.co[0] ?? 0, MAX_TANKS),
+          healers: clampCount(compact.co[1] ?? 0, MAX_HEALERS),
+          dps: clampCount(compact.co[2] ?? 0, MAX_DPS),
+        }
+      : { ...DEFAULT_COMPOSITION };
+
   return {
     name: compact.n,
     trialId: compact.to?.ti || undefined,
     notes: compact.no,
+    composition,
     tanks,
     healers,
     dps,

--- a/discord-bot/src/roster/decoder.ts
+++ b/discord-bot/src/roster/decoder.ts
@@ -205,7 +205,7 @@ function decodeDPS(d: CompactDPS): DecodedRosterSlot {
   // Prefer structured set fields; fall back to legacy gs array
   let sets: string[];
   if (d.s1 != null || d.s2 != null || d.ms != null) {
-    sets = collectSets([d.s1, d.s2, d.ms], d.as);
+    sets = collectSets([d.s1, d.s2, d.ms], d.as) ?? [];
   } else if (d.gs?.length) {
     sets = d.gs.map((id) => getSetName(id)).filter(Boolean);
   } else {

--- a/discord-bot/src/roster/embed-builder.test.ts
+++ b/discord-bot/src/roster/embed-builder.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildRosterText, splitMessages, buildRosterActionRows } from './embed-builder';
+import {
+  buildRosterText,
+  splitMessages,
+  buildRosterActionRows,
+  buildRolePingLine,
+} from './embed-builder';
 import type { DecodedRoster, RosterSnapshot } from './types';
 
 const mockSnapshot: RosterSnapshot = {
@@ -179,5 +184,50 @@ describe('buildRosterActionRows', () => {
     const rows = buildRosterActionRows('abc-xyz');
     const buttons = rows[0].components ?? [];
     expect(buttons[0].custom_id).toContain('abc-xyz');
+  });
+});
+
+describe('buildRolePingLine', () => {
+  const TANK = '100000000000000001';
+  const HEALER = '100000000000000002';
+  const DD = '100000000000000003';
+
+  it('returns null when no ping config is provided', () => {
+    expect(buildRolePingLine(mockDecoded, undefined)).toBeNull();
+  });
+
+  it('returns null when config has no usable role IDs', () => {
+    expect(buildRolePingLine(mockDecoded, {})).toBeNull();
+  });
+
+  it('pings configured roles that are present in the roster', () => {
+    const result = buildRolePingLine(mockDecoded, { tank: TANK, healer: HEALER, dd: DD });
+    expect(result).not.toBeNull();
+    expect(result?.roleIds).toEqual([TANK, HEALER, DD]);
+    expect(result?.content).toContain(`<@&${TANK}>`);
+    expect(result?.content).toContain(`<@&${HEALER}>`);
+    expect(result?.content).toContain(`<@&${DD}>`);
+  });
+
+  it('skips role types that are absent from the roster', () => {
+    const tanksOnly: DecodedRoster = { tanks: mockDecoded.tanks, healers: [], dps: [] };
+    const result = buildRolePingLine(tanksOnly, { tank: TANK, healer: HEALER, dd: DD });
+    expect(result?.roleIds).toEqual([TANK]);
+    expect(result?.content).not.toContain(`<@&${HEALER}>`);
+  });
+
+  it('de-duplicates when the same role is configured for multiple types', () => {
+    const result = buildRolePingLine(mockDecoded, { tank: TANK, healer: TANK, dd: DD });
+    expect(result?.roleIds).toEqual([TANK, DD]);
+  });
+
+  it('ignores malformed (non-snowflake) role IDs', () => {
+    const result = buildRolePingLine(mockDecoded, { tank: '@everyone', healer: HEALER, dd: 'abc' });
+    expect(result?.roleIds).toEqual([HEALER]);
+  });
+
+  it('returns null when configured roles map to empty role sections', () => {
+    const empty: DecodedRoster = { tanks: [], healers: [], dps: mockDecoded.dps };
+    expect(buildRolePingLine(empty, { tank: TANK, healer: HEALER })).toBeNull();
   });
 });

--- a/discord-bot/src/roster/embed-builder.test.ts
+++ b/discord-bot/src/roster/embed-builder.test.ts
@@ -216,6 +216,30 @@ describe('buildRolePingLine', () => {
     expect(result?.content).not.toContain(`<@&${HEALER}>`);
   });
 
+  it('pings based on composition even when slots are unfilled (blank roster)', () => {
+    // The encoder only stores filled slots, so a "seeking signups" roster has
+    // empty arrays but a full composition — pings must still fire.
+    const blank: DecodedRoster = {
+      composition: { tanks: 2, healers: 2, dps: 8 },
+      tanks: [],
+      healers: [],
+      dps: [],
+    };
+    const result = buildRolePingLine(blank, { tank: TANK, healer: HEALER, dd: DD });
+    expect(result?.roleIds).toEqual([TANK, HEALER, DD]);
+  });
+
+  it('honors a composition that excludes a role (e.g. no healers)', () => {
+    const noHealers: DecodedRoster = {
+      composition: { tanks: 2, healers: 0, dps: 8 },
+      tanks: [],
+      healers: [],
+      dps: [],
+    };
+    const result = buildRolePingLine(noHealers, { tank: TANK, healer: HEALER, dd: DD });
+    expect(result?.roleIds).toEqual([TANK, DD]);
+  });
+
   it('de-duplicates when the same role is configured for multiple types', () => {
     const result = buildRolePingLine(mockDecoded, { tank: TANK, healer: TANK, dd: DD });
     expect(result?.roleIds).toEqual([TANK, DD]);

--- a/discord-bot/src/roster/embed-builder.ts
+++ b/discord-bot/src/roster/embed-builder.ts
@@ -232,8 +232,13 @@ export interface RolePingResult {
 /**
  * Build a one-off "@role a new run is up" ping for the roles configured in the
  * guild config. Only pings a role type (tank/healer/dd) when that role is both
- * configured *and* present in the roster, so members aren't pinged for slots
- * the roster doesn't contain.
+ * configured *and* part of the roster's composition, so members aren't pinged
+ * for slots the roster doesn't contain.
+ *
+ * Slot *counts* (composition) drive this, not filled-entry counts: the encoder
+ * only stores filled slots, so a blank "seeking signups" roster has empty
+ * arrays but still wants its full composition (default 2/2/8) — which is
+ * exactly the case where signup pings matter most.
  *
  * Returns `null` when there is nothing to ping — callers should skip sending.
  */
@@ -243,6 +248,13 @@ export function buildRolePingLine(
 ): RolePingResult | null {
   if (!rolePingIds) return null;
 
+  // Prefer composition (slots requested); fall back to filled-entry counts when
+  // composition is unavailable (e.g. older decoded payloads).
+  const comp = decoded.composition;
+  const tankCount = comp?.tanks ?? decoded.tanks.length;
+  const healerCount = comp?.healers ?? decoded.healers.length;
+  const dpsCount = comp?.dps ?? decoded.dps.length;
+
   const mentions: string[] = [];
   const roleIds: string[] = [];
   const add = (id: string | undefined, present: boolean) => {
@@ -251,9 +263,9 @@ export function buildRolePingLine(
     mentions.push(`<@&${id}>`);
   };
 
-  add(rolePingIds.tank, decoded.tanks.length > 0);
-  add(rolePingIds.healer, decoded.healers.length > 0);
-  add(rolePingIds.dd, decoded.dps.length > 0);
+  add(rolePingIds.tank, tankCount > 0);
+  add(rolePingIds.healer, healerCount > 0);
+  add(rolePingIds.dd, dpsCount > 0);
 
   if (roleIds.length === 0) return null;
   return { content: `📢 A new roster is up — ${mentions.join(' ')}`, roleIds };

--- a/discord-bot/src/roster/embed-builder.ts
+++ b/discord-bot/src/roster/embed-builder.ts
@@ -217,6 +217,48 @@ export function splitMessages(text: string): string[] {
   return chunks;
 }
 
+// ── Role Pings ──────────────────────────────────────────────────────────────
+
+/** Discord snowflake (17–20 digits). Guards against malformed/injected IDs. */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
+export interface RolePingResult {
+  /** Message content with role mentions. */
+  content: string;
+  /** Role IDs to allow in `allowed_mentions.roles` (de-duplicated, validated). */
+  roleIds: string[];
+}
+
+/**
+ * Build a one-off "@role a new run is up" ping for the roles configured in the
+ * guild config. Only pings a role type (tank/healer/dd) when that role is both
+ * configured *and* present in the roster, so members aren't pinged for slots
+ * the roster doesn't contain.
+ *
+ * Returns `null` when there is nothing to ping — callers should skip sending.
+ */
+export function buildRolePingLine(
+  decoded: DecodedRoster,
+  rolePingIds?: { tank?: string | undefined; healer?: string | undefined; dd?: string | undefined },
+): RolePingResult | null {
+  if (!rolePingIds) return null;
+
+  const mentions: string[] = [];
+  const roleIds: string[] = [];
+  const add = (id: string | undefined, present: boolean) => {
+    if (!id || !present || !SNOWFLAKE_RE.test(id) || roleIds.includes(id)) return;
+    roleIds.push(id);
+    mentions.push(`<@&${id}>`);
+  };
+
+  add(rolePingIds.tank, decoded.tanks.length > 0);
+  add(rolePingIds.healer, decoded.healers.length > 0);
+  add(rolePingIds.dd, decoded.dps.length > 0);
+
+  if (roleIds.length === 0) return null;
+  return { content: `📢 A new roster is up — ${mentions.join(' ')}`, roleIds };
+}
+
 // ── Action Rows ─────────────────────────────────────────────────────────────
 
 export function buildRosterActionRows(rosterId: string): DiscordComponent[] {

--- a/discord-bot/src/roster/kv.ts
+++ b/discord-bot/src/roster/kv.ts
@@ -169,6 +169,29 @@ export async function releasePublishLock(
   await env.ROSTERS.delete(`${LOCK_PREFIX}:${guildId}:${rosterId}`);
 }
 
+// ── Rate limiting ────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort fixed-window rate limit backed by KV. Returns true if the action
+ * is allowed, false once the caller has hit `max` actions within
+ * `windowSeconds`. Not strictly atomic (KV read-then-write), which is fine for
+ * throttling abuse — it can admit a few extra under a burst but caps runaway
+ * channel/ping creation.
+ */
+export async function checkRosterRateLimit(
+  env: Env,
+  key: string,
+  max: number,
+  windowSeconds: number,
+): Promise<boolean> {
+  const rlKey = `rl:${key}`;
+  const raw = await env.ROSTERS.get(rlKey);
+  const count = raw ? parseInt(raw, 10) : 0;
+  if (count >= max) return false;
+  await env.ROSTERS.put(rlKey, String(count + 1), { expirationTtl: windowSeconds });
+  return true;
+}
+
 // ── Guild Config CRUD ───────────────────────────────────────────────────────
 
 function guildConfigKey(guildId: string): string {

--- a/discord-bot/src/roster/publish.test.ts
+++ b/discord-bot/src/roster/publish.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePublishTarget } from './publish';
+import type { GuildConfig } from './types';
+
+const baseConfig = (overrides: Partial<GuildConfig> = {}): GuildConfig => ({
+  guildId: '123456789012345678',
+  namePattern: '{day-short}-{time}-{trial}',
+  ...overrides,
+});
+
+describe('resolvePublishTarget', () => {
+  it('creates a new channel when no default channel is configured', () => {
+    expect(resolvePublishTarget(baseConfig())).toEqual({ mode: 'create' });
+  });
+
+  it('posts into the configured default channel when set to a valid snowflake', () => {
+    const target = resolvePublishTarget(baseConfig({ defaultChannelId: '987654321098765432' }));
+    expect(target).toEqual({ mode: 'existing', channelId: '987654321098765432' });
+  });
+
+  it('falls back to creating a channel when the default channel is not a snowflake', () => {
+    expect(resolvePublishTarget(baseConfig({ defaultChannelId: 'not-an-id' }))).toEqual({
+      mode: 'create',
+    });
+  });
+
+  it('falls back to creating a channel when the default channel is an empty string', () => {
+    expect(resolvePublishTarget(baseConfig({ defaultChannelId: '' }))).toEqual({ mode: 'create' });
+  });
+});

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -416,12 +416,25 @@ export async function publishDirect(env: Env, req: DirectPublishRequest): Promis
   }
 }
 
-/** Derive a stable, collision-resistant lock key from a direct-publish payload. */
+/**
+ * Derive a stable, collision-resistant lock key from a direct-publish payload.
+ * Includes every field that distinguishes one publish from another, so a rapid
+ * double-click (identical payload) contends on the lock, while genuinely
+ * different submissions — e.g. the same roster scheduled for two event times —
+ * don't falsely block each other. guildId is already in the KV key prefix;
+ * ownerUserId is intentionally excluded so two users submitting identical
+ * content still de-dupe. Fields are NUL-joined so values can't bleed across
+ * boundaries.
+ */
 async function contentLockKey(req: DirectPublishRequest): Promise<string> {
   const material = [
     req.title,
+    req.description ?? '',
+    req.trial_id ?? '',
+    (req.tags ?? []).join(','),
     req.channelNameOverride ?? '',
     req.categoryId ?? '',
+    req.eventTime ?? '',
     req.roster_data,
   ].join(' ');
   const bytes = new TextEncoder().encode(material);

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -297,6 +297,15 @@ export interface RefreshResult {
   refreshedCount?: number | undefined;
 }
 
+export interface RefreshOptions {
+  /**
+   * When a roster's channel/messages are gone, recreate the channel. Defaults
+   * to true for user-initiated refreshes. The hub webhook passes false so an
+   * automatic re-sync never resurrects a channel staff deliberately deleted.
+   */
+  allowRecreate?: boolean;
+}
+
 /**
  * Refresh all Discord channels linked to a roster across all guilds.
  * Called by the webhook from roster-hub-api and by /roster refresh.
@@ -305,7 +314,9 @@ export async function refreshRoster(
   env: Env,
   rosterId: string,
   scopeGuildId?: string,
+  opts: RefreshOptions = {},
 ): Promise<RefreshResult> {
+  const allowRecreate = opts.allowRecreate ?? true;
   // Fetch the latest snapshot — hub API for normal IDs, KV for direct-publish
   const fetchResult = await fetchRosterSnapshot(env, rosterId);
   let snapshot = fetchResult.status === 'ok' ? fetchResult.snapshot : null;
@@ -377,6 +388,8 @@ export async function refreshRoster(
       decoded,
       channelName,
       mapping.categoryId,
+      undefined,
+      allowRecreate,
     );
 
     if (result.ok) {
@@ -578,6 +591,7 @@ async function refreshExistingMapping(
   channelName: string,
   categoryId?: string,
   eventTime?: string,
+  allowRecreate = true,
 ): Promise<InternalRefreshResult> {
   const text = buildRosterText(snapshot, decoded, eventTime);
   const chunks = splitMessages(text);
@@ -613,7 +627,14 @@ async function refreshExistingMapping(
     const messageIds = await sendRosterMessages(env, mapping.channelId, chunks, components);
     return { ok: true, channelId: mapping.channelId, messageId: messageIds };
   } catch (err) {
-    console.warn('[refresh] re-post to existing channel failed, recreating:', err);
+    console.warn('[refresh] re-post to existing channel failed:', err);
+  }
+
+  // The channel/messages are gone. Only recreate for user-initiated refreshes —
+  // an automatic (webhook) re-sync must not resurrect a channel staff deleted on
+  // purpose. The mapping is left intact so a transient failure can recover later.
+  if (!allowRecreate) {
+    return { ok: false, error: 'Channel no longer exists; skipping automatic recreate.' };
   }
 
   // Channel was deleted — recreate

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -18,7 +18,12 @@ import type { DiscordComponent, Env } from '../types.js';
 import { fetchRosterSnapshot } from './api.js';
 import { resolveChannelName } from './channel-name.js';
 import { decodeRosterData } from './decoder.js';
-import { buildRosterText, splitMessages, buildRosterActionRows } from './embed-builder.js';
+import {
+  buildRosterText,
+  splitMessages,
+  buildRosterActionRows,
+  buildRolePingLine,
+} from './embed-builder.js';
 import {
   findMappingsForRoster,
   getMappingByRosterId,
@@ -29,7 +34,13 @@ import {
   releasePublishLock,
   KV_PREFIX,
 } from './kv.js';
-import type { ChannelNameContext, DecodedRoster, RosterMapping, RosterSnapshot } from './types.js';
+import type {
+  ChannelNameContext,
+  DecodedRoster,
+  GuildConfig,
+  RosterMapping,
+  RosterSnapshot,
+} from './types.js';
 
 // ── Snapshot → Channel Name Context ────────────────────────────────────────
 
@@ -221,6 +232,7 @@ async function doPublishRoster(env: Env, req: PublishRequest): Promise<PublishRe
       snapshot,
       decoded,
       req.eventTime,
+      config.rolePingIds,
     );
     if (!created.ok) return created;
     channelId = created.channelId!;
@@ -387,18 +399,37 @@ export async function publishDirect(env: Env, req: DirectPublishRequest): Promis
     .slice(0, 6);
   const syntheticId = `direct-${Date.now().toString(36)}-${suffix}`;
 
-  // Acquire lock using the synthetic ID (unique, so no contention here —
-  // but guards against rapid double-clicks sending the same request twice)
-  const locked = await acquirePublishLock(env, req.guildId, syntheticId);
+  // Acquire lock keyed on the *content* (not the random synthetic ID): a rapid
+  // double-click sends two identical requests that would each mint a different
+  // synthetic ID, so locking on the ID would never collide and both would
+  // create a channel. Hashing the payload makes duplicate submissions contend.
+  const lockKey = await contentLockKey(req);
+  const locked = await acquirePublishLock(env, req.guildId, lockKey);
   if (!locked) {
-    return { ok: false, error: 'A publish is already in progress. Please wait.' };
+    return { ok: false, error: 'A publish is already in progress for this roster. Please wait.' };
   }
 
   try {
     return await doPublishDirect(env, req, syntheticId);
   } finally {
-    await releasePublishLock(env, req.guildId, syntheticId);
+    await releasePublishLock(env, req.guildId, lockKey);
   }
+}
+
+/** Derive a stable, collision-resistant lock key from a direct-publish payload. */
+async function contentLockKey(req: DirectPublishRequest): Promise<string> {
+  const material = [
+    req.title,
+    req.channelNameOverride ?? '',
+    req.categoryId ?? '',
+    req.roster_data,
+  ].join(' ');
+  const bytes = new TextEncoder().encode(material);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `dedupe-${hex.slice(0, 32)}`;
 }
 
 async function doPublishDirect(
@@ -446,6 +477,7 @@ async function doPublishDirect(
     snapshot,
     decoded,
     req.eventTime,
+    config.rolePingIds,
   );
 
   if (!result.ok) return result;
@@ -580,6 +612,7 @@ async function createNewRosterChannel(
   snapshot: RosterSnapshot,
   decoded: Awaited<ReturnType<typeof decodeRosterData>>,
   eventTime?: string,
+  rolePingIds?: GuildConfig['rolePingIds'],
 ): Promise<InternalRefreshResult> {
   const channelOptions: Parameters<typeof createChannel>[2] = {
     name: channelName,
@@ -603,6 +636,20 @@ async function createNewRosterChannel(
   }
 
   try {
+    // Best-effort role ping (opt-in via guild config). Sent as its own message
+    // so it's never re-sent on refresh and a ping failure can't block the post.
+    const ping = buildRolePingLine(decoded, rolePingIds);
+    if (ping) {
+      try {
+        await sendMessage(env, channel.id, {
+          content: ping.content,
+          allowed_mentions: { parse: [], roles: ping.roleIds },
+        });
+      } catch (pingErr) {
+        console.warn('[publish] role ping failed (non-fatal):', pingErr);
+      }
+    }
+
     const text = buildRosterText(snapshot, decoded, eventTime);
     const chunks = splitMessages(text);
     const components = buildRosterActionRows(snapshot.id);

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -136,6 +136,27 @@ async function detectOpenRunsCategory(env: Env, guildId: string): Promise<string
   }
 }
 
+// ── Publish target resolution ───────────────────────────────────────────────
+
+export type PublishTarget = { mode: 'existing'; channelId: string } | { mode: 'create' };
+
+const CHANNEL_SNOWFLAKE = /^\d{17,20}$/;
+
+/**
+ * Decide where a roster should be published:
+ *   - into the guild's configured default channel (when set to a valid
+ *     snowflake) — posting alongside other rosters, no channel created; or
+ *   - a freshly created per-roster channel (the default behaviour).
+ *
+ * Exported for unit testing.
+ */
+export function resolvePublishTarget(config: GuildConfig): PublishTarget {
+  if (config.defaultChannelId && CHANNEL_SNOWFLAKE.test(config.defaultChannelId)) {
+    return { mode: 'existing', channelId: config.defaultChannelId };
+  }
+  return { mode: 'create' };
+}
+
 // ── Publish Request/Response ────────────────────────────────────────────────
 
 export interface PublishRequest {
@@ -223,17 +244,28 @@ async function doPublishRoster(env: Env, req: PublishRequest): Promise<PublishRe
     channelId = refreshed.channelId!;
     messageId = refreshed.messageId!;
   } else {
-    // Create new channel + message
-    const created = await createNewRosterChannel(
-      env,
-      req.guildId,
-      channelName,
-      categoryId,
-      snapshot,
-      decoded,
-      req.eventTime,
-      config.rolePingIds,
-    );
+    // Post into the configured default channel, or create a new channel.
+    const target = resolvePublishTarget(config);
+    const created =
+      target.mode === 'existing'
+        ? await postRosterToDefaultChannel(
+            env,
+            target.channelId,
+            snapshot,
+            decoded,
+            req.eventTime,
+            config.rolePingIds,
+          )
+        : await createNewRosterChannel(
+            env,
+            req.guildId,
+            channelName,
+            categoryId,
+            snapshot,
+            decoded,
+            req.eventTime,
+            config.rolePingIds,
+          );
     if (!created.ok) return created;
     channelId = created.channelId!;
     messageId = created.messageId!;
@@ -482,16 +514,27 @@ async function doPublishDirect(
   const categoryId =
     req.categoryId ?? config.defaultCategoryId ?? (await detectOpenRunsCategory(env, req.guildId));
 
-  const result = await createNewRosterChannel(
-    env,
-    req.guildId,
-    channelName,
-    categoryId,
-    snapshot,
-    decoded,
-    req.eventTime,
-    config.rolePingIds,
-  );
+  const target = resolvePublishTarget(config);
+  const result =
+    target.mode === 'existing'
+      ? await postRosterToDefaultChannel(
+          env,
+          target.channelId,
+          snapshot,
+          decoded,
+          req.eventTime,
+          config.rolePingIds,
+        )
+      : await createNewRosterChannel(
+          env,
+          req.guildId,
+          channelName,
+          categoryId,
+          snapshot,
+          decoded,
+          req.eventTime,
+          config.rolePingIds,
+        );
 
   if (!result.ok) return result;
 
@@ -615,6 +658,74 @@ async function sendRosterMessages(
   return ids.join(',');
 }
 
+// ── Post roster into an existing channel ────────────────────────────────────
+
+/**
+ * Send the role ping (best-effort) + roster messages into an existing channel.
+ * Used both after creating a fresh channel and when posting into a configured
+ * default channel. Does not create or delete channels.
+ */
+async function sendRosterToChannel(
+  env: Env,
+  channelId: string,
+  snapshot: RosterSnapshot,
+  decoded: Awaited<ReturnType<typeof decodeRosterData>>,
+  eventTime?: string,
+  rolePingIds?: GuildConfig['rolePingIds'],
+): Promise<string> {
+  // Best-effort role ping (opt-in via guild config). Sent as its own message
+  // so it's never re-sent on refresh and a ping failure can't block the post.
+  const ping = buildRolePingLine(decoded, rolePingIds);
+  if (ping) {
+    try {
+      await sendMessage(env, channelId, {
+        content: ping.content,
+        allowed_mentions: { parse: [], roles: ping.roleIds },
+      });
+    } catch (pingErr) {
+      console.warn('[publish] role ping failed (non-fatal):', pingErr);
+    }
+  }
+
+  const text = buildRosterText(snapshot, decoded, eventTime);
+  const chunks = splitMessages(text);
+  const components = buildRosterActionRows(snapshot.id);
+  return sendRosterMessages(env, channelId, chunks, components);
+}
+
+/**
+ * Post a roster into the guild's configured default channel (no channel
+ * creation). Returns an error result if the channel rejects the message
+ * (e.g. it was deleted or the bot lost access) — unlike the create path, we
+ * never created the channel so there's nothing to clean up.
+ */
+async function postRosterToDefaultChannel(
+  env: Env,
+  channelId: string,
+  snapshot: RosterSnapshot,
+  decoded: Awaited<ReturnType<typeof decodeRosterData>>,
+  eventTime?: string,
+  rolePingIds?: GuildConfig['rolePingIds'],
+): Promise<InternalRefreshResult> {
+  try {
+    const messageId = await sendRosterToChannel(
+      env,
+      channelId,
+      snapshot,
+      decoded,
+      eventTime,
+      rolePingIds,
+    );
+    return { ok: true, channelId, messageId };
+  } catch (err) {
+    console.error('[publish] post to default channel failed:', err);
+    return {
+      ok: false,
+      error: 'Failed to post into the configured default channel. Check the bot has access to it.',
+    };
+  }
+}
+
 // ── Create a new channel + post roster ──────────────────────────────────────
 
 async function createNewRosterChannel(
@@ -649,25 +760,14 @@ async function createNewRosterChannel(
   }
 
   try {
-    // Best-effort role ping (opt-in via guild config). Sent as its own message
-    // so it's never re-sent on refresh and a ping failure can't block the post.
-    const ping = buildRolePingLine(decoded, rolePingIds);
-    if (ping) {
-      try {
-        await sendMessage(env, channel.id, {
-          content: ping.content,
-          allowed_mentions: { parse: [], roles: ping.roleIds },
-        });
-      } catch (pingErr) {
-        console.warn('[publish] role ping failed (non-fatal):', pingErr);
-      }
-    }
-
-    const text = buildRosterText(snapshot, decoded, eventTime);
-    const chunks = splitMessages(text);
-    const components = buildRosterActionRows(snapshot.id);
-    const messageIds = await sendRosterMessages(env, channel.id, chunks, components);
-
+    const messageIds = await sendRosterToChannel(
+      env,
+      channel.id,
+      snapshot,
+      decoded,
+      eventTime,
+      rolePingIds,
+    );
     return { ok: true, channelId: channel.id, messageId: messageIds };
   } catch (err) {
     console.error('[publish] send message failed, cleaning up orphaned channel:', err);

--- a/discord-bot/src/roster/rate-limit.test.ts
+++ b/discord-bot/src/roster/rate-limit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { checkRosterRateLimit } from './kv';
+import type { Env } from '../types';
+
+/** Minimal in-memory KV stub — only the get/put used by the rate limiter. */
+function makeKv(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(): Env {
+  return { ROSTERS: makeKv() } as unknown as Env;
+}
+
+describe('checkRosterRateLimit', () => {
+  it('allows up to the limit then blocks', async () => {
+    const env = makeEnv();
+    const results: boolean[] = [];
+    for (let i = 0; i < 6; i++) {
+      results.push(await checkRosterRateLimit(env, 'publish:g:u', 5, 60));
+    }
+    expect(results).toEqual([true, true, true, true, true, false]);
+  });
+
+  it('tracks distinct keys independently', async () => {
+    const env = makeEnv();
+    expect(await checkRosterRateLimit(env, 'publish:g:userA', 1, 60)).toBe(true);
+    expect(await checkRosterRateLimit(env, 'publish:g:userA', 1, 60)).toBe(false);
+    // Different user key is unaffected
+    expect(await checkRosterRateLimit(env, 'publish:g:userB', 1, 60)).toBe(true);
+  });
+});

--- a/discord-bot/src/roster/types.ts
+++ b/discord-bot/src/roster/types.ts
@@ -113,6 +113,13 @@ export interface DecodedRosterSlot {
 export interface DecodedRoster {
   name?: string | undefined;
   trialId?: string | undefined;
+  /**
+   * Slot counts the roster asks for (default 2/2/8). The encoder only stores
+   * *filled* slots, so this — not the array lengths below — reflects how many
+   * tanks/healers/DDs a roster actually wants (e.g. a blank "seeking signups"
+   * roster has empty arrays but a full composition).
+   */
+  composition?: { tanks: number; healers: number; dps: number } | undefined;
   tanks: DecodedRosterSlot[];
   healers: DecodedRosterSlot[];
   dps: DecodedRosterSlot[];

--- a/src/pages/DiscordServerConfigPage.tsx
+++ b/src/pages/DiscordServerConfigPage.tsx
@@ -521,7 +521,8 @@ export const DiscordServerConfigPage: React.FC = () => {
 
     try {
       const body: Record<string, unknown> = {
-        defaultChannelId: defaultChannelId || undefined,
+        // Always send a string: '' explicitly clears the default posting channel.
+        defaultChannelId,
         defaultCategoryId: defaultCategoryId || undefined,
         namePattern,
         allowedRoleIds: allowedRoleIds.map((r) => r.id),
@@ -558,7 +559,8 @@ export const DiscordServerConfigPage: React.FC = () => {
 
   // Get text channels grouped by category
   const categories = channels.filter((c) => c.type === 4);
-  // textChannels removed — category-based auto-create is the primary flow
+  // Text channels (type 0) — used by the optional "default posting channel" picker
+  const textChannels = channels.filter((c) => c.type === 0);
 
   // Filter guilds by search
   const filteredGuilds = useMemo(() => {
@@ -1010,6 +1012,60 @@ export const DiscordServerConfigPage: React.FC = () => {
                 </Alert>
               </Collapse>
             )}
+
+            {/* Default Posting Channel */}
+            <ConfigSection
+              icon={<TagIcon sx={{ color: '#5865F2', fontSize: 18 }} />}
+              title="Default Posting Channel"
+              description="Optionally post every roster into one existing channel instead of creating a new channel per roster."
+              isDark={isDark}
+              badge={
+                <Chip
+                  label="Optional"
+                  size="small"
+                  sx={{
+                    fontSize: '0.65rem',
+                    height: 18,
+                    background: isDark
+                      ? 'linear-gradient(135deg, rgba(88,101,242,0.15), rgba(88,101,242,0.08))'
+                      : 'rgba(88,101,242,0.08)',
+                    color: '#5865F2',
+                    border: '1px solid rgba(88,101,242,0.15)',
+                  }}
+                />
+              }
+            >
+              <FormControl fullWidth size="small">
+                <InputLabel>Channel</InputLabel>
+                <Select
+                  value={defaultChannelId}
+                  label="Channel"
+                  onChange={(e: SelectChangeEvent) => setDefaultChannelId(e.target.value)}
+                >
+                  <MenuItem value="">
+                    <em>Auto-create a channel per roster</em>
+                  </MenuItem>
+                  {textChannels.map((ch) => (
+                    <MenuItem key={ch.id} value={ch.id}>
+                      # {ch.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Typography
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  mt: 1,
+                  color: isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.4)',
+                  fontSize: '0.68rem',
+                }}
+              >
+                When set, all rosters are posted here and the category &amp; channel-name settings
+                below are ignored. Leave on &ldquo;Auto-create&rdquo; for a dedicated channel per
+                roster.
+              </Typography>
+            </ConfigSection>
 
             {/* Default Category */}
             <ConfigSection


### PR DESCRIPTION
## Discord roster bot audit + fixes

A full pass over the roster side of `discord-bot/` plus the web config page, **and** the process gap that let the bugs land.

**Verification:** discord-bot `tsc` clean (standalone) · **75/75** unit tests · Worker bundles (`wrangler deploy --dry-run`) · clean `npm ci` in an isolated checkout. Frontend: root `tsc`, ESLint, Prettier clean. Secrets are Cloudflare-side, so a quick live smoke test on the esotk server is still recommended (real `@role` ping notifying; posts landing in a default channel).

### Fixed
1. **Bot didn't type-check** 🔴 — `DiscordRole` cast, `undefined`-typed `sets`.
2. **Role pings never fired** 🔴 — now posted once on initial publish, driven by roster **composition** (v3 `co`, default 2/2/8) so blank "seeking signups" rosters ping correctly (Codex catch). Snowflake-validated, scoped `allowed_mentions`, best-effort.
3. **Double-click → duplicate channels** 🟠 — `publishDirect` now locks on a content hash.
4. **`set-name-pattern` validation** 🟡 — trim + 100-char cap.
5. **`defaultChannelId` ("Default posting channel") was dead on both ends** 🟠 — now wired end-to-end: `resolvePublishTarget()` posts into the configured channel or creates one; refresh is roster-scoped so a shared channel works (button uses its encoded roster ID; `/roster refresh` refreshes every roster in the channel); snowflake-validated, empty clears. Frontend gets a "Default Posting Channel" picker.
6. **Refresh falsely reported success** when a roster's mapping was gone — now gated on `refreshedCount > 0`.
7. **No rate limit on `/roster publish` / `/roster link` / refresh** 🟠 — added per-user KV limits (publish/link 5/min, refresh 10/min). Closes the burst channel/ping-spam vector the new ping feature could amplify.
8. **Refresh resurrected intentionally-deleted channels** 🟠 — the hub webhook now passes `allowRecreate: false`, so an automatic re-sync skips a missing channel instead of recreating it; user-initiated refreshes still recreate.
9. **`set-role-pings` snowflake validation** 🟡 — parity with the HTTP path.

### Root cause of #1: no CI for the bot
`discord-bot/` is a separate package the root PR Checks never covered — which is *why* the typecheck errors reached `main`. Added a **`Discord Bot CI`** workflow (typecheck + tests on `discord-bot/**` changes) and **regenerated `discord-bot/package-lock.json`**, which was out of sync (missing `vitest`) and would have failed `npm ci`. The new `discord-bot` check runs on this PR.

### Tests
`decoder.test.ts` (composition), role-ping builder tests, `resolvePublishTarget` tests, `rate-limit.test.ts` (in-memory KV).

### Remaining (deliberate, not changed)
- **Sign-up buttons are a v0 stub** (each click posts a fresh public "interested" message; no persistence/toggle) — full sign-up tracking is its own feature.
- **`checkRosterRateLimit`/publish lock are read-then-write** (best-effort, not atomic) — adequate for throttling; hard guarantees would need Durable Objects.

https://claude.ai/code/session_01HsuYhaxoPsGB3CwT68taNA