### PR TITLE
feat(companion): ESOTK Companion — capture champion points + build gaps, show them on player cards

### DIFF
--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -56,7 +56,9 @@ end
 
 -- Read a GetPlayerStat value only if one of the STAT_ constants exists this API version.
 local function stat(...)
-  local opt = _G["BONUS_OPTION_DEFAULT"] or 0
+  -- Buff-inclusive final value, exactly as the in-game character sheet reads it.
+  -- (There is no BONUS_OPTION_DEFAULT constant; STAT_BONUS_OPTION_APPLY_BONUS == 0.)
+  local opt = _G["STAT_BONUS_OPTION_APPLY_BONUS"] or 0
   for i = 1, select("#", ...) do
     local constName = select(i, ...)
     local c = _G[constName]
@@ -131,7 +133,8 @@ local function captureStats()
     weaponDamage    = stat("STAT_POWER", "STAT_WEAPON_POWER", "STAT_WEAPON_AND_SPELL_DAMAGE"),
     spellCrit       = stat("STAT_SPELL_CRITICAL"),
     weaponCrit      = stat("STAT_CRITICAL_STRIKE"),
-    critDamage      = stat("STAT_CRITICAL_DAMAGE"),
+    -- Crit DAMAGE has no client-side stat constant; it is summed from CP +
+    -- sets + mundus + passives on the ESOTK side (see CritDamageUtils).
     spellPen        = stat("STAT_SPELL_PENETRATION"),
     physicalPen     = stat("STAT_PHYSICAL_PENETRATION"),
     magickaRegen    = stat("STAT_MAGICKA_REGEN_COMBAT"),
@@ -176,11 +179,20 @@ end
 local function captureBars()
   local bars = {}
   local cats = { front = _G["HOTBAR_CATEGORY_PRIMARY"], back = _G["HOTBAR_CATEGORY_BACKUP"] }
+  local ACT_CRAFTED = _G["ACTION_TYPE_CRAFTED_ABILITY"]
   for label, cat in pairs(cats) do
     if cat ~= nil then
       local barSlots = {}
       for slot = 3, 8 do  -- 3..7 = abilities, 8 = ultimate
-        barSlots[slot] = call("GetSlotBoundId", slot, cat)
+        local boundId = call("GetSlotBoundId", slot, cat)
+        -- Scribed (crafted) slots return a small craftedAbilityId, not the real
+        -- abilityId. Resolve it so the bar carries true abilityIds like the log does.
+        if ACT_CRAFTED ~= nil and boundId and boundId ~= 0
+          and call("GetSlotType", slot, cat) == ACT_CRAFTED then
+          barSlots[slot] = call("GetAbilityIdForCraftedAbilityId", boundId) or boundId
+        else
+          barSlots[slot] = boundId
+        end
       end
       bars[label] = barSlots
     end

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -54,13 +54,18 @@ local function call(fnName, ...)
   return r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12
 end
 
--- Read a GetPlayerStat value only if the STAT_ constant is defined this API version.
-local function stat(constName)
-  local c = _G[constName]
-  if c == nil then return nil end
+-- Read a GetPlayerStat value only if one of the STAT_ constants exists this API version.
+local function stat(...)
   local opt = _G["BONUS_OPTION_DEFAULT"] or 0
-  local v = call("GetPlayerStat", c, opt)
-  return v
+  for i = 1, select("#", ...) do
+    local constName = select(i, ...)
+    local c = _G[constName]
+    if c ~= nil then
+      local v = call("GetPlayerStat", c, opt)
+      if v ~= nil then return v end
+    end
+  end
+  return nil
 end
 
 -- ----------------------------------------------------------------------------
@@ -122,8 +127,8 @@ local function captureStats()
     maxMagicka      = stat("STAT_MAGICKA_MAX"),
     maxHealth       = stat("STAT_HEALTH_MAX"),
     maxStamina      = stat("STAT_STAMINA_MAX"),
-    spellDamage     = stat("STAT_SPELL_POWER"),
-    weaponDamage    = stat("STAT_WEAPON_POWER"),
+    spellDamage     = stat("STAT_SPELL_POWER", "STAT_WEAPON_AND_SPELL_DAMAGE"),
+    weaponDamage    = stat("STAT_POWER", "STAT_WEAPON_POWER", "STAT_WEAPON_AND_SPELL_DAMAGE"),
     spellCrit       = stat("STAT_SPELL_CRITICAL"),
     weaponCrit      = stat("STAT_CRITICAL_STRIKE"),
     critDamage      = stat("STAT_CRITICAL_DAMAGE"),
@@ -190,7 +195,9 @@ end
 local function tryCapture(label, fn)
   local ok, result = pcall(fn)
   if ok then return result end
-  d("[ESOTK] capture '" .. label .. "' failed: " .. tostring(result))
+  if SV and SV.verbose and type(d) == "function" then
+    d("[ESOTK] capture '" .. label .. "' failed: " .. tostring(result))
+  end
   return nil
 end
 
@@ -200,6 +207,8 @@ local function Snapshot(reason)
   local zoneIndex = call("GetUnitZoneIndex", "player")
 
   local snap = {
+    schemaVersion = ADDON.schemaVersion,
+    season    = ADDON.season,
     -- match keys (see ESOTK matcher): character + server + UTC timestamp
     ts        = call("GetTimeStamp"),               -- UNIX seconds, server/UTC
     char      = call("GetUnitName", "player"),

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -59,29 +59,28 @@ end
 -- ----------------------------------------------------------------------------
 
 -- THE headline gap: full champion point allocation + slotted stars + total.
--- VERIFIED against the DynamicCP add-on source (Kyzderp/DynamicCP, src/API.lua):
---   * GetNumPointsSpentOnChampionSkill(skillId) — ONE arg (championSkillId is globally unique)
---   * GetChampionSkillName(skillId)             — ONE arg
---   * slotted stars: GetSlotBoundId(slotIndex, HOTBAR_CATEGORY_CHAMPION), slots 1..12
---     (Craft/Green = 1-4, Warfare/Blue = 5-8, Fitness/Red = 9-12 per DynamicCP OFFSETS)
--- PENDING final in-game confirmation (standard CP2.0 enumeration; DynamicCP hardcodes the
--- three trees so it couldn't cross-check these names): GetNumChampionDisciplines /
--- GetChampionDisciplineId / GetNumChampionDisciplineSkills / GetChampionSkillId. They're
--- guarded, so a wrong name yields an empty allocation (slotted + total still captured)
--- rather than an error.
+-- VERIFIED against official ZOS source (esoui championdatamanager.lua) + DynamicCP:
+--   for disciplineIndex = 1, GetNumChampionDisciplines() do
+--     disciplineId = GetChampionDisciplineId(disciplineIndex)
+--     GetNumChampionDisciplineSkills(disciplineIndex)   -- takes the INDEX, not the id
+--     GetChampionSkillId(disciplineIndex, skillIndex)    -- takes the INDEX, not the id
+--     GetChampionDisciplineType(disciplineId)            -- takes the id
+--   GetNumPointsSpentOnChampionSkill(skillId)            -- ONE arg (skillId globally unique)
+--   slotted: GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION), slots 1..12
+--            (Craft 1-4 / Warfare 5-8 / Fitness 9-12 per DynamicCP OFFSETS)
 local function captureChampionPoints()
   local cp = { total = call("GetUnitChampionPoints", "player"), disciplines = {}, slotted = {} }
 
   local numDisciplines = call("GetNumChampionDisciplines") or 0
-  for di = 1, numDisciplines do
-    local disciplineId = call("GetChampionDisciplineId", di)
+  for disciplineIndex = 1, numDisciplines do
+    local disciplineId = call("GetChampionDisciplineId", disciplineIndex)
     if disciplineId then
       local skills, spent = {}, 0
-      local numSkills = call("GetNumChampionDisciplineSkills", disciplineId) or 0
-      for si = 1, numSkills do
-        local skillId = call("GetChampionSkillId", disciplineId, si)
+      local numSkills = call("GetNumChampionDisciplineSkills", disciplineIndex) or 0 -- index
+      for skillIndex = 1, numSkills do
+        local skillId = call("GetChampionSkillId", disciplineIndex, skillIndex) -- (index, index)
         if skillId then
-          local points = call("GetNumPointsSpentOnChampionSkill", skillId) -- single arg (verified)
+          local points = call("GetNumPointsSpentOnChampionSkill", skillId) -- single arg
           if points and points > 0 then
             skills[skillId] = points -- key by skillId so ESOTK can name it
             spent = spent + points
@@ -90,8 +89,8 @@ local function captureChampionPoints()
       end
       cp.disciplines[disciplineId] = {
         id = disciplineId,
-        type = call("GetChampionDisciplineType", disciplineId),
-        spent = spent, -- summed from skills (avoids an unconfirmed per-discipline call)
+        type = call("GetChampionDisciplineType", disciplineId), -- takes the id
+        spent = spent, -- summed from skills
         skills = skills,
       }
     end

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -1,0 +1,268 @@
+--[[
+  ESOTK Companion — fills the gaps ESO Logs can't see.
+
+  ESO Logs (the encounter log) records what happened in combat but is structurally
+  blind to a chunk of the build that produced it. The single biggest gap is the
+  **champion point allocation** — the log carries CP *rank* and the slotted stars as
+  buffs, but never the points spent across every star. This add-on reads that (and the
+  other un-logged build data) live from the official API and writes it to
+  SavedVariables, which ESO Toolkit (esotk.com) ingests and renders on player cards,
+  matched to the log by character + server + timestamp.
+
+  Design notes
+  - Read-only. We only read state and write our own SavedVariables. No input
+    automation, no combat decisions — same ToS-safe posture as CombatMetrics/Hodor.
+  - Robust to API drift. ESO bumps the API every season and renames/retires functions
+    and STAT_/constants. Every capture subsystem runs inside pcall and every global
+    constant is nil-guarded, so a single missing symbol degrades one field instead of
+    crashing the add-on.
+  - Canonical snapshot moment. GetPlayerStat returns the *live* buff-inclusive value, so
+    a snapshot taken mid-fight includes group buffs and is not comparable across players.
+    We snapshot on leaving combat (and on demand), which is the closest practical
+    "self-buffed" baseline. The snapshot is tagged so ESOTK knows how it was taken.
+]]--
+
+local ADDON = {
+  name = "ESOTKCompanion",
+  schemaVersion = 1,
+  season = "U50",          -- bump per ESO season; ESOTK uses this to pick the right caps/data
+  maxSnapshots = 200,      -- ring buffer; oldest dropped beyond this
+  snapshotMode = "combatEnd",
+}
+
+local SV  -- SavedVariables handle (ESOTKCompanionSV, account-wide)
+
+-- ----------------------------------------------------------------------------
+-- helpers
+-- ----------------------------------------------------------------------------
+
+-- Call fn(...) only if it exists; returns nil otherwise (API may rename functions).
+local function call(fnName, ...)
+  local fn = _G[fnName]
+  if type(fn) == "function" then
+    return fn(...)
+  end
+  return nil
+end
+
+-- Read a GetPlayerStat value only if the STAT_ constant is defined this API version.
+local function stat(constName)
+  local c = _G[constName]
+  if c == nil then return nil end
+  local opt = _G["BONUS_OPTION_DEFAULT"] or 0
+  local v = call("GetPlayerStat", c, opt)
+  return v
+end
+
+-- ----------------------------------------------------------------------------
+-- capture subsystems (each wrapped in pcall by Snapshot())
+-- ----------------------------------------------------------------------------
+
+-- THE headline gap: full champion point allocation + slotted stars + total.
+local function captureChampionPoints()
+  local cp = { total = call("GetUnitChampionPoints", "player"), disciplines = {}, slotted = {} }
+
+  local numDisciplines = call("GetNumChampionDisciplines") or 0
+  for di = 1, numDisciplines do
+    local disciplineId = call("GetChampionDisciplineId", di)
+    if disciplineId then
+      local disc = {
+        id = disciplineId,
+        type = call("GetChampionDisciplineType", disciplineId),
+        spent = call("GetNumPointsSpentInChampionDiscipline", disciplineId),
+        skills = {},
+      }
+      local numSkills = call("GetNumChampionDisciplineSkills", disciplineId) or 0
+      for si = 1, numSkills do
+        local skillId = call("GetChampionSkillId", disciplineId, si)
+        if skillId then
+          local spent = call("GetNumPointsSpentOnChampionSkill", disciplineId, skillId)
+          if spent and spent > 0 then
+            disc.skills[skillId] = spent  -- key by skillId so ESOTK can name it
+          end
+        end
+      end
+      cp.disciplines[disciplineId] = disc
+    end
+  end
+
+  -- 12 slotted stars (4 per discipline) via the champion hotbar category.
+  local champCat = _G["HOTBAR_CATEGORY_CHAMPION"]
+  if champCat ~= nil then
+    for slot = 1, 12 do
+      cp.slotted[slot] = call("GetSlotBoundId", slot, champCat)
+    end
+  end
+
+  return cp
+end
+
+-- Final derived stats the log never carries (crit, penetration, recovery, …).
+local function captureStats()
+  return {
+    maxMagicka      = stat("STAT_MAGICKA_MAX"),
+    maxHealth       = stat("STAT_HEALTH_MAX"),
+    maxStamina      = stat("STAT_STAMINA_MAX"),
+    spellDamage     = stat("STAT_SPELL_POWER"),
+    weaponDamage    = stat("STAT_WEAPON_POWER"),
+    spellCrit       = stat("STAT_SPELL_CRITICAL"),
+    weaponCrit      = stat("STAT_CRITICAL_STRIKE"),
+    spellPen        = stat("STAT_SPELL_PENETRATION"),
+    physicalPen     = stat("STAT_PHYSICAL_PENETRATION"),
+    magickaRegen    = stat("STAT_MAGICKA_REGEN_COMBAT"),
+    staminaRegen    = stat("STAT_STAMINA_REGEN_COMBAT"),
+    healthRegen     = stat("STAT_HEALTH_REGEN_COMBAT"),
+    physicalResist  = stat("STAT_PHYSICAL_RESIST"),
+    spellResist     = stat("STAT_SPELL_RESIST"),
+    critResist      = stat("STAT_CRITICAL_RESISTANCE"),
+  }
+end
+
+-- Attribute point split (Magicka / Health / Stamina).
+local function captureAttributes()
+  local AM, AH, AS = _G["ATTRIBUTE_MAGICKA"], _G["ATTRIBUTE_HEALTH"], _G["ATTRIBUTE_STAMINA"]
+  return {
+    magicka = AM and call("GetAttributeSpentPoints", AM) or nil,
+    health  = AH and call("GetAttributeSpentPoints", AH) or nil,
+    stamina = AS and call("GetAttributeSpentPoints", AS) or nil,
+  }
+end
+
+-- Long-term effects (mundus is a permanent buff; food/drink is a long buff).
+-- We record raw ability IDs and let ESOTK resolve mundus/food by ID — language-agnostic.
+local function captureLongTermEffects()
+  local effects = {}
+  local n = call("GetNumBuffs", "player") or 0
+  for i = 1, n do
+    local name, started, ending, _, _, _, _, _, _, _, abilityId = call("GetUnitBuffInfo", "player", i)
+    if abilityId then
+      effects[#effects + 1] = {
+        id = abilityId,
+        name = name,
+        duration = (started and ending) and (ending - started) or 0, -- 0 == permanent (e.g. mundus)
+      }
+    end
+  end
+  return effects
+end
+
+-- Both action bars (front/back). Redundant with the log, but lets ESOTK derive
+-- subclass skill lines without a second source, and verifies the matched actor.
+local function captureBars()
+  local bars = {}
+  local cats = { front = _G["HOTBAR_CATEGORY_PRIMARY"], back = _G["HOTBAR_CATEGORY_BACKUP"] }
+  for label, cat in pairs(cats) do
+    if cat ~= nil then
+      local barSlots = {}
+      for slot = 3, 8 do  -- 3..7 = abilities, 8 = ultimate
+        barSlots[slot] = call("GetSlotBoundId", slot, cat)
+      end
+      bars[label] = barSlots
+    end
+  end
+  return bars
+end
+
+-- ----------------------------------------------------------------------------
+-- snapshot
+-- ----------------------------------------------------------------------------
+
+local function tryCapture(label, fn)
+  local ok, result = pcall(fn)
+  if ok then return result end
+  d("[ESOTK] capture '" .. label .. "' failed: " .. tostring(result))
+  return nil
+end
+
+local function Snapshot(reason)
+  if not SV or SV.enabled == false then return end
+
+  local snap = {
+    -- match keys (see ESOTK matcher): character + server + UTC timestamp
+    ts        = call("GetTimeStamp"),               -- UNIX seconds, server/UTC
+    char      = call("GetUnitName", "player"),
+    account   = call("GetDisplayName"),
+    server    = call("GetWorldName"),
+    -- context
+    zoneId    = call("GetZoneId", call("GetUnitZoneIndex", "player")),
+    classId   = call("GetUnitClassId", "player"),
+    raceId    = call("GetUnitRaceId", "player"),
+    level     = call("GetUnitLevel", "player"),
+    cpRank    = call("GetUnitChampionPoints", "player"),
+    role      = call("GetGroupMemberSelectedRole", "player"),
+    reason    = reason,                              -- "combatEnd" | "manual"
+    -- the gaps ESO Logs can't see:
+    cp        = tryCapture("championPoints", captureChampionPoints),
+    stats     = tryCapture("stats", captureStats),
+    attrs     = tryCapture("attributes", captureAttributes),
+    effects   = tryCapture("longTermEffects", captureLongTermEffects),
+    bars      = tryCapture("bars", captureBars),
+  }
+
+  local snaps = SV.snapshots
+  snaps[#snaps + 1] = snap
+  while #snaps > ADDON.maxSnapshots do
+    table.remove(snaps, 1)  -- drop oldest
+  end
+
+  if SV.verbose then
+    local pts = snap.cp and snap.cp.total or "?"
+    d("[ESOTK] snapshot saved (" .. tostring(reason) .. ") — CP " .. tostring(pts)
+      .. ", " .. tostring(#snaps) .. " stored. Upload SavedVariables/ESOTKCompanion.lua to esotk.com.")
+  end
+end
+
+-- ----------------------------------------------------------------------------
+-- events & commands
+-- ----------------------------------------------------------------------------
+
+local combatDebounce = false
+local function OnCombatState(_, inCombat)
+  if inCombat then return end                 -- snapshot when leaving combat
+  if ADDON.snapshotMode ~= "combatEnd" then return end
+  if combatDebounce then return end
+  combatDebounce = true
+  -- small delay so end-of-fight buffs/stats settle before reading
+  zo_callLater(function()
+    combatDebounce = false
+    Snapshot("combatEnd")
+  end, 1500)
+end
+
+local function OnAddOnLoaded(_, addonName)
+  if addonName ~= ADDON.name then return end
+  EVENT_MANAGER:UnregisterForEvent(ADDON.name, EVENT_ADD_ON_LOADED)
+
+  SV = ZO_SavedVars:NewAccountWide("ESOTKCompanionSV", ADDON.schemaVersion, nil, {
+    schemaVersion = ADDON.schemaVersion,
+    season        = ADDON.season,
+    enabled       = true,
+    verbose       = true,
+    snapshots     = {},
+  })
+  -- keep season tag current even on existing saves
+  SV.schemaVersion = ADDON.schemaVersion
+  SV.season = ADDON.season
+
+  EVENT_MANAGER:RegisterForEvent(ADDON.name, EVENT_PLAYER_COMBAT_STATE, OnCombatState)
+
+  SLASH_COMMANDS["/esotk"] = function(arg)
+    arg = zo_strlower(arg or "")
+    if arg == "off" then
+      SV.enabled = false; d("[ESOTK] capture disabled.")
+    elseif arg == "on" then
+      SV.enabled = true; d("[ESOTK] capture enabled.")
+    elseif arg == "clear" then
+      SV.snapshots = {}; d("[ESOTK] snapshots cleared.")
+    elseif arg == "verbose" then
+      SV.verbose = not SV.verbose; d("[ESOTK] verbose = " .. tostring(SV.verbose))
+    else
+      Snapshot("manual")
+      d("[ESOTK] snapshot taken. /esotk on|off|clear|verbose")
+    end
+  end
+
+  d("[ESOTK] Companion loaded. Capturing champion points + build on combat end. Type /esotk to snapshot now.")
+end
+
+EVENT_MANAGER:RegisterForEvent(ADDON.name, EVENT_ADD_ON_LOADED, OnAddOnLoaded)

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -3,7 +3,7 @@
 
   ESO Logs (the encounter log) records what happened in combat but is structurally
   blind to a chunk of the build that produced it. The single biggest gap is the
-  **champion point allocation** — the log carries CP *rank* and the slotted stars as
+  **champion point allocation** - the log carries CP *rank* and the slotted stars as
   buffs, but never the points spent across every star. This add-on reads that (and the
   other un-logged build data) live from the official API and writes it to
   SavedVariables, which ESO Toolkit (esotk.com) ingests and renders on player cards,
@@ -11,7 +11,7 @@
 
   Design notes
   - Read-only. We only read state and write our own SavedVariables. No input
-    automation, no combat decisions — same ToS-safe posture as CombatMetrics/Hodor.
+    automation, no combat decisions - same ToS-safe posture as CombatMetrics/Hodor.
   - Robust to API drift. ESO bumps the API every season and renames/retires functions
     and STAT_/constants. Every capture subsystem runs inside pcall and every global
     constant is nil-guarded, so a single missing symbol degrades one field instead of
@@ -121,7 +121,7 @@ local function captureChampionPoints()
   return cp
 end
 
--- Final derived stats the log never carries (crit, penetration, recovery, …).
+-- Final derived stats the log never carries (crit, penetration, recovery, ...).
 local function captureStats()
   return {
     maxMagicka      = stat("STAT_MAGICKA_MAX"),
@@ -188,6 +188,51 @@ local function captureBars()
   return bars
 end
 
+local function scriptInfo(scriptId, scriptSlot)
+  if not scriptId or scriptId == 0 then return nil end
+  return {
+    id = scriptId,
+    slot = scriptSlot,
+    name = call("GetCraftedAbilityScriptDisplayName", scriptId),
+    icon = call("GetCraftedAbilityScriptIcon", scriptId),
+  }
+end
+
+-- Authoritative scribing setup. Logs can reveal many scribed effects, but not every
+-- active script reliably; the local action bar API can read the grimoire + scripts.
+local function captureScribing()
+  local scribing = {}
+  local cats = { front = _G["HOTBAR_CATEGORY_PRIMARY"], back = _G["HOTBAR_CATEGORY_BACKUP"] }
+  for label, cat in pairs(cats) do
+    if cat ~= nil then
+      for slot = 3, 8 do -- 3..7 = abilities, 8 = ultimate
+        local craftedAbilityId = call("GetSlotBoundId", slot, cat)
+        if craftedAbilityId and craftedAbilityId ~= 0 then
+          local s1, s2, s3 = call("GetCraftedAbilityActiveScriptIds", craftedAbilityId)
+          local scripts = {}
+          local i1 = scriptInfo(s1, 1)
+          local i2 = scriptInfo(s2, 2)
+          local i3 = scriptInfo(s3, 3)
+          if i1 then scripts[1] = i1 end
+          if i2 then scripts[2] = i2 end
+          if i3 then scripts[3] = i3 end
+
+          if next(scripts) ~= nil then
+            scribing[#scribing + 1] = {
+              abilityId = craftedAbilityId,
+              name = call("GetCraftedAbilityDisplayName", craftedAbilityId) or call("GetAbilityName", craftedAbilityId),
+              bar = label,
+              slot = slot,
+              scripts = scripts,
+            }
+          end
+        end
+      end
+    end
+  end
+  return scribing
+end
+
 -- ----------------------------------------------------------------------------
 -- snapshot
 -- ----------------------------------------------------------------------------
@@ -230,6 +275,7 @@ local function Snapshot(reason)
     attrs     = tryCapture("attributes", captureAttributes),
     effects   = tryCapture("longTermEffects", captureLongTermEffects),
     bars      = tryCapture("bars", captureBars),
+    scribing  = tryCapture("scribing", captureScribing),
   }
 
   if not snap.ts or not snap.char then
@@ -247,7 +293,7 @@ local function Snapshot(reason)
 
   if SV.verbose then
     local pts = snap.cp and snap.cp.total or "?"
-    d("[ESOTK] snapshot saved (" .. tostring(reason) .. ") — CP " .. tostring(pts)
+    d("[ESOTK] snapshot saved (" .. tostring(reason) .. ") - CP " .. tostring(pts)
       .. ", " .. tostring(#snaps) .. " stored. Upload SavedVariables/ESOTKCompanion.lua to esotk.com.")
   end
 end
@@ -302,7 +348,7 @@ local function OnAddOnLoaded(_, addonName)
     end
   end
 
-  d("[ESOTK] Companion loaded. Capturing champion points + build on combat end. Type /esotk to snapshot now.")
+  d("[ESOTK] Companion loaded. Capturing champion points, stats and scribing on combat end. Type /esotk to snapshot now.")
 end
 
 EVENT_MANAGER:RegisterForEvent(ADDON.name, EVENT_ADD_ON_LOADED, OnAddOnLoaded)

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -39,10 +39,19 @@ local SV  -- SavedVariables handle (ESOTKCompanionSV, account-wide)
 -- Call fn(...) only if it exists; returns nil otherwise (API may rename functions).
 local function call(fnName, ...)
   local fn = _G[fnName]
-  if type(fn) == "function" then
-    return fn(...)
+  if type(fn) ~= "function" then
+    return nil
   end
-  return nil
+
+  local ok, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12 = pcall(fn, ...)
+  if not ok then
+    if SV and SV.verbose and type(d) == "function" then
+      d("[ESOTK] API call '" .. tostring(fnName) .. "' failed: " .. tostring(r1))
+    end
+    return nil
+  end
+
+  return r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12
 end
 
 -- Read a GetPlayerStat value only if the STAT_ constant is defined this API version.
@@ -117,6 +126,7 @@ local function captureStats()
     weaponDamage    = stat("STAT_WEAPON_POWER"),
     spellCrit       = stat("STAT_SPELL_CRITICAL"),
     weaponCrit      = stat("STAT_CRITICAL_STRIKE"),
+    critDamage      = stat("STAT_CRITICAL_DAMAGE"),
     spellPen        = stat("STAT_SPELL_PENETRATION"),
     physicalPen     = stat("STAT_PHYSICAL_PENETRATION"),
     magickaRegen    = stat("STAT_MAGICKA_REGEN_COMBAT"),
@@ -187,6 +197,8 @@ end
 local function Snapshot(reason)
   if not SV or SV.enabled == false then return end
 
+  local zoneIndex = call("GetUnitZoneIndex", "player")
+
   local snap = {
     -- match keys (see ESOTK matcher): character + server + UTC timestamp
     ts        = call("GetTimeStamp"),               -- UNIX seconds, server/UTC
@@ -194,9 +206,11 @@ local function Snapshot(reason)
     account   = call("GetDisplayName"),
     server    = call("GetWorldName"),
     -- context
-    zoneId    = call("GetZoneId", call("GetUnitZoneIndex", "player")),
+    zoneId    = zoneIndex and call("GetZoneId", zoneIndex) or nil,
     classId   = call("GetUnitClassId", "player"),
+    className = call("GetUnitClass", "player"),
     raceId    = call("GetUnitRaceId", "player"),
+    raceName  = call("GetUnitRace", "player"),
     level     = call("GetUnitLevel", "player"),
     cpRank    = call("GetUnitChampionPoints", "player"),
     role      = call("GetGroupMemberSelectedRole", "player"),
@@ -208,6 +222,13 @@ local function Snapshot(reason)
     effects   = tryCapture("longTermEffects", captureLongTermEffects),
     bars      = tryCapture("bars", captureBars),
   }
+
+  if not snap.ts or not snap.char then
+    if SV.verbose and type(d) == "function" then
+      d("[ESOTK] snapshot skipped: missing timestamp or character name.")
+    end
+    return
+  end
 
   local snaps = SV.snapshots
   snaps[#snaps + 1] = snap

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -59,6 +59,16 @@ end
 -- ----------------------------------------------------------------------------
 
 -- THE headline gap: full champion point allocation + slotted stars + total.
+-- VERIFIED against the DynamicCP add-on source (Kyzderp/DynamicCP, src/API.lua):
+--   * GetNumPointsSpentOnChampionSkill(skillId) — ONE arg (championSkillId is globally unique)
+--   * GetChampionSkillName(skillId)             — ONE arg
+--   * slotted stars: GetSlotBoundId(slotIndex, HOTBAR_CATEGORY_CHAMPION), slots 1..12
+--     (Craft/Green = 1-4, Warfare/Blue = 5-8, Fitness/Red = 9-12 per DynamicCP OFFSETS)
+-- PENDING final in-game confirmation (standard CP2.0 enumeration; DynamicCP hardcodes the
+-- three trees so it couldn't cross-check these names): GetNumChampionDisciplines /
+-- GetChampionDisciplineId / GetNumChampionDisciplineSkills / GetChampionSkillId. They're
+-- guarded, so a wrong name yields an empty allocation (slotted + total still captured)
+-- rather than an error.
 local function captureChampionPoints()
   local cp = { total = call("GetUnitChampionPoints", "player"), disciplines = {}, slotted = {} }
 
@@ -66,27 +76,28 @@ local function captureChampionPoints()
   for di = 1, numDisciplines do
     local disciplineId = call("GetChampionDisciplineId", di)
     if disciplineId then
-      local disc = {
-        id = disciplineId,
-        type = call("GetChampionDisciplineType", disciplineId),
-        spent = call("GetNumPointsSpentInChampionDiscipline", disciplineId),
-        skills = {},
-      }
+      local skills, spent = {}, 0
       local numSkills = call("GetNumChampionDisciplineSkills", disciplineId) or 0
       for si = 1, numSkills do
         local skillId = call("GetChampionSkillId", disciplineId, si)
         if skillId then
-          local spent = call("GetNumPointsSpentOnChampionSkill", disciplineId, skillId)
-          if spent and spent > 0 then
-            disc.skills[skillId] = spent  -- key by skillId so ESOTK can name it
+          local points = call("GetNumPointsSpentOnChampionSkill", skillId) -- single arg (verified)
+          if points and points > 0 then
+            skills[skillId] = points -- key by skillId so ESOTK can name it
+            spent = spent + points
           end
         end
       end
-      cp.disciplines[disciplineId] = disc
+      cp.disciplines[disciplineId] = {
+        id = disciplineId,
+        type = call("GetChampionDisciplineType", disciplineId),
+        spent = spent, -- summed from skills (avoids an unconfirmed per-discipline call)
+        skills = skills,
+      }
     end
   end
 
-  -- 12 slotted stars (4 per discipline) via the champion hotbar category.
+  -- Slotted stars (verified): slots 1..12 via the champion hotbar category.
   local champCat = _G["HOTBAR_CATEGORY_CHAMPION"]
   if champCat ~= nil then
     for slot = 1, 12 do

--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -85,7 +85,9 @@ end
 --   slotted: GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION), slots 1..12
 --            (Craft 1-4 / Warfare 5-8 / Fitness 9-12 per DynamicCP OFFSETS)
 local function captureChampionPoints()
-  local cp = { total = call("GetUnitChampionPoints", "player"), disciplines = {}, slotted = {} }
+  -- names[skillId] = localized star name straight from the client, so ESOTK can
+  -- read every star cleanly even for ids its canonical map doesn't know yet.
+  local cp = { total = call("GetUnitChampionPoints", "player"), disciplines = {}, slotted = {}, names = {} }
 
   local numDisciplines = call("GetNumChampionDisciplines") or 0
   for disciplineIndex = 1, numDisciplines do
@@ -99,6 +101,7 @@ local function captureChampionPoints()
           local points = call("GetNumPointsSpentOnChampionSkill", skillId) -- single arg
           if points and points > 0 then
             skills[skillId] = points -- key by skillId so ESOTK can name it
+            cp.names[skillId] = call("GetChampionSkillName", skillId)
             spent = spent + points
           end
         end
@@ -116,7 +119,11 @@ local function captureChampionPoints()
   local champCat = _G["HOTBAR_CATEGORY_CHAMPION"]
   if champCat ~= nil then
     for slot = 1, 12 do
-      cp.slotted[slot] = call("GetSlotBoundId", slot, champCat)
+      local boundId = call("GetSlotBoundId", slot, champCat)
+      cp.slotted[slot] = boundId
+      if boundId and boundId ~= 0 then
+        cp.names[boundId] = call("GetChampionSkillName", boundId)
+      end
     end
   end
 

--- a/addon/ESOTKCompanion/ESOTKCompanion.txt
+++ b/addon/ESOTKCompanion/ESOTKCompanion.txt
@@ -1,6 +1,6 @@
 ; ESOTK Companion — in-game add-on manifest
 ; Captures the build/character data ESO Logs cannot see (champion point
-; allocation, final stats, attributes, mundus/food) and writes it to
+; allocation, final stats, attributes, mundus/food, scribing) and writes it to
 ; SavedVariables for ESO Toolkit (esotk.com) to read and show on player cards.
 ;
 ; APIVersion: bump every ESO season (U50 = June 2026). Keep two versions listed
@@ -12,7 +12,7 @@
 ## AddOnVersion: 1
 ## APIVersion: 101047 101049
 ## SavedVariables: ESOTKCompanionSV
-## Description: Captures champion points, final stats and attributes ESO Logs can't see, for ESO Toolkit player cards.
+## Description: Captures champion points, final stats, attributes and scribing ESO Logs can't see, for ESO Toolkit player cards.
 ## OptionalDependsOn: LibAddonMenu-2.0
 
 ESOTKCompanion.lua

--- a/addon/ESOTKCompanion/ESOTKCompanion.txt
+++ b/addon/ESOTKCompanion/ESOTKCompanion.txt
@@ -1,0 +1,18 @@
+; ESOTK Companion — in-game add-on manifest
+; Captures the build/character data ESO Logs cannot see (champion point
+; allocation, final stats, attributes, mundus/food) and writes it to
+; SavedVariables for ESO Toolkit (esotk.com) to read and show on player cards.
+;
+; APIVersion: bump every ESO season (U50 = June 2026). Keep two versions listed
+; so the add-on keeps loading across a patch boundary.
+
+## Title: ESOTK Companion
+## Author: ESO Toolkit
+## Version: 0.1.0
+## AddOnVersion: 1
+## APIVersion: 101047 101049
+## SavedVariables: ESOTKCompanionSV
+## Description: Captures champion points, final stats and attributes ESO Logs can't see, for ESO Toolkit player cards.
+## OptionalDependsOn: LibAddonMenu-2.0
+
+ESOTKCompanion.lua

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -15,13 +15,13 @@ uploaded log (by character + server + timestamp) and overlays the build on the r
 
 ## What it captures
 
-| Field | Why it's a gap |
-|---|---|
-| **Champion points** — full per-star allocation, the 12 slotted stars, total | The log has CP *rank* only, never the allocation. **The headline feature.** |
-| **Final stats** — max mag/stam/health, spell/weapon damage, crit, **penetration**, recovery, resistances | Computed client-side, never logged. Powers ESOTK's "you're over the 18,200 pen cap" coaching. |
-| **Attributes** — Magicka/Health/Stamina split | Not logged. |
-| **Long-term effects** — raw buff IDs (mundus is permanent, food is long) | ESOTK resolves mundus/food by ID (language-agnostic). |
-| **Both action bars** — front/back ability IDs | Lets ESOTK derive subclass skill lines and verify the matched actor. |
+| Field                                                                                                                                                | Why it's a gap                                                                                |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Champion points** — full per-star allocation, the 12 slotted stars, total                                                                          | The log has CP _rank_ only, never the allocation. **The headline feature.**                   |
+| **Final stats** — max mag/stam/health, spell/weapon damage, crit chance, crit damage when exposed by the API, **penetration**, recovery, resistances | Computed client-side, never logged. Powers ESOTK's "you're over the 18,200 pen cap" coaching. |
+| **Attributes** — Magicka/Health/Stamina split                                                                                                        | Not logged.                                                                                   |
+| **Long-term effects** — raw buff IDs (mundus is permanent, food is long)                                                                             | ESOTK resolves mundus/food by ID (language-agnostic).                                         |
+| **Both action bars** — front/back ability IDs                                                                                                        | Lets ESOTK derive subclass skill lines and verify the matched actor.                          |
 
 ## Install
 
@@ -50,14 +50,15 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
   schemaVersion = 1, season = "U50", enabled = true,
   snapshots = { [1] = {
     ts = 1749384000, char = "Charname", account = "@account", server = "NA",
-    zoneId = 1196, classId = 6, raceId = 4, level = 50, cpRank = 3600,
+    zoneId = 1196, classId = 6, className = "Arcanist",
+    raceId = 4, raceName = "Khajiit", level = 50, cpRank = 3600,
     role = 1, reason = "combatEnd",
     cp = {
       total = 3600,
       disciplines = { [<disciplineId>] = { id=, type=, spent=, skills = { [<skillId>] = <points> } } },
       slotted = { [1] = <skillId>, … [12] = <skillId> },
     },
-    stats  = { spellDamage=, physicalPen=, weaponCrit=, … },
+    stats  = { spellDamage=, physicalPen=, weaponCrit=, critDamage=, … },
     attrs  = { magicka=0, health=64, stamina=0 },
     effects = { { id=13984, name="Boon: The Lover", duration=0 }, … },
     bars   = { front = { [3]=, …, [8]= }, back = { … } },
@@ -69,18 +70,18 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
 
 Verified against real add-on source / API references (not guessed):
 
-| Call | Status | Source |
-|---|---|---|
-| `GetNumPointsSpentOnChampionSkill(skillId)` — **single arg** | ✅ verified | DynamicCP `src/API.lua` |
-| `GetChampionSkillName(skillId)` — single arg | ✅ verified | DynamicCP `src/API.lua` |
-| Slotted stars: `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 (Craft 1-4 / Warfare 5-8 / Fitness 9-12) | ✅ verified | DynamicCP `OFFSETS` |
-| `GetAttributeSpentPoints(attributeType)` → points | ✅ verified | eso-api dump |
-| `GetItemLinkSetInfo(link, equipped)` → hasSet,…,numEquipped,maxEquipped,setId · `GetItemLink(BAG_WORN, slot)` | ✅ verified | ESOUI wiki / forums |
-| Mundus = buff-based via `GetUnitBuffInfo` ability id (no direct getter) | ✅ verified | ESOUI |
-| Potion: `GetSlotItemLink(quickslot)` | ✅ verified | ESOUI |
-| `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax | ✅ verified | UESP |
+| Call                                                                                                                                                                                                      | Status                             | Source                          |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------- |
+| `GetNumPointsSpentOnChampionSkill(skillId)` — **single arg**                                                                                                                                              | ✅ verified                        | DynamicCP `src/API.lua`         |
+| `GetChampionSkillName(skillId)` — single arg                                                                                                                                                              | ✅ verified                        | DynamicCP `src/API.lua`         |
+| Slotted stars: `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 (Craft 1-4 / Warfare 5-8 / Fitness 9-12)                                                                                      | ✅ verified                        | DynamicCP `OFFSETS`             |
+| `GetAttributeSpentPoints(attributeType)` → points                                                                                                                                                         | ✅ verified                        | eso-api dump                    |
+| `GetItemLinkSetInfo(link, equipped)` → hasSet,…,numEquipped,maxEquipped,setId · `GetItemLink(BAG_WORN, slot)`                                                                                             | ✅ verified                        | ESOUI wiki / forums             |
+| Mundus = buff-based via `GetUnitBuffInfo` ability id (no direct getter)                                                                                                                                   | ✅ verified                        | ESOUI                           |
+| Potion: `GetSlotItemLink(quickslot)`                                                                                                                                                                      | ✅ verified                        | ESOUI                           |
+| `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax                                                                                                                                             | ✅ verified                        | UESP                            |
 | **Discipline enumeration**: `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`, `GetChampionDisciplineType(id)` | ✅ verified — **note index vs id** | esoui `championdatamanager.lua` |
-| `STAT_*` constants (spell/weapon dmg, crit, pen, regen, resist, max) | ✅ verified (names) | esoui API constants |
+| `STAT_*` constants (spell/weapon dmg, crit, pen, regen, resist, max)                                                                                                                                      | ✅ verified (names)                | esoui API constants             |
 
 > **Gotcha confirmed from source:** `GetNumChampionDisciplineSkills` and
 > `GetChampionSkillId` take the discipline **index**, while `GetChampionDisciplineType`

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -65,6 +65,23 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
 } } } }
 ```
 
+## API verification status
+
+Verified against real add-on source / API references (not guessed):
+
+| Call | Status | Source |
+|---|---|---|
+| `GetNumPointsSpentOnChampionSkill(skillId)` — **single arg** | ✅ verified | DynamicCP `src/API.lua` |
+| `GetChampionSkillName(skillId)` — single arg | ✅ verified | DynamicCP `src/API.lua` |
+| Slotted stars: `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 (Craft 1-4 / Warfare 5-8 / Fitness 9-12) | ✅ verified | DynamicCP `OFFSETS` |
+| `GetAttributeSpentPoints(attributeType)` → points | ✅ verified | eso-api dump |
+| `GetItemLinkSetInfo(link, equipped)` → hasSet,…,numEquipped,maxEquipped,setId · `GetItemLink(BAG_WORN, slot)` | ✅ verified | ESOUI wiki / forums |
+| Mundus = buff-based via `GetUnitBuffInfo` ability id (no direct getter) | ✅ verified | ESOUI |
+| Potion: `GetSlotItemLink(quickslot)` | ✅ verified | ESOUI |
+| `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax | ✅ verified | UESP |
+| **Discipline enumeration**: `GetNumChampionDisciplines` / `GetChampionDisciplineId` / `GetNumChampionDisciplineSkills` / `GetChampionSkillId` | ⏳ **pending in-game** — standard CP2.0 API but not cross-checked (DynamicCP hardcodes trees). Guarded: wrong name → empty allocation, not a crash | — |
+| `STAT_*` constants (spell/weapon dmg, pen, crit) | ⏳ pending — nil-guarded | — |
+
 ## Notes for maintainers
 
 - **Per-season pass:** bump `## APIVersion` in the manifest and `ADDON.season` in the
@@ -72,8 +89,6 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
 - **Robustness:** every capture runs under `pcall` and every global constant is
   nil-guarded, so an API rename degrades one field instead of crashing — but check the
   chat for `[ESOTK] capture '…' failed` lines after a patch and fix the offending call.
-- **Verify against live API** (couldn't be run here): the champion slotted-star read
-  (`GetSlotBoundId` + `HOTBAR_CATEGORY_CHAMPION`), `GetNumPointsSpentInChampionDiscipline`,
-  and the `STAT_*` constants for spell/weapon damage. The allocation read
-  (`GetNumPointsSpentOnChampionSkill` per discipline/skill) is the core and should be
-  confirmed first.
+- **Confirm the ⏳ rows in-game first** (allocation enumeration + `STAT_*` names). If the
+  enumeration names differ, the fallback is to iterate a bundled list of championSkillIds
+  and call the verified `GetNumPointsSpentOnChampionSkill(skillId)` on each.

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -49,6 +49,7 @@ Account-wide via `ZO_SavedVars`, a ring buffer of per-fight snapshots:
 ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
   schemaVersion = 1, season = "U50", enabled = true,
   snapshots = { [1] = {
+    schemaVersion = 1, season = "U50",
     ts = 1749384000, char = "Charname", account = "@account", server = "NA",
     zoneId = 1196, classId = 6, className = "Arcanist",
     raceId = 4, raceName = "Khajiit", level = 50, cpRank = 3600,
@@ -81,7 +82,7 @@ Verified against real add-on source / API references (not guessed):
 | Potion: `GetSlotItemLink(quickslot)`                                                                                                                                                                      | ✅ verified                        | ESOUI                           |
 | `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax                                                                                                                                             | ✅ verified                        | UESP                            |
 | **Discipline enumeration**: `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`, `GetChampionDisciplineType(id)` | ✅ verified — **note index vs id** | esoui `championdatamanager.lua` |
-| `STAT_*` constants (spell/weapon dmg, crit, pen, regen, resist, max)                                                                                                                                      | ✅ verified (names)                | esoui API constants             |
+| `STAT_*` constants (`STAT_POWER` for weapon damage, spell dmg, crit, pen, regen, resist, max)                                                                                                             | ✅ verified (names)                | esoui API constants             |
 
 > **Gotcha confirmed from source:** `GetNumChampionDisciplineSkills` and
 > `GetChampionSkillId` take the discipline **index**, while `GetChampionDisciplineType`

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -79,8 +79,12 @@ Verified against real add-on source / API references (not guessed):
 | Mundus = buff-based via `GetUnitBuffInfo` ability id (no direct getter) | ✅ verified | ESOUI |
 | Potion: `GetSlotItemLink(quickslot)` | ✅ verified | ESOUI |
 | `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax | ✅ verified | UESP |
-| **Discipline enumeration**: `GetNumChampionDisciplines` / `GetChampionDisciplineId` / `GetNumChampionDisciplineSkills` / `GetChampionSkillId` | ⏳ **pending in-game** — standard CP2.0 API but not cross-checked (DynamicCP hardcodes trees). Guarded: wrong name → empty allocation, not a crash | — |
-| `STAT_*` constants (spell/weapon dmg, pen, crit) | ⏳ pending — nil-guarded | — |
+| **Discipline enumeration**: `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`, `GetChampionDisciplineType(id)` | ✅ verified — **note index vs id** | esoui `championdatamanager.lua` |
+| `STAT_*` constants (spell/weapon dmg, crit, pen, regen, resist, max) | ✅ verified (names) | esoui API constants |
+
+> **Gotcha confirmed from source:** `GetNumChampionDisciplineSkills` and
+> `GetChampionSkillId` take the discipline **index**, while `GetChampionDisciplineType`
+> takes the discipline **id**. Mixing them silently returns wrong/no data.
 
 ## Notes for maintainers
 
@@ -89,6 +93,6 @@ Verified against real add-on source / API references (not guessed):
 - **Robustness:** every capture runs under `pcall` and every global constant is
   nil-guarded, so an API rename degrades one field instead of crashing — but check the
   chat for `[ESOTK] capture '…' failed` lines after a patch and fix the offending call.
-- **Confirm the ⏳ rows in-game first** (allocation enumeration + `STAT_*` names). If the
-  enumeration names differ, the fallback is to iterate a bundled list of championSkillIds
-  and call the verified `GetNumPointsSpentOnChampionSkill(skillId)` on each.
+- **Last thing to validate live:** run it once in-game to confirm the captured numbers
+  match the in-game character sheet / CP screen for a known build (the function names are
+  source-verified; this just confirms the values land correctly).

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -1,0 +1,79 @@
+# ESOTK Companion (in-game add-on)
+
+Fills the gaps **ESO Logs can't see** and feeds them to [ESO Toolkit](https://esotk.com)
+so they show on player cards — starting with **champion points**.
+
+ESO Logs records what happened in combat, but the encounter log never carries the full
+**champion point allocation**, your **final stats** (crit, penetration, recovery), your
+**attribute split**, or your **mundus/food**. This add-on reads them live from the
+official ESO API and writes them to SavedVariables; ESOTK matches each snapshot to your
+uploaded log (by character + server + timestamp) and overlays the build on the report.
+
+> Read-only, ToS-safe (no automation), PC-only (console can't export SavedVariables).
+> See the full strategy in
+> [`documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md`](../../documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md).
+
+## What it captures
+
+| Field | Why it's a gap |
+|---|---|
+| **Champion points** — full per-star allocation, the 12 slotted stars, total | The log has CP *rank* only, never the allocation. **The headline feature.** |
+| **Final stats** — max mag/stam/health, spell/weapon damage, crit, **penetration**, recovery, resistances | Computed client-side, never logged. Powers ESOTK's "you're over the 18,200 pen cap" coaching. |
+| **Attributes** — Magicka/Health/Stamina split | Not logged. |
+| **Long-term effects** — raw buff IDs (mundus is permanent, food is long) | ESOTK resolves mundus/food by ID (language-agnostic). |
+| **Both action bars** — front/back ability IDs | Lets ESOTK derive subclass skill lines and verify the matched actor. |
+
+## Install
+
+1. Copy the `ESOTKCompanion` folder to your ESO add-ons directory:
+   `Documents/Elder Scrolls Online/live/AddOns/ESOTKCompanion/`
+2. Enable **ESOTK Companion** on the add-ons screen and `/reloadui`.
+
+## Use
+
+- It snapshots **automatically when you leave combat**. No action needed.
+- `/esotk` — snapshot **now**
+- `/esotk on` / `/esotk off` — enable/disable capture
+- `/esotk clear` — wipe stored snapshots
+- `/esotk verbose` — toggle chat confirmations
+
+Then upload `Documents/Elder Scrolls Online/live/SavedVariables/ESOTKCompanion.lua`
+to ESOTK (or let it read the folder), and your champion points + build appear on the
+player card for the matching log.
+
+## SavedVariables shape (`ESOTKCompanionSV`)
+
+Account-wide via `ZO_SavedVars`, a ring buffer of per-fight snapshots:
+
+```lua
+ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
+  schemaVersion = 1, season = "U50", enabled = true,
+  snapshots = { [1] = {
+    ts = 1749384000, char = "Charname", account = "@account", server = "NA",
+    zoneId = 1196, classId = 6, raceId = 4, level = 50, cpRank = 3600,
+    role = 1, reason = "combatEnd",
+    cp = {
+      total = 3600,
+      disciplines = { [<disciplineId>] = { id=, type=, spent=, skills = { [<skillId>] = <points> } } },
+      slotted = { [1] = <skillId>, … [12] = <skillId> },
+    },
+    stats  = { spellDamage=, physicalPen=, weaponCrit=, … },
+    attrs  = { magicka=0, health=64, stamina=0 },
+    effects = { { id=13984, name="Boon: The Lover", duration=0 }, … },
+    bars   = { front = { [3]=, …, [8]= }, back = { … } },
+  } },
+} } } }
+```
+
+## Notes for maintainers
+
+- **Per-season pass:** bump `## APIVersion` in the manifest and `ADDON.season` in the
+  Lua each ESO season; re-verify any `STAT_*`/champion function names that changed.
+- **Robustness:** every capture runs under `pcall` and every global constant is
+  nil-guarded, so an API rename degrades one field instead of crashing — but check the
+  chat for `[ESOTK] capture '…' failed` lines after a patch and fix the offending call.
+- **Verify against live API** (couldn't be run here): the champion slotted-star read
+  (`GetSlotBoundId` + `HOTBAR_CATEGORY_CHAMPION`), `GetNumPointsSpentInChampionDiscipline`,
+  and the `STAT_*` constants for spell/weapon damage. The allocation read
+  (`GetNumPointsSpentOnChampionSkill` per discipline/skill) is the core and should be
+  confirmed first.

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -19,7 +19,7 @@ timestamp, then overlays the build on the report.
 | Field                                                                                                                                                | Why it's a gap                                                                                |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | **Champion points** — full per-star allocation, the 12 slotted stars, total                                                                          | The log has CP _rank_ only, never the allocation. **The headline feature.**                   |
-| **Final stats** — max mag/stam/health, spell/weapon damage, crit chance, crit damage when exposed by the API, **penetration**, recovery, resistances | Computed client-side, never logged. Powers ESOTK's "you're over the 18,200 pen cap" coaching. |
+| **Final stats** — max mag/stam/health, spell/weapon damage, crit chance, **penetration**, recovery, resistances | Computed client-side, never logged. Shown as a point-in-time character-sheet reading (read on leaving combat, buffs fading). Crit damage has no ESO stat constant, so ESOTK derives it from the log instead. |
 | **Attributes** — Magicka/Health/Stamina split                                                                                                        | Not logged.                                                                                   |
 | **Long-term effects** — raw buff IDs (mundus is permanent, food is long)                                                                             | ESOTK resolves mundus/food by ID (language-agnostic).                                         |
 | **Both action bars** — front/back ability IDs                                                                                                        | Lets ESOTK derive subclass skill lines and verify the matched actor.                          |
@@ -61,7 +61,7 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
       disciplines = { [<disciplineId>] = { id=, type=, spent=, skills = { [<skillId>] = <points> } } },
       slotted = { [1] = <skillId>, … [12] = <skillId> },
     },
-    stats  = { spellDamage=, physicalPen=, weaponCrit=, critDamage=, … },
+    stats  = { spellDamage=, physicalPen=, weaponCrit=, … },
     attrs  = { magicka=0, health=64, stamina=0 },
     effects = { { id=13984, name="Boon: The Lover", duration=0 }, … },
     bars   = { front = { [3]=, …, [8]= }, back = { … } },

--- a/addon/ESOTKCompanion/README.md
+++ b/addon/ESOTKCompanion/README.md
@@ -5,9 +5,10 @@ so they show on player cards — starting with **champion points**.
 
 ESO Logs records what happened in combat, but the encounter log never carries the full
 **champion point allocation**, your **final stats** (crit, penetration, recovery), your
-**attribute split**, or your **mundus/food**. This add-on reads them live from the
-official ESO API and writes them to SavedVariables; ESOTK matches each snapshot to your
-uploaded log (by character + server + timestamp) and overlays the build on the report.
+**attribute split**, your **mundus/food**, or the exact **scribing scripts** on your
+bars. This add-on reads them live from the official ESO API and writes them to
+SavedVariables; ESOTK matches each snapshot to your uploaded log by character, server and
+timestamp, then overlays the build on the report.
 
 > Read-only, ToS-safe (no automation), PC-only (console can't export SavedVariables).
 > See the full strategy in
@@ -22,6 +23,7 @@ uploaded log (by character + server + timestamp) and overlays the build on the r
 | **Attributes** — Magicka/Health/Stamina split                                                                                                        | Not logged.                                                                                   |
 | **Long-term effects** — raw buff IDs (mundus is permanent, food is long)                                                                             | ESOTK resolves mundus/food by ID (language-agnostic).                                         |
 | **Both action bars** — front/back ability IDs                                                                                                        | Lets ESOTK derive subclass skill lines and verify the matched actor.                          |
+| **Scribing scripts** — grimoire + active focus/signature/affix script IDs                                                                            | Captures Class Mastery and other scripts authoritatively instead of guessing from log events. |
 
 ## Install
 
@@ -38,8 +40,8 @@ uploaded log (by character + server + timestamp) and overlays the build on the r
 - `/esotk verbose` — toggle chat confirmations
 
 Then upload `Documents/Elder Scrolls Online/live/SavedVariables/ESOTKCompanion.lua`
-to ESOTK (or let it read the folder), and your champion points + build appear on the
-player card for the matching log.
+to ESOTK (or let it read the folder), and your champion points, stats, buffs and
+scribed skills appear on the player card for the matching log.
 
 ## SavedVariables shape (`ESOTKCompanionSV`)
 
@@ -63,6 +65,15 @@ ESOTKCompanionSV = { Default = { ["@account"] = { ["$AccountWide"] = {
     attrs  = { magicka=0, health=64, stamina=0 },
     effects = { { id=13984, name="Boon: The Lover", duration=0 }, … },
     bars   = { front = { [3]=, …, [8]= }, back = { … } },
+    scribing = {
+      { abilityId=217340, name="Shattering Knife", bar="front", slot=3,
+        scripts = {
+          [1] = { id=, slot=1, name=, icon= },
+          [2] = { id=, slot=2, name="Class Mastery", icon= },
+          [3] = { id=, slot=3, name=, icon= },
+        },
+      },
+    },
   } },
 } } } }
 ```
@@ -77,10 +88,8 @@ Verified against real add-on source / API references (not guessed):
 | `GetChampionSkillName(skillId)` — single arg                                                                                                                                                              | ✅ verified                        | DynamicCP `src/API.lua`         |
 | Slotted stars: `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 (Craft 1-4 / Warfare 5-8 / Fitness 9-12)                                                                                      | ✅ verified                        | DynamicCP `OFFSETS`             |
 | `GetAttributeSpentPoints(attributeType)` → points                                                                                                                                                         | ✅ verified                        | eso-api dump                    |
-| `GetItemLinkSetInfo(link, equipped)` → hasSet,…,numEquipped,maxEquipped,setId · `GetItemLink(BAG_WORN, slot)`                                                                                             | ✅ verified                        | ESOUI wiki / forums             |
 | Mundus = buff-based via `GetUnitBuffInfo` ability id (no direct getter)                                                                                                                                   | ✅ verified                        | ESOUI                           |
-| Potion: `GetSlotItemLink(quickslot)`                                                                                                                                                                      | ✅ verified                        | ESOUI                           |
-| `GetUnitPower(unitTag, powerType)` → current,max,effectiveMax                                                                                                                                             | ✅ verified                        | UESP                            |
+| Scribing: `GetCraftedAbilityActiveScriptIds(craftedAbilityId)`, `GetCraftedAbilityScriptDisplayName(scriptId)`, `GetCraftedAbilityDisplayName(craftedAbilityId)`                                          | ✅ verified                        | local add-on source             |
 | **Discipline enumeration**: `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`, `GetChampionDisciplineType(id)` | ✅ verified — **note index vs id** | esoui `championdatamanager.lua` |
 | `STAT_*` constants (`STAT_POWER` for weapon damage, spell dmg, crit, pen, regen, resist, max)                                                                                                             | ✅ verified (names)                | esoui API constants             |
 

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -105,15 +105,17 @@ ESOTK is unusually well-positioned because the integration surfaces already exis
 |---|---|
 | **Player cards** (the headline ask) | CP allocation, final stats (crit/pen/recovery), mundus, food, attribute split — shown inline. |
 | **Loadout Manager** | Already imports Lua SavedVariables. Add an `ESOTKCompanion` format alongside Wizard's Wardrobe. |
-| **Build Hub** | "Get Addons" deep-link to **Kalpa** addon manager already exists — ship the companion as a Kalpa pack so install is one click. |
+| **Build Hub** | "Get Addons" deep-link to **Kalpa** addon manager already exists (now an *optional* convenience tier — see §9). Primary install is the standard Minion/manual route every ESO addon uses. |
 | **Roster Hub** | `recommended_addons` column already exists; the companion becomes a recommended/required raid add-on, and roster build-checks validate against captured CP/stats. |
 | **Fight Replay** | Lock-on stats panel can show the *real* build behind an actor. |
 | **Scribing detection** | Cross-check detected scripts against authoritatively-reported slotted scripts. |
 
-The **Kalpa** addon manager + deep-link (`GetAddonsButton`) is the distribution
-channel and is the natural place to **automate the upload**: Kalpa already manages the
-SavedVariables directory, so it can read `ESOTKCompanion.lua` and POST it to ESOTK
-without the user hand-uploading a file. That closes the "no HTTP from Lua" gap cleanly.
+> **Distribution note (revised):** the original draft leaned on the **Kalpa** addon
+> manager to auto-upload SavedVariables. That's still a valid *optional* convenience,
+> but it should **not** be required — asking users to install a separate desktop app
+> they don't trust is the single biggest adoption killer (it's exactly the friction
+> that makes the ESO Logs Electron uploader a barrier). The transport strategy is now
+> **no-install-first**; see §9–§11. Kalpa becomes one opt-in tier, not the front door.
 
 ---
 
@@ -135,8 +137,10 @@ without the user hand-uploading a file. That closes the "no HTTP from Lua" gap c
 5. **Whole-group capture via LibGroupBroadcast** — the raid logger's single upload
    carries all 12 builds. This is what turns it from "nice for me" into "the group
    tool". Mirror the Hodor/LibGroupCombatStats model.
-6. **Kalpa auto-upload** — Kalpa reads the SV file and posts to ESOTK; zero manual
-   steps. Optionally a clipboard build-code as the no-Kalpa fallback.
+6. **No-install browser folder-sync (the UVP)** — ESOTK uses the **File System Access
+   API** to read the SavedVariables (and optionally `Logs/Encounter.log`) folder
+   directly from the browser after a one-time permission grant. No desktop app. See
+   §9–§11. Kalpa auto-upload and a copy/paste build-code are fallback tiers.
 7. **Build-correctness flags on player cards** — derive issues from captured data
    (no food, low penetration for the content, wrong mundus, unspent CP/attributes,
    under-quality gear). ESOTK already has `detectBuildIssues` — feed it real data.
@@ -213,6 +217,110 @@ builds on the same schema and matcher.
 
 ---
 
+## 9. Getting data in **without** trusted desktop software (the real problem)
+
+ESO Lua **cannot make outbound HTTP requests** — by design. So *something* has to carry
+the SavedVariables data from disk to ESOTK. The market has only ever used three
+mechanisms, and the whole adoption question is which one we lead with.
+
+### How the market actually does it
+
+| Tool | Transport | Friction |
+|---|---|---|
+| **ESO Logs** (combat logs) | **Electron desktop uploader** ("Companion") that tails `Encounter.log` and POSTs it | Must download + trust a native app. *This is the friction we're avoiding.* |
+| **ESO-Database** | Desktop **client** *or* **manual file upload** on their site | Client = trust friction; manual = works but tedious |
+| **CombatMetrics → ESO-Hub** | In-game **copy/paste build code** into the Build Editor | Zero install; proven and popular |
+| **UESP uespLog**, **TTC**, etc. | Manual SavedVariables upload / separate client | Mixed |
+| **Wizard's Wardrobe → ESOTK** | Manual `.lua` upload (already shipped here) | Zero install |
+
+**Verdict:** every "frictionless and trusted" success story is **either copy/paste a
+code, or upload the file through the browser**. The desktop-uploader path is exactly
+what users resist. So we don't ship a desktop app — we make the **browser** the
+ingestion engine.
+
+### The tiered, no-install transport ladder
+
+> Lead with the lowest-friction option each browser supports; degrade gracefully.
+
+**Tier 1 — File System Access API folder-sync (hero path, Chromium).**
+ESOTK calls `showDirectoryPicker()` once; the user points it at
+`Documents/Elder Scrolls Online/live/`. We store the directory handle in **IndexedDB**,
+so on every later visit a **single click** (`requestPermission`) re-reads
+`SavedVariables/ESOTKCompanion.lua` — and, if granted, `Logs/Encounter.log` too. No
+download, nothing to trust beyond the browser's own permission prompt. This is the
+**unique value proposition**: *ESO Logs needs an Electron app to read your log folder;
+ESOTK does it from the tab you already have open.*
+- Works in **Chrome / Edge / Opera / Brave 86+** (the majority of desktop, and ESO
+  add-on users are PC/desktop by definition).
+- **Not** in Firefox or Safari — Mozilla and Apple have declined the local-disk
+  pickers permanently. Those users fall to Tier 2/3.
+
+**Tier 2 — Copy/paste build code (universal, proven).**
+The add-on renders a compressed, encoded build string in an in-game **edit box**; the
+user selects-all + Ctrl+C and pastes it into ESOTK. This is precisely the
+CombatMetrics → ESO-Hub flow, so ESO players already understand it.
+- **Constraint:** ESO's direct clipboard write is a *protected/illegal call* — we
+  cannot auto-copy; the user must Ctrl+C from the editbox. And a single copy is capped
+  near **~1023 characters**, so the payload must be compressed (one player's
+  CP+stats+attributes fits comfortably; a 12-person raid needs chunking or Tier 1/3).
+
+**Tier 3 — Manual `.lua` upload (works everywhere, already built).**
+Drag-drop the SavedVariables file into ESOTK. Firefox/Safari fallback and the
+universal safety net. ESOTK's existing `luaParser.ts` already does this for Wizard's
+Wardrobe; we extend it to the `ESOTKCompanion` format.
+
+**Tier 4 — Kalpa auto-upload (optional power-user convenience, not required).**
+For users who already run Kalpa, it can POST the SV file automatically. Strictly
+opt-in; never the on-ramp.
+
+---
+
+## 10. Piggyback before you ask for a new install
+
+The cheapest trust is **no new addon at all**. A large share of the target audience
+already runs **CombatMetrics**, **Hodor Reflexes**, and **Wizard's Wardrobe** — all of
+which write SavedVariables that ESOTK can read via the same Tier 1/3 transport.
+
+- **CombatMetrics** already records per-fight data and can export a build (gear/skills/
+  CP) — ESOTK can ingest its SV directly.
+- **Wizard's Wardrobe** — already parsed here today.
+- **Hodor / LibGroupCombatStats** — already aggregates *group* DPS/HPS/Ult.
+
+**Strategy:** ESOTK should **read what users already have first**, and the
+purpose-built ESOTK Companion add-on only needs to fill the residual gaps those tools
+*don't* persist — chiefly **full CP allocation, final derived stats, and group-wide
+build aggregation in one file**. This reframes the companion from "install our thing"
+to "we already work with your existing addons; install ours only for the extra 20%."
+That is a materially easier adoption pitch.
+
+---
+
+## 11. Unique value proposition — what only ESOTK can deliver
+
+The build-sharing space is crowded (ESO-Hub Build Editor, Alcast, Arzyel, Hack the
+Minotaur). But **every one of them shares a *static, hand-made* build**. None of them
+tie a build to **what actually happened in a logged fight**. That gap is ours:
+
+1. **Build ↔ log correlation on the player card.** ESO-Hub shows a build; ESOTK shows
+   *the build the player was actually running when they pulled 92k on this boss*,
+   stitched onto the ESO Logs report. Nobody else does this.
+2. **Whole-group truth from one source.** Via LibGroupBroadcast, one logger's single
+   file yields all 12 members' real builds, auto-attached to the report — a raid-lead
+   superpower, not a personal toy.
+3. **No desktop uploader.** The only browser-native ingestion in the ESO space: grant a
+   folder once, done. Direct contrast with ESO Logs' required Electron app.
+4. **Diagnostics the log can't compute.** "Top DPS but no food", "0 penetration into a
+   resistant boss", "unspent CP", "wrong mundus for the role" — derived from data ESO
+   Logs structurally never sees, surfaced inline. Feeds the existing
+   `detectBuildIssues`.
+5. **Closed loop.** Design a loadout in ESOTK → play it → log it → ESOTK confirms you
+   ran what you planned and shows the result. Build sites are open-loop; we close it.
+
+**Positioning one-liner:** *Other sites show you a build. ESOTK shows you the build that
+won the parse — for your whole raid — with nothing to install.*
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -227,5 +335,11 @@ builds on the same schema and matcher.
 - [Champion Point Import add-on](https://esoui.com/downloads/info3421-ChampionPointImport.html)
 - [Dynamic CP (Champion Points 2.0)](https://www.esoui.com/downloads/info2952-DynamicCPChampionPoints2.0.html)
 - [Fix for LibGroupBroadcast — ESO Forums (2026)](https://forums.elderscrollsonline.com/en-gb/discussion/679406/fix-for-libgroupbroadcast)
+- [ESO Logs Uploader (Electron app) — Archon](https://www.archon.gg/eso/articles/help/uploader)
+- [ESO-Database Export AddOn](https://www.esoui.com/downloads/info916-ESO-Database.comExportAddOn.html) · [Manual data upload](https://www.eso-database.com/en/manual-data-upload/)
+- [File System Access API — Chrome for Developers](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access) · [Persistent permissions](https://developer.chrome.com/blog/persistent-permissions-for-the-file-system-access-api) · [caniuse browser support](https://caniuse.com/native-filesystem-api)
+- [browser-fs-access (legacy fallback helper)](https://github.com/GoogleChromeLabs/browser-fs-access)
+- [Chat2Clipboard (in-game copy pattern)](https://www.esoui.com/downloads/info553-Chat2Clipboard.html) · [Illegal Call CopyAllTextToClipboard — ESOUI](https://www.esoui.com/forums/showthread.php?t=6012)
+- [ESO-Hub Build Editor (import/export, CombatMetrics integration)](https://eso-hub.com/en/build-editor)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -680,6 +680,83 @@ The two fields that must never break without a version bump: `ts` + `char`/`serv
 
 ---
 
+## 20. Capture methodology & data accuracy (get this right or the coaching lies)
+
+`GetPlayerStat` returns the **current, live** value — it *includes* whatever buffs are
+active at the instant you read it (food, mundus, CP, **and** group buffs like Major
+Courage / Major Slayer in combat). So *when* we snapshot changes the numbers, and naïve
+capture produces misleading coaching. Standardise it:
+
+- **Capture a canonical "baseline" snapshot out of combat, self-buffed** (food + mundus
+  + CP, no group buffs). This is the apples-to-apples build value to compare against
+  caps and across players. Trigger on `EVENT_PLAYER_COMBAT_STATE` (combat end) or a
+  manual "snapshot now," not mid-pull.
+- Optionally also capture an **in-combat** reading to show buffed peaks — but label it
+  distinctly; never feed buffed numbers into "are you at the pen cap" math.
+- **Penetration/crit caps are content-aware.** The 18,200 cap is the PvE
+  trial/dungeon-boss resist; **PvP targets have their own (much higher, variable)
+  resistances**, so the coaching engine must branch on PvE vs PvP and, ideally, the
+  specific encounter. Don't hard-code 18,200 everywhere.
+- **Match on IDs, not names.** Ability/set/food names are localised per client language;
+  store ability IDs, set IDs, food item IDs, mundus IDs — resolve to display names in
+  ESOTK (which already maintains that data). Keeps non-English clients working.
+- **Stamp validity.** Each snapshot carries its season/patch (§17 `season`) so coaching
+  uses the right caps and set data for that point in time.
+
+## 21. Beyond trials — PvP & organized-group audiences
+
+Build capture + compliance isn't only a PvE-trial play:
+
+- ESO Logs, **CombatMetrics**, and **Easy Stalking** already log **Cyrodiil, Imperial
+  City and Battlegrounds**, and **PvpMeter** shows the appetite for PvP performance
+  tracking — so logged PvP data exists to enrich.
+- **Organized PvP groups are *more* build-prescriptive than PvE**: Cyrodiil ball/bomb
+  groups run tightly-specified sets, resistances, and synergies. A role-aware compliance
+  check ("everyone on the prescribed proc set / resist threshold / purge build") maps
+  directly onto how these groups already operate — arguably a stronger fit than PvE.
+- This widens the audience well past the hardcore trial niche (reinforced by Overland
+  Difficulty in 2026, §17) without building anything new — the same capture + ruleset
+  engine, with content-aware caps (§20).
+
+## 22. Privacy, consent & staying ToS-safe
+
+Builds are semi-personal and competitive, and the live layer shares them — so consent is
+a first-class design concern, not an afterthought:
+
+- **Broadcasting is opt-in**, with a clear in-game toggle (LibAddonMenu) and a visible
+  indicator of what's shared. Mirror the reason Hodor is perceived as benign:
+  transparent, read-only, user-controlled.
+- **Granularity** — let players share only a compliance verdict (pass/fail bits) without
+  exposing exact stats/gear, for groups that want enforcement without doxxing builds.
+- **ESOTK-side retention/redaction** — companion data is ESOTK's (§15); honour
+  delete/anonymise requests and don't surface a player's build on reports they didn't
+  consent to. Respect ESO Logs' own anonymisation (don't de-anonymise via the companion).
+- **ToS line stays bright:** read state, evaluate, display, broadcast opt-in summaries —
+  **no input automation, no combat decision-making.** This is the same posture that
+  keeps CombatMetrics/Hodor sanctioned, and it must never be crossed for a "convenience"
+  feature.
+
+## 23. Maintenance, dependencies & risk
+
+- **ESO breaks add-ons every major update** — and with the 2026 **Seasonal cadence
+  (every 3–6 months)** that's more often. The API version bumps, ability/set IDs shift,
+  and CP trees change. Budget a **per-season maintenance pass**: bump the API version,
+  re-run `gear-data-regen`/`class-skill-regen`, refresh caps/ruleset presets, validate
+  the schema migration (LibSavedVars).
+- **Third-party lib fragility** — the live layer leans on LibGroupBroadcast /
+  LibGroupCombatStats, which themselves break on patches (there was a *"Fix for
+  LibGroupBroadcast"* thread in 2026). Treat the live layer as the volatile part and the
+  SavedVariables capture as the stable core, so a broken broadcast lib never blocks the
+  deep web value.
+- **Adoption dependency** — group features scale with how many members run it; the
+  free/OSS posture (§16) and piggybacking on existing add-ons (§10) are the mitigations.
+- **Single-maintainer bus risk** — LibGroupCombatStats/Hodor are largely one author
+  (m00nyONE). Vendoring or contributing upstream reduces exposure if that stalls.
+- **Scope risk** — §12's full platform is large. Ship the §8 vertical slice first; treat
+  the dashboard, ruleset engine, and ecosystem hooks as sequenced phases, not v1.
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -719,5 +796,7 @@ The two fields that must never break without a version bump: `ts` + `char`/`serv
 - [ESO 2026 Class Identity Refresh & subclassing / Class Mastery Passives](https://hacktheminotaur.com/eso-guides/eso-class-updates-2026-the-class-identity-refresh/)
 - [Console can't access /encounterlog files (ESO Forums)](https://forums.elderscrollsonline.com/en/discussion/679575/problem-consoles-cannot-access-logs-generated-by-encounterlog) · [Console add-ons guide](https://alcasthq.com/eso-addons-console-guide/)
 - [LibSavedVars (scoped + migration)](https://github.com/silvereyes333/LibSavedVars) · [LibAddonMenu-2.0](https://www.esoui.com/downloads/info7-LibAddonMenu.html)
+- [GetPlayerStat (UESP function reference)](https://esodata.uesp.net/100010/data/g/e/t/GetPlayerStat.html) · [Character sheet & advanced stats explained](https://www.eso-u.com/articles/player_character_sheet_and_advanced_stats_ui_explained)
+- [Easy Stalking — auto-log Cyrodiil/IC/BG](https://www.esoui.com/downloads/info2332-EasyStalking-Encounterlog.html) · [PvpMeter](https://forums.elderscrollsonline.com/en/discussion/387159/addon-pvpmeter-graphical-tracker-for-your-kill-death-in-pvp-and-history-of-your-bg-duel-played) · [PvP addons guide — NirnStorm](https://nirnstorm.com/eso/guides/pvp-addons-guide/)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -21,7 +21,7 @@ surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & op
 19. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
 21. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
 · 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it) ·
-26. Ruleset / criteria schema (the compliance engine).
+26. Ruleset / criteria schema (the compliance engine) — incl. 26.1 readiness flow & 26.2 verified checks.
 
 ---
 
@@ -986,6 +986,52 @@ Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity
 > log-dependent checks after. The `eval` tag is what keeps "is everyone ready?" honest
 > in-game and "was everyone actually optimal?" exact on the web.
 
+### 26.1 Canonical in-game readiness flow (logs not required)
+
+The agreed live-compliance loop, and why it sidesteps the bandwidth limit entirely:
+
+1. **Raid lead authors a static ruleset on the web** (per role/content). It stays put
+   until they change it.
+2. **Synced into the add-on** once (file / import code / broadcast).
+3. **Each client checks *itself*** against the ruleset (it has full data about its own
+   character).
+4. **Each client broadcasts only a per-rule pass/fail bitfield** — ~2–4 bytes, re-sent
+   only when something changes. **You broadcast verdicts, never builds.**
+5. **Group frames show a red X** on anyone non-compliant.
+6. **Click → expands the exact failures**, *reconstructed locally* from each client's own
+   copy of the ruleset (bit *i* → rule *i* → "Wrong mundus — needs The Lover"). Zero
+   extra bandwidth for the detail.
+
+Logs never enter this loop (they aren't instant). The log is a **post-hoc bonus layer**
+for the one thing that needs it — exact *effective* penetration and buff/debuff uptimes.
+
+**Why the bandwidth objection dies here:** the only thing on the wire is a few-byte,
+static, on-change verdict — smaller than the DPS numbers Hodor already shares. The full
+build is never transmitted for this feature; the readable "what's missing" is rebuilt
+from local data.
+
+### 26.2 Verified client-side checks (API confirmed, not assumed)
+
+Every readiness check below was confirmed against real add-on source / API references
+(see Sources), so the add-on reads them from the player's *own* client with no inspection:
+
+| Requirement | Confirmed read | Source |
+|---|---|---|
+| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` (single arg) over enumerated skills | DynamicCP `src/API.lua` |
+| **Champion points** (slotted) | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 | DynamicCP `OFFSETS` |
+| **Gear set** | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped` | ESOUI |
+| **Food** | active buff via `GetUnitBuffInfo("player", i)` ability id | ESOUI |
+| **Mundus** | active buff id (no direct getter — match a known mundus boon id list) | ESOUI |
+| **Potion** | `GetSlotItemLink(quickslotIndex)` | ESOUI |
+| **Attributes** | `GetAttributeSpentPoints(attributeType)` → points | eso-api dump |
+| **Self penetration / crit** | `GetPlayerStat(STAT_*)` (constants nil-guarded) | UESP |
+
+> **Still pending live confirmation (flagged, not assumed):** the CP discipline-
+> enumeration function names (`GetNumChampionDisciplines` etc.) and the exact `STAT_*`
+> constant names. Both are guarded so a wrong name degrades one field instead of
+> crashing; the fallback for enumeration is a bundled championSkillId list iterated with
+> the verified single-arg `GetNumPointsSpentOnChampionSkill`.
+
 ---
 
 ## Sources
@@ -1035,5 +1081,8 @@ Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity
 - [GetUnitPower (current/max for any unitTag)](https://esoapi.uesp.net/100020/data/g/e/t/GetUnitPower.html) · [GetUnitBuffInfo (group buffs)](https://esodata.uesp.net/100016/data/g/e/t/GetUnitBuffInfo.html) · [UnitTag reference](https://wiki.esoui.com/UnitTag)
 - [LibGroupBroadcast custom-protocol API (DeclareProtocol/AddField/NumericField/ArrayField)](https://github.com/sirinsidiator/ESO-LibGroupBroadcast) · [Broadcasting API thread](https://www.esoui.com/forums/showthread.php?p=51019)
 - [RdK Group Tool — group query of equipment/CP/stats/mundus over map pins](https://www.esoui.com/downloads/info2475-RdKGroupTool.html) · [Taos Group Tools](https://esoui.com/downloads/info1962-TaosGroupTools.html)
+- [DynamicCP source — verified champion-point API (single-arg `GetNumPointsSpentOnChampionSkill`, slot OFFSETS)](https://github.com/Kyzderp/DynamicCP)
+- [GetItemLinkSetInfo (numEquipped/setId) — ESOUI wiki](https://wiki.esoui.com/GetItemLink) · [GetItemLink](https://wiki.esoui.com/GetItemLink)
+- [Mundus detection is buff-id-based via GetUnitBuffInfo (no direct getter)](https://www.esoui.com/forums/showthread.php?t=2225) · [Quickslot read GetSlotItemLink](https://www.esoui.com/forums/showthread.php?t=6286)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -20,7 +20,8 @@ surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & op
 17. Why now — the 2026 meta · 18. Platform reality & a console-only opportunity ·
 19. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
 21. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
-· 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it).
+· 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it) ·
+26. Ruleset / criteria schema (the compliance engine).
 
 ---
 
@@ -896,6 +897,94 @@ only later, as a convenience, if users want full builds visible in-game without 
 - Bulk transfer is **out-of-combat only** (and courteous on the shared channel).
 - Everyone who should appear must run the add-on and opt in (§12.6) — verdicts/builds
   come from each player's own client, never from inspection.
+
+---
+
+## 26. Ruleset / criteria schema (the compliance engine, concretely)
+
+§12.2 introduced the role-aware ruleset; here is the actual model, because it's the
+centrepiece and the self-vs-effective split (§11.1.1) makes a naïve "list of thresholds"
+wrong.
+
+### The rule model
+
+A **ruleset** targets a role (and optionally an encounter/content) and holds rules.
+Each **rule** is a small, declarative assertion plus — crucially — **where it can be
+evaluated**:
+
+```jsonc
+{
+  "id": "vCR-dps", "version": 3, "season": "U50",
+  "label": "Crimson Veldt — DPS", "role": "dps", "content": "vCrimsonVeldt",
+  "rules": [
+    // --- evaluable in-game by the player's own client (live, pre-pull) ---
+    { "id": "food",    "field": "food.active",      "op": "eq",  "value": true,
+      "severity": "error", "eval": "client", "label": "Eat food" },
+    { "id": "mundus",  "field": "mundus.id",        "op": "in",  "value": [13984, 13975],
+      "severity": "warn",  "eval": "client", "label": "Lover / Thief mundus" },
+    { "id": "critdmg", "field": "crit.damagePct",   "op": "lte", "value": 125,
+      "severity": "warn",  "eval": "client", "label": "Crit damage ≤ 125% cap" },
+    { "id": "attrs",   "field": "attrs.stamina",    "op": "gte", "value": 64,
+      "severity": "info",  "eval": "client", "label": "All attributes in Stamina" },
+    { "id": "sets",    "field": "gear.setIds",      "op": "containsAll", "value": [<deadly>, <sulxan>],
+      "severity": "warn",  "eval": "client", "label": "Deadly + Sul-Xan" },
+    // --- needs the uploaded log to be exact (post-hoc) ---
+    { "id": "pen",     "field": "penetration.effective", "op": "between", "value": [18000, 18400],
+      "severity": "error", "eval": "log", "liveApprox": { "field": "penetration.self",
+        "op": "gte", "assumedGroupPen": 11030 },
+      "label": "≈18.2k effective pen, no over-pen" },
+    { "id": "breach",  "field": "log.targetDebuffUptime.MajorBreach", "op": "gte", "value": 95,
+      "severity": "info",  "eval": "log", "scope": "group", "label": "Major Breach ≥95%" }
+  ]
+}
+```
+
+Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity:
+`error | warn | info` (drives card colour + whether it blocks a ready-check).
+
+### Two evaluation contexts (this is the important part)
+
+- **`eval: "client"`** — the player's own client has the data about *itself* (self
+  stats, CP allocation, attributes, mundus, food, **its own gear/sets**). It evaluates
+  these live and broadcasts only the resulting bits (§25). Works **pre-pull**, in-game.
+- **`eval: "log"`** — needs the uploaded report (effective penetration via the boss's
+  debuffs, buff/debuff uptimes, group-scope checks). **ESOTK** evaluates these post-hoc
+  by combining the snapshot with the log.
+- **`liveApprox`** — bridges the two for penetration. Effective pen can't be known
+  before the pull (depends on the group's debuffs on the boss), so the live check uses
+  `self-pen ≥ 18,200 − assumedGroupPen`. A standard tank kit supplies ≈**11,030** (Major
+  + Minor Breach + gold Crusher), so a DPS needs ≈**7,170** self-pen to be on track; the
+  exact verdict is recomputed from the log afterwards. The ruleset carries the
+  assumption so the live light is meaningful without pretending to be exact.
+
+### Compile → sync → evaluate → report
+
+1. **Author on the web.** Raid lead builds/edits the ruleset in ESOTK (defaults shipped
+   per content/season; reuse `detectBuildIssues`). Human-readable JSON lives server-side.
+2. **Compile to a compact "rule program."** Strip to the `eval: "client"` rules, map
+   each `id` → a fixed **bit index**, and encode `{fieldId, op, value}` into a small
+   blob. The client never needs the prose — just the field/op/value tuples.
+3. **Sync down** (§12.2): FSA write-mode file, import code, or broadcast.
+4. **Evaluate client-side** → produce the compliance **bitfield** (bit *i* = rule *i*
+   pass/fail) → broadcast over LibGroupBroadcast (§25).
+5. **Aggregate + complete on the web.** The raid-lead dashboard shows the live bits; on
+   upload, ESOTK evaluates the `eval: "log"` rules and merges, producing the final
+   per-player, per-fight compliance — including exact effective pen.
+
+### Versioning & safety
+
+- A compliance bitfield is meaningless without its **ruleset id + version** — broadcast
+  them together and handshake; mismatched versions degrade to "unknown," never to a
+  wrong green.
+- Ship **presets** (e.g. a sane default: food required, mundus sensible, self-pen on
+  track, crit-dmg ≤ cap, attributes spent) so a lead gets value with zero authoring; let
+  them override per content.
+- Rules reference IDs (set/mundus/food/ability), never localised names (§20).
+
+> Net: the ruleset is one declarative document, but it **runs in two places** — the
+> client checks what it can see about itself before the pull, and ESOTK finishes the
+> log-dependent checks after. The `eval` tag is what keeps "is everyone ready?" honest
+> in-game and "was everyone actually optimal?" exact on the web.
 
 ---
 

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -506,6 +506,84 @@ into the concrete platform above and confirms nobody else occupies the space.
 
 ---
 
+## 15. Data plane & the matching algorithm (the two expensive-to-change pieces)
+
+### Where the companion data lives
+
+The ESO Logs API v2 is **OAuth + an hourly points quota** (the RPGLogs platform; WCL's
+sibling API is ~3,600 points/hr, ESO Logs is comparable) and it is **read-oriented** —
+combat logs are uploaded through the Companion app, and there is **no public endpoint to
+write build data into someone's report.** So companion data cannot live *inside* ESO
+Logs. It lives in **ESOTK's own backend**, keyed by `reportCode` + actor, and is
+**overlaid client-side** when ESOTK renders a report. Practical rules:
+
+- Cache report metadata; **one API fetch per report**, then reuse — respect the points
+  quota (ESOTK already proxies the API today).
+- The companion payload is ESOTK's data, under ESOTK's retention/privacy rules — not
+  ESO Logs'. Clean separation, and it means **the feature works even on reports ESOTK
+  doesn't own**, as long as we can match an actor.
+
+### Matching a snapshot to a report/fight/actor
+
+Inputs available:
+- **Report:** absolute `startTime`, and per-fight `startTime`/`endTime` as **ms offsets
+  from report start**, plus `size`, `isKill`, `name`, and `masterData.actors`
+  (player name + server + type/role).
+- **Companion snapshot:** character name, `@account`, zone, and **absolute UTC
+  timestamp** per fight/pull (we control this format).
+
+Algorithm (tiered, fuzzy by design):
+1. **Direct key** — if the user supplied both (e.g. pasted the `reportCode` when
+   uploading the snapshot), bind directly.
+2. **Actor + time + zone** — match `masterData.actors` name + server to the snapshot's
+   character/server, require the snapshot UTC to fall within `report.start … report.end`
+   (and zone to agree), and attach to the nearest fight by offset.
+3. **Manual fallback** — present unmatched snapshots in ESOTK with an "attach to this
+   player" picker.
+
+**Gotchas that must be designed for from day one:**
+- **Anonymised reports** — ESO Logs can hide player names ("Random 1"), which breaks
+  name matching entirely → tier-2 fails, fall to manual (tier 3) or require the direct
+  key (tier 1).
+- **`@displayName` may not be exposed** by the API for privacy → match on character
+  name + server, keep `@account` only inside the snapshot.
+- **Name collisions / multiple chars per account / mid-session swaps** → disambiguate by
+  time window + role, and keep the manual override.
+- **Multiple snapshots per session** → snapshot per-fight (or on meaningful change) and
+  pick the one nearest each fight, so re-slots between pulls are captured (§5 P2 #11).
+
+These two — **the snapshot schema and this matcher** — are the parts most expensive to
+change later (§6). Version the schema explicitly and build the manual-attach fallback
+before any of the fancier features.
+
+---
+
+## 16. Sustainability & positioning (free add-on, premium web)
+
+ZeniMax's policy is unambiguous: **add-ons may not be monetised** — only donations are
+permitted, and in practice donations are negligible. That isn't a problem; it *defines*
+the model:
+
+- **The add-on is free, lean, and ideally open-source.** That's mandatory (ToS) and also
+  optimal for adoption and trust — the same posture that makes Hodor and LUIE widely
+  installed. Its job is **reach**: get into as many raids as possible and be the data
+  source + live layer.
+- **ESOTK (the website) is not an add-on**, so it can carry a **premium tier** — exactly
+  the ESO Logs / Warcraft Logs model (free core analysis, paid subscription for the
+  deeper extras). Revenue candidates: extended build/history retention, advanced stat
+  coaching, larger guild rosters, officer/attendance analytics, private guild spaces.
+- **Division of labour:** the free add-on drives the funnel and the network effect (the
+  more raiders run it, the better every dashboard gets); the web tier captures value.
+  Never paywall the in-game compliance basics — that would throttle the adoption the
+  whole platform depends on.
+
+This also reinforces the §14 moat: a competitor would need *both* a trusted free add-on
+*and* a web analytics business to copy it, and the add-on side can never be monetised to
+fund the web side directly — so the only durable path is exactly ESOTK's: build the web
+product first (already done) and let a free add-on feed it.
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -538,5 +616,8 @@ into the concrete platform above and confirms nobody else occupies the space.
 - [Group Synergy Tracker](https://esoui.com/downloads/info2429-GroupSynergyTracker.html)
 - [RaidTools (beta — ready check, buff/food checker)](https://www.esoui.com/downloads/info1969-RaidTools.html) · [RaidLead Essentials (discontinued)](https://www.esoui.com/downloads/info1201-RaidLeadEssentials.html)
 - [ESO-Database Game Data & Leaderboards API](https://game-data.eso-database.com/)
+- [ESO Logs API documentation — Archon](https://www.archon.gg/eso/articles/help/API-documentation) · [ESO Logs Python (rate-limit/points)](https://esologs-python.readthedocs.io/)
+- [ESO Logs report/fights schema (startTime offsets, masterData)](https://articles.esologs.com/help/intro-to-scripts)
+- [Add-on monetisation forbidden by ZOS — donations only (ESO Forums)](https://forums.elderscrollsonline.com/en/discussion/370469/do-add-on-devs-mod-programmers-get-compensated-in-any-way)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -1017,20 +1017,22 @@ Every readiness check below was confirmed against real add-on source / API refer
 
 | Requirement | Confirmed read | Source |
 |---|---|---|
-| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` (single arg) over enumerated skills | DynamicCP `src/API.lua` |
+| **Champion points** (enumerate) | `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)` | esoui `championdatamanager.lua` |
+| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` — single arg | DynamicCP `src/API.lua` |
 | **Champion points** (slotted) | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 | DynamicCP `OFFSETS` |
 | **Gear set** | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped` | ESOUI |
 | **Food** | active buff via `GetUnitBuffInfo("player", i)` ability id | ESOUI |
 | **Mundus** | active buff id (no direct getter — match a known mundus boon id list) | ESOUI |
 | **Potion** | `GetSlotItemLink(quickslotIndex)` | ESOUI |
 | **Attributes** | `GetAttributeSpentPoints(attributeType)` → points | eso-api dump |
-| **Self penetration / crit** | `GetPlayerStat(STAT_*)` (constants nil-guarded) | UESP |
+| **Self penetration / crit** | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_WEAPON_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants |
 
-> **Still pending live confirmation (flagged, not assumed):** the CP discipline-
-> enumeration function names (`GetNumChampionDisciplines` etc.) and the exact `STAT_*`
-> constant names. Both are guarded so a wrong name degrades one field instead of
-> crashing; the fallback for enumeration is a bundled championSkillId list iterated with
-> the verified single-arg `GetNumPointsSpentOnChampionSkill`.
+> **Index-vs-id gotcha (confirmed from ZOS source).** `GetNumChampionDisciplineSkills`
+> and `GetChampionSkillId` take the discipline **index**; `GetChampionDisciplineType`
+> takes the discipline **id**; `GetNumPointsSpentOnChampionSkill` takes the **skillId**.
+> Mixing them returns wrong/empty data — a real bug caught during verification. Only
+> step left is a one-time in-game run to confirm captured values match the character
+> sheet; the function names and arities are now source-verified.
 
 ---
 
@@ -1082,6 +1084,7 @@ Every readiness check below was confirmed against real add-on source / API refer
 - [LibGroupBroadcast custom-protocol API (DeclareProtocol/AddField/NumericField/ArrayField)](https://github.com/sirinsidiator/ESO-LibGroupBroadcast) · [Broadcasting API thread](https://www.esoui.com/forums/showthread.php?p=51019)
 - [RdK Group Tool — group query of equipment/CP/stats/mundus over map pins](https://www.esoui.com/downloads/info2475-RdKGroupTool.html) · [Taos Group Tools](https://esoui.com/downloads/info1962-TaosGroupTools.html)
 - [DynamicCP source — verified champion-point API (single-arg `GetNumPointsSpentOnChampionSkill`, slot OFFSETS)](https://github.com/Kyzderp/DynamicCP)
+- [Official ZOS source — champion enumeration (`GetNumChampionDisciplines`/`GetChampionDisciplineId`/`GetNumChampionDisciplineSkills`/`GetChampionSkillId`, index-vs-id)](https://github.com/esoui/esoui/blob/master/esoui/ingame/champion/championdatamanager.lua) · [ESOUIDocumentation.txt (STAT_* constants)](https://github.com/esoui/esoui/blob/master/ESOUIDocumentation.txt)
 - [GetItemLinkSetInfo (numEquipped/setId) — ESOUI wiki](https://wiki.esoui.com/GetItemLink) · [GetItemLink](https://wiki.esoui.com/GetItemLink)
 - [Mundus detection is buff-id-based via GetUnitBuffInfo (no direct getter)](https://www.esoui.com/forums/showthread.php?t=2225) · [Quickslot read GetSlotItemLink](https://www.esoui.com/forums/showthread.php?t=6286)
 </content>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -727,6 +727,7 @@ ESOTKCompanionSV = { ["Default"] = { ["@account"] = { ["$AccountWide"] = {
   schemaVersion = 1,
   season        = "U50",                 -- per-season/patch tag (§17)
   snapshots = { [1] = {
+    schemaVersion = 1, season = "U50",
     ts      = 1749384000,                -- GetTimeStamp() — UTC match key (§15)
     char    = "Charname", server = "NA", -- match key vs masterData.actors
     zoneId  = 1196, zone = "Crimson Veldt",
@@ -1029,17 +1030,17 @@ from local data.
 Every readiness check below was confirmed against real add-on source / API references
 (see Sources), so the add-on reads them from the player's _own_ client with no inspection:
 
-| Requirement                      | Confirmed read                                                                                                                                             | Source                          |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **Champion points** (enumerate)  | `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`               | esoui `championdatamanager.lua` |
-| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` — single arg                                                                                                   | DynamicCP `src/API.lua`         |
-| **Champion points** (slotted)    | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12                                                                                               | DynamicCP `OFFSETS`             |
-| **Gear set**                     | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped`                                                                  | ESOUI                           |
-| **Food**                         | active buff via `GetUnitBuffInfo("player", i)` ability id                                                                                                  | ESOUI                           |
-| **Mundus**                       | active buff id (no direct getter — match a known mundus boon id list)                                                                                      | ESOUI                           |
-| **Potion**                       | `GetSlotItemLink(quickslotIndex)`                                                                                                                          | ESOUI                           |
-| **Attributes**                   | `GetAttributeSpentPoints(attributeType)` → points                                                                                                          | eso-api dump                    |
-| **Self penetration / crit**      | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_WEAPON_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants             |
+| Requirement                      | Confirmed read                                                                                                                                      | Source                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Champion points** (enumerate)  | `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`        | esoui `championdatamanager.lua` |
+| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` — single arg                                                                                            | DynamicCP `src/API.lua`         |
+| **Champion points** (slotted)    | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12                                                                                        | DynamicCP `OFFSETS`             |
+| **Gear set**                     | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped`                                                           | ESOUI                           |
+| **Food**                         | active buff via `GetUnitBuffInfo("player", i)` ability id                                                                                           | ESOUI                           |
+| **Mundus**                       | active buff id (no direct getter — match a known mundus boon id list)                                                                               | ESOUI                           |
+| **Potion**                       | `GetSlotItemLink(quickslotIndex)`                                                                                                                   | ESOUI                           |
+| **Attributes**                   | `GetAttributeSpentPoints(attributeType)` → points                                                                                                   | eso-api dump                    |
+| **Self penetration / crit**      | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants             |
 
 > **Index-vs-id gotcha (confirmed from ZOS source).** `GetNumChampionDisciplineSkills`
 > and `GetChampionSkillId` take the discipline **index**; `GetChampionDisciplineType`

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -62,18 +62,18 @@ encounter) actually carries **more than most people realise**:
 
 What is **never** emitted and therefore impossible for ESO Logs to show:
 
-| Missing data                                                                                                                               | Why it matters                                                                                              | API source (in-game)                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| **Champion Point _allocation_** — points spent per star across all 3 trees, not just the 4 slotted                                         | The #1 ask. Two players with identical gear can have wildly different CP and the log can't tell them apart. | `GetNumPointsSpentOnChampionSkill`, `GetChampionPointsPlayerProgressionData` |
-| **Final derived stats**: max mag/stam/health, spell/weapon damage, **crit %, crit damage, penetration, recovery, resistances, mitigation** | These are computed client-side and never logged. The single most requested "why is my DPS low" diagnostic.  | `GetPlayerStat(STAT_*)`                                                      |
-| **Attribute point split** (Mag/Health/Stam)                                                                                                | Build correctness check.                                                                                    | `GetAttributeSpentPoints(attribute)`                                         |
-| **Exact enchant magnitude** & **trait quality nuance**                                                                                     | Log gives enchant _type/level_, not the rolled value.                                                       | `GetItemLink` + `GetItemLinkEnchantInfo`                                     |
-| **Mundus stone (named)**                                                                                                                   | Only inferable from a buff ID today.                                                                        | buff detection / `GetItemLink` of the boon                                   |
-| **Active food/drink (named, with duration)**                                                                                               | Inferable from buff today; add-on can name it + flag "no food".                                             | buff scan                                                                    |
-| **Skill/CP passives unlocked, skill point spend**                                                                                          | Build completeness.                                                                                         | skill-line API                                                               |
-| **Scribing scripts actually slotted** (grimoire + 3 scripts)                                                                               | ESOTK already _detects_ scribing from events; the add-on can report it **authoritatively**.                 | scribing API                                                                 |
-| **Companion build** (gear/skills)                                                                                                          | Solo/duo content.                                                                                           | companion API                                                                |
-| **Vampire/Werewolf stage, riding skills, CP curve preset**                                                                                 | Minor but cheap.                                                                                            | misc API                                                                     |
+| Missing data                                                                                                                                                                                                                                                                                 | Why it matters                                                                                              | API source (in-game)                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Champion Point _allocation_** — points spent per star across all 3 trees, not just the 4 slotted                                                                                                                                                                                           | The #1 ask. Two players with identical gear can have wildly different CP and the log can't tell them apart. | `GetNumPointsSpentOnChampionSkill`, `GetChampionPointsPlayerProgressionData` |
+| **Final derived stats**: max mag/stam/health, spell/weapon damage, **crit %, penetration, recovery, resistances, mitigation** (read once on leaving combat, so the time-varying stats are point-in-time; **crit damage** has no ESO stat constant and is derived from the log, not captured) | These are computed client-side and never logged. The single most requested "why is my DPS low" diagnostic.  | `GetPlayerStat(STAT_*)`                                                      |
+| **Attribute point split** (Mag/Health/Stam)                                                                                                                                                                                                                                                  | Build correctness check.                                                                                    | `GetAttributeSpentPoints(attribute)`                                         |
+| **Exact enchant magnitude** & **trait quality nuance**                                                                                                                                                                                                                                       | Log gives enchant _type/level_, not the rolled value.                                                       | `GetItemLink` + `GetItemLinkEnchantInfo`                                     |
+| **Mundus stone (named)**                                                                                                                                                                                                                                                                     | Only inferable from a buff ID today.                                                                        | buff detection / `GetItemLink` of the boon                                   |
+| **Active food/drink (named, with duration)**                                                                                                                                                                                                                                                 | Inferable from buff today; add-on can name it + flag "no food".                                             | buff scan                                                                    |
+| **Skill/CP passives unlocked, skill point spend**                                                                                                                                                                                                                                            | Build completeness.                                                                                         | skill-line API                                                               |
+| **Scribing scripts actually slotted** (grimoire + 3 scripts)                                                                                                                                                                                                                                 | ESOTK already _detects_ scribing from events; the add-on can report it **authoritatively**.                 | scribing API                                                                 |
+| **Companion build** (gear/skills)                                                                                                                                                                                                                                                            | Solo/duo content.                                                                                           | companion API                                                                |
+| **Vampire/Werewolf stage, riding skills, CP curve preset**                                                                                                                                                                                                                                   | Minor but cheap.                                                                                            | misc API                                                                     |
 
 **Takeaway:** the highest-value, _uniquely-addon_ data is **CP allocation + final
 stats + attributes + authoritative scribing scripts**. Gear and slotted skills are
@@ -1079,20 +1079,23 @@ The report-page upload UI is now wired through `PlayersPanel` local state and
    - `startTime` / `endTime`: from the `ReportEntry` (`src/store/report/reportSlice.ts`,
      absolute UNIX ms).
 3. **Compute per-player props:**
-   `buildCompanionBuildsForReport(result.all, matchableReport, { coaching: { assumedGroupPen } })`
+   `buildCompanionBuildsForReport(result.all, matchableReport, { targetFightId })`
    → `Map<actorId, { championPoints, coaching, stats, effects, scribing, snapshot, fightId }>`.
 4. **Render:** players come from `selectPlayersByIdForContext` keyed by `player.id`
    (already imported in `PlayerCard.tsx`; cards are rendered via
    `PlayersPanel`/`PlayersPanelView`/`LazyPlayerCard`). Pass
    `companionBuild={companionBuildsByPlayer[player.id]}` to each `PlayerCard`. Absent ⇒ panel renders
    nothing (no change to existing cards). When present, the panel shows CP allocation,
-   captured buffs, final stats, stat coaching and authoritative captured scribing scripts.
+   captured buffs, the character sheet at capture (point-in-time, volatile stats separated
+   from stable), plain stat-reading coaching (self penetration, crit chance) and
+   authoritative captured scribing scripts.
 
-**Notes:** `displayName` ↔ `snapshot.account` (optional cross-check). For _exact_
-effective penetration, later pass the boss's Major Breach/Crusher uptime from the log as
-`assumedGroupPen` with `groupPenIsExact: true` (§11.1.1); until then the standard-kit
-estimate is fine. Parsed snapshots are currently held in local component state; they're
-per-session, not persisted server-side.
+**Notes:** `displayName` ↔ `snapshot.account` (optional cross-check). Penetration is
+surfaced as a plain point-in-time self-pen reading only — the shipped `computeStatCoaching`
+takes no group-pen option and issues no over/under-cap verdict. An _exact_ effective-pen
+verdict (self-pen + the boss's Major Breach/Crusher/Alkosh uptimes from the log, §11.1.1)
+is the job of the future log-derived penetration engine, not the snapshot. Parsed snapshots
+are currently held in local component state; they're per-session, not persisted server-side.
 
 ---
 

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -314,6 +314,38 @@ With the companion's exact stats we can compute, per player, against hard ESO ca
 These read like a coach sitting next to the parse. **This is the headline UVP**, far
 more useful than "here's a build."
 
+#### 11.1.1 "Self" vs "effective" — how penetration & crit get to 100% accuracy
+
+ESOTK estimates pen/crit from the log's gear today; the companion replaces the guess.
+But two of these stats split into a **self** part (on your character sheet) and an
+**effective** part (depends on the target/buffs), and being precise about that split is
+what makes the coaching trustworthy:
+
+| Stat | Self part (add-on, exact) | Effective part (not on your sheet) | How ESOTK gets 100% |
+|---|---|---|---|
+| **Penetration** | `GetPlayerStat(STAT_*_PENETRATION)` = gear/traits (Sharpened), sets (Spriggan), CP (Piercing), Lover mundus, light-armour passives — **exact** | **Group armour debuffs on the boss** (Major/Minor Breach, Crusher, Alkosh, Crimson Oath, Runic Sunder) reduce the *target's* resist, so they're **not in your stat** | add-on's exact self-pen **+ the log's debuff uptime on the boss** = exact effective pen vs the 18,200 cap |
+| **Crit chance** | crit rating ÷ 21,918 — exact **at the moment read** | Temporary buffs (Major/Minor Savagery/Prophecy from potions/sets) fluctuate | snapshot a **self-buffed baseline** (canonical) ± an in-combat read for buffed peaks |
+| **Crit damage** | base 50% + Shadow mundus, Backstabber, medium-armour, set sources — readable/derivable | Temporary **Major/Minor Force**; Backstabber is positional | same: baseline vs in-combat, and Backstabber is conditional |
+
+**The key correction to "we're just guessing":**
+- Your **personal/self** penetration and crit become **100% exact** — `GetPlayerStat` is
+  the game's own number, not an estimate. That alone removes the guesswork ESOTK does now.
+- The **effective** numbers depend on things the character sheet never holds —
+  **target debuffs** (for pen) and **temporary buffs** (for crit). Penetration's missing
+  half is **exactly what the combat log records** (debuff auras on the boss), so the
+  add-on + log together are exact where neither is alone. (An add-on *can* also compute
+  "pen on target" live by scanning the boss's debuffs — what CombatMetrics / Dynamic
+  Stats / Meterskull already do — but for a logged fight, combining with the log is the
+  clean split.)
+- **Snapshot timing matters** (see §20): read the canonical baseline **out of combat,
+  self-buffed**, so cross-player comparisons are apples-to-apples; optionally add an
+  in-combat read for buffed values. Never feed a buffed in-combat reading into the
+  "are you at the cap" math without accounting for what was up.
+
+> Restated as the moat: the add-on supplies the half the log can't see (your tuning),
+> the log supplies the half the add-on can't see (what's on the boss), and ESOTK is the
+> only place the two combine into an exact effective number.
+
 ### 11.2 Champion Point allocation audit
 
 Full per-star allocation (invisible to the log) checked against the content: unspent
@@ -889,6 +921,8 @@ only later, as a convenience, if users want full builds visible in-game without 
 - [ESO-Hub Build Editor (import/export, CombatMetrics integration)](https://eso-hub.com/en/build-editor)
 - [ESO penetration & the 18,200 cap (over-penetration is wasted)](https://hyperioxes.com/eso/tools/penetration-calculator)
 - [ESO critical damage 125% hard cap / crit rating ÷ 21,918](https://eso-hub.com/en/guides/critical-damage) · [UESP: Critical Damage](https://en.uesp.net/wiki/Online:Critical_Damage)
+- [Penetration = personal sources vs group armour debuffs on the target (Breach/Crusher/Alkosh)](https://forums.elderscrollsonline.com/en/discussion/477907/penetration-calculation-and-how-it-works) · [Penetration overview — TerminalESO](https://terminaleso.wordpress.com/penetration/)
+- [Add-ons computing live pen-on-target by scanning boss debuffs — Dynamic Stats](https://esoui.com/downloads/info3917-Dynamicstats.html) · [Meterskull](https://www.esoui.com/downloads/info3941-MeterskullArmorPowerCriticalPenetrationMeter.html)
 - [LibGroupBroadcast — 32 bytes/sec group data limit](https://www.esoui.com/downloads/info1337-LibGroupSocket.html) · [LibGroupSocket source](https://github.com/ESOUIMods/LibGroupSocket/blob/master/LibGroupSocket.lua/)
 - [LUI Extended (MIT, custom group/raid frames)](https://www.esoui.com/downloads/info818-LuiExtended.html) · [GitHub](https://github.com/DakJaniels/LuiExtended)
 - [ESOUI Wiki — UnitTag / group APIs](https://wiki.esoui.com/UnitTag)

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -426,6 +426,12 @@ The user is right that the win is integrating with what raids already run:
   quickslot before the pull.
 - **Buff-assignment uptime** — assign Major Breach / Z'en / Slayer to players and track
   whether they actually maintain it (cross-checked against the log).
+- **Trial score & leaderboard capture** — read the live trial score (time + deaths +
+  hardmode) and leaderboard placement, attach to the report, and trend it per prog
+  night in roster-hub. (No combat log carries the score.)
+- **Tank/healer-specific compliance** — taunt uptime (cf. the *Untaunted* addon),
+  debuff coverage (Major Breach/Vuln), synergy throughput (cf. *Group Synergy
+  Tracker*) — role checks that go beyond "is the build legal".
 
 ### 12.6 Honest limits on the live layer
 
@@ -443,6 +449,60 @@ The user is right that the win is integrating with what raids already run:
 in-game — every player self-checks against your rules, the raid lead sees green/red at a
 glance, and the whole night flows back to the web as build-correlated history. The web
 is the brain; the add-on is the raid's nervous system.*
+
+---
+
+## 13. Integration feasibility matrix (verified per add-on)
+
+The §12.4 "plug in, don't rebuild" claim, checked against each target's actual hook.
+Legend: ✅ documented/public · ⚠️ open-source but no formal API (integratable, more
+fragile) · 🔲 no API (overlay only).
+
+| Target | Integration hook | Status | What the ESOTK Companion does | Effort |
+|---|---|---|---|---|
+| **LibGroupCombatStats** | Public dev API: `RegisterAddon(name, {"DPS","HPS","ULT"})`, observable data, callbacks `(unitTag, data)` | ✅ | Consume live DPS/HPS/ULT for the dashboard; ride its group join + broadcast infra; **propose a build/compliance category upstream** so the whole ecosystem benefits | Low |
+| **Hodor Reflexes** | Built on LibGroupCombatStats; same group session | ✅ | Coexist on one data bus; render alongside Hodor numbers (no separate join) | Low |
+| **LibGroupBroadcast** | Serialize/queue API within the 32 B/s budget | ✅ | Our own compact compliance-verdict protocol | Medium |
+| **LUI Extended** | MIT source; custom Player/Group/Raid/Boss frames, class/role colouring, aura tracking | ✅ source | Annotate its raid frames with compliance dots, or reuse its frame code | Medium |
+| **Wizard's Wardrobe** | SavedVariables schema (already parsed here) + auto-equip | ✅ | Verify the equipped setup matches the assignment; offer one-click correct setup | Low–Med |
+| **CombatMetrics** | SavedVariables + build export code | ✅ | Read existing SV so users needn't run our add-on for basics (§10) | Low |
+| **RaidNotifier** | Open source; `StartCountdown()` / `AddAnnouncement()` | ⚠️ | Tie roster assignments (interrupt/portal/sync) to on-screen announcements | Medium |
+| **Untaunted** | Open-source taunt/debuff tracker | ⚠️ | Source taunt-uptime for tank compliance (integrate or reimplement the read) | Medium |
+| **Bandits UI** | Group frames + buff/timer + combat notifications | 🔲 | Overlay compliance on its frames; **must not double-notify** (BUI + RaidNotifier already conflict) | Med–High |
+
+**Takeaway:** the spine is **LibGroupCombatStats** — it already solved group join,
+broadcast queuing, and a clean callback API, and its author (m00nyONE) maintains the
+companion libs (LibCustomNames/Icons). Build on it rather than rolling our own bus, and
+the Hodor user base is reachable on day one.
+
+---
+
+## 14. Competitive landscape & white space
+
+What exists today, and the gap we'd own:
+
+| Tool / category | What it does | What it can't do |
+|---|---|---|
+| **ESO Logs** | Authoritative post-hoc combat analysis | Read-only, after the fact; no build truth (stats/CP), no live layer, no roster rules |
+| **Build sites** (ESO-Hub, Alcast, Arzyel) | Static, hand-made build display & sharing | Open-loop — never tied to a real fight or a live group |
+| **Hodor / LibGroupCombatStats** | Live group DPS/HPS/ULT share | Combat numbers only — no build, no compliance, no web link |
+| **CombatMetrics** | Personal combat + build export code | Personal, not group; no rules; not roster-aware |
+| **RaidNotifier / BUI** | Mechanic alerts, frames, timers | No build compliance, no web roster, no analytics |
+| **RaidLead Essentials** | Ready-check + simple planner | **Discontinued** |
+| **RaidTools** (beta) | Ready-check + buff/food checker | Beta/niche; not role-aware; not web-connected |
+
+**The unclaimed quadrant:** a **web-roster-driven, role-aware, live build-compliance
+system that also produces post-hoc build-correlated analytics.** Every competitor sits
+on one axis (live *or* post-hoc; combat *or* build; personal *or* group; in-game *or*
+web). ESOTK is the only project positioned to join all of them, because it already owns
+the web roster-hub, the log analytics, and `detectBuildIssues`. Notably, ESOTK's
+in-development companion is *already publicly described* as "roster validation, group
+management, and gear inspection inside the ESO client" — this research sharpens that
+into the concrete platform above and confirms nobody else occupies the space.
+
+> The moat isn't any single feature — it's the **loop**: plan on web → enforce in game
+> → analyse on web. A pure add-on (no web brain) or a pure web tool (no in-game hands)
+> can't close it. ESOTK already has both halves.
 
 ---
 
@@ -471,5 +531,12 @@ is the brain; the add-on is the raid's nervous system.*
 - [LibGroupBroadcast — 32 bytes/sec group data limit](https://www.esoui.com/downloads/info1337-LibGroupSocket.html) · [LibGroupSocket source](https://github.com/ESOUIMods/LibGroupSocket/blob/master/LibGroupSocket.lua/)
 - [LUI Extended (MIT, custom group/raid frames)](https://www.esoui.com/downloads/info818-LuiExtended.html) · [GitHub](https://github.com/DakJaniels/LuiExtended)
 - [ESOUI Wiki — UnitTag / group APIs](https://wiki.esoui.com/UnitTag)
+- [LibGroupCombatStats — developer API (RegisterAddon, callbacks)](https://github.com/m00nyONE/LibGroupCombatStats)
+- [RaidNotifier (open source, StartCountdown/AddAnnouncement)](https://github.com/kyoma/ESO-RaidNotifier)
+- [Bandits User Interface](https://esoui.com/downloads/info1643-BanditsUserInterface.html)
+- [Untaunted — taunt/debuff tracker (open source)](https://github.com/Solinur/Untaunted)
+- [Group Synergy Tracker](https://esoui.com/downloads/info2429-GroupSynergyTracker.html)
+- [RaidTools (beta — ready check, buff/food checker)](https://www.esoui.com/downloads/info1969-RaidTools.html) · [RaidLead Essentials (discontinued)](https://www.esoui.com/downloads/info1201-RaidLeadEssentials.html)
+- [ESO-Database Game Data & Leaderboards API](https://game-data.eso-database.com/)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -730,7 +730,7 @@ ESOTKCompanionSV = { ["Default"] = { ["@account"] = { ["$AccountWide"] = {
     ts      = 1749384000,                -- GetTimeStamp() — UTC match key (§15)
     char    = "Charname", server = "NA", -- match key vs masterData.actors
     zoneId  = 1196, zone = "Crimson Veldt",
-    classId = 6, raceId = 4, role = "dps",
+    classId = 6, className = "Arcanist", raceId = 4, raceName = "Khajiit", role = "dps",
     -- gaps the log can't see:
     cp = { warfare = { [starId]=pts }, fitness = {…}, craft = {…},
            slotted = { [1]=starId, …, [12]=starId } },

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -584,6 +584,102 @@ product first (already done) and let a free add-on feed it.
 
 ---
 
+## 17. Why now — the 2026 meta makes the build gap bigger
+
+ESO's 2026 shift to a **Seasonal model** (3–6 month content blocks replacing the annual
+Chapter; Season 1 ships with **Update 50 on 8 June 2026** — *today* — including the
+**Crimson Veldt** trial) directly increases the value of build capture:
+
+- **Subclassing + Class Mastery Passives (the big one).** The 2026 Class Identity
+  Refresh lets players **mix skill lines across classes**, and adds **Class Mastery
+  Passives** that *only pure-class builds* can slot (pick 2 of 5; auto-refunded the
+  moment you subclass). This explodes build variety and creates a **fresh capture gap**:
+  the log's ability IDs reveal *which* skills are slotted, but **whether a player is
+  pure-class (and which Mastery Passives) vs. subclassed, and which three skill lines
+  they chose**, is new build state worth capturing — and a new axis for compliance
+  rules ("this fight wants the pure-class Mastery Passive build"). Nothing surfaces this
+  yet.
+- **Seasonal itemisation churn.** New sets (Night Market, new Thieves Guild mythic) and
+  balance every season mean rulesets and set/CP data need a **per-season cadence**. The
+  schema must carry a season/patch tag, and ESOTK's existing data-regen skills
+  (`gear-data-regen`, `class-skill-regen`) should run each season.
+- **Overland Difficulty (Seasoned/Master)** makes builds matter outside trials too,
+  widening the audience for stat coaching beyond the hardcore raid niche.
+
+**Implication:** ship capture of **CP allocation + subclass lines + Class Mastery
+Passives + final stats** as the v1 payload — it's both the user's ask *and* the freshest
+gap the 2026 systems opened. Tag every snapshot and ruleset with the season/patch.
+
+## 18. Platform reality (and a console-only opportunity)
+
+The web pipeline is **hard PC-only**, more strictly than first stated:
+
+- Console (PS5 / Xbox) **got add-ons in Update 46 (June 2025) but only UI-focused
+  ones** — no gameplay/combat scripts.
+- Console can run `/encounterlog`, **but the platform security model blocks access to
+  the log files and SavedVariables entirely** — there is *no* way to export either, even
+  via the add-on API. So console has **no ESO Logs and no way to upload to ESOTK**.
+
+Therefore: ESOTK + companion capture/upload is PC-only; console reports simply don't
+exist to enrich. **But** that same gap is an opening: console raiders have *no* combat
+analysis at all. A **purely in-game, web-free live layer** (the §12 compliance dashboard
++ ready-check, sharing compact verdicts over LibGroupBroadcast) could be uniquely
+valuable on console — *if* it qualifies as a "UI add-on" and the group-data libs are
+permitted there. **Unverified and likely later-phase**, but it's a genuine
+blue-ocean angle no PC-centric competitor is chasing. Flag it as a research spike, not a
+v1 commitment.
+
+## 19. Recommended add-on tech stack & a concrete SavedVariables schema
+
+**Libraries (all standard, well-maintained):**
+
+- **`GetTimeStamp()`** → UNIX seconds in server time — the exact key for matching to ESO
+  Logs' absolute report `startTime` (§15). Stamp every snapshot with it.
+- **LibSavedVars** — scoped (server/account/character) saved vars **with migration**;
+  use it to version the schema so per-season changes don't corrupt old data.
+- **LibAddonMenu-2.0** — the settings panel (toggles for broadcast opt-in, ruleset sync,
+  what to capture).
+- **LibGroupBroadcast** + **LibGroupCombatStats** — the live layer bus (§12, §13).
+- **LibCombat** — combat data feed (what CombatMetrics/Hodor build on) if we compute
+  any live combat metrics ourselves.
+
+**Draft schema (`ESOTKCompanionSV`)** — illustrative, versioned, per-fight snapshots:
+
+```lua
+ESOTKCompanionSV = { ["Default"] = { ["@account"] = { ["$AccountWide"] = {
+  schemaVersion = 1,
+  season        = "U50",                 -- per-season/patch tag (§17)
+  snapshots = { [1] = {
+    ts      = 1749384000,                -- GetTimeStamp() — UTC match key (§15)
+    char    = "Charname", server = "NA", -- match key vs masterData.actors
+    zoneId  = 1196, zone = "Crimson Veldt",
+    classId = 6, raceId = 4, role = "dps",
+    -- gaps the log can't see:
+    cp = { warfare = { [starId]=pts }, fitness = {…}, craft = {…},
+           slotted = { [1]=starId, …, [12]=starId } },
+    masteryPassives = { id, id },         -- 2026 pure-class passives (§17)
+    subclassLines   = { lineId, lineId, lineId }, -- 2026 subclassing (§17)
+    attrs  = { magicka=0, health=64, stamina=0 },
+    mundus = "The Lover",
+    food   = { id=12345, name="Bewitched Sugar Skulls" },
+    stats  = { maxMag=, maxStam=, maxHealth=, spellDmg=, weaponDmg=,
+               critRating=, critDmg=, penPhys=, penSpell=,
+               recovMag=, recovStam=, recovHealth=, resistPhys=, resistSpell= },
+    -- redundant with the log (optional / verification only):
+    bars = { front={…}, back={…} }, gear = { [slot]={link,trait,enchant,quality,setId} },
+    -- live-layer output:
+    rulesetId  = "vCR-dps-v3",
+    compliance = { food=true, mundus=true, pen=false, sets=true, cp=true },
+  } },
+  rulesets = {},                          -- inbound from ESOTK (FSA write / import code)
+} } } }
+```
+
+The two fields that must never break without a version bump: `ts` + `char`/`server`
+(the matcher's keys) and `schemaVersion`. Everything else is additive.
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -619,5 +715,9 @@ product first (already done) and let a free add-on feed it.
 - [ESO Logs API documentation — Archon](https://www.archon.gg/eso/articles/help/API-documentation) · [ESO Logs Python (rate-limit/points)](https://esologs-python.readthedocs.io/)
 - [ESO Logs report/fights schema (startTime offsets, masterData)](https://articles.esologs.com/help/intro-to-scripts)
 - [Add-on monetisation forbidden by ZOS — donations only (ESO Forums)](https://forums.elderscrollsonline.com/en/discussion/370469/do-add-on-devs-mod-programmers-get-compensated-in-any-way)
+- [ESO 2026 roadmap & Seasons](https://hacktheminotaur.com/eso-guides/eso-2026-roadmap-seasons-updates/) · [Update 50 guide (Crimson Veldt, Werewolf, Class Mastery)](https://arzyelbuilds.com/eso-update-50/)
+- [ESO 2026 Class Identity Refresh & subclassing / Class Mastery Passives](https://hacktheminotaur.com/eso-guides/eso-class-updates-2026-the-class-identity-refresh/)
+- [Console can't access /encounterlog files (ESO Forums)](https://forums.elderscrollsonline.com/en/discussion/679575/problem-consoles-cannot-access-logs-generated-by-encounterlog) · [Console add-ons guide](https://alcasthq.com/eso-addons-console-guide/)
+- [LibSavedVars (scoped + migration)](https://github.com/silvereyes333/LibSavedVars) · [LibAddonMenu-2.0](https://www.esoui.com/downloads/info7-LibAddonMenu.html)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -76,8 +76,9 @@ What is **never** emitted and therefore impossible for ESO Logs to show:
 | **Vampire/Werewolf stage, riding skills, CP curve preset**                                                                                 | Minor but cheap.                                                                                            | misc API                                                                     |
 
 **Takeaway:** the highest-value, _uniquely-addon_ data is **CP allocation + final
-stats + attributes**. Gear and slotted skills are mostly redundant with the log
-(useful as a verification/fallback, and to fill console/non-logged sessions).
+stats + attributes + authoritative scribing scripts**. Gear and slotted skills are
+mostly redundant with the log (useful as a verification/fallback, and to fill
+console/non-logged sessions).
 
 ---
 
@@ -743,6 +744,10 @@ ESOTKCompanionSV = { ["Default"] = { ["@account"] = { ["$AccountWide"] = {
     stats  = { maxMag=, maxStam=, maxHealth=, spellDmg=, weaponDmg=,
                critRating=, critDmg=, penPhys=, penSpell=,
                recovMag=, recovStam=, recovHealth=, resistPhys=, resistSpell= },
+    scribing = {
+      { abilityId=217340, name="Shattering Knife", bar="front", slot=3,
+        scripts = { [1]={id=,name=}, [2]={id=,name="Class Mastery"}, [3]={id=,name=} } },
+    },
     -- redundant with the log (optional / verification only):
     bars = { front={…}, back={…} }, gear = { [slot]={link,trait,enchant,quality,setId} },
     -- live-layer output:
@@ -1041,6 +1046,7 @@ Every readiness check below was confirmed against real add-on source / API refer
 | **Potion**                       | `GetSlotItemLink(quickslotIndex)`                                                                                                                   | ESOUI                           |
 | **Attributes**                   | `GetAttributeSpentPoints(attributeType)` → points                                                                                                   | eso-api dump                    |
 | **Self penetration / crit**      | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants             |
+| **Scribing scripts**             | `GetCraftedAbilityActiveScriptIds(craftedAbilityId)` + script/name/icon helpers                                                                     | local add-on source             |
 
 > **Index-vs-id gotcha (confirmed from ZOS source).** `GetNumChampionDisciplineSkills`
 > and `GetChampionSkillId` take the discipline **index**; `GetChampionDisciplineType`
@@ -1074,12 +1080,13 @@ The report-page upload UI is now wired through `PlayersPanel` local state and
      absolute UNIX ms).
 3. **Compute per-player props:**
    `buildCompanionBuildsForReport(result.all, matchableReport, { coaching: { assumedGroupPen } })`
-   → `Map<actorId, { championPoints, coaching, stats, effects, snapshot, fightId }>`.
+   → `Map<actorId, { championPoints, coaching, stats, effects, scribing, snapshot, fightId }>`.
 4. **Render:** players come from `selectPlayersByIdForContext` keyed by `player.id`
    (already imported in `PlayerCard.tsx`; cards are rendered via
    `PlayersPanel`/`PlayersPanelView`/`LazyPlayerCard`). Pass
    `companionBuild={companionBuildsByPlayer[player.id]}` to each `PlayerCard`. Absent ⇒ panel renders
-   nothing (no change to existing cards).
+   nothing (no change to existing cards). When present, the panel shows CP allocation,
+   captured buffs, final stats, stat coaching and authoritative captured scribing scripts.
 
 **Notes:** `displayName` ↔ `snapshot.account` (optional cross-check). For _exact_
 effective penetration, later pass the boss's Major Breach/Crusher uptime from the log as

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -20,7 +20,7 @@ surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & op
 17. Why now — the 2026 meta · 18. Platform reality & a console-only opportunity ·
 19. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
 21. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
-· 24. Consolidated roadmap.
+· 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it).
 
 ---
 
@@ -477,7 +477,7 @@ fragile) · 🔲 no API (overlay only).
 
 | Target | Integration hook | Status | What the ESOTK Companion does | Effort |
 |---|---|---|---|---|
-| **LibGroupCombatStats** | Public dev API: `RegisterAddon(name, {"DPS","HPS","ULT"})`, observable data, callbacks `(unitTag, data)` | ✅ | Consume live DPS/HPS/ULT for the dashboard; ride its group join + broadcast infra; **propose a build/compliance category upstream** so the whole ecosystem benefits | Low |
+| **LibGroupCombatStats** | Public dev API: `RegisterAddon(name, {"DPS","HPS","ULT"})`, observable data, callbacks `(unitTag, data)` | ✅ | **Consume** live DPS/HPS/ULT for the dashboard. Its categories are fixed (DPS/HPS/ULT) — our own build/compliance data rides **LibGroupBroadcast** directly instead (§25) | Low |
 | **Hodor Reflexes** | Built on LibGroupCombatStats; same group session | ✅ | Coexist on one data bus; render alongside Hodor numbers (no separate join) | Low |
 | **LibGroupBroadcast** | Serialize/queue API within the 32 B/s budget | ✅ | Our own compact compliance-verdict protocol | Medium |
 | **LUI Extended** | MIT source; custom Player/Group/Raid/Boss frames, class/role colouring, aura tracking | ✅ source | Annotate its raid frames with compliance dots, or reuse its frame code | Medium |
@@ -507,6 +507,16 @@ What exists today, and the gap we'd own:
 | **RaidNotifier / BUI** | Mechanic alerts, frames, timers | No build compliance, no web roster, no analytics |
 | **RaidLead Essentials** | Ready-check + simple planner | **Discontinued** |
 | **RaidTools** (beta) | Ready-check + buff/food checker | Beta/niche; not role-aware; not web-connected |
+| **RdK Group Tool** | **Guild-admin *query* of group members' equipment, CP, stats, mundus, skills** (opt-in, off by default; PvP-focused) | In-game only; no ESO Logs correlation, no web analytics/history, no cap-aware coaching; a query tool, not a platform |
+| **Taos Group Tools / GroupSpy** | Group ult frames, buff-food indicators, group info | Coordination widgets, not build compliance or analytics |
+
+> **Correction (important).** An earlier draft of this doc claimed "no competitor shares
+> full builds." That is **wrong**: **RdK Group Tool already shares equipment, CP, stats
+> and mundus across the group** (admin-gated, opt-in, over map pins — see §25). So the
+> capability is *not* novel. What remains genuinely unclaimed is the **combination**: a
+> web-roster-driven, role-aware, **log-correlated** compliance + analytics platform.
+> RdK proves the in-game transport works; it just stops at an in-game PvP query tool with
+> no web brain, no ESO Logs link, and no coaching/history.
 
 **The unclaimed quadrant:** a **web-roster-driven, role-aware, live build-compliance
 system that also produces post-hoc build-correlated analytics.** Every competitor sits
@@ -515,7 +525,7 @@ web). ESOTK is the only project positioned to join all of them, because it alrea
 the web roster-hub, the log analytics, and `detectBuildIssues`. Notably, ESOTK's
 in-development companion is *already publicly described* as "roster validation, group
 management, and gear inspection inside the ESO client" — this research sharpens that
-into the concrete platform above and confirms nobody else occupies the space.
+into the concrete platform above.
 
 > The moat isn't any single feature — it's the **loop**: plan on web → enforce in game
 > → analyse on web. A pure add-on (no web brain) or a pure web tool (no in-game hands)
@@ -523,11 +533,10 @@ into the concrete platform above and confirms nobody else occupies the space.
 
 **One more structural advantage:** ESO has **no native gear/build inspection** — ZOS
 deliberately disabled it to curb toxicity, and the API won't expose another player's
-gear. So the *only* way to see a teammate's full build in-game is if they **opt in to
-broadcast it** — which is exactly our model. No direct competitor shares full builds
-(stats/CP), and even the community's standard answer to "how do I see someone's build?"
-is "check esologs" — which only has gear, not the stats/CP/attributes we capture. We're
-filling a gap the base game intentionally left open *and* nobody else fills.
+gear/stats (`GetPlayerStat` is self-only; there is no `GetUnitStat`). So the *only* way
+to see a teammate's full build is if they **opt in to broadcast it** from their own
+client — which is exactly our model, and the model RdK already uses. The base game left
+this gap open on purpose; our edge is wiring it to logs + web, not the sharing itself.
 
 ---
 
@@ -812,6 +821,52 @@ three things the whole platform rests on.
 
 ---
 
+## 25. Group-share transport — how to actually broadcast it
+
+Now that opt-in group sharing is accepted, here's the concrete "how", grounded in the
+real libraries and an existing precedent (RdK Group Tool).
+
+### Two libraries, two jobs
+- **LibGroupCombatStats** — *consume only*. Clean callback API, but its categories are
+  fixed (DPS/HPS/ULT). Use it to pull live combat numbers into the dashboard; it is **not**
+  where custom build/compliance data goes.
+- **LibGroupBroadcast 2.0** (sirinsidiator) — *the vehicle for our own data*. It exposes
+  a real custom-protocol API: `DeclareProtocol(id, name)` (id/name must be globally
+  unique, reserved on the ESOUI wiki), then `AddField(...)` built from `CreateFlagField`
+  (booleans → single bits), `CreateNumericField` (range-limited ints — declare min/max so
+  it uses the fewest bits), enum/array/reserved fields. The library bit-packs to the
+  minimum and fairly shares the **~32 B/s** group budget across all add-ons.
+
+### Two payload tiers (driven by the byte budget)
+1. **Live compliance verdict** — what we broadcast in/around combat. A handful of
+   `FlagField`s (`food`, `mundus`, `pen`, `sets`, `cp`, `roleOK`) plus maybe one or two
+   small bucketed numerics. That's a few **bits**, trivially within budget. Each client
+   self-evaluates against the synced ruleset (§12.2) and broadcasts only this verdict;
+   the raid lead aggregates into the dashboard.
+2. **Full build** (CP allocation + exact stats + gear) — far too big for the live
+   trickle. Two ways to move it, neither needs a desktop app:
+   - **Per-member SavedVariables upload (recommended for the website).** Each player
+     uploads their own file; ESOTK matches and assembles the group. No byte budget at
+     all, exact data. Simplest and most reliable.
+   - **In-game bulk query over map pins** — the **RdK Group Tool precedent**: a guild
+     admin can already *query* members' equipment/CP/stats/mundus, transferred over map
+     pins, opt-in and off by default. Proves full-build P2P transfer works; it's just
+     slow, so do it **out of combat / pre-pull**, on demand.
+
+### Recommendation
+Live **verdicts via LibGroupBroadcast** for the in-game dashboard; **full builds via
+per-member SavedVariables upload** for the website. Add RdK-style in-game bulk query
+only later, as a convenience, if users want full builds visible in-game without uploading.
+
+### Constraints to design in now
+- Reserve a unique protocol id+name on the ESOUI wiki; **version the protocol** and
+  handshake so mismatched add-on versions degrade cleanly.
+- Bulk transfer is **out-of-combat only** (and courteous on the shared channel).
+- Everyone who should appear must run the add-on and opt in (§12.6) — verdicts/builds
+  come from each player's own client, never from inspection.
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -854,5 +909,8 @@ three things the whole platform rests on.
 - [GetPlayerStat (UESP function reference)](https://esodata.uesp.net/100010/data/g/e/t/GetPlayerStat.html) · [Character sheet & advanced stats explained](https://www.eso-u.com/articles/player_character_sheet_and_advanced_stats_ui_explained)
 - [Easy Stalking — auto-log Cyrodiil/IC/BG](https://www.esoui.com/downloads/info2332-EasyStalking-Encounterlog.html) · [PvpMeter](https://forums.elderscrollsonline.com/en/discussion/387159/addon-pvpmeter-graphical-tracker-for-your-kill-death-in-pvp-and-history-of-your-bg-duel-played) · [PvP addons guide — NirnStorm](https://nirnstorm.com/eso/guides/pvp-addons-guide/)
 - [No native gear inspection in ESO (ZOS design, anti-toxicity)](https://forums.elderscrollsonline.com/en/discussion/619375/ability-to-inspect-players-in-eso) · [Why you can't inspect other players](https://forums.elderscrollsonline.com/en/discussion/566890/why-cant-i-inspect-other-players-noob-question)
+- [GetUnitPower (current/max for any unitTag)](https://esoapi.uesp.net/100020/data/g/e/t/GetUnitPower.html) · [GetUnitBuffInfo (group buffs)](https://esodata.uesp.net/100016/data/g/e/t/GetUnitBuffInfo.html) · [UnitTag reference](https://wiki.esoui.com/UnitTag)
+- [LibGroupBroadcast custom-protocol API (DeclareProtocol/AddField/NumericField/ArrayField)](https://github.com/sirinsidiator/ESO-LibGroupBroadcast) · [Broadcasting API thread](https://www.esoui.com/forums/showthread.php?p=51019)
+- [RdK Group Tool — group query of equipment/CP/stats/mundus over map pins](https://www.esoui.com/downloads/info2475-RdKGroupTool.html) · [Taos Group Tools](https://esoui.com/downloads/info1962-TaosGroupTools.html)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -1,0 +1,231 @@
+# ESOTK Companion Add-on — Research & Strategy (June 2026)
+
+> Research brief for the in-game ESO add-on that pairs with ESO Toolkit (ESOTK).
+> Goal: capture the build/character data that ESO Logs **cannot** see, and feed it
+> back into ESOTK so player cards, build-hub, roster-hub and fight-replay show a
+> complete picture.
+
+---
+
+## 1. The core thesis
+
+ESO Logs is excellent at **what happened in combat** (damage, healing, casts, buffs,
+deaths, timelines). It is structurally blind to **why** — the character build that
+produced those numbers. That blindness is not a bug in ESO Logs; it is a limit of the
+data source. The game's **encounter log** (`Encounter.log`, the file the ESO Logs
+add-on uploads) only writes what ZeniMax chose to emit, and ZeniMax deliberately
+**disabled real-time logging** years ago to prevent in-combat automation. So the log
+is a post-hoc, partial snapshot.
+
+An **in-game add-on** runs inside the ESO Lua sandbox and can read the *live* character
+state through the official API — including everything the log omits. That is the gap
+we fill. The add-on captures the missing build data, and ESOTK stitches it onto the
+log it already analyses, matching by character/account + timestamp + zone.
+
+**One-line pitch:** *ESO Logs tells you the player did 92k DPS. The ESOTK Companion
+tells you they did it on a 66-trait CP build with 18k penetration, Deadly/Sul-Xan,
+Lover mundus, and Bewitched Sugar Skulls — and shows it on the player card.*
+
+---
+
+## 2. Gap analysis — what the log already has vs. what it misses
+
+The raw `Encounter.log` `PLAYER_INFO` line (emitted per player when they enter an
+encounter) actually carries **more than most people realise**:
+
+| Already in the log / ESO Logs | Notes |
+|---|---|
+| Equipped gear: item IDs, **trait, set, display quality, enchant type/level/quality**, item level, per slot | Both bars. ESO Logs surfaces gear on player pages. |
+| Slotted abilities (front + back bar ability IDs) | Morphs are derivable from the ID. |
+| "Long-term effects" list (passives + buffs) incl. the **CP-slotted stars**, mundus buff, food/drink buff, vampire/WW | Present as buff IDs, but not labelled as "this is the build". |
+| CP **rank** (total earned) | Not the allocation. |
+| Race/class | Derivable; class is explicit, race partially. |
+
+What is **never** emitted and therefore impossible for ESO Logs to show:
+
+| Missing data | Why it matters | API source (in-game) |
+|---|---|---|
+| **Champion Point *allocation*** — points spent per star across all 3 trees, not just the 4 slotted | The #1 ask. Two players with identical gear can have wildly different CP and the log can't tell them apart. | `GetNumPointsSpentOnChampionSkill`, `GetChampionPointsPlayerProgressionData` |
+| **Final derived stats**: max mag/stam/health, spell/weapon damage, **crit %, crit damage, penetration, recovery, resistances, mitigation** | These are computed client-side and never logged. The single most requested "why is my DPS low" diagnostic. | `GetPlayerStat(STAT_*)` |
+| **Attribute point split** (Mag/Health/Stam) | Build correctness check. | `GetAttributeSpentPoints(attribute)` |
+| **Exact enchant magnitude** & **trait quality nuance** | Log gives enchant *type/level*, not the rolled value. | `GetItemLink` + `GetItemLinkEnchantInfo` |
+| **Mundus stone (named)** | Only inferable from a buff ID today. | buff detection / `GetItemLink` of the boon |
+| **Active food/drink (named, with duration)** | Inferable from buff today; add-on can name it + flag "no food". | buff scan |
+| **Skill/CP passives unlocked, skill point spend** | Build completeness. | skill-line API |
+| **Scribing scripts actually slotted** (grimoire + 3 scripts) | ESOTK already *detects* scribing from events; the add-on can report it **authoritatively**. | scribing API |
+| **Companion build** (gear/skills) | Solo/duo content. | companion API |
+| **Vampire/Werewolf stage, riding skills, CP curve preset** | Minor but cheap. | misc API |
+
+**Takeaway:** the highest-value, *uniquely-addon* data is **CP allocation + final
+stats + attributes**. Gear and slotted skills are mostly redundant with the log
+(useful as a verification/fallback, and to fill console/non-logged sessions).
+
+---
+
+## 3. What the ESO Lua API lets us capture (the toolbox)
+
+The add-on runs in ESO's sandboxed Lua VM (same environment as CombatMetrics, Hodor
+Reflexes, Wizard's Wardrobe). Relevant capabilities:
+
+- **Character snapshot** — all derived stats via `GetPlayerStat`, CP allocation,
+  attributes, gear with full link detail, both ability bars, mundus, active food,
+  race/class/alliance, skill points.
+- **Event hooks** — `EVENT_PLAYER_COMBAT_STATE`, `EVENT_PLAYER_ACTIVATED`,
+  `EVENT_CHAMPION_POINT_UPDATE`, gear/skill change events. Lets us snapshot **at the
+  same moment the log starts a fight**, so data lines up with the encounter.
+- **SavedVariables** — the add-on writes a Lua table to disk
+  (`.../SavedVariables/ESOTKCompanion.lua`). ESOTK **already has a Lua importer**
+  (`luaParser.ts` / Wizard's Wardrobe), so ingesting our own format is a small step.
+- **Group broadcast** — `LibGroupBroadcast` (formerly LibGroupSocket; recently
+  patched, 2026) + `LibGroupCombatStats` already share live DPS/HPS/Ult across the
+  group. **We can ride the same channel to collect the whole group's build data into
+  the logger's single SavedVariables file.** This is the multiplier: one upload =
+  12 complete builds.
+- **Clipboard / chat export** — generate a compressed, encoded build string in-game
+  (the Wizard's Wardrobe / build-import-code pattern) that a user pastes into ESOTK.
+
+**Hard constraints to design around:**
+- **PC-only.** Add-ons don't run on console (even though console now has encounter
+  logging). Console users get the log-only experience; the companion is a PC perk.
+- **No real-time push to web from in-game.** ESO Lua has no outbound HTTP. Transport
+  to ESOTK is always file-upload or copy/paste (or via the Kalpa manager, below).
+- **ZOS ToS / "no automation."** We only *read* state and *report* it — no input
+  automation, no combat decisions. Safe, in line with CombatMetrics/Hodor.
+- **Matching problem.** SavedVariables isn't stamped with the ESO Logs report code.
+  We match on `@account` + character + zone + UTC timestamp window. Design for fuzzy
+  matching from day one.
+
+---
+
+## 4. How it plugs into ESOTK (we already have the rails)
+
+ESOTK is unusually well-positioned because the integration surfaces already exist:
+
+| ESOTK surface | What the companion data adds |
+|---|---|
+| **Player cards** (the headline ask) | CP allocation, final stats (crit/pen/recovery), mundus, food, attribute split — shown inline. |
+| **Loadout Manager** | Already imports Lua SavedVariables. Add an `ESOTKCompanion` format alongside Wizard's Wardrobe. |
+| **Build Hub** | "Get Addons" deep-link to **Kalpa** addon manager already exists — ship the companion as a Kalpa pack so install is one click. |
+| **Roster Hub** | `recommended_addons` column already exists; the companion becomes a recommended/required raid add-on, and roster build-checks validate against captured CP/stats. |
+| **Fight Replay** | Lock-on stats panel can show the *real* build behind an actor. |
+| **Scribing detection** | Cross-check detected scripts against authoritatively-reported slotted scripts. |
+
+The **Kalpa** addon manager + deep-link (`GetAddonsButton`) is the distribution
+channel and is the natural place to **automate the upload**: Kalpa already manages the
+SavedVariables directory, so it can read `ESOTKCompanion.lua` and POST it to ESOTK
+without the user hand-uploading a file. That closes the "no HTTP from Lua" gap cleanly.
+
+---
+
+## 5. Ranked ideas
+
+### P0 — Build the core gap-filler (do these first)
+1. **Champion Point allocation capture** — full per-star spend, all trees. The
+   marquee feature and the user's stated priority. Render on player cards as a compact
+   CP summary + expandable tree.
+2. **Final stat snapshot** — crit, penetration, recovery, spell/weapon damage, max
+   resources, resistances. The "why" behind the DPS number.
+3. **Attribute split + mundus + food (named)** — cheap to capture, high diagnostic
+   value, enables build-correctness flags ("running no food", "Atronach on a stamina
+   build?").
+4. **SavedVariables format + ESOTK importer** — define a stable schema; extend the
+   existing Lua import path. Match to report by account+char+zone+timestamp.
+
+### P1 — Make it effortless and group-wide
+5. **Whole-group capture via LibGroupBroadcast** — the raid logger's single upload
+   carries all 12 builds. This is what turns it from "nice for me" into "the group
+   tool". Mirror the Hodor/LibGroupCombatStats model.
+6. **Kalpa auto-upload** — Kalpa reads the SV file and posts to ESOTK; zero manual
+   steps. Optionally a clipboard build-code as the no-Kalpa fallback.
+7. **Build-correctness flags on player cards** — derive issues from captured data
+   (no food, low penetration for the content, wrong mundus, unspent CP/attributes,
+   under-quality gear). ESOTK already has `detectBuildIssues` — feed it real data.
+
+### P2 — Differentiators / longer tail
+8. **Scribing ground-truth** — report actually-slotted grimoire + 3 scripts; reconcile
+   with ESOTK's event-based detection.
+9. **Pre-fight readiness check** — in-game, before pull: "everyone fed, buffed,
+   CP-slotted correctly?" surfaced both in-game and in roster-hub.
+10. **Companion (pet) build capture** for solo/duo logs.
+11. **Time-series build deltas** — capture per-fight so ESOTK can show "you swapped
+    mundus / re-slotted CP between pulls", and trend stats across a session.
+12. **Loadout round-trip** — export an ESOTK-designed loadout back to a format the
+    companion (or Wizard's Wardrobe) can equip, closing the design→play→log loop.
+
+---
+
+## 6. Recommended architecture (phased)
+
+```
+In-game add-on (Lua)
+  ├─ snapshot on EVENT_PLAYER_COMBAT_STATE / fight start
+  │    → CP alloc, stats, attributes, gear, bars, mundus, food, scribing
+  ├─ LibGroupBroadcast → collect groupmates' snapshots (P1)
+  └─ write ESOTKCompanion.lua (versioned schema, keyed by char+zone+UTC)
+        │
+        ├─ Path A (P0): user uploads / pastes build-code → ESOTK Loadout import
+        └─ Path B (P1): Kalpa reads SV file → POST to ESOTK API
+                          │
+ESOTK web (this repo)
+  ├─ Lua import (extend luaParser.ts with ESOTKCompanion format)
+  ├─ matcher: companion snapshot ↔ ESO Logs report/fight/actor
+  ├─ enrich player_data slice with build payload
+  └─ render: player cards · build-hub · roster checks · fight-replay
+```
+
+**Build the matcher and schema versioning first** — they are the parts most expensive
+to change later. Everything else is additive.
+
+---
+
+## 7. Risks & open questions
+
+- **Matching reliability** — name changes, mid-session character swaps, multiple chars
+  per account. Need a deterministic key + a manual "attach to this player" fallback in
+  ESOTK.
+- **Privacy/consent** — group-wide capture broadcasts each member's build. Make
+  broadcasting opt-in and let players see/redact what's shared (mirror how Hodor is
+  perceived as benign by being read-only + transparent).
+- **Schema churn** — ESO updates CP trees and item data every quarter; version the SV
+  schema and ESOTK's importer, and reuse the existing data-regen skills
+  (`class-skill-regen`, `gear-data-regen`) to stay current.
+- **Console** — explicitly out of scope for capture; ensure ESOTK degrades gracefully
+  to log-only for console reports.
+- **Adoption** — value scales with how many group members run it; lean hard on the
+  group-broadcast model so one logger covers the raid, and on Kalpa for frictionless
+  install + upload.
+
+---
+
+## 8. Suggested first milestone
+
+A vertical slice that proves the loop end-to-end:
+
+1. Add-on captures **CP allocation + final stats + mundus + food** for the **local
+   player only**, writes `ESOTKCompanion.lua`.
+2. ESOTK importer parses it and **renders CP + stats on that player's card** when the
+   uploaded log matches.
+3. Ship the add-on as a **Kalpa pack** with a Build-Hub "Get Companion" button.
+
+That delivers the user's headline request (champion points on player cards) with the
+smallest surface area, and every later idea (group capture, auto-upload, build flags)
+builds on the same schema and matcher.
+
+---
+
+## Sources
+
+- [ESO Logs — Getting Started](https://www.esologs.com/help/start)
+- [Encounter Logging — ESO Forums](https://forums.elderscrollsonline.com/en/discussion/467949/encounter-logging)
+- [ESO-Logs-parser (encounter log format)](https://github.com/FuyuByakko/ESO-Logs-parser)
+- [ESO Logs v2 GraphQL API docs](https://www.esologs.com/v2-api-docs/eso/)
+- [LibGroupCombatStats (esoui)](https://www.esoui.com/downloads/info4024-LibGroupCombatStats.html) · [GitHub](https://github.com/m00nyONE/LibGroupCombatStats)
+- [LibGroupBroadcast (formerly LibGroupSocket)](https://www.esoui.com/downloads/download1337-LibGroupBroadcastformerlyLibGroupSocket)
+- [HodorReflexes — DPS & Ult share](https://www.esoui.com/downloads/info2311-HodorReflexes-DPSUltimateShare.html) · [GitHub](https://github.com/m00nyONE/HodorReflexes)
+- [Combat Metrics (esoui)](https://www.esoui.com/downloads/download1360-CombatMetrics)
+- [ESOUI Wiki — API reference](https://wiki.esoui.com/API)
+- [Champion Point Import add-on](https://esoui.com/downloads/info3421-ChampionPointImport.html)
+- [Dynamic CP (Champion Points 2.0)](https://www.esoui.com/downloads/info2952-DynamicCPChampionPoints2.0.html)
+- [Fix for LibGroupBroadcast — ESO Forums (2026)](https://forums.elderscrollsonline.com/en-gb/discussion/679406/fix-for-libgroupbroadcast)
+</content>
+</invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -1055,18 +1055,18 @@ Every readiness check below was confirmed against real add-on source / API refer
 
 The ESOTK side is built and unit-tested (parser → matcher → view-model + coaching →
 `buildCompanionBuildsForReport` → `CompanionBuildPanel` → `PlayerCard.companionBuild`).
-The only remaining work is the report-page upload UI, and the wiring is paint-by-numbers
-against these **verified** store/types (confirmed by reading the code, not assumed):
+The report-page upload UI is now wired through `PlayersPanel` local state and
+`PlayersPanelView.companionBuildsByPlayer`, using these **verified** store/types
+(confirmed by reading the code, not assumed):
 
 1. **Ingest the file.** Reuse the existing Lua-import UX (Loadout Manager already does a
    `FileReader` `.lua` upload). Run the bytes through
    `parseESOTKCompanionSavedVariables(text)` → `CompanionParseResult` (`.all` snapshots).
 2. **Build `MatchableReport`** from report state:
    - `actors`: from report `masterData` actors — `ReportActorFragment` has
-     `{ id, name, displayName, anonymous }` (`src/graphql/gql/graphql.ts`). Map
+     `{ id, name, displayName, anonymous, server }` (`src/graphql/gql/graphql.ts`). Map
      `id`→actor id, `name`→character (the match key). `anonymous === true` ⇒ names are
-     hidden, so the matcher falls back to manual attach (already handled). There is **no
-     per-actor `server`** field — match on name; use report-level server only if needed.
+     hidden, so no automatic match is possible. Use `server` when ESO Logs exposes it.
    - `fights`: `selectReportFights` / `selectReportFightsForContext`
      (`src/store/report/reportSelectors.ts`) — each fight has `id`, `startTime`,
      `endTime` (ms offsets from report start).
@@ -1074,18 +1074,18 @@ against these **verified** store/types (confirmed by reading the code, not assum
      absolute UNIX ms).
 3. **Compute per-player props:**
    `buildCompanionBuildsForReport(result.all, matchableReport, { coaching: { assumedGroupPen } })`
-   → `Map<actorId, { championPoints, coaching, snapshot, fightId }>`.
+   → `Map<actorId, { championPoints, coaching, stats, effects, snapshot, fightId }>`.
 4. **Render:** players come from `selectPlayersByIdForContext` keyed by `player.id`
    (already imported in `PlayerCard.tsx`; cards are rendered via
    `PlayersPanel`/`PlayersPanelView`/`LazyPlayerCard`). Pass
-   `companionBuild={builds.get(player.id)}` to each `PlayerCard`. Absent ⇒ panel renders
+   `companionBuild={companionBuildsByPlayer[player.id]}` to each `PlayerCard`. Absent ⇒ panel renders
    nothing (no change to existing cards).
 
 **Notes:** `displayName` ↔ `snapshot.account` (optional cross-check). For _exact_
 effective penetration, later pass the boss's Major Breach/Crusher uptime from the log as
 `assumedGroupPen` with `groupPenIsExact: true` (§11.1.1); until then the standard-kit
-estimate is fine. Hold the parsed snapshots in local component state or a small slice —
-they're per-session, not persisted server-side.
+estimate is fine. Parsed snapshots are currently held in local component state; they're
+per-session, not persisted server-side.
 
 ---
 

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -11,17 +11,18 @@
 > methodology, and risk. The consolidated roadmap is in **§24**.
 
 ### Contents
+
 1. The core thesis · 2. Gap analysis · 3. ESO Lua API toolbox · 4. ESOTK integration
-surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & open questions
-· 8. First milestone · 9. Transport is plumbing · 10. Read existing add-ons first ·
-11. The real UVPs (stat-aware coaching) · 12. The in-game raid-command layer ·
-13. Integration feasibility matrix · 14. Competitive landscape & white space ·
-15. Data plane & matching algorithm · 16. Sustainability (free add-on, premium web) ·
-17. Why now — the 2026 meta · 18. Platform reality & a console-only opportunity ·
-19. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
-21. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
-· 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it) ·
-26. Ruleset / criteria schema (the compliance engine) — incl. 26.1 readiness flow & 26.2 verified checks.
+   surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & open questions
+   · 8. First milestone · 9. Transport is plumbing · 10. Read existing add-ons first ·
+2. The real UVPs (stat-aware coaching) · 12. The in-game raid-command layer ·
+3. Integration feasibility matrix · 14. Competitive landscape & white space ·
+4. Data plane & matching algorithm · 16. Sustainability (free add-on, premium web) ·
+5. Why now — the 2026 meta · 18. Platform reality & a console-only opportunity ·
+6. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
+7. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
+   · 24. Consolidated roadmap · 25. Group-share transport (how to broadcast it) ·
+8. Ruleset / criteria schema (compliance engine) · 27. Report-page upload integration map.
 
 ---
 
@@ -35,14 +36,14 @@ add-on uploads) only writes what ZeniMax chose to emit, and ZeniMax deliberately
 **disabled real-time logging** years ago to prevent in-combat automation. So the log
 is a post-hoc, partial snapshot.
 
-An **in-game add-on** runs inside the ESO Lua sandbox and can read the *live* character
+An **in-game add-on** runs inside the ESO Lua sandbox and can read the _live_ character
 state through the official API — including everything the log omits. That is the gap
 we fill. The add-on captures the missing build data, and ESOTK stitches it onto the
 log it already analyses, matching by character/account + timestamp + zone.
 
-**One-line pitch:** *ESO Logs tells you the player did 92k DPS. The ESOTK Companion
+**One-line pitch:** _ESO Logs tells you the player did 92k DPS. The ESOTK Companion
 tells you they did it on a 66-trait CP build with 18k penetration, Deadly/Sul-Xan,
-Lover mundus, and Bewitched Sugar Skulls — and shows it on the player card.*
+Lover mundus, and Bewitched Sugar Skulls — and shows it on the player card._
 
 ---
 
@@ -51,30 +52,30 @@ Lover mundus, and Bewitched Sugar Skulls — and shows it on the player card.*
 The raw `Encounter.log` `PLAYER_INFO` line (emitted per player when they enter an
 encounter) actually carries **more than most people realise**:
 
-| Already in the log / ESO Logs | Notes |
-|---|---|
-| Equipped gear: item IDs, **trait, set, display quality, enchant type/level/quality**, item level, per slot | Both bars. ESO Logs surfaces gear on player pages. |
-| Slotted abilities (front + back bar ability IDs) | Morphs are derivable from the ID. |
+| Already in the log / ESO Logs                                                                                        | Notes                                                         |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Equipped gear: item IDs, **trait, set, display quality, enchant type/level/quality**, item level, per slot           | Both bars. ESO Logs surfaces gear on player pages.            |
+| Slotted abilities (front + back bar ability IDs)                                                                     | Morphs are derivable from the ID.                             |
 | "Long-term effects" list (passives + buffs) incl. the **CP-slotted stars**, mundus buff, food/drink buff, vampire/WW | Present as buff IDs, but not labelled as "this is the build". |
-| CP **rank** (total earned) | Not the allocation. |
-| Race/class | Derivable; class is explicit, race partially. |
+| CP **rank** (total earned)                                                                                           | Not the allocation.                                           |
+| Race/class                                                                                                           | Derivable; class is explicit, race partially.                 |
 
 What is **never** emitted and therefore impossible for ESO Logs to show:
 
-| Missing data | Why it matters | API source (in-game) |
-|---|---|---|
-| **Champion Point *allocation*** — points spent per star across all 3 trees, not just the 4 slotted | The #1 ask. Two players with identical gear can have wildly different CP and the log can't tell them apart. | `GetNumPointsSpentOnChampionSkill`, `GetChampionPointsPlayerProgressionData` |
-| **Final derived stats**: max mag/stam/health, spell/weapon damage, **crit %, crit damage, penetration, recovery, resistances, mitigation** | These are computed client-side and never logged. The single most requested "why is my DPS low" diagnostic. | `GetPlayerStat(STAT_*)` |
-| **Attribute point split** (Mag/Health/Stam) | Build correctness check. | `GetAttributeSpentPoints(attribute)` |
-| **Exact enchant magnitude** & **trait quality nuance** | Log gives enchant *type/level*, not the rolled value. | `GetItemLink` + `GetItemLinkEnchantInfo` |
-| **Mundus stone (named)** | Only inferable from a buff ID today. | buff detection / `GetItemLink` of the boon |
-| **Active food/drink (named, with duration)** | Inferable from buff today; add-on can name it + flag "no food". | buff scan |
-| **Skill/CP passives unlocked, skill point spend** | Build completeness. | skill-line API |
-| **Scribing scripts actually slotted** (grimoire + 3 scripts) | ESOTK already *detects* scribing from events; the add-on can report it **authoritatively**. | scribing API |
-| **Companion build** (gear/skills) | Solo/duo content. | companion API |
-| **Vampire/Werewolf stage, riding skills, CP curve preset** | Minor but cheap. | misc API |
+| Missing data                                                                                                                               | Why it matters                                                                                              | API source (in-game)                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Champion Point _allocation_** — points spent per star across all 3 trees, not just the 4 slotted                                         | The #1 ask. Two players with identical gear can have wildly different CP and the log can't tell them apart. | `GetNumPointsSpentOnChampionSkill`, `GetChampionPointsPlayerProgressionData` |
+| **Final derived stats**: max mag/stam/health, spell/weapon damage, **crit %, crit damage, penetration, recovery, resistances, mitigation** | These are computed client-side and never logged. The single most requested "why is my DPS low" diagnostic.  | `GetPlayerStat(STAT_*)`                                                      |
+| **Attribute point split** (Mag/Health/Stam)                                                                                                | Build correctness check.                                                                                    | `GetAttributeSpentPoints(attribute)`                                         |
+| **Exact enchant magnitude** & **trait quality nuance**                                                                                     | Log gives enchant _type/level_, not the rolled value.                                                       | `GetItemLink` + `GetItemLinkEnchantInfo`                                     |
+| **Mundus stone (named)**                                                                                                                   | Only inferable from a buff ID today.                                                                        | buff detection / `GetItemLink` of the boon                                   |
+| **Active food/drink (named, with duration)**                                                                                               | Inferable from buff today; add-on can name it + flag "no food".                                             | buff scan                                                                    |
+| **Skill/CP passives unlocked, skill point spend**                                                                                          | Build completeness.                                                                                         | skill-line API                                                               |
+| **Scribing scripts actually slotted** (grimoire + 3 scripts)                                                                               | ESOTK already _detects_ scribing from events; the add-on can report it **authoritatively**.                 | scribing API                                                                 |
+| **Companion build** (gear/skills)                                                                                                          | Solo/duo content.                                                                                           | companion API                                                                |
+| **Vampire/Werewolf stage, riding skills, CP curve preset**                                                                                 | Minor but cheap.                                                                                            | misc API                                                                     |
 
-**Takeaway:** the highest-value, *uniquely-addon* data is **CP allocation + final
+**Takeaway:** the highest-value, _uniquely-addon_ data is **CP allocation + final
 stats + attributes**. Gear and slotted skills are mostly redundant with the log
 (useful as a verification/fallback, and to fill console/non-logged sessions).
 
@@ -103,11 +104,12 @@ Reflexes, Wizard's Wardrobe). Relevant capabilities:
   (the Wizard's Wardrobe / build-import-code pattern) that a user pastes into ESOTK.
 
 **Hard constraints to design around:**
+
 - **PC-only.** Add-ons don't run on console (even though console now has encounter
   logging). Console users get the log-only experience; the companion is a PC perk.
 - **No real-time push to web from in-game.** ESO Lua has no outbound HTTP. Transport
   to ESOTK is always file-upload or copy/paste (or via the Kalpa manager, below).
-- **ZOS ToS / "no automation."** We only *read* state and *report* it — no input
+- **ZOS ToS / "no automation."** We only _read_ state and _report_ it — no input
   automation, no combat decisions. Safe, in line with CombatMetrics/Hodor.
 - **Matching problem.** SavedVariables isn't stamped with the ESO Logs report code.
   We match on `@account` + character + zone + UTC timestamp window. Design for fuzzy
@@ -119,17 +121,17 @@ Reflexes, Wizard's Wardrobe). Relevant capabilities:
 
 ESOTK is unusually well-positioned because the integration surfaces already exist:
 
-| ESOTK surface | What the companion data adds |
-|---|---|
-| **Player cards** (the headline ask) | CP allocation, final stats (crit/pen/recovery), mundus, food, attribute split — shown inline. |
-| **Loadout Manager** | Already imports Lua SavedVariables. Add an `ESOTKCompanion` format alongside Wizard's Wardrobe. |
-| **Build Hub** | "Get Addons" deep-link to **Kalpa** addon manager already exists (now an *optional* convenience tier — see §9). Primary install is the standard Minion/manual route every ESO addon uses. |
-| **Roster Hub** | `recommended_addons` column already exists; the companion becomes a recommended/required raid add-on, and roster build-checks validate against captured CP/stats. |
-| **Fight Replay** | Lock-on stats panel can show the *real* build behind an actor. |
-| **Scribing detection** | Cross-check detected scripts against authoritatively-reported slotted scripts. |
+| ESOTK surface                       | What the companion data adds                                                                                                                                                              |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Player cards** (the headline ask) | CP allocation, final stats (crit/pen/recovery), mundus, food, attribute split — shown inline.                                                                                             |
+| **Loadout Manager**                 | Already imports Lua SavedVariables. Add an `ESOTKCompanion` format alongside Wizard's Wardrobe.                                                                                           |
+| **Build Hub**                       | "Get Addons" deep-link to **Kalpa** addon manager already exists (now an _optional_ convenience tier — see §9). Primary install is the standard Minion/manual route every ESO addon uses. |
+| **Roster Hub**                      | `recommended_addons` column already exists; the companion becomes a recommended/required raid add-on, and roster build-checks validate against captured CP/stats.                         |
+| **Fight Replay**                    | Lock-on stats panel can show the _real_ build behind an actor.                                                                                                                            |
+| **Scribing detection**              | Cross-check detected scripts against authoritatively-reported slotted scripts.                                                                                                            |
 
 > **Distribution note (revised):** the original draft leaned on the **Kalpa** addon
-> manager to auto-upload SavedVariables. That's still a valid *optional* convenience,
+> manager to auto-upload SavedVariables. That's still a valid _optional_ convenience,
 > but it should **not** be required — asking users to install a separate desktop app
 > they don't trust is the single biggest adoption killer (it's exactly the friction
 > that makes the ESO Logs Electron uploader a barrier). The transport strategy is now
@@ -140,6 +142,7 @@ ESOTK is unusually well-positioned because the integration surfaces already exis
 ## 5. Ranked ideas
 
 ### P0 — Build the core gap-filler (do these first)
+
 1. **Champion Point allocation capture** — full per-star spend, all trees. The
    marquee feature and the user's stated priority. Render on player cards as a compact
    CP summary + expandable tree.
@@ -152,6 +155,7 @@ ESOTK is unusually well-positioned because the integration surfaces already exis
    existing Lua import path. Match to report by account+char+zone+timestamp.
 
 ### P1 — Make it effortless and group-wide
+
 5. **Whole-group capture via LibGroupBroadcast** — the raid logger's single upload
    carries all 12 builds. This is what turns it from "nice for me" into "the group
    tool". Mirror the Hodor/LibGroupCombatStats model.
@@ -164,6 +168,7 @@ ESOTK is unusually well-positioned because the integration surfaces already exis
    under-quality gear). ESOTK already has `detectBuildIssues` — feed it real data.
 
 ### P2 — Differentiators / longer tail
+
 8. **Scribing ground-truth** — report actually-slotted grimoire + 3 scripts; reconcile
    with ESOTK's event-based detection.
 9. **Pre-fight readiness check** — in-game, before pull: "everyone fed, buffed,
@@ -245,18 +250,18 @@ schema and matcher.
 ## 9. Transport is plumbing, not a value proposition
 
 > **Correction to the earlier draft.** A previous version pitched "no desktop app /
-> browser folder-sync" as a headline UVP. That's wrong for *this* audience: **every log
+> browser folder-sync" as a headline UVP. That's wrong for _this_ audience: **every log
 > ESOTK analyses already arrived via the ESO Logs uploader**, so our users have already
 > installed and trusted a native desktop app. "No install" wins us nothing — it's
 > table stakes they've already paid. Transport is a solved, boring problem; the value is
-> in what we *do* with the data (§11). Pick the simplest transport and move on:
+> in what we _do_ with the data (§11). Pick the simplest transport and move on:
 
-| Option | When to use | Effort |
-|---|---|---|
-| **Manual `.lua` upload** | Default. Already shipped (`luaParser.ts` for Wizard's Wardrobe) — extend to `ESOTKCompanion`. Works in every browser. | ~none |
-| **File System Access API folder-sync** | Nice-to-have for Chromium users who don't want to re-pick the file each session. Store the handle in IndexedDB, re-read on a click. *Convenience, not a differentiator.* | low |
-| **Copy/paste build code** | Single-player quick share, no file. Note ESO can't auto-copy (protected call) and caps a copy near ~1023 chars, so compress. | low |
-| **Kalpa auto-upload** | Opt-in only, for users already on Kalpa. Never the on-ramp. | medium |
+| Option                                 | When to use                                                                                                                                                              | Effort |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| **Manual `.lua` upload**               | Default. Already shipped (`luaParser.ts` for Wizard's Wardrobe) — extend to `ESOTKCompanion`. Works in every browser.                                                    | ~none  |
+| **File System Access API folder-sync** | Nice-to-have for Chromium users who don't want to re-pick the file each session. Store the handle in IndexedDB, re-read on a click. _Convenience, not a differentiator._ | low    |
+| **Copy/paste build code**              | Single-player quick share, no file. Note ESO can't auto-copy (protected call) and caps a copy near ~1023 chars, so compress.                                             | low    |
+| **Kalpa auto-upload**                  | Opt-in only, for users already on Kalpa. Never the on-ramp.                                                                                                              | medium |
 
 The only transport constraint that actually shapes design: ESO Lua **can't make HTTP
 calls**, so the data always lands on disk first and ESOTK reads it. That's it. Don't
@@ -272,7 +277,7 @@ add-ons users **already run**, instead of demanding ours from day one.
 - **CombatMetrics** records per-fight data and can already export a build code — ESOTK
   can read its SV directly.
 - **Wizard's Wardrobe** — already parsed here today.
-- **Hodor / LibGroupCombatStats** — already aggregates *group* DPS/HPS/Ult.
+- **Hodor / LibGroupCombatStats** — already aggregates _group_ DPS/HPS/Ult.
 
 So the purpose-built ESOTK Companion only needs to capture the **residual gap** those
 tools don't persist — chiefly **full CP allocation, exact final stats, attribute split,
@@ -284,29 +289,29 @@ and group-wide aggregation in one file**. Smaller add-on, easier ask, faster val
 
 The test for every idea below: **does it require joining the player's true build data
 (which the log lacks) with the combat log (which the build sites lack)?** If yes, it's
-something *no* existing tool — ESO Logs, ESO-Hub, CombatMetrics, Hodor — can produce.
+something _no_ existing tool — ESO Logs, ESO-Hub, CombatMetrics, Hodor — can produce.
 That intersection is the entire moat. Pure build display (ESO-Hub) and pure combat
 display (ESO Logs) are both already done; we own the **overlap**.
 
-ESOTK already *estimates* some of these stats from the log — there are
+ESOTK already _estimates_ some of these stats from the log — there are
 `CalculatePenetration` and `CalculateCriticalDamage` workers in the codebase today. The
 companion's job is to **turn those estimates into ground truth** and unlock coaching
 that estimates can't support.
 
 ### 11.1 Stat-aware optimisation coaching (the killer feature)
 
-The log shows you hit for X. It cannot tell you whether your *stats* were efficient.
+The log shows you hit for X. It cannot tell you whether your _stats_ were efficient.
 With the companion's exact stats we can compute, per player, against hard ESO caps:
 
 - **Penetration vs the 18,200 cap.** Trial/dungeon bosses sit at 18,200 resist; every
   point of pen **over** that is wasted and every point **under** is lost damage. We can
-  say *exactly*: "You're at 21,400 pen — 3,200 wasted; drop Sharpened/a pen glyph and
+  say _exactly_: "You're at 21,400 pen — 3,200 wasted; drop Sharpened/a pen glyph and
   gain ~X% damage," or "16,900 — 1,300 short, you're losing mitigation-adjusted
-  damage." This is *the* most common end-game optimisation question and **nothing can
+  damage." This is _the_ most common end-game optimisation question and **nothing can
   answer it without the player's real pen + the boss in the log.**
 - **Crit damage vs the 125% hard cap** (225% total). Flag over-cap crit-damage stacking
   (wasted) and under-cap headroom.
-- **Crit *chance* value** — crit rating ÷ 21,918 → %, weighed against current crit
+- **Crit _chance_ value** — crit rating ÷ 21,918 → %, weighed against current crit
   damage and group buffs to advise "more crit chance vs. more weapon/spell damage here."
 - **Recovery / sustain vs. actual resource behaviour in the log** — pair real recovery
   stats with the log's resource events to flag over-sustain (wasted regen you could
@@ -322,19 +327,20 @@ But two of these stats split into a **self** part (on your character sheet) and 
 **effective** part (depends on the target/buffs), and being precise about that split is
 what makes the coaching trustworthy:
 
-| Stat | Self part (add-on, exact) | Effective part (not on your sheet) | How ESOTK gets 100% |
-|---|---|---|---|
-| **Penetration** | `GetPlayerStat(STAT_*_PENETRATION)` = gear/traits (Sharpened), sets (Spriggan), CP (Piercing), Lover mundus, light-armour passives — **exact** | **Group armour debuffs on the boss** (Major/Minor Breach, Crusher, Alkosh, Crimson Oath, Runic Sunder) reduce the *target's* resist, so they're **not in your stat** | add-on's exact self-pen **+ the log's debuff uptime on the boss** = exact effective pen vs the 18,200 cap |
-| **Crit chance** | crit rating ÷ 21,918 — exact **at the moment read** | Temporary buffs (Major/Minor Savagery/Prophecy from potions/sets) fluctuate | snapshot a **self-buffed baseline** (canonical) ± an in-combat read for buffed peaks |
-| **Crit damage** | base 50% + Shadow mundus, Backstabber, medium-armour, set sources — readable/derivable | Temporary **Major/Minor Force**; Backstabber is positional | same: baseline vs in-combat, and Backstabber is conditional |
+| Stat            | Self part (add-on, exact)                                                                                                                      | Effective part (not on your sheet)                                                                                                                                   | How ESOTK gets 100%                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Penetration** | `GetPlayerStat(STAT_*_PENETRATION)` = gear/traits (Sharpened), sets (Spriggan), CP (Piercing), Lover mundus, light-armour passives — **exact** | **Group armour debuffs on the boss** (Major/Minor Breach, Crusher, Alkosh, Crimson Oath, Runic Sunder) reduce the _target's_ resist, so they're **not in your stat** | add-on's exact self-pen **+ the log's debuff uptime on the boss** = exact effective pen vs the 18,200 cap |
+| **Crit chance** | crit rating ÷ 21,918 — exact **at the moment read**                                                                                            | Temporary buffs (Major/Minor Savagery/Prophecy from potions/sets) fluctuate                                                                                          | snapshot a **self-buffed baseline** (canonical) ± an in-combat read for buffed peaks                      |
+| **Crit damage** | base 50% + Shadow mundus, Backstabber, medium-armour, set sources — readable/derivable                                                         | Temporary **Major/Minor Force**; Backstabber is positional                                                                                                           | same: baseline vs in-combat, and Backstabber is conditional                                               |
 
 **The key correction to "we're just guessing":**
+
 - Your **personal/self** penetration and crit become **100% exact** — `GetPlayerStat` is
   the game's own number, not an estimate. That alone removes the guesswork ESOTK does now.
 - The **effective** numbers depend on things the character sheet never holds —
   **target debuffs** (for pen) and **temporary buffs** (for crit). Penetration's missing
   half is **exactly what the combat log records** (debuff auras on the boss), so the
-  add-on + log together are exact where neither is alone. (An add-on *can* also compute
+  add-on + log together are exact where neither is alone. (An add-on _can_ also compute
   "pen on target" live by scanning the boss's debuffs — what CombatMetrics / Dynamic
   Stats / Meterskull already do — but for a logged fight, combining with the log is the
   clean split.)
@@ -366,7 +372,7 @@ superpower, and the LibGroupBroadcast capture makes it one upload.
 Because snapshots are per-fight and per-session, ESOTK (with Roster Hub) can show
 **how a player's build changed over weeks and what it did to their numbers**: "Switched
 Deadly → Coral 3 weeks ago, boss DPS +4%," or "dropped a pen glyph and fell below cap —
-parse dropped." Open-loop build sites can't do this; it needs the build *and* the
+parse dropped." Open-loop build sites can't do this; it needs the build _and_ the
 historical logs ESOTK already stores.
 
 ### 11.5 Closed design→play→verify loop
@@ -375,9 +381,9 @@ Design a loadout in the Loadout Manager → play it → log it → ESOTK confirm
 ran what you planned (gear/CP/mundus/food/skills match) and shows the result. Every
 other build tool is open-loop (design, then hope); we verify against reality.
 
-**Positioning one-liner:** *ESO Logs shows what you did. ESO-Hub shows a build. ESOTK is
+**Positioning one-liner:** _ESO Logs shows what you did. ESO-Hub shows a build. ESOTK is
 the only place that tells your whole raid whether the build was actually any good —
-"you're 3,200 over the pen cap, that's wasted damage" — straight off the parse.*
+"you're 3,200 over the pen cap, that's wasted damage" — straight off the parse._
 
 > **Deliberately dropped from the UVP list:** re-capturing gear and slotted skills
 > (already in the log) and "no desktop install" (audience already runs the ESO Logs
@@ -387,13 +393,13 @@ the only place that tells your whole raid whether the build was actually any goo
 
 ## 12. The bigger vision — an in-game raid-command layer, two-way synced with ESOTK
 
-> **Reframe.** Sections 1–11 treat the add-on as a *passive capture pipe* → web. The
+> **Reframe.** Sections 1–11 treat the add-on as a _passive capture pipe_ → web. The
 > larger opportunity is a **two-way platform**: ESOTK is the brain (define rosters,
 > rules, assignments, analytics on the web), the add-on is the **eyes and hands in the
 > raid** (enforce and surface them live, in-game), and data flows **both directions**.
 > This is the part that has no real competitor — ESO Logs is read-only post-hoc,
 > build sites are open-loop, and no tool connects a web raid-planner to a live in-game
-> HUD. Below is what's possible *and* what the engine constraints actually allow.
+> HUD. Below is what's possible _and_ what the engine constraints actually allow.
 
 ### 12.1 The one constraint that shapes everything: 32 bytes/second
 
@@ -402,12 +408,12 @@ Group data sharing (LibGroupBroadcast, the bus Hodor rides) is hard-capped by ES
 to stream full builds for 12 people. It is the reason Hodor only shares tiny DPS/Ult
 numbers. **So we do not stream builds — we split the system into two layers:**
 
-| Layer | Runs where | Carries | Channel | Limit |
-|---|---|---|---|---|
-| **Live layer** | In-game, real-time | A compact **compliance verdict** + a few key live stats per player | LibGroupBroadcast | 32 B/s — fine for bitfields |
-| **Deep layer** | Web, post-hoc | The **full** build: CP allocation, exact stats, gear, history | SavedVariables file → ESOTK | none |
+| Layer          | Runs where         | Carries                                                            | Channel                     | Limit                       |
+| -------------- | ------------------ | ------------------------------------------------------------------ | --------------------------- | --------------------------- |
+| **Live layer** | In-game, real-time | A compact **compliance verdict** + a few key live stats per player | LibGroupBroadcast           | 32 B/s — fine for bitfields |
+| **Deep layer** | Web, post-hoc      | The **full** build: CP allocation, exact stats, gear, history      | SavedVariables file → ESOTK | none                        |
 
-**Edge-compute is the trick.** Every player's add-on already knows *their own* full
+**Edge-compute is the trick.** Every player's add-on already knows _their own_ full
 build and the shared ruleset, so **each client evaluates itself locally** and
 broadcasts only the verdict — e.g. a 1-byte bitfield (`food✓ mundus✓ pen✓ sets✓ CP✓`)
 plus one or two bucketed stats. The raid lead's add-on aggregates those few-byte
@@ -418,10 +424,10 @@ goes over the wire.
 
 This is the user's "flag criteria you set" idea, made concrete and role-aware:
 
-- **Define on ESOTK (web):** per **role** and per **encounter**, a ruleset — *DPS must
+- **Define on ESOTK (web):** per **role** and per **encounter**, a ruleset — _DPS must
   hit ≥18,200 pen, run [required set], be fed, slot [CP stars]; healers must run
   [sets], maintain ≥X recovery and Major Courage; tanks must hold taunt uptime and run
-  [sets]*. ESOTK already has roster-hub role composition and `detectBuildIssues` to
+  [sets]_. ESOTK already has roster-hub role composition and `detectBuildIssues` to
   build this on.
 - **Sync down to the game.** Three viable bridges (no desktop app needed):
   1. **FSA API write-mode** — ESOTK writes the ruleset into the SavedVariables folder
@@ -441,14 +447,14 @@ never alt-tabs. Using the group APIs (`GetGroupUnitTagByIndex`,
 `GetGroupMemberSelectedRole`, …) the add-on renders a live grid of all 12 members with
 red/green compliance dots, missing-requirement callouts, and live DPS/HPS/Ult from the
 LibGroupCombatStats bus it already shares with Hodor. **A pre-pull "ready check"**
-posts *"3 not ready: @x no food, @y wrong mundus, @z 2,400 under pen cap"* to the lead
+posts _"3 not ready: @x no food, @y wrong mundus, @z 2,400 under pen cap"_ to the lead
 (or group chat) — something no tool does today.
 
 ### 12.4 Ecosystem integration (don't rebuild — plug in)
 
 The user is right that the win is integrating with what raids already run:
 
-- **Hodor / LibGroupCombatStats** — *the* group combat-data bus. Publish our compliance
+- **Hodor / LibGroupCombatStats** — _the_ group combat-data bus. Publish our compliance
   data alongside Hodor's DPS so the whole ecosystem can read it; ride the same join.
 - **LUI Extended (LUIE)** — MIT-licensed, provides class/role-colored Group/Raid frames
   and buff/debuff tracking. Integrate by **annotating its frames** with compliance
@@ -467,7 +473,7 @@ The user is right that the win is integrating with what raids already run:
 - **Assignment overlays** — push portal/interrupt/taunt/sync assignments from the web
   roster to in-game prompts keyed to each player.
 - **Live self-HUD** — turn ESOTK's `CalculatePenetration`/`CalculateCriticalDamage`
-  estimates into a real-time personal readout: *"1,300 under pen cap right now."*
+  estimates into a real-time personal readout: _"1,300 under pen cap right now."_
 - **Instant debrief** — on a wipe, the add-on snapshots who died first / who broke
   compliance and syncs it to the ESOTK report.
 - **Attendance & progression tracking** — pull counts, wipe reasons, who showed,
@@ -479,13 +485,13 @@ The user is right that the win is integrating with what raids already run:
 - **Trial score & leaderboard capture** — read the live trial score (time + deaths +
   hardmode) and leaderboard placement, attach to the report, and trend it per prog
   night in roster-hub. (No combat log carries the score.)
-- **Tank/healer-specific compliance** — taunt uptime (cf. the *Untaunted* addon),
-  debuff coverage (Major Breach/Vuln), synergy throughput (cf. *Group Synergy
-  Tracker*) — role checks that go beyond "is the build legal".
+- **Tank/healer-specific compliance** — taunt uptime (cf. the _Untaunted_ addon),
+  debuff coverage (Major Breach/Vuln), synergy throughput (cf. _Group Synergy
+  Tracker_) — role checks that go beyond "is the build legal".
 
 ### 12.6 Honest limits on the live layer
 
-- **32 B/s** means live data is *verdicts and a few stats*, never full builds — design
+- **32 B/s** means live data is _verdicts and a few stats_, never full builds — design
   for it (§12.1). Don't promise live gear/CP streaming.
 - **You can't read another player's build** directly — they must run the add-on and
   opt in to broadcast. Value scales with raid adoption (lean on raid-lead mandate).
@@ -495,10 +501,10 @@ The user is right that the win is integrating with what raids already run:
 - **FSA write-mode is Chromium-only** — import-code/broadcast are the cross-browser
   fallbacks for ruleset sync.
 
-**Vision one-liner:** *Plan the raid on ESOTK, and the add-on becomes its live enforcer
+**Vision one-liner:** _Plan the raid on ESOTK, and the add-on becomes its live enforcer
 in-game — every player self-checks against your rules, the raid lead sees green/red at a
 glance, and the whole night flows back to the web as build-correlated history. The web
-is the brain; the add-on is the raid's nervous system.*
+is the brain; the add-on is the raid's nervous system._
 
 ---
 
@@ -508,17 +514,17 @@ The §12.4 "plug in, don't rebuild" claim, checked against each target's actual 
 Legend: ✅ documented/public · ⚠️ open-source but no formal API (integratable, more
 fragile) · 🔲 no API (overlay only).
 
-| Target | Integration hook | Status | What the ESOTK Companion does | Effort |
-|---|---|---|---|---|
-| **LibGroupCombatStats** | Public dev API: `RegisterAddon(name, {"DPS","HPS","ULT"})`, observable data, callbacks `(unitTag, data)` | ✅ | **Consume** live DPS/HPS/ULT for the dashboard. Its categories are fixed (DPS/HPS/ULT) — our own build/compliance data rides **LibGroupBroadcast** directly instead (§25) | Low |
-| **Hodor Reflexes** | Built on LibGroupCombatStats; same group session | ✅ | Coexist on one data bus; render alongside Hodor numbers (no separate join) | Low |
-| **LibGroupBroadcast** | Serialize/queue API within the 32 B/s budget | ✅ | Our own compact compliance-verdict protocol | Medium |
-| **LUI Extended** | MIT source; custom Player/Group/Raid/Boss frames, class/role colouring, aura tracking | ✅ source | Annotate its raid frames with compliance dots, or reuse its frame code | Medium |
-| **Wizard's Wardrobe** | SavedVariables schema (already parsed here) + auto-equip | ✅ | Verify the equipped setup matches the assignment; offer one-click correct setup | Low–Med |
-| **CombatMetrics** | SavedVariables + build export code | ✅ | Read existing SV so users needn't run our add-on for basics (§10) | Low |
-| **RaidNotifier** | Open source; `StartCountdown()` / `AddAnnouncement()` | ⚠️ | Tie roster assignments (interrupt/portal/sync) to on-screen announcements | Medium |
-| **Untaunted** | Open-source taunt/debuff tracker | ⚠️ | Source taunt-uptime for tank compliance (integrate or reimplement the read) | Medium |
-| **Bandits UI** | Group frames + buff/timer + combat notifications | 🔲 | Overlay compliance on its frames; **must not double-notify** (BUI + RaidNotifier already conflict) | Med–High |
+| Target                  | Integration hook                                                                                         | Status    | What the ESOTK Companion does                                                                                                                                             | Effort   |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **LibGroupCombatStats** | Public dev API: `RegisterAddon(name, {"DPS","HPS","ULT"})`, observable data, callbacks `(unitTag, data)` | ✅        | **Consume** live DPS/HPS/ULT for the dashboard. Its categories are fixed (DPS/HPS/ULT) — our own build/compliance data rides **LibGroupBroadcast** directly instead (§25) | Low      |
+| **Hodor Reflexes**      | Built on LibGroupCombatStats; same group session                                                         | ✅        | Coexist on one data bus; render alongside Hodor numbers (no separate join)                                                                                                | Low      |
+| **LibGroupBroadcast**   | Serialize/queue API within the 32 B/s budget                                                             | ✅        | Our own compact compliance-verdict protocol                                                                                                                               | Medium   |
+| **LUI Extended**        | MIT source; custom Player/Group/Raid/Boss frames, class/role colouring, aura tracking                    | ✅ source | Annotate its raid frames with compliance dots, or reuse its frame code                                                                                                    | Medium   |
+| **Wizard's Wardrobe**   | SavedVariables schema (already parsed here) + auto-equip                                                 | ✅        | Verify the equipped setup matches the assignment; offer one-click correct setup                                                                                           | Low–Med  |
+| **CombatMetrics**       | SavedVariables + build export code                                                                       | ✅        | Read existing SV so users needn't run our add-on for basics (§10)                                                                                                         | Low      |
+| **RaidNotifier**        | Open source; `StartCountdown()` / `AddAnnouncement()`                                                    | ⚠️        | Tie roster assignments (interrupt/portal/sync) to on-screen announcements                                                                                                 | Medium   |
+| **Untaunted**           | Open-source taunt/debuff tracker                                                                         | ⚠️        | Source taunt-uptime for tank compliance (integrate or reimplement the read)                                                                                               | Medium   |
+| **Bandits UI**          | Group frames + buff/timer + combat notifications                                                         | 🔲        | Overlay compliance on its frames; **must not double-notify** (BUI + RaidNotifier already conflict)                                                                        | Med–High |
 
 **Takeaway:** the spine is **LibGroupCombatStats** — it already solved group join,
 broadcast queuing, and a clean callback API, and its author (m00nyONE) maintains the
@@ -531,32 +537,32 @@ the Hodor user base is reachable on day one.
 
 What exists today, and the gap we'd own:
 
-| Tool / category | What it does | What it can't do |
-|---|---|---|
-| **ESO Logs** | Authoritative post-hoc combat analysis | Read-only, after the fact; no build truth (stats/CP), no live layer, no roster rules |
-| **Build sites** (ESO-Hub, Alcast, Arzyel) | Static, hand-made build display & sharing | Open-loop — never tied to a real fight or a live group |
-| **Hodor / LibGroupCombatStats** | Live group DPS/HPS/ULT share | Combat numbers only — no build, no compliance, no web link |
-| **CombatMetrics** | Personal combat + build export code | Personal, not group; no rules; not roster-aware |
-| **RaidNotifier / BUI** | Mechanic alerts, frames, timers | No build compliance, no web roster, no analytics |
-| **RaidLead Essentials** | Ready-check + simple planner | **Discontinued** |
-| **RaidTools** (beta) | Ready-check + buff/food checker | Beta/niche; not role-aware; not web-connected |
-| **RdK Group Tool** | **Guild-admin *query* of group members' equipment, CP, stats, mundus, skills** (opt-in, off by default; PvP-focused) | In-game only; no ESO Logs correlation, no web analytics/history, no cap-aware coaching; a query tool, not a platform |
-| **Taos Group Tools / GroupSpy** | Group ult frames, buff-food indicators, group info | Coordination widgets, not build compliance or analytics |
+| Tool / category                           | What it does                                                                                                         | What it can't do                                                                                                     |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **ESO Logs**                              | Authoritative post-hoc combat analysis                                                                               | Read-only, after the fact; no build truth (stats/CP), no live layer, no roster rules                                 |
+| **Build sites** (ESO-Hub, Alcast, Arzyel) | Static, hand-made build display & sharing                                                                            | Open-loop — never tied to a real fight or a live group                                                               |
+| **Hodor / LibGroupCombatStats**           | Live group DPS/HPS/ULT share                                                                                         | Combat numbers only — no build, no compliance, no web link                                                           |
+| **CombatMetrics**                         | Personal combat + build export code                                                                                  | Personal, not group; no rules; not roster-aware                                                                      |
+| **RaidNotifier / BUI**                    | Mechanic alerts, frames, timers                                                                                      | No build compliance, no web roster, no analytics                                                                     |
+| **RaidLead Essentials**                   | Ready-check + simple planner                                                                                         | **Discontinued**                                                                                                     |
+| **RaidTools** (beta)                      | Ready-check + buff/food checker                                                                                      | Beta/niche; not role-aware; not web-connected                                                                        |
+| **RdK Group Tool**                        | **Guild-admin _query_ of group members' equipment, CP, stats, mundus, skills** (opt-in, off by default; PvP-focused) | In-game only; no ESO Logs correlation, no web analytics/history, no cap-aware coaching; a query tool, not a platform |
+| **Taos Group Tools / GroupSpy**           | Group ult frames, buff-food indicators, group info                                                                   | Coordination widgets, not build compliance or analytics                                                              |
 
 > **Correction (important).** An earlier draft of this doc claimed "no competitor shares
 > full builds." That is **wrong**: **RdK Group Tool already shares equipment, CP, stats
 > and mundus across the group** (admin-gated, opt-in, over map pins — see §25). So the
-> capability is *not* novel. What remains genuinely unclaimed is the **combination**: a
+> capability is _not_ novel. What remains genuinely unclaimed is the **combination**: a
 > web-roster-driven, role-aware, **log-correlated** compliance + analytics platform.
 > RdK proves the in-game transport works; it just stops at an in-game PvP query tool with
 > no web brain, no ESO Logs link, and no coaching/history.
 
 **The unclaimed quadrant:** a **web-roster-driven, role-aware, live build-compliance
 system that also produces post-hoc build-correlated analytics.** Every competitor sits
-on one axis (live *or* post-hoc; combat *or* build; personal *or* group; in-game *or*
+on one axis (live _or_ post-hoc; combat _or_ build; personal _or_ group; in-game _or_
 web). ESOTK is the only project positioned to join all of them, because it already owns
 the web roster-hub, the log analytics, and `detectBuildIssues`. Notably, ESOTK's
-in-development companion is *already publicly described* as "roster validation, group
+in-development companion is _already publicly described_ as "roster validation, group
 management, and gear inspection inside the ESO client" — this research sharpens that
 into the concrete platform above.
 
@@ -566,7 +572,7 @@ into the concrete platform above.
 
 **One more structural advantage:** ESO has **no native gear/build inspection** — ZOS
 deliberately disabled it to curb toxicity, and the API won't expose another player's
-gear/stats (`GetPlayerStat` is self-only; there is no `GetUnitStat`). So the *only* way
+gear/stats (`GetPlayerStat` is self-only; there is no `GetUnitStat`). So the _only_ way
 to see a teammate's full build is if they **opt in to broadcast it** from their own
 client — which is exactly our model, and the model RdK already uses. The base game left
 this gap open on purpose; our edge is wiring it to logs + web, not the sharing itself.
@@ -580,7 +586,7 @@ this gap open on purpose; our edge is wiring it to logs + web, not the sharing i
 The ESO Logs API v2 is **OAuth + an hourly points quota** (the RPGLogs platform; WCL's
 sibling API is ~3,600 points/hr, ESO Logs is comparable) and it is **read-oriented** —
 combat logs are uploaded through the Companion app, and there is **no public endpoint to
-write build data into someone's report.** So companion data cannot live *inside* ESO
+write build data into someone's report.** So companion data cannot live _inside_ ESO
 Logs. It lives in **ESOTK's own backend**, keyed by `reportCode` + actor, and is
 **overlaid client-side** when ESOTK renders a report. Practical rules:
 
@@ -593,6 +599,7 @@ Logs. It lives in **ESOTK's own backend**, keyed by `reportCode` + actor, and is
 ### Matching a snapshot to a report/fight/actor
 
 Inputs available:
+
 - **Report:** absolute `startTime`, and per-fight `startTime`/`endTime` as **ms offsets
   from report start**, plus `size`, `isKill`, `name`, and `masterData.actors`
   (player name + server + type/role).
@@ -600,6 +607,7 @@ Inputs available:
   timestamp** per fight/pull (we control this format).
 
 Algorithm (tiered, fuzzy by design):
+
 1. **Direct key** — if the user supplied both (e.g. pasted the `reportCode` when
    uploading the snapshot), bind directly.
 2. **Actor + time + zone** — match `masterData.actors` name + server to the snapshot's
@@ -609,6 +617,7 @@ Algorithm (tiered, fuzzy by design):
    player" picker.
 
 **Gotchas that must be designed for from day one:**
+
 - **Anonymised reports** — ESO Logs can hide player names ("Random 1"), which breaks
   name matching entirely → tier-2 fails, fall to manual (tier 3) or require the direct
   key (tier 1).
@@ -628,7 +637,7 @@ before any of the fancier features.
 ## 16. Sustainability & positioning (free add-on, premium web)
 
 ZeniMax's policy is unambiguous: **add-ons may not be monetised** — only donations are
-permitted, and in practice donations are negligible. That isn't a problem; it *defines*
+permitted, and in practice donations are negligible. That isn't a problem; it _defines_
 the model:
 
 - **The add-on is free, lean, and ideally open-source.** That's mandatory (ToS) and also
@@ -644,8 +653,8 @@ the model:
   Never paywall the in-game compliance basics — that would throttle the adoption the
   whole platform depends on.
 
-This also reinforces the §14 moat: a competitor would need *both* a trusted free add-on
-*and* a web analytics business to copy it, and the add-on side can never be monetised to
+This also reinforces the §14 moat: a competitor would need _both_ a trusted free add-on
+_and_ a web analytics business to copy it, and the add-on side can never be monetised to
 fund the web side directly — so the only durable path is exactly ESOTK's: build the web
 product first (already done) and let a free add-on feed it.
 
@@ -654,14 +663,14 @@ product first (already done) and let a free add-on feed it.
 ## 17. Why now — the 2026 meta makes the build gap bigger
 
 ESO's 2026 shift to a **Seasonal model** (3–6 month content blocks replacing the annual
-Chapter; Season 1 ships with **Update 50 on 8 June 2026** — *today* — including the
+Chapter; Season 1 ships with **Update 50 on 8 June 2026** — _today_ — including the
 **Crimson Veldt** trial) directly increases the value of build capture:
 
 - **Subclassing + Class Mastery Passives (the big one).** The 2026 Class Identity
   Refresh lets players **mix skill lines across classes**, and adds **Class Mastery
-  Passives** that *only pure-class builds* can slot (pick 2 of 5; auto-refunded the
+  Passives** that _only pure-class builds_ can slot (pick 2 of 5; auto-refunded the
   moment you subclass). This explodes build variety and creates a **fresh capture gap**:
-  the log's ability IDs reveal *which* skills are slotted, but **whether a player is
+  the log's ability IDs reveal _which_ skills are slotted, but **whether a player is
   pure-class (and which Mastery Passives) vs. subclassed, and which three skill lines
   they chose**, is new build state worth capturing — and a new axis for compliance
   rules ("this fight wants the pure-class Mastery Passive build"). Nothing surfaces this
@@ -674,7 +683,7 @@ Chapter; Season 1 ships with **Update 50 on 8 June 2026** — *today* — includ
   widening the audience for stat coaching beyond the hardcore raid niche.
 
 **Implication:** ship capture of **CP allocation + subclass lines + Class Mastery
-Passives + final stats** as the v1 payload — it's both the user's ask *and* the freshest
+Passives + final stats** as the v1 payload — it's both the user's ask _and_ the freshest
 gap the 2026 systems opened. Tag every snapshot and ruleset with the season/patch.
 
 ## 18. Platform reality (and a console-only opportunity)
@@ -684,17 +693,18 @@ The web pipeline is **hard PC-only**, more strictly than first stated:
 - Console (PS5 / Xbox) **got add-ons in Update 46 (June 2025) but only UI-focused
   ones** — no gameplay/combat scripts.
 - Console can run `/encounterlog`, **but the platform security model blocks access to
-  the log files and SavedVariables entirely** — there is *no* way to export either, even
+  the log files and SavedVariables entirely** — there is _no_ way to export either, even
   via the add-on API. So console has **no ESO Logs and no way to upload to ESOTK**.
 
 Therefore: ESOTK + companion capture/upload is PC-only; console reports simply don't
-exist to enrich. **But** that same gap is an opening: console raiders have *no* combat
+exist to enrich. **But** that same gap is an opening: console raiders have _no_ combat
 analysis at all. A **purely in-game, web-free live layer** (the §12 compliance dashboard
-+ ready-check, sharing compact verdicts over LibGroupBroadcast) could be uniquely
-valuable on console — *if* it qualifies as a "UI add-on" and the group-data libs are
-permitted there. **Unverified and likely later-phase**, but it's a genuine
-blue-ocean angle no PC-centric competitor is chasing. Flag it as a research spike, not a
-v1 commitment.
+
+- ready-check, sharing compact verdicts over LibGroupBroadcast) could be uniquely
+  valuable on console — _if_ it qualifies as a "UI add-on" and the group-data libs are
+  permitted there. **Unverified and likely later-phase**, but it's a genuine
+  blue-ocean angle no PC-centric competitor is chasing. Flag it as a research spike, not a
+  v1 commitment.
 
 ## 19. Recommended add-on tech stack & a concrete SavedVariables schema
 
@@ -749,15 +759,15 @@ The two fields that must never break without a version bump: `ts` + `char`/`serv
 
 ## 20. Capture methodology & data accuracy (get this right or the coaching lies)
 
-`GetPlayerStat` returns the **current, live** value — it *includes* whatever buffs are
+`GetPlayerStat` returns the **current, live** value — it _includes_ whatever buffs are
 active at the instant you read it (food, mundus, CP, **and** group buffs like Major
-Courage / Major Slayer in combat). So *when* we snapshot changes the numbers, and naïve
+Courage / Major Slayer in combat). So _when_ we snapshot changes the numbers, and naïve
 capture produces misleading coaching. Standardise it:
 
 - **Capture a canonical "baseline" snapshot out of combat, self-buffed** (food + mundus
-  + CP, no group buffs). This is the apples-to-apples build value to compare against
-  caps and across players. Trigger on `EVENT_PLAYER_COMBAT_STATE` (combat end) or a
-  manual "snapshot now," not mid-pull.
+  - CP, no group buffs). This is the apples-to-apples build value to compare against
+    caps and across players. Trigger on `EVENT_PLAYER_COMBAT_STATE` (combat end) or a
+    manual "snapshot now," not mid-pull.
 - Optionally also capture an **in-combat** reading to show buffed peaks — but label it
   distinctly; never feed buffed numbers into "are you at the pen cap" math.
 - **Penetration/crit caps are content-aware.** The 18,200 cap is the PvE
@@ -777,7 +787,7 @@ Build capture + compliance isn't only a PvE-trial play:
 - ESO Logs, **CombatMetrics**, and **Easy Stalking** already log **Cyrodiil, Imperial
   City and Battlegrounds**, and **PvpMeter** shows the appetite for PvP performance
   tracking — so logged PvP data exists to enrich.
-- **Organized PvP groups are *more* build-prescriptive than PvE**: Cyrodiil ball/bomb
+- **Organized PvP groups are _more_ build-prescriptive than PvE**: Cyrodiil ball/bomb
   groups run tightly-specified sets, resistances, and synergies. A role-aware compliance
   check ("everyone on the prescribed proc set / resist threshold / purge build") maps
   directly onto how these groups already operate — arguably a stronger fit than PvE.
@@ -813,8 +823,8 @@ a first-class design concern, not an afterthought:
   re-run `gear-data-regen`/`class-skill-regen`, refresh caps/ruleset presets, validate
   the schema migration (LibSavedVars).
 - **Third-party lib fragility** — the live layer leans on LibGroupBroadcast /
-  LibGroupCombatStats, which themselves break on patches (there was a *"Fix for
-  LibGroupBroadcast"* thread in 2026). Treat the live layer as the volatile part and the
+  LibGroupCombatStats, which themselves break on patches (there was a _"Fix for
+  LibGroupBroadcast"_ thread in 2026). Treat the live layer as the volatile part and the
   SavedVariables capture as the stable core, so a broken broadcast lib never blocks the
   deep web value.
 - **Adoption dependency** — group features scale with how many members run it; the
@@ -831,17 +841,17 @@ a first-class design concern, not an afterthought:
 Pulling the scattered phasing into one sequence. Each phase is independently shippable
 and builds on the prior schema + matcher.
 
-| Phase | Deliverable | Why this order | Key refs |
-|---|---|---|---|
-| **0 — Foundations** | Versioned `ESOTKCompanionSV` schema + the report↔snapshot matcher (incl. manual-attach fallback) | Most expensive to change later; everything depends on it | §15, §19 |
-| **1 — Vertical slice** | Add-on captures local player's **CP allocation + final stats + mundus + food + subclass/mastery**; ESOTK renders it on the player card with the **pen-vs-cap coaching** insight | Delivers the headline ask *and* one genuinely useful, non-redundant insight on day one | §8, §11.1, §17 |
-| **2 — Effortless ingest** | Manual `.lua` upload (extend `luaParser.ts`); optional FSA folder-sync / copy-paste code | Transport is plumbing — make it painless, don't over-build | §9 |
-| **3 — Read existing add-ons** | Ingest CombatMetrics / Wizard's Wardrobe SavedVariables | Lowers the adoption ask before requiring our add-on | §10 |
-| **4 — Whole-group capture** | LibGroupBroadcast/LibGroupCombatStats group snapshots → one logger covers the raid | Turns a personal tool into a raid tool; the network effect | §12.1, §13 |
-| **5 — Compliance engine** | Role-aware rulesets defined on ESOTK → synced to game → client-side eval → results on web | The raid-lead value; feeds `detectBuildIssues` | §11.3, §12.2 |
-| **6 — In-game dashboard** | Live raid-lead grid + pre-pull ready-check, in-client | Mirrors the web dashboard where the lead actually is | §12.3 |
-| **7 — Ecosystem hooks** | LibGroupCombatStats category, LUIE frame annotation, Wizard's Wardrobe verify, RaidNotifier assignments | Plug into what raids already run | §12.4, §13 |
-| **8 — Longitudinal + reach** | Build-vs-performance history; PvP content-aware caps; console live-layer spike | Compounding value + audience expansion | §11.4, §21, §18 |
+| Phase                         | Deliverable                                                                                                                                                                     | Why this order                                                                         | Key refs        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------- |
+| **0 — Foundations**           | Versioned `ESOTKCompanionSV` schema + the report↔snapshot matcher (incl. manual-attach fallback)                                                                                | Most expensive to change later; everything depends on it                               | §15, §19        |
+| **1 — Vertical slice**        | Add-on captures local player's **CP allocation + final stats + mundus + food + subclass/mastery**; ESOTK renders it on the player card with the **pen-vs-cap coaching** insight | Delivers the headline ask _and_ one genuinely useful, non-redundant insight on day one | §8, §11.1, §17  |
+| **2 — Effortless ingest**     | Manual `.lua` upload (extend `luaParser.ts`); optional FSA folder-sync / copy-paste code                                                                                        | Transport is plumbing — make it painless, don't over-build                             | §9              |
+| **3 — Read existing add-ons** | Ingest CombatMetrics / Wizard's Wardrobe SavedVariables                                                                                                                         | Lowers the adoption ask before requiring our add-on                                    | §10             |
+| **4 — Whole-group capture**   | LibGroupBroadcast/LibGroupCombatStats group snapshots → one logger covers the raid                                                                                              | Turns a personal tool into a raid tool; the network effect                             | §12.1, §13      |
+| **5 — Compliance engine**     | Role-aware rulesets defined on ESOTK → synced to game → client-side eval → results on web                                                                                       | The raid-lead value; feeds `detectBuildIssues`                                         | §11.3, §12.2    |
+| **6 — In-game dashboard**     | Live raid-lead grid + pre-pull ready-check, in-client                                                                                                                           | Mirrors the web dashboard where the lead actually is                                   | §12.3           |
+| **7 — Ecosystem hooks**       | LibGroupCombatStats category, LUIE frame annotation, Wizard's Wardrobe verify, RaidNotifier assignments                                                                         | Plug into what raids already run                                                       | §12.4, §13      |
+| **8 — Longitudinal + reach**  | Build-vs-performance history; PvP content-aware caps; console live-layer spike                                                                                                  | Compounding value + audience expansion                                                 | §11.4, §21, §18 |
 
 **Cross-cutting, every phase:** opt-in consent (§22), ID-not-name matching + canonical
 baseline snapshot (§20), per-season maintenance pass (§23), free add-on / premium web
@@ -860,10 +870,11 @@ Now that opt-in group sharing is accepted, here's the concrete "how", grounded i
 real libraries and an existing precedent (RdK Group Tool).
 
 ### Two libraries, two jobs
-- **LibGroupCombatStats** — *consume only*. Clean callback API, but its categories are
+
+- **LibGroupCombatStats** — _consume only_. Clean callback API, but its categories are
   fixed (DPS/HPS/ULT). Use it to pull live combat numbers into the dashboard; it is **not**
   where custom build/compliance data goes.
-- **LibGroupBroadcast 2.0** (sirinsidiator) — *the vehicle for our own data*. It exposes
+- **LibGroupBroadcast 2.0** (sirinsidiator) — _the vehicle for our own data_. It exposes
   a real custom-protocol API: `DeclareProtocol(id, name)` (id/name must be globally
   unique, reserved on the ESOUI wiki), then `AddField(...)` built from `CreateFlagField`
   (booleans → single bits), `CreateNumericField` (range-limited ints — declare min/max so
@@ -871,6 +882,7 @@ real libraries and an existing precedent (RdK Group Tool).
   minimum and fairly shares the **~32 B/s** group budget across all add-ons.
 
 ### Two payload tiers (driven by the byte budget)
+
 1. **Live compliance verdict** — what we broadcast in/around combat. A handful of
    `FlagField`s (`food`, `mundus`, `pen`, `sets`, `cp`, `roleOK`) plus maybe one or two
    small bucketed numerics. That's a few **bits**, trivially within budget. Each client
@@ -882,16 +894,18 @@ real libraries and an existing precedent (RdK Group Tool).
      uploads their own file; ESOTK matches and assembles the group. No byte budget at
      all, exact data. Simplest and most reliable.
    - **In-game bulk query over map pins** — the **RdK Group Tool precedent**: a guild
-     admin can already *query* members' equipment/CP/stats/mundus, transferred over map
+     admin can already _query_ members' equipment/CP/stats/mundus, transferred over map
      pins, opt-in and off by default. Proves full-build P2P transfer works; it's just
      slow, so do it **out of combat / pre-pull**, on demand.
 
 ### Recommendation
+
 Live **verdicts via LibGroupBroadcast** for the in-game dashboard; **full builds via
 per-member SavedVariables upload** for the website. Add RdK-style in-game bulk query
 only later, as a convenience, if users want full builds visible in-game without uploading.
 
 ### Constraints to design in now
+
 - Reserve a unique protocol id+name on the ESOUI wiki; **version the protocol** and
   handshake so mismatched add-on versions degrade cleanly.
 - Bulk transfer is **out-of-combat only** (and courteous on the shared channel).
@@ -944,7 +958,7 @@ Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity
 
 ### Two evaluation contexts (this is the important part)
 
-- **`eval: "client"`** — the player's own client has the data about *itself* (self
+- **`eval: "client"`** — the player's own client has the data about _itself_ (self
   stats, CP allocation, attributes, mundus, food, **its own gear/sets**). It evaluates
   these live and broadcasts only the resulting bits (§25). Works **pre-pull**, in-game.
 - **`eval: "log"`** — needs the uploaded report (effective penetration via the boss's
@@ -953,9 +967,9 @@ Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity
 - **`liveApprox`** — bridges the two for penetration. Effective pen can't be known
   before the pull (depends on the group's debuffs on the boss), so the live check uses
   `self-pen ≥ 18,200 − assumedGroupPen`. A standard tank kit supplies ≈**11,030** (Major
-  + Minor Breach + gold Crusher), so a DPS needs ≈**7,170** self-pen to be on track; the
-  exact verdict is recomputed from the log afterwards. The ruleset carries the
-  assumption so the live light is meaningful without pretending to be exact.
+  - Minor Breach + gold Crusher), so a DPS needs ≈**7,170** self-pen to be on track; the
+    exact verdict is recomputed from the log afterwards. The ruleset carries the
+    assumption so the live light is meaningful without pretending to be exact.
 
 ### Compile → sync → evaluate → report
 
@@ -965,7 +979,7 @@ Operators: `eq | in | gte | lte | between | containsAll | containsAny`. Severity
    each `id` → a fixed **bit index**, and encode `{fieldId, op, value}` into a small
    blob. The client never needs the prose — just the field/op/value tuples.
 3. **Sync down** (§12.2): FSA write-mode file, import code, or broadcast.
-4. **Evaluate client-side** → produce the compliance **bitfield** (bit *i* = rule *i*
+4. **Evaluate client-side** → produce the compliance **bitfield** (bit _i_ = rule _i_
    pass/fail) → broadcast over LibGroupBroadcast (§25).
 5. **Aggregate + complete on the web.** The raid-lead dashboard shows the live bits; on
    upload, ESOTK evaluates the `eval: "log"` rules and merges, producing the final
@@ -993,17 +1007,17 @@ The agreed live-compliance loop, and why it sidesteps the bandwidth limit entire
 1. **Raid lead authors a static ruleset on the web** (per role/content). It stays put
    until they change it.
 2. **Synced into the add-on** once (file / import code / broadcast).
-3. **Each client checks *itself*** against the ruleset (it has full data about its own
+3. **Each client checks _itself_** against the ruleset (it has full data about its own
    character).
 4. **Each client broadcasts only a per-rule pass/fail bitfield** — ~2–4 bytes, re-sent
    only when something changes. **You broadcast verdicts, never builds.**
 5. **Group frames show a red X** on anyone non-compliant.
-6. **Click → expands the exact failures**, *reconstructed locally* from each client's own
-   copy of the ruleset (bit *i* → rule *i* → "Wrong mundus — needs The Lover"). Zero
+6. **Click → expands the exact failures**, _reconstructed locally_ from each client's own
+   copy of the ruleset (bit _i_ → rule _i_ → "Wrong mundus — needs The Lover"). Zero
    extra bandwidth for the detail.
 
 Logs never enter this loop (they aren't instant). The log is a **post-hoc bonus layer**
-for the one thing that needs it — exact *effective* penetration and buff/debuff uptimes.
+for the one thing that needs it — exact _effective_ penetration and buff/debuff uptimes.
 
 **Why the bandwidth objection dies here:** the only thing on the wire is a few-byte,
 static, on-change verdict — smaller than the DPS numbers Hodor already shares. The full
@@ -1013,19 +1027,19 @@ from local data.
 ### 26.2 Verified client-side checks (API confirmed, not assumed)
 
 Every readiness check below was confirmed against real add-on source / API references
-(see Sources), so the add-on reads them from the player's *own* client with no inspection:
+(see Sources), so the add-on reads them from the player's _own_ client with no inspection:
 
-| Requirement | Confirmed read | Source |
-|---|---|---|
-| **Champion points** (enumerate) | `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)` | esoui `championdatamanager.lua` |
-| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` — single arg | DynamicCP `src/API.lua` |
-| **Champion points** (slotted) | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12 | DynamicCP `OFFSETS` |
-| **Gear set** | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped` | ESOUI |
-| **Food** | active buff via `GetUnitBuffInfo("player", i)` ability id | ESOUI |
-| **Mundus** | active buff id (no direct getter — match a known mundus boon id list) | ESOUI |
-| **Potion** | `GetSlotItemLink(quickslotIndex)` | ESOUI |
-| **Attributes** | `GetAttributeSpentPoints(attributeType)` → points | eso-api dump |
-| **Self penetration / crit** | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_WEAPON_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants |
+| Requirement                      | Confirmed read                                                                                                                                             | Source                          |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Champion points** (enumerate)  | `GetNumChampionDisciplines()`, `GetChampionDisciplineId(index)`, `GetNumChampionDisciplineSkills(index)`, `GetChampionSkillId(index, index)`               | esoui `championdatamanager.lua` |
+| **Champion points** (allocation) | `GetNumPointsSpentOnChampionSkill(skillId)` — single arg                                                                                                   | DynamicCP `src/API.lua`         |
+| **Champion points** (slotted)    | `GetSlotBoundId(slot, HOTBAR_CATEGORY_CHAMPION)`, slots 1–12                                                                                               | DynamicCP `OFFSETS`             |
+| **Gear set**                     | `GetItemLink(BAG_WORN, slot)` → `GetItemLinkSetInfo(link, true)` → `setId`, `numEquipped`                                                                  | ESOUI                           |
+| **Food**                         | active buff via `GetUnitBuffInfo("player", i)` ability id                                                                                                  | ESOUI                           |
+| **Mundus**                       | active buff id (no direct getter — match a known mundus boon id list)                                                                                      | ESOUI                           |
+| **Potion**                       | `GetSlotItemLink(quickslotIndex)`                                                                                                                          | ESOUI                           |
+| **Attributes**                   | `GetAttributeSpentPoints(attributeType)` → points                                                                                                          | eso-api dump                    |
+| **Self penetration / crit**      | `GetPlayerStat(STAT_*)` — `STAT_SPELL_POWER/STAT_WEAPON_POWER/STAT_CRITICAL_STRIKE/STAT_SPELL_CRITICAL/STAT_PHYSICAL_PENETRATION/STAT_SPELL_PENETRATION/…` | esoui API constants             |
 
 > **Index-vs-id gotcha (confirmed from ZOS source).** `GetNumChampionDisciplineSkills`
 > and `GetChampionSkillId` take the discipline **index**; `GetChampionDisciplineType`
@@ -1033,6 +1047,44 @@ Every readiness check below was confirmed against real add-on source / API refer
 > Mixing them returns wrong/empty data — a real bug caught during verification. Only
 > step left is a one-time in-game run to confirm captured values match the character
 > sheet; the function names and arities are now source-verified.
+
+---
+
+## 27. Report-page upload integration map (verified entry points)
+
+The ESOTK side is built and unit-tested (parser → matcher → view-model + coaching →
+`buildCompanionBuildsForReport` → `CompanionBuildPanel` → `PlayerCard.companionBuild`).
+The only remaining work is the report-page upload UI, and the wiring is paint-by-numbers
+against these **verified** store/types (confirmed by reading the code, not assumed):
+
+1. **Ingest the file.** Reuse the existing Lua-import UX (Loadout Manager already does a
+   `FileReader` `.lua` upload). Run the bytes through
+   `parseESOTKCompanionSavedVariables(text)` → `CompanionParseResult` (`.all` snapshots).
+2. **Build `MatchableReport`** from report state:
+   - `actors`: from report `masterData` actors — `ReportActorFragment` has
+     `{ id, name, displayName, anonymous }` (`src/graphql/gql/graphql.ts`). Map
+     `id`→actor id, `name`→character (the match key). `anonymous === true` ⇒ names are
+     hidden, so the matcher falls back to manual attach (already handled). There is **no
+     per-actor `server`** field — match on name; use report-level server only if needed.
+   - `fights`: `selectReportFights` / `selectReportFightsForContext`
+     (`src/store/report/reportSelectors.ts`) — each fight has `id`, `startTime`,
+     `endTime` (ms offsets from report start).
+   - `startTime` / `endTime`: from the `ReportEntry` (`src/store/report/reportSlice.ts`,
+     absolute UNIX ms).
+3. **Compute per-player props:**
+   `buildCompanionBuildsForReport(result.all, matchableReport, { coaching: { assumedGroupPen } })`
+   → `Map<actorId, { championPoints, coaching, snapshot, fightId }>`.
+4. **Render:** players come from `selectPlayersByIdForContext` keyed by `player.id`
+   (already imported in `PlayerCard.tsx`; cards are rendered via
+   `PlayersPanel`/`PlayersPanelView`/`LazyPlayerCard`). Pass
+   `companionBuild={builds.get(player.id)}` to each `PlayerCard`. Absent ⇒ panel renders
+   nothing (no change to existing cards).
+
+**Notes:** `displayName` ↔ `snapshot.account` (optional cross-check). For _exact_
+effective penetration, later pass the boss's Major Breach/Crusher uptime from the log as
+`assumedGroupPen` with `groupPenIsExact: true` (§11.1.1); until then the standard-kit
+estimate is fine. Hold the parsed snapshots in local component state or a small slice —
+they're per-session, not persisted server-side.
 
 ---
 
@@ -1084,8 +1136,8 @@ Every readiness check below was confirmed against real add-on source / API refer
 - [LibGroupBroadcast custom-protocol API (DeclareProtocol/AddField/NumericField/ArrayField)](https://github.com/sirinsidiator/ESO-LibGroupBroadcast) · [Broadcasting API thread](https://www.esoui.com/forums/showthread.php?p=51019)
 - [RdK Group Tool — group query of equipment/CP/stats/mundus over map pins](https://www.esoui.com/downloads/info2475-RdKGroupTool.html) · [Taos Group Tools](https://esoui.com/downloads/info1962-TaosGroupTools.html)
 - [DynamicCP source — verified champion-point API (single-arg `GetNumPointsSpentOnChampionSkill`, slot OFFSETS)](https://github.com/Kyzderp/DynamicCP)
-- [Official ZOS source — champion enumeration (`GetNumChampionDisciplines`/`GetChampionDisciplineId`/`GetNumChampionDisciplineSkills`/`GetChampionSkillId`, index-vs-id)](https://github.com/esoui/esoui/blob/master/esoui/ingame/champion/championdatamanager.lua) · [ESOUIDocumentation.txt (STAT_* constants)](https://github.com/esoui/esoui/blob/master/ESOUIDocumentation.txt)
+- [Official ZOS source — champion enumeration (`GetNumChampionDisciplines`/`GetChampionDisciplineId`/`GetNumChampionDisciplineSkills`/`GetChampionSkillId`, index-vs-id)](https://github.com/esoui/esoui/blob/master/esoui/ingame/champion/championdatamanager.lua) · [ESOUIDocumentation.txt (STAT\_\* constants)](https://github.com/esoui/esoui/blob/master/ESOUIDocumentation.txt)
 - [GetItemLinkSetInfo (numEquipped/setId) — ESOUI wiki](https://wiki.esoui.com/GetItemLink) · [GetItemLink](https://wiki.esoui.com/GetItemLink)
 - [Mundus detection is buff-id-based via GetUnitBuffInfo (no direct getter)](https://www.esoui.com/forums/showthread.php?t=2225) · [Quickslot read GetSlotItemLink](https://www.esoui.com/forums/showthread.php?t=6286)
-</content>
-</invoke>
+  </content>
+  </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -1,9 +1,26 @@
 # ESOTK Companion Add-on — Research & Strategy (June 2026)
 
 > Research brief for the in-game ESO add-on that pairs with ESO Toolkit (ESOTK).
-> Goal: capture the build/character data that ESO Logs **cannot** see, and feed it
-> back into ESOTK so player cards, build-hub, roster-hub and fight-replay show a
-> complete picture.
+> Goal: capture the build/character data that ESO Logs **cannot** see, feed it back into
+> ESOTK, and grow into a two-way raid-command platform (plan on web → enforce in game →
+> analyse on web).
+>
+> **Scope note:** this doc evolved over several research passes. §1–§11 cover the core
+> capture-and-coaching product; §12+ expand to the live in-game platform, integration,
+> competitive positioning, data/transport plumbing, business model, the 2026 meta,
+> methodology, and risk. The consolidated roadmap is in **§24**.
+
+### Contents
+1. The core thesis · 2. Gap analysis · 3. ESO Lua API toolbox · 4. ESOTK integration
+surfaces · 5. Ranked ideas (P0–P2) · 6. Phased architecture · 7. Risks & open questions
+· 8. First milestone · 9. Transport is plumbing · 10. Read existing add-ons first ·
+11. The real UVPs (stat-aware coaching) · 12. The in-game raid-command layer ·
+13. Integration feasibility matrix · 14. Competitive landscape & white space ·
+15. Data plane & matching algorithm · 16. Sustainability (free add-on, premium web) ·
+17. Why now — the 2026 meta · 18. Platform reality & a console-only opportunity ·
+19. Tech stack & SavedVariables schema · 20. Capture methodology & accuracy ·
+21. Beyond trials — PvP audiences · 22. Privacy, consent & ToS · 23. Maintenance & risk
+· 24. Consolidated roadmap.
 
 ---
 
@@ -504,6 +521,14 @@ into the concrete platform above and confirms nobody else occupies the space.
 > → analyse on web. A pure add-on (no web brain) or a pure web tool (no in-game hands)
 > can't close it. ESOTK already has both halves.
 
+**One more structural advantage:** ESO has **no native gear/build inspection** — ZOS
+deliberately disabled it to curb toxicity, and the API won't expose another player's
+gear. So the *only* way to see a teammate's full build in-game is if they **opt in to
+broadcast it** — which is exactly our model. No direct competitor shares full builds
+(stats/CP), and even the community's standard answer to "how do I see someone's build?"
+is "check esologs" — which only has gear, not the stats/CP/attributes we capture. We're
+filling a gap the base game intentionally left open *and* nobody else fills.
+
 ---
 
 ## 15. Data plane & the matching algorithm (the two expensive-to-change pieces)
@@ -725,7 +750,9 @@ a first-class design concern, not an afterthought:
 
 - **Broadcasting is opt-in**, with a clear in-game toggle (LibAddonMenu) and a visible
   indicator of what's shared. Mirror the reason Hodor is perceived as benign:
-  transparent, read-only, user-controlled.
+  transparent, read-only, user-controlled. This **aligns with ZOS's own design intent**
+  — they disabled native inspection precisely to prevent unwanted build-snooping, so a
+  consent-first, opt-in share is the only model that respects that line (§14).
 - **Granularity** — let players share only a compliance verdict (pass/fail bits) without
   exposing exact stats/gear, for groups that want enforcement without doxxing builds.
 - **ESOTK-side retention/redaction** — companion data is ESOTK's (§15); honour
@@ -754,6 +781,34 @@ a first-class design concern, not an afterthought:
   (m00nyONE). Vendoring or contributing upstream reduces exposure if that stalls.
 - **Scope risk** — §12's full platform is large. Ship the §8 vertical slice first; treat
   the dashboard, ruleset engine, and ecosystem hooks as sequenced phases, not v1.
+
+---
+
+## 24. Consolidated roadmap
+
+Pulling the scattered phasing into one sequence. Each phase is independently shippable
+and builds on the prior schema + matcher.
+
+| Phase | Deliverable | Why this order | Key refs |
+|---|---|---|---|
+| **0 — Foundations** | Versioned `ESOTKCompanionSV` schema + the report↔snapshot matcher (incl. manual-attach fallback) | Most expensive to change later; everything depends on it | §15, §19 |
+| **1 — Vertical slice** | Add-on captures local player's **CP allocation + final stats + mundus + food + subclass/mastery**; ESOTK renders it on the player card with the **pen-vs-cap coaching** insight | Delivers the headline ask *and* one genuinely useful, non-redundant insight on day one | §8, §11.1, §17 |
+| **2 — Effortless ingest** | Manual `.lua` upload (extend `luaParser.ts`); optional FSA folder-sync / copy-paste code | Transport is plumbing — make it painless, don't over-build | §9 |
+| **3 — Read existing add-ons** | Ingest CombatMetrics / Wizard's Wardrobe SavedVariables | Lowers the adoption ask before requiring our add-on | §10 |
+| **4 — Whole-group capture** | LibGroupBroadcast/LibGroupCombatStats group snapshots → one logger covers the raid | Turns a personal tool into a raid tool; the network effect | §12.1, §13 |
+| **5 — Compliance engine** | Role-aware rulesets defined on ESOTK → synced to game → client-side eval → results on web | The raid-lead value; feeds `detectBuildIssues` | §11.3, §12.2 |
+| **6 — In-game dashboard** | Live raid-lead grid + pre-pull ready-check, in-client | Mirrors the web dashboard where the lead actually is | §12.3 |
+| **7 — Ecosystem hooks** | LibGroupCombatStats category, LUIE frame annotation, Wizard's Wardrobe verify, RaidNotifier assignments | Plug into what raids already run | §12.4, §13 |
+| **8 — Longitudinal + reach** | Build-vs-performance history; PvP content-aware caps; console live-layer spike | Compounding value + audience expansion | §11.4, §21, §18 |
+
+**Cross-cutting, every phase:** opt-in consent (§22), ID-not-name matching + canonical
+baseline snapshot (§20), per-season maintenance pass (§23), free add-on / premium web
+(§16).
+
+**If you do only three things:** (1) lock the schema + matcher, (2) ship CP + stats +
+pen-cap coaching on the player card, (3) make group capture work via LibGroupCombatStats.
+That sequence proves the headline ask, the unique insight, and the network effect — the
+three things the whole platform rests on.
 
 ---
 
@@ -798,5 +853,6 @@ a first-class design concern, not an afterthought:
 - [LibSavedVars (scoped + migration)](https://github.com/silvereyes333/LibSavedVars) · [LibAddonMenu-2.0](https://www.esoui.com/downloads/info7-LibAddonMenu.html)
 - [GetPlayerStat (UESP function reference)](https://esodata.uesp.net/100010/data/g/e/t/GetPlayerStat.html) · [Character sheet & advanced stats explained](https://www.eso-u.com/articles/player_character_sheet_and_advanced_stats_ui_explained)
 - [Easy Stalking — auto-log Cyrodiil/IC/BG](https://www.esoui.com/downloads/info2332-EasyStalking-Encounterlog.html) · [PvpMeter](https://forums.elderscrollsonline.com/en/discussion/387159/addon-pvpmeter-graphical-tracker-for-your-kill-death-in-pvp-and-history-of-your-bg-duel-played) · [PvP addons guide — NirnStorm](https://nirnstorm.com/eso/guides/pvp-addons-guide/)
+- [No native gear inspection in ESO (ZOS design, anti-toxicity)](https://forums.elderscrollsonline.com/en/discussion/619375/ability-to-inspect-players-in-eso) · [Why you can't inspect other players](https://forums.elderscrollsonline.com/en/discussion/566890/why-cant-i-inspect-other-players-noob-question)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -335,6 +335,117 @@ the only place that tells your whole raid whether the build was actually any goo
 
 ---
 
+## 12. The bigger vision — an in-game raid-command layer, two-way synced with ESOTK
+
+> **Reframe.** Sections 1–11 treat the add-on as a *passive capture pipe* → web. The
+> larger opportunity is a **two-way platform**: ESOTK is the brain (define rosters,
+> rules, assignments, analytics on the web), the add-on is the **eyes and hands in the
+> raid** (enforce and surface them live, in-game), and data flows **both directions**.
+> This is the part that has no real competitor — ESO Logs is read-only post-hoc,
+> build sites are open-loop, and no tool connects a web raid-planner to a live in-game
+> HUD. Below is what's possible *and* what the engine constraints actually allow.
+
+### 12.1 The one constraint that shapes everything: 32 bytes/second
+
+Group data sharing (LibGroupBroadcast, the bus Hodor rides) is hard-capped by ESO at
+**~32 bytes per second per add-on**, riding the map-ping channel. That is far too little
+to stream full builds for 12 people. It is the reason Hodor only shares tiny DPS/Ult
+numbers. **So we do not stream builds — we split the system into two layers:**
+
+| Layer | Runs where | Carries | Channel | Limit |
+|---|---|---|---|---|
+| **Live layer** | In-game, real-time | A compact **compliance verdict** + a few key live stats per player | LibGroupBroadcast | 32 B/s — fine for bitfields |
+| **Deep layer** | Web, post-hoc | The **full** build: CP allocation, exact stats, gear, history | SavedVariables file → ESOTK | none |
+
+**Edge-compute is the trick.** Every player's add-on already knows *their own* full
+build and the shared ruleset, so **each client evaluates itself locally** and
+broadcasts only the verdict — e.g. a 1-byte bitfield (`food✓ mundus✓ pen✓ sets✓ CP✓`)
+plus one or two bucketed stats. The raid lead's add-on aggregates those few-byte
+messages into a live dashboard. No bandwidth problem, because the heavy lifting never
+goes over the wire.
+
+### 12.2 The criteria / ruleset engine (the centrepiece)
+
+This is the user's "flag criteria you set" idea, made concrete and role-aware:
+
+- **Define on ESOTK (web):** per **role** and per **encounter**, a ruleset — *DPS must
+  hit ≥18,200 pen, run [required set], be fed, slot [CP stars]; healers must run
+  [sets], maintain ≥X recovery and Major Courage; tanks must hold taunt uptime and run
+  [sets]*. ESOTK already has roster-hub role composition and `detectBuildIssues` to
+  build this on.
+- **Sync down to the game.** Three viable bridges (no desktop app needed):
+  1. **FSA API write-mode** — ESOTK writes the ruleset into the SavedVariables folder
+     (`requestPermission({mode:'readwrite'})`); the add-on loads it on `/reloadui`.
+     Genuinely bidirectional, browser-only.
+  2. **Import code** — ESOTK emits a ruleset code; raid lead pastes it into the add-on.
+  3. **Broadcast** — only the raid lead needs it configured; it streams to the group's
+     add-ons out of combat (slow at 32 B/s, but a one-time ~10–30s pre-pull sync).
+- **Evaluate live, in-game.** Each client checks itself; the raid lead sees who passes.
+- **Report back up.** Compliance + the full capture flow to ESOTK for the post-fight
+  report, player cards, and roster history.
+
+### 12.3 In-game raid-lead dashboard (mirror the web dashboard, live)
+
+ESOTK already has a raid-lead dashboard on the site; mirror it **in-game** so the lead
+never alt-tabs. Using the group APIs (`GetGroupUnitTagByIndex`,
+`GetGroupMemberSelectedRole`, …) the add-on renders a live grid of all 12 members with
+red/green compliance dots, missing-requirement callouts, and live DPS/HPS/Ult from the
+LibGroupCombatStats bus it already shares with Hodor. **A pre-pull "ready check"**
+posts *"3 not ready: @x no food, @y wrong mundus, @z 2,400 under pen cap"* to the lead
+(or group chat) — something no tool does today.
+
+### 12.4 Ecosystem integration (don't rebuild — plug in)
+
+The user is right that the win is integrating with what raids already run:
+
+- **Hodor / LibGroupCombatStats** — *the* group combat-data bus. Publish our compliance
+  data alongside Hodor's DPS so the whole ecosystem can read it; ride the same join.
+- **LUI Extended (LUIE)** — MIT-licensed, provides class/role-colored Group/Raid frames
+  and buff/debuff tracking. Integrate by **annotating its frames** with compliance
+  state (or learn from its frame code). Open source makes this tractable.
+- **Bandits UI / custom raid frames** — same pattern: overlay a compliance dot per
+  member on whichever frames the raid uses, rather than forcing ours.
+- **Wizard's Wardrobe** — already parsed here. The add-on can **verify the equipped
+  setup matches the assignment** and prompt an auto-equip if not.
+- **RaidNotifier / Code's Combat Alerts** — tie ESOTK roster **assignments** (who
+  interrupts, who takes which portal/sync) to on-screen reminders.
+
+### 12.5 Expanded idea catalogue (beyond build capture)
+
+- **Auto-roster from the live group** — read current members + roles and **populate
+  ESOTK's roster-hub automatically**, killing manual entry. (Huge, underrated.)
+- **Assignment overlays** — push portal/interrupt/taunt/sync assignments from the web
+  roster to in-game prompts keyed to each player.
+- **Live self-HUD** — turn ESOTK's `CalculatePenetration`/`CalculateCriticalDamage`
+  estimates into a real-time personal readout: *"1,300 under pen cap right now."*
+- **Instant debrief** — on a wipe, the add-on snapshots who died first / who broke
+  compliance and syncs it to the ESOTK report.
+- **Attendance & progression tracking** — pull counts, wipe reasons, who showed,
+  auto-logged to roster-hub over a prog night.
+- **Consumable/repair pre-check** — flag low gear durability, missing poisons, empty
+  quickslot before the pull.
+- **Buff-assignment uptime** — assign Major Breach / Z'en / Slayer to players and track
+  whether they actually maintain it (cross-checked against the log).
+
+### 12.6 Honest limits on the live layer
+
+- **32 B/s** means live data is *verdicts and a few stats*, never full builds — design
+  for it (§12.1). Don't promise live gear/CP streaming.
+- **You can't read another player's build** directly — they must run the add-on and
+  opt in to broadcast. Value scales with raid adoption (lean on raid-lead mandate).
+- **No in-combat automation / no input** — read, evaluate, display only. Stays ToS-safe
+  like Hodor/CombatMetrics.
+- **PC-only** (no console add-ons); console raids get the web/log-only experience.
+- **FSA write-mode is Chromium-only** — import-code/broadcast are the cross-browser
+  fallbacks for ruleset sync.
+
+**Vision one-liner:** *Plan the raid on ESOTK, and the add-on becomes its live enforcer
+in-game — every player self-checks against your rules, the raid lead sees green/red at a
+glance, and the whole night flows back to the web as build-correlated history. The web
+is the brain; the add-on is the raid's nervous system.*
+
+---
+
 ## Sources
 
 - [ESO Logs — Getting Started](https://www.esologs.com/help/start)
@@ -357,5 +468,8 @@ the only place that tells your whole raid whether the build was actually any goo
 - [ESO-Hub Build Editor (import/export, CombatMetrics integration)](https://eso-hub.com/en/build-editor)
 - [ESO penetration & the 18,200 cap (over-penetration is wasted)](https://hyperioxes.com/eso/tools/penetration-calculator)
 - [ESO critical damage 125% hard cap / crit rating ÷ 21,918](https://eso-hub.com/en/guides/critical-damage) · [UESP: Critical Damage](https://en.uesp.net/wiki/Online:Critical_Damage)
+- [LibGroupBroadcast — 32 bytes/sec group data limit](https://www.esoui.com/downloads/info1337-LibGroupSocket.html) · [LibGroupSocket source](https://github.com/ESOUIMods/LibGroupSocket/blob/master/LibGroupSocket.lua/)
+- [LUI Extended (MIT, custom group/raid frames)](https://www.esoui.com/downloads/info818-LuiExtended.html) · [GitHub](https://github.com/DakJaniels/LuiExtended)
+- [ESOUI Wiki — UnitTag / group APIs](https://wiki.esoui.com/UnitTag)
 </content>
 </invoke>

--- a/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
+++ b/documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md
@@ -196,8 +196,11 @@ to change later. Everything else is additive.
 - **Console** — explicitly out of scope for capture; ensure ESOTK degrades gracefully
   to log-only for console reports.
 - **Adoption** — value scales with how many group members run it; lean hard on the
-  group-broadcast model so one logger covers the raid, and on Kalpa for frictionless
-  install + upload.
+  group-broadcast model so one logger covers the raid. Reduce the ask further by reading
+  data from add-ons users already run (§10) before requiring ours.
+- **Redundancy** — do **not** re-sell things the log already provides (gear, slotted
+  skills) or "no install" (the audience already runs the ESO Logs uploader). The value
+  is the stat-aware coaching in §11.1, not the plumbing.
 
 ---
 
@@ -207,117 +210,128 @@ A vertical slice that proves the loop end-to-end:
 
 1. Add-on captures **CP allocation + final stats + mundus + food** for the **local
    player only**, writes `ESOTKCompanion.lua`.
-2. ESOTK importer parses it and **renders CP + stats on that player's card** when the
-   uploaded log matches.
-3. Ship the add-on as a **Kalpa pack** with a Build-Hub "Get Companion" button.
+2. ESOTK parses it (extend `luaParser.ts`), matches it to the uploaded log, and
+   **renders CP + the stat-aware pen/crit coaching from §11.1 on that player's card** —
+   "you're 3,200 over the 18,200 pen cap." That single insight is the proof of value,
+   not the raw build display.
+3. Distribute via the normal Minion/manual route; offer the optional file upload or
+   folder-sync in ESOTK to ingest it.
 
-That delivers the user's headline request (champion points on player cards) with the
-smallest surface area, and every later idea (group capture, auto-upload, build flags)
-builds on the same schema and matcher.
+That delivers the user's headline request (champion points on player cards) **plus** a
+genuinely useful, non-redundant insight on day one, with the smallest surface area.
+Every later idea (group capture, compliance grid, build history) builds on the same
+schema and matcher.
 
 ---
 
-## 9. Getting data in **without** trusted desktop software (the real problem)
+## 9. Transport is plumbing, not a value proposition
 
-ESO Lua **cannot make outbound HTTP requests** — by design. So *something* has to carry
-the SavedVariables data from disk to ESOTK. The market has only ever used three
-mechanisms, and the whole adoption question is which one we lead with.
+> **Correction to the earlier draft.** A previous version pitched "no desktop app /
+> browser folder-sync" as a headline UVP. That's wrong for *this* audience: **every log
+> ESOTK analyses already arrived via the ESO Logs uploader**, so our users have already
+> installed and trusted a native desktop app. "No install" wins us nothing — it's
+> table stakes they've already paid. Transport is a solved, boring problem; the value is
+> in what we *do* with the data (§11). Pick the simplest transport and move on:
 
-### How the market actually does it
-
-| Tool | Transport | Friction |
+| Option | When to use | Effort |
 |---|---|---|
-| **ESO Logs** (combat logs) | **Electron desktop uploader** ("Companion") that tails `Encounter.log` and POSTs it | Must download + trust a native app. *This is the friction we're avoiding.* |
-| **ESO-Database** | Desktop **client** *or* **manual file upload** on their site | Client = trust friction; manual = works but tedious |
-| **CombatMetrics → ESO-Hub** | In-game **copy/paste build code** into the Build Editor | Zero install; proven and popular |
-| **UESP uespLog**, **TTC**, etc. | Manual SavedVariables upload / separate client | Mixed |
-| **Wizard's Wardrobe → ESOTK** | Manual `.lua` upload (already shipped here) | Zero install |
+| **Manual `.lua` upload** | Default. Already shipped (`luaParser.ts` for Wizard's Wardrobe) — extend to `ESOTKCompanion`. Works in every browser. | ~none |
+| **File System Access API folder-sync** | Nice-to-have for Chromium users who don't want to re-pick the file each session. Store the handle in IndexedDB, re-read on a click. *Convenience, not a differentiator.* | low |
+| **Copy/paste build code** | Single-player quick share, no file. Note ESO can't auto-copy (protected call) and caps a copy near ~1023 chars, so compress. | low |
+| **Kalpa auto-upload** | Opt-in only, for users already on Kalpa. Never the on-ramp. | medium |
 
-**Verdict:** every "frictionless and trusted" success story is **either copy/paste a
-code, or upload the file through the browser**. The desktop-uploader path is exactly
-what users resist. So we don't ship a desktop app — we make the **browser** the
-ingestion engine.
-
-### The tiered, no-install transport ladder
-
-> Lead with the lowest-friction option each browser supports; degrade gracefully.
-
-**Tier 1 — File System Access API folder-sync (hero path, Chromium).**
-ESOTK calls `showDirectoryPicker()` once; the user points it at
-`Documents/Elder Scrolls Online/live/`. We store the directory handle in **IndexedDB**,
-so on every later visit a **single click** (`requestPermission`) re-reads
-`SavedVariables/ESOTKCompanion.lua` — and, if granted, `Logs/Encounter.log` too. No
-download, nothing to trust beyond the browser's own permission prompt. This is the
-**unique value proposition**: *ESO Logs needs an Electron app to read your log folder;
-ESOTK does it from the tab you already have open.*
-- Works in **Chrome / Edge / Opera / Brave 86+** (the majority of desktop, and ESO
-  add-on users are PC/desktop by definition).
-- **Not** in Firefox or Safari — Mozilla and Apple have declined the local-disk
-  pickers permanently. Those users fall to Tier 2/3.
-
-**Tier 2 — Copy/paste build code (universal, proven).**
-The add-on renders a compressed, encoded build string in an in-game **edit box**; the
-user selects-all + Ctrl+C and pastes it into ESOTK. This is precisely the
-CombatMetrics → ESO-Hub flow, so ESO players already understand it.
-- **Constraint:** ESO's direct clipboard write is a *protected/illegal call* — we
-  cannot auto-copy; the user must Ctrl+C from the editbox. And a single copy is capped
-  near **~1023 characters**, so the payload must be compressed (one player's
-  CP+stats+attributes fits comfortably; a 12-person raid needs chunking or Tier 1/3).
-
-**Tier 3 — Manual `.lua` upload (works everywhere, already built).**
-Drag-drop the SavedVariables file into ESOTK. Firefox/Safari fallback and the
-universal safety net. ESOTK's existing `luaParser.ts` already does this for Wizard's
-Wardrobe; we extend it to the `ESOTKCompanion` format.
-
-**Tier 4 — Kalpa auto-upload (optional power-user convenience, not required).**
-For users who already run Kalpa, it can POST the SV file automatically. Strictly
-opt-in; never the on-ramp.
+The only transport constraint that actually shapes design: ESO Lua **can't make HTTP
+calls**, so the data always lands on disk first and ESOTK reads it. That's it. Don't
+over-invest here.
 
 ---
 
-## 10. Piggyback before you ask for a new install
+## 10. Don't make users re-enter what they already have
 
-The cheapest trust is **no new addon at all**. A large share of the target audience
-already runs **CombatMetrics**, **Hodor Reflexes**, and **Wizard's Wardrobe** — all of
-which write SavedVariables that ESOTK can read via the same Tier 1/3 transport.
+Independent of transport, a real friction reducer: ESOTK can read SavedVariables from
+add-ons users **already run**, instead of demanding ours from day one.
 
-- **CombatMetrics** already records per-fight data and can export a build (gear/skills/
-  CP) — ESOTK can ingest its SV directly.
+- **CombatMetrics** records per-fight data and can already export a build code — ESOTK
+  can read its SV directly.
 - **Wizard's Wardrobe** — already parsed here today.
 - **Hodor / LibGroupCombatStats** — already aggregates *group* DPS/HPS/Ult.
 
-**Strategy:** ESOTK should **read what users already have first**, and the
-purpose-built ESOTK Companion add-on only needs to fill the residual gaps those tools
-*don't* persist — chiefly **full CP allocation, final derived stats, and group-wide
-build aggregation in one file**. This reframes the companion from "install our thing"
-to "we already work with your existing addons; install ours only for the extra 20%."
-That is a materially easier adoption pitch.
+So the purpose-built ESOTK Companion only needs to capture the **residual gap** those
+tools don't persist — chiefly **full CP allocation, exact final stats, attribute split,
+and group-wide aggregation in one file**. Smaller add-on, easier ask, faster value.
 
 ---
 
-## 11. Unique value proposition — what only ESOTK can deliver
+## 11. The actual unique value props (non-redundant, genuinely useful)
 
-The build-sharing space is crowded (ESO-Hub Build Editor, Alcast, Arzyel, Hack the
-Minotaur). But **every one of them shares a *static, hand-made* build**. None of them
-tie a build to **what actually happened in a logged fight**. That gap is ours:
+The test for every idea below: **does it require joining the player's true build data
+(which the log lacks) with the combat log (which the build sites lack)?** If yes, it's
+something *no* existing tool — ESO Logs, ESO-Hub, CombatMetrics, Hodor — can produce.
+That intersection is the entire moat. Pure build display (ESO-Hub) and pure combat
+display (ESO Logs) are both already done; we own the **overlap**.
 
-1. **Build ↔ log correlation on the player card.** ESO-Hub shows a build; ESOTK shows
-   *the build the player was actually running when they pulled 92k on this boss*,
-   stitched onto the ESO Logs report. Nobody else does this.
-2. **Whole-group truth from one source.** Via LibGroupBroadcast, one logger's single
-   file yields all 12 members' real builds, auto-attached to the report — a raid-lead
-   superpower, not a personal toy.
-3. **No desktop uploader.** The only browser-native ingestion in the ESO space: grant a
-   folder once, done. Direct contrast with ESO Logs' required Electron app.
-4. **Diagnostics the log can't compute.** "Top DPS but no food", "0 penetration into a
-   resistant boss", "unspent CP", "wrong mundus for the role" — derived from data ESO
-   Logs structurally never sees, surfaced inline. Feeds the existing
-   `detectBuildIssues`.
-5. **Closed loop.** Design a loadout in ESOTK → play it → log it → ESOTK confirms you
-   ran what you planned and shows the result. Build sites are open-loop; we close it.
+ESOTK already *estimates* some of these stats from the log — there are
+`CalculatePenetration` and `CalculateCriticalDamage` workers in the codebase today. The
+companion's job is to **turn those estimates into ground truth** and unlock coaching
+that estimates can't support.
 
-**Positioning one-liner:** *Other sites show you a build. ESOTK shows you the build that
-won the parse — for your whole raid — with nothing to install.*
+### 11.1 Stat-aware optimisation coaching (the killer feature)
+
+The log shows you hit for X. It cannot tell you whether your *stats* were efficient.
+With the companion's exact stats we can compute, per player, against hard ESO caps:
+
+- **Penetration vs the 18,200 cap.** Trial/dungeon bosses sit at 18,200 resist; every
+  point of pen **over** that is wasted and every point **under** is lost damage. We can
+  say *exactly*: "You're at 21,400 pen — 3,200 wasted; drop Sharpened/a pen glyph and
+  gain ~X% damage," or "16,900 — 1,300 short, you're losing mitigation-adjusted
+  damage." This is *the* most common end-game optimisation question and **nothing can
+  answer it without the player's real pen + the boss in the log.**
+- **Crit damage vs the 125% hard cap** (225% total). Flag over-cap crit-damage stacking
+  (wasted) and under-cap headroom.
+- **Crit *chance* value** — crit rating ÷ 21,918 → %, weighed against current crit
+  damage and group buffs to advise "more crit chance vs. more weapon/spell damage here."
+- **Recovery / sustain vs. actual resource behaviour in the log** — pair real recovery
+  stats with the log's resource events to flag over-sustain (wasted regen you could
+  trade for damage) or genuine starvation.
+
+These read like a coach sitting next to the parse. **This is the headline UVP**, far
+more useful than "here's a build."
+
+### 11.2 Champion Point allocation audit
+
+Full per-star allocation (invisible to the log) checked against the content: unspent
+points, sub-optimal slottables for the boss, missing damage/sustain stars. Per player,
+across the raid.
+
+### 11.3 Group readiness / compliance grid (raid-lead tool)
+
+One screen for the whole group, joining build + log: **food active? correct mundus for
+role? CP slotted? gear gold-quality? all enchants present? attributes sane?** Surfaced
+in Roster Hub and feedable to the existing `detectBuildIssues`. No tool does a
+group-wide build-compliance check tied to a real log — this is a genuine officer
+superpower, and the LibGroupBroadcast capture makes it one upload.
+
+### 11.4 Longitudinal build-vs-performance history
+
+Because snapshots are per-fight and per-session, ESOTK (with Roster Hub) can show
+**how a player's build changed over weeks and what it did to their numbers**: "Switched
+Deadly → Coral 3 weeks ago, boss DPS +4%," or "dropped a pen glyph and fell below cap —
+parse dropped." Open-loop build sites can't do this; it needs the build *and* the
+historical logs ESOTK already stores.
+
+### 11.5 Closed design→play→verify loop
+
+Design a loadout in the Loadout Manager → play it → log it → ESOTK confirms you actually
+ran what you planned (gear/CP/mundus/food/skills match) and shows the result. Every
+other build tool is open-loop (design, then hope); we verify against reality.
+
+**Positioning one-liner:** *ESO Logs shows what you did. ESO-Hub shows a build. ESOTK is
+the only place that tells your whole raid whether the build was actually any good —
+"you're 3,200 over the pen cap, that's wasted damage" — straight off the parse.*
+
+> **Deliberately dropped from the UVP list:** re-capturing gear and slotted skills
+> (already in the log) and "no desktop install" (audience already runs the ESO Logs
+> uploader). Both are redundant. Lead with the stat-aware coaching in §11.1.
 
 ---
 
@@ -341,5 +355,7 @@ won the parse — for your whole raid — with nothing to install.*
 - [browser-fs-access (legacy fallback helper)](https://github.com/GoogleChromeLabs/browser-fs-access)
 - [Chat2Clipboard (in-game copy pattern)](https://www.esoui.com/downloads/info553-Chat2Clipboard.html) · [Illegal Call CopyAllTextToClipboard — ESOUI](https://www.esoui.com/forums/showthread.php?t=6012)
 - [ESO-Hub Build Editor (import/export, CombatMetrics integration)](https://eso-hub.com/en/build-editor)
+- [ESO penetration & the 18,200 cap (over-penetration is wasted)](https://hyperioxes.com/eso/tools/penetration-calculator)
+- [ESO critical damage 125% hard cap / crit rating ÷ 21,918](https://eso-hub.com/en/guides/critical-damage) · [UESP: Critical Damage](https://en.uesp.net/wiki/Online:Critical_Damage)
 </content>
 </invoke>

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionChampionPoints.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionChampionPoints.test.ts
@@ -1,0 +1,56 @@
+import { ChampionPointTree } from '@/types/champion-points';
+
+import { buildChampionPointsViewModel, UNKNOWN_TREE } from '../esotkCompanionChampionPoints';
+import type { CompanionChampionPoints } from '../esotkCompanionParser';
+
+// 25 = Deadly Aim (Warfare), 27 = Thaumaturge (Warfare), 4 = Untamed Aggression (Fitness),
+// 999999 = unmapped id → Unknown bucket.
+const cp: CompanionChampionPoints = {
+  total: 3600,
+  disciplines: {
+    1: { id: 1, skills: { 25: 50, 27: 20 } },
+    3: { id: 3, skills: { 4: 50, 999999: 10 } },
+  },
+  slotted: { 1: 29, 5: 25, 9: 4 },
+};
+
+describe('buildChampionPointsViewModel', () => {
+  it('returns null for empty input', () => {
+    expect(buildChampionPointsViewModel(undefined)).toBeNull();
+    expect(buildChampionPointsViewModel({ disciplines: {}, slotted: {} })).toBeNull();
+  });
+
+  it('flattens allocation, names stars, and sorts by points desc', () => {
+    const vm = buildChampionPointsViewModel(cp)!;
+    expect(vm.total).toBe(3600);
+    expect(vm.totalAllocated).toBe(130); // 50+20+50+10
+    // 50,50,20,10 → ties (25 & 4 at 50) break by id ascending
+    expect(vm.allocated.map((s) => s.id)).toEqual([4, 25, 27, 999999]);
+    const deadly = vm.allocated.find((s) => s.id === 25)!;
+    expect(deadly.name).toBe('Deadly Aim');
+    expect(deadly.tree).toBe(ChampionPointTree.Warfare);
+    expect(deadly.verified).toBe(true);
+  });
+
+  it('buckets unmapped ids under Unknown with a fallback name', () => {
+    const vm = buildChampionPointsViewModel(cp)!;
+    const unknown = vm.byTree[UNKNOWN_TREE];
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0].id).toBe(999999);
+    expect(unknown[0].name).toContain('Unknown');
+    expect(unknown[0].verified).toBe(false);
+  });
+
+  it('groups by tree', () => {
+    const vm = buildChampionPointsViewModel(cp)!;
+    expect(vm.byTree[ChampionPointTree.Warfare].map((s) => s.id).sort()).toEqual([25, 27]);
+    expect(vm.byTree[ChampionPointTree.Fitness].map((s) => s.id)).toEqual([4]);
+    expect(vm.byTree[ChampionPointTree.Craft]).toHaveLength(0);
+  });
+
+  it('lists slotted stars in slot order, named, dropping empty slots', () => {
+    const vm = buildChampionPointsViewModel(cp)!;
+    expect(vm.slotted.map((s) => s.slot)).toEqual([1, 5, 9]);
+    expect(vm.slotted.find((s) => s.slot === 5)!.name).toBe('Deadly Aim');
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionChampionPoints.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionChampionPoints.test.ts
@@ -53,4 +53,17 @@ describe('buildChampionPointsViewModel', () => {
     expect(vm.slotted.map((s) => s.slot)).toEqual([1, 5, 9]);
     expect(vm.slotted.find((s) => s.slot === 5)!.name).toBe('Deadly Aim');
   });
+
+  it('falls back to the addon-captured name for ids the canonical map does not know', () => {
+    const withNames: CompanionChampionPoints = {
+      disciplines: { 1: { id: 1, type: 1, spent: 10, skills: { 999999: 10 } } },
+      slotted: { 5: 999999 },
+      names: { 999999: 'Some Obscure Star' },
+    };
+    const vm = buildChampionPointsViewModel(withNames)!;
+    const star = vm.allocated.find((s) => s.id === 999999)!;
+    expect(star.name).toBe('Some Obscure Star'); // captured name, not "Unknown"
+    expect(star.verified).toBe(false); // still not a canonical-map hit
+    expect(vm.slotted.find((s) => s.slot === 5)!.name).toBe('Some Obscure Star');
+  });
 });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
@@ -68,6 +68,12 @@ describe('computeStatCoaching — crit', () => {
     expect(cc.detail).toContain('100%');
   });
 
+  it('caps displayed crit chance at 100%', () => {
+    const cc = computeStatCoaching({ weaponCrit: 30000 }).find((i) => i.id === 'critChance')!;
+    expect(cc.value).toBe(100);
+    expect(cc.detail).toContain('100%');
+  });
+
   it('returns nothing for undefined stats', () => {
     expect(computeStatCoaching(undefined)).toEqual([]);
   });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
@@ -11,10 +11,19 @@ describe('computeStatCoaching — penetration', () => {
     expect(pen.detail).toMatch(/point-in-time/i);
   });
 
-  it('uses the higher of physical/spell penetration', () => {
+  it('uses the higher of physical/spell penetration (spell higher)', () => {
     const stats: CompanionStats = { physicalPen: 5000, spellPen: 9000 };
     const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
     expect(pen.value).toBe(9000);
+    // Below the cap, but still no over/under verdict — the cap comparison is gone.
+    expect(pen.severity).toBe('info');
+  });
+
+  it('uses the higher of physical/spell penetration (physical higher)', () => {
+    const stats: CompanionStats = { physicalPen: 9000, spellPen: 5000 };
+    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
+    expect(pen.value).toBe(9000);
+    expect(pen.severity).toBe('info');
   });
 
   it('skips penetration when there is no data', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
@@ -1,0 +1,74 @@
+import {
+  computeStatCoaching,
+  PVE_PENETRATION_CAP,
+  STANDARD_GROUP_PEN,
+} from '../esotkCompanionCoaching';
+import type { CompanionStats } from '../esotkCompanionParser';
+
+describe('computeStatCoaching — penetration', () => {
+  it('flags over-penetration as wasted', () => {
+    const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP + 3200 };
+    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
+    expect(pen.severity).toBe('warn');
+    expect(pen.label).toMatch(/over/i);
+    expect(pen.detail).toContain('3,200');
+    expect(pen.value).toBe(PVE_PENETRATION_CAP + 3200);
+  });
+
+  it('flags under-penetration as lost damage', () => {
+    const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP - 1300 };
+    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
+    expect(pen.label).toMatch(/under/i);
+    expect(pen.detail).toContain('1,300');
+  });
+
+  it('reports on-cap as good', () => {
+    const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP };
+    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
+    expect(pen.severity).toBe('good');
+  });
+
+  it('adds an assumed group-pen contribution for a live estimate', () => {
+    // self 7,200 + 11,030 group ≈ 18,230 → on cap
+    const stats: CompanionStats = { physicalPen: 7200 };
+    const pen = computeStatCoaching(stats, { assumedGroupPen: STANDARD_GROUP_PEN }).find(
+      (i) => i.id === 'penetration',
+    )!;
+    expect(pen.severity).toBe('good');
+    expect(pen.detail).toContain('assumed');
+    expect(pen.value).toBe(7200 + STANDARD_GROUP_PEN);
+  });
+
+  it('uses the higher of physical/spell penetration', () => {
+    const stats: CompanionStats = { physicalPen: 5000, spellPen: PVE_PENETRATION_CAP };
+    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
+    expect(pen.severity).toBe('good');
+  });
+
+  it('skips penetration when there is no data', () => {
+    expect(computeStatCoaching({}).find((i) => i.id === 'penetration')).toBeUndefined();
+  });
+});
+
+describe('computeStatCoaching — crit', () => {
+  it('flags crit damage over the 125% cap', () => {
+    const cd = computeStatCoaching({ critDamage: 130 }).find((i) => i.id === 'critDamage')!;
+    expect(cd.severity).toBe('warn');
+    expect(cd.detail).toContain('5%');
+  });
+
+  it('reports crit damage headroom under the cap', () => {
+    const cd = computeStatCoaching({ critDamage: 110 }).find((i) => i.id === 'critDamage')!;
+    expect(cd.severity).toBe('info');
+    expect(cd.detail).toContain('15%');
+  });
+
+  it('converts crit rating to a percentage', () => {
+    const cc = computeStatCoaching({ weaponCrit: 21918 }).find((i) => i.id === 'critChance')!;
+    expect(cc.detail).toContain('100%');
+  });
+
+  it('returns nothing for undefined stats', () => {
+    expect(computeStatCoaching(undefined)).toEqual([]);
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionCoaching.test.ts
@@ -1,48 +1,20 @@
-import {
-  computeStatCoaching,
-  PVE_PENETRATION_CAP,
-  STANDARD_GROUP_PEN,
-} from '../esotkCompanionCoaching';
+import { computeStatCoaching, PVE_PENETRATION_CAP } from '../esotkCompanionCoaching';
 import type { CompanionStats } from '../esotkCompanionParser';
 
 describe('computeStatCoaching — penetration', () => {
-  it('flags over-penetration as wasted', () => {
+  it('reports self penetration as a point-in-time figure, not a cap verdict', () => {
     const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP + 3200 };
     const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
-    expect(pen.severity).toBe('warn');
-    expect(pen.label).toMatch(/over/i);
-    expect(pen.detail).toContain('3,200');
+    expect(pen.severity).toBe('info');
+    expect(pen.label).not.toMatch(/over|under|cap/i);
     expect(pen.value).toBe(PVE_PENETRATION_CAP + 3200);
-  });
-
-  it('flags under-penetration as lost damage', () => {
-    const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP - 1300 };
-    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
-    expect(pen.label).toMatch(/under/i);
-    expect(pen.detail).toContain('1,300');
-  });
-
-  it('reports on-cap as good', () => {
-    const stats: CompanionStats = { physicalPen: PVE_PENETRATION_CAP };
-    const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
-    expect(pen.severity).toBe('good');
-  });
-
-  it('adds an assumed group-pen contribution for a live estimate', () => {
-    // self 7,200 + 11,030 group ≈ 18,230 → on cap
-    const stats: CompanionStats = { physicalPen: 7200 };
-    const pen = computeStatCoaching(stats, { assumedGroupPen: STANDARD_GROUP_PEN }).find(
-      (i) => i.id === 'penetration',
-    )!;
-    expect(pen.severity).toBe('good');
-    expect(pen.detail).toContain('assumed');
-    expect(pen.value).toBe(7200 + STANDARD_GROUP_PEN);
+    expect(pen.detail).toMatch(/point-in-time/i);
   });
 
   it('uses the higher of physical/spell penetration', () => {
-    const stats: CompanionStats = { physicalPen: 5000, spellPen: PVE_PENETRATION_CAP };
+    const stats: CompanionStats = { physicalPen: 5000, spellPen: 9000 };
     const pen = computeStatCoaching(stats).find((i) => i.id === 'penetration')!;
-    expect(pen.severity).toBe('good');
+    expect(pen.value).toBe(9000);
   });
 
   it('skips penetration when there is no data', () => {
@@ -51,18 +23,6 @@ describe('computeStatCoaching — penetration', () => {
 });
 
 describe('computeStatCoaching — crit', () => {
-  it('flags crit damage over the 125% cap', () => {
-    const cd = computeStatCoaching({ critDamage: 130 }).find((i) => i.id === 'critDamage')!;
-    expect(cd.severity).toBe('warn');
-    expect(cd.detail).toContain('5%');
-  });
-
-  it('reports crit damage headroom under the cap', () => {
-    const cd = computeStatCoaching({ critDamage: 110 }).find((i) => i.id === 'critDamage')!;
-    expect(cd.severity).toBe('info');
-    expect(cd.detail).toContain('15%');
-  });
-
   it('converts crit rating to a percentage', () => {
     const cc = computeStatCoaching({ weaponCrit: 21918 }).find((i) => i.id === 'critChance')!;
     expect(cc.detail).toContain('100%');

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -49,10 +49,8 @@ describe('matchCompanionSnapshots', () => {
     const near = snap({ ts: REPORT_START_S + 31 * 60, char: 'Casts-A-Lot' });
     const far = snap({ ts: REPORT_START_S + 2 * 60, char: 'Casts-A-Lot' });
     const { matches } = matchCompanionSnapshots([far, near], report);
-    // both are in-window (distance 0); the matcher keeps the first 0-distance hit,
-    // so assert it matched one of them and reported zero distance
     expect(matches.get(1)?.distanceMs).toBe(0);
-    expect([near, far]).toContain(matches.get(1)?.snapshot);
+    expect(matches.get(1)?.snapshot).toBe(near);
   });
 
   it('rejects server mismatch', () => {
@@ -60,6 +58,32 @@ describe('matchCompanionSnapshots', () => {
     const { matches, unmatched } = matchCompanionSnapshots([s], report);
     expect(matches.has(1)).toBe(false);
     expect(unmatched).toContain(s);
+  });
+
+  it('matches server names case-insensitively', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'na' });
+    const { matches } = matchCompanionSnapshots([s], report);
+    expect(matches.get(1)?.snapshot).toBe(s);
+  });
+
+  it('uses the target fight to select the correct combat-end snapshot', () => {
+    const firstFight = snap({
+      ts: REPORT_START_S + 5 * 60 + 2,
+      char: 'Casts-A-Lot',
+      server: 'NA',
+    });
+    const secondFight = snap({
+      ts: REPORT_START_S + 35 * 60 + 2,
+      char: 'Casts-A-Lot',
+      server: 'NA',
+    });
+
+    const { matches } = matchCompanionSnapshots([firstFight, secondFight], report, {
+      targetFightId: 'f2',
+    });
+
+    expect(matches.get(1)?.snapshot).toBe(secondFight);
+    expect(matches.get(1)?.fightId).toBe('f2');
   });
 
   it('rejects snapshots outside the report window (beyond slop)', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -1,7 +1,9 @@
 import type { CompanionSnapshot } from '../esotkCompanionParser';
 import { matchCompanionSnapshots, type MatchableReport } from '../esotkCompanionMatcher';
 
-function snap(partial: Partial<CompanionSnapshot> & { ts: number; char: string }): CompanionSnapshot {
+function snap(
+  partial: Partial<CompanionSnapshot> & { ts: number; char: string },
+): CompanionSnapshot {
   return { ...partial };
 }
 

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -19,8 +19,8 @@ const report: MatchableReport = {
     { id: 2, name: 'Tanky-Mctankface', server: 'NA' },
   ],
   fights: [
-    { id: 'f1', startTime: 0, endTime: 5 * 60 * 1000 },
-    { id: 'f2', startTime: 30 * 60 * 1000, endTime: 35 * 60 * 1000 },
+    { id: 'f1', startTime: 0, endTime: 5 * 60 * 1000, zoneId: 1196 },
+    { id: 'f2', startTime: 30 * 60 * 1000, endTime: 35 * 60 * 1000, zoneId: 1196 },
   ],
 };
 
@@ -84,6 +84,22 @@ describe('matchCompanionSnapshots', () => {
 
     expect(matches.get(1)?.snapshot).toBe(secondFight);
     expect(matches.get(1)?.fightId).toBe('f2');
+  });
+
+  it('rejects snapshots whose zone disagrees with the target fight', () => {
+    const s = snap({
+      ts: REPORT_START_S + 60,
+      char: 'Casts-A-Lot',
+      server: 'NA',
+      zoneId: 9999,
+    });
+
+    const { matches, unmatched } = matchCompanionSnapshots([s], report, {
+      targetFightId: 'f1',
+    });
+
+    expect(matches.has(1)).toBe(false);
+    expect(unmatched).toContain(s);
   });
 
   it('rejects snapshots outside the report window (beyond slop)', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -14,9 +14,11 @@ const REPORT_START_S = REPORT_START_MS / 1000;
 const report: MatchableReport = {
   startTime: REPORT_START_MS,
   endTime: REPORT_START_MS + 60 * 60 * 1000, // 1h
+  // ESO Logs actors carry region-tagged servers like "PC-NA" — a different vocabulary
+  // from the addon's "NA Megaserver", which is exactly what the region match must bridge.
   actors: [
-    { id: 1, name: 'Casts-A-Lot', server: 'NA' },
-    { id: 2, name: 'Tanky-Mctankface', server: 'NA' },
+    { id: 1, name: 'Casts-A-Lot', server: 'PC-NA' },
+    { id: 2, name: 'Tanky-Mctankface', server: 'PC-NA' },
   ],
   fights: [
     { id: 'f1', startTime: 0, endTime: 5 * 60 * 1000, zoneId: 1196 },
@@ -25,8 +27,8 @@ const report: MatchableReport = {
 };
 
 describe('matchCompanionSnapshots', () => {
-  it('matches an actor to an in-window snapshot by name and server', () => {
-    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'NA' });
+  it('matches an actor to an in-window snapshot across server vocabularies (NA Megaserver ↔ PC-NA)', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'NA Megaserver' });
     const { matches } = matchCompanionSnapshots([s], report);
     expect(matches.get(1)?.snapshot).toBe(s);
     expect(matches.get(1)?.distanceMs).toBe(0);
@@ -53,15 +55,22 @@ describe('matchCompanionSnapshots', () => {
     expect(matches.get(1)?.snapshot).toBe(near);
   });
 
-  it('rejects server mismatch', () => {
-    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'EU' });
+  it('rejects a provable region conflict (EU Megaserver ↔ PC-NA)', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'EU Megaserver' });
     const { matches, unmatched } = matchCompanionSnapshots([s], report);
     expect(matches.has(1)).toBe(false);
     expect(unmatched).toContain(s);
   });
 
-  it('matches server names case-insensitively', () => {
-    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'na' });
+  it('classifies region from either vocabulary, case-insensitively', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'na megaserver' });
+    const { matches } = matchCompanionSnapshots([s], report);
+    expect(matches.get(1)?.snapshot).toBe(s);
+  });
+
+  it('falls through to name + time when the snapshot server is unclassifiable', () => {
+    // e.g. "PTS" or an empty/unknown world — never reject on this alone.
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'PTS' });
     const { matches } = matchCompanionSnapshots([s], report);
     expect(matches.get(1)?.snapshot).toBe(s);
   });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -1,0 +1,77 @@
+import type { CompanionSnapshot } from '../esotkCompanionParser';
+import { matchCompanionSnapshots, type MatchableReport } from '../esotkCompanionMatcher';
+
+function snap(partial: Partial<CompanionSnapshot> & { ts: number; char: string }): CompanionSnapshot {
+  return { ...partial };
+}
+
+// Report starts at a round UNIX ms; snapshots use UNIX seconds.
+const REPORT_START_MS = 1_749_384_000_000;
+const REPORT_START_S = REPORT_START_MS / 1000;
+
+const report: MatchableReport = {
+  startTime: REPORT_START_MS,
+  endTime: REPORT_START_MS + 60 * 60 * 1000, // 1h
+  actors: [
+    { id: 1, name: 'Casts-A-Lot', server: 'NA' },
+    { id: 2, name: 'Tanky-Mctankface', server: 'NA' },
+  ],
+  fights: [
+    { id: 'f1', startTime: 0, endTime: 5 * 60 * 1000 },
+    { id: 'f2', startTime: 30 * 60 * 1000, endTime: 35 * 60 * 1000 },
+  ],
+};
+
+describe('matchCompanionSnapshots', () => {
+  it('matches an actor to an in-window snapshot by name and server', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'NA' });
+    const { matches } = matchCompanionSnapshots([s], report);
+    expect(matches.get(1)?.snapshot).toBe(s);
+    expect(matches.get(1)?.distanceMs).toBe(0);
+  });
+
+  it('attaches the nearest fight', () => {
+    // snapshot taken ~just after fight f2's window
+    const s = snap({ ts: REPORT_START_S + 33 * 60, char: 'Casts-A-Lot', server: 'NA' });
+    const { matches } = matchCompanionSnapshots([s], report);
+    expect(matches.get(1)?.fightId).toBe('f2');
+  });
+
+  it('is case-insensitive and tolerates a leading @', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: '@casts-a-lot' });
+    const { matches } = matchCompanionSnapshots([s], report);
+    expect(matches.get(1)?.snapshot).toBe(s);
+  });
+
+  it('picks the closest snapshot when several match', () => {
+    const near = snap({ ts: REPORT_START_S + 31 * 60, char: 'Casts-A-Lot' });
+    const far = snap({ ts: REPORT_START_S + 2 * 60, char: 'Casts-A-Lot' });
+    const { matches } = matchCompanionSnapshots([far, near], report);
+    // both are in-window (distance 0); the matcher keeps the first 0-distance hit,
+    // so assert it matched one of them and reported zero distance
+    expect(matches.get(1)?.distanceMs).toBe(0);
+    expect([near, far]).toContain(matches.get(1)?.snapshot);
+  });
+
+  it('rejects server mismatch', () => {
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'EU' });
+    const { matches, unmatched } = matchCompanionSnapshots([s], report);
+    expect(matches.has(1)).toBe(false);
+    expect(unmatched).toContain(s);
+  });
+
+  it('rejects snapshots outside the report window (beyond slop)', () => {
+    const s = snap({ ts: REPORT_START_S + 24 * 60 * 60, char: 'Casts-A-Lot' }); // a day later
+    const { matches, unmatched } = matchCompanionSnapshots([s], report);
+    expect(matches.has(1)).toBe(false);
+    expect(unmatched).toContain(s);
+  });
+
+  it('returns unmatched snapshots (e.g. anonymised report names)', () => {
+    const anonReport: MatchableReport = { ...report, actors: [{ id: 9, name: 'Random 1' }] };
+    const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot' });
+    const { matches, unmatched } = matchCompanionSnapshots([s], anonReport);
+    expect(matches.size).toBe(0);
+    expect(unmatched).toEqual([s]);
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -22,7 +22,9 @@ ESOTKCompanionSV =
                         ["server"] = "NA",
                         ["zoneId"] = 1196,
                         ["classId"] = 6,
+                        ["className"] = "Arcanist",
                         ["raceId"] = 4,
+                        ["raceName"] = "Khajiit",
                         ["level"] = 50,
                         ["cpRank"] = 3600,
                         ["role"] = 1,
@@ -56,6 +58,7 @@ ESOTKCompanionSV =
                             ["spellDamage"] = 4500,
                             ["physicalPen"] = 18200,
                             ["weaponCrit"] = 8000,
+                            ["critDamage"] = 125,
                         },
                         ["attrs"] =
                         {
@@ -134,6 +137,7 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.stats!.spellDamage).toBe(4500);
     expect(snap.stats!.physicalPen).toBe(18200);
     expect(snap.stats!.weaponCrit).toBe(8000);
+    expect(snap.stats!.critDamage).toBe(125);
     expect(snap.attributes).toEqual({ magicka: 0, health: 0, stamina: 64 });
   });
 
@@ -142,6 +146,10 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.char).toBe('Casts-A-Lot');
     expect(snap.server).toBe('NA');
     expect(snap.ts).toBe(1749384000);
+    expect(snap.classId).toBe(6);
+    expect(snap.className).toBe('Arcanist');
+    expect(snap.raceId).toBe(4);
+    expect(snap.raceName).toBe('Khajiit');
     expect(snap.effects).toEqual([{ id: 13984, name: 'Boon: The Lover', duration: 0 }]);
     expect(snap.bars!.front).toEqual({ 3: 28800, 4: 38901 });
     expect(snap.bars!.back).toEqual({ 3: 46324 });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -1,7 +1,4 @@
-import {
-  isESOTKCompanionFormat,
-  parseESOTKCompanionSavedVariables,
-} from '../esotkCompanionParser';
+import { isESOTKCompanionFormat, parseESOTKCompanionSavedVariables } from '../esotkCompanionParser';
 
 const SAMPLE = `
 ESOTKCompanionSV =

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -16,6 +16,8 @@ ESOTKCompanionSV =
                 {
                     [1] =
                     {
+                        ["schemaVersion"] = 2,
+                        ["season"] = "U51",
                         ["ts"] = 1749384000,
                         ["char"] = "Casts-A-Lot",
                         ["account"] = "@brayden",
@@ -100,6 +102,7 @@ describe('parseESOTKCompanionSavedVariables', () => {
   it('detects the companion format', () => {
     expect(isESOTKCompanionFormat(SAMPLE)).toBe(true);
     expect(isESOTKCompanionFormat('SomethingElseSV = {}')).toBe(false);
+    expect(isESOTKCompanionFormat('ESOTKCompanionSV = {}')).toBe(false);
   });
 
   it('returns null for non-companion files', () => {
@@ -146,6 +149,8 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.char).toBe('Casts-A-Lot');
     expect(snap.server).toBe('NA');
     expect(snap.ts).toBe(1749384000);
+    expect(snap.schemaVersion).toBe(2);
+    expect(snap.season).toBe('U51');
     expect(snap.classId).toBe(6);
     expect(snap.className).toBe('Arcanist');
     expect(snap.raceId).toBe(4);
@@ -153,6 +158,13 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.effects).toEqual([{ id: 13984, name: 'Boon: The Lover', duration: 0 }]);
     expect(snap.bars!.front).toEqual({ 3: 28800, 4: 38901 });
     expect(snap.bars!.back).toEqual({ 3: 46324 });
+  });
+
+  it('falls back to bucket metadata when a snapshot omits account/schema/season', () => {
+    const snap = parseESOTKCompanionSavedVariables(SAMPLE)!.all[1];
+    expect(snap.account).toBe('@brayden');
+    expect(snap.schemaVersion).toBe(1);
+    expect(snap.season).toBe('U50');
   });
 
   it('drops snapshots missing the match keys (ts / char)', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -171,8 +171,6 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.stats!.spellDamage).toBe(4500);
     expect(snap.stats!.physicalPen).toBe(18200);
     expect(snap.stats!.weaponCrit).toBe(8000);
-    // Crit damage is never captured (no ESO stat constant) — ESOTK computes it instead.
-    expect(snap.stats!.critDamage).toBeUndefined();
     expect(snap.attributes).toEqual({ magicka: 0, health: 0, stamina: 64 });
   });
 

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -1,0 +1,163 @@
+import {
+  isESOTKCompanionFormat,
+  parseESOTKCompanionSavedVariables,
+} from '../esotkCompanionParser';
+
+const SAMPLE = `
+ESOTKCompanionSV =
+{
+    ["Default"] =
+    {
+        ["@brayden"] =
+        {
+            ["$AccountWide"] =
+            {
+                ["schemaVersion"] = 1,
+                ["season"] = "U50",
+                ["enabled"] = true,
+                ["snapshots"] =
+                {
+                    [1] =
+                    {
+                        ["ts"] = 1749384000,
+                        ["char"] = "Casts-A-Lot",
+                        ["account"] = "@brayden",
+                        ["server"] = "NA",
+                        ["zoneId"] = 1196,
+                        ["classId"] = 6,
+                        ["raceId"] = 4,
+                        ["level"] = 50,
+                        ["cpRank"] = 3600,
+                        ["role"] = 1,
+                        ["reason"] = "combatEnd",
+                        ["cp"] =
+                        {
+                            ["total"] = 3600,
+                            ["disciplines"] =
+                            {
+                                [1] =
+                                {
+                                    ["id"] = 1,
+                                    ["type"] = 0,
+                                    ["spent"] = 100,
+                                    ["skills"] =
+                                    {
+                                        [25] = 50,
+                                        [27] = 50,
+                                    },
+                                },
+                            },
+                            ["slotted"] =
+                            {
+                                [1] = 29,
+                                [5] = 25,
+                                [9] = 4,
+                            },
+                        },
+                        ["stats"] =
+                        {
+                            ["spellDamage"] = 4500,
+                            ["physicalPen"] = 18200,
+                            ["weaponCrit"] = 8000,
+                        },
+                        ["attrs"] =
+                        {
+                            ["magicka"] = 0,
+                            ["health"] = 0,
+                            ["stamina"] = 64,
+                        },
+                        ["effects"] =
+                        {
+                            [1] =
+                            {
+                                ["id"] = 13984,
+                                ["name"] = "Boon: The Lover",
+                                ["duration"] = 0,
+                            },
+                        },
+                        ["bars"] =
+                        {
+                            ["front"] = { [3] = 28800, [4] = 38901 },
+                            ["back"] = { [3] = 46324 },
+                        },
+                    },
+                    [2] =
+                    {
+                        ["ts"] = 1749384600,
+                        ["char"] = "Casts-A-Lot",
+                        ["server"] = "NA",
+                        ["reason"] = "manual",
+                        ["cp"] = { ["total"] = 3600, ["disciplines"] = {}, ["slotted"] = {} },
+                    },
+                },
+            },
+        },
+    },
+}
+`;
+
+describe('parseESOTKCompanionSavedVariables', () => {
+  it('detects the companion format', () => {
+    expect(isESOTKCompanionFormat(SAMPLE)).toBe(true);
+    expect(isESOTKCompanionFormat('SomethingElseSV = {}')).toBe(false);
+  });
+
+  it('returns null for non-companion files', () => {
+    expect(parseESOTKCompanionSavedVariables('WizardsWardrobeSV = {}')).toBeNull();
+  });
+
+  it('parses snapshots grouped by account, ordered by timestamp', () => {
+    const result = parseESOTKCompanionSavedVariables(SAMPLE);
+    expect(result).not.toBeNull();
+    expect(result!.schemaVersion).toBe(1);
+    expect(result!.season).toBe('U50');
+    expect(Object.keys(result!.byAccount)).toEqual(['@brayden']);
+    expect(result!.all).toHaveLength(2);
+    expect(result!.all[0].ts).toBeLessThan(result!.all[1].ts);
+  });
+
+  it('captures the full champion point allocation — the gap ESO Logs lacks', () => {
+    const result = parseESOTKCompanionSavedVariables(SAMPLE)!;
+    const cp = result.all[0].championPoints!;
+    expect(cp.total).toBe(3600);
+
+    // per-star allocation, keyed by skill id
+    expect(cp.disciplines[1].spent).toBe(100);
+    expect(cp.disciplines[1].skills[25]).toBe(50);
+    expect(cp.disciplines[1].skills[27]).toBe(50);
+
+    // the 12 slotted stars (sparse)
+    expect(cp.slotted[1]).toBe(29);
+    expect(cp.slotted[5]).toBe(25);
+    expect(cp.slotted[9]).toBe(4);
+  });
+
+  it('captures final stats and attributes the API never exposes', () => {
+    const snap = parseESOTKCompanionSavedVariables(SAMPLE)!.all[0];
+    expect(snap.stats!.spellDamage).toBe(4500);
+    expect(snap.stats!.physicalPen).toBe(18200);
+    expect(snap.stats!.weaponCrit).toBe(8000);
+    expect(snap.attributes).toEqual({ magicka: 0, health: 0, stamina: 64 });
+  });
+
+  it('captures match keys, effects and bars', () => {
+    const snap = parseESOTKCompanionSavedVariables(SAMPLE)!.all[0];
+    expect(snap.char).toBe('Casts-A-Lot');
+    expect(snap.server).toBe('NA');
+    expect(snap.ts).toBe(1749384000);
+    expect(snap.effects).toEqual([{ id: 13984, name: 'Boon: The Lover', duration: 0 }]);
+    expect(snap.bars!.front).toEqual({ 3: 28800, 4: 38901 });
+    expect(snap.bars!.back).toEqual({ 3: 46324 });
+  });
+
+  it('drops snapshots missing the match keys (ts / char)', () => {
+    const broken = `
+      ESOTKCompanionSV = { ["Default"] = { ["@x"] = { ["$AccountWide"] = {
+        ["schemaVersion"] = 1,
+        ["snapshots"] = { [1] = { ["char"] = "NoTimestamp" }, [2] = { ["ts"] = 1 } },
+      } } } }
+    `;
+    // both snapshots are unusable (one lacks ts, one lacks char) → no result
+    expect(parseESOTKCompanionSavedVariables(broken)).toBeNull();
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -82,6 +82,38 @@ ESOTKCompanionSV =
                             ["front"] = { [3] = 28800, [4] = 38901 },
                             ["back"] = { [3] = 46324 },
                         },
+                        ["scribing"] =
+                        {
+                            [1] =
+                            {
+                                ["abilityId"] = 217340,
+                                ["name"] = "Shattering Knife",
+                                ["bar"] = "front",
+                                ["slot"] = 3,
+                                ["scripts"] =
+                                {
+                                    [1] =
+                                    {
+                                        ["id"] = 1,
+                                        ["slot"] = 1,
+                                        ["name"] = "Magic Damage",
+                                        ["icon"] = "script_magic",
+                                    },
+                                    [2] =
+                                    {
+                                        ["id"] = 31,
+                                        ["slot"] = 2,
+                                        ["name"] = "Class Mastery",
+                                    },
+                                    [3] =
+                                    {
+                                        ["id"] = 42,
+                                        ["slot"] = 3,
+                                        ["name"] = "Major Breach",
+                                    },
+                                },
+                            },
+                        },
                     },
                     [2] =
                     {
@@ -158,6 +190,9 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.effects).toEqual([{ id: 13984, name: 'Boon: The Lover', duration: 0 }]);
     expect(snap.bars!.front).toEqual({ 3: 28800, 4: 38901 });
     expect(snap.bars!.back).toEqual({ 3: 46324 });
+    expect(snap.scribing![0].abilityId).toBe(217340);
+    expect(snap.scribing![0].name).toBe('Shattering Knife');
+    expect(snap.scribing![0].scripts[2].name).toBe('Class Mastery');
   });
 
   it('falls back to bucket metadata when a snapshot omits account/schema/season', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -21,7 +21,7 @@ ESOTKCompanionSV =
                         ["ts"] = 1749384000,
                         ["char"] = "Casts-A-Lot",
                         ["account"] = "@brayden",
-                        ["server"] = "NA",
+                        ["server"] = "NA Megaserver",
                         ["zoneId"] = 1196,
                         ["classId"] = 6,
                         ["className"] = "Arcanist",
@@ -60,7 +60,6 @@ ESOTKCompanionSV =
                             ["spellDamage"] = 4500,
                             ["physicalPen"] = 18200,
                             ["weaponCrit"] = 8000,
-                            ["critDamage"] = 125,
                         },
                         ["attrs"] =
                         {
@@ -119,7 +118,7 @@ ESOTKCompanionSV =
                     {
                         ["ts"] = 1749384600,
                         ["char"] = "Casts-A-Lot",
-                        ["server"] = "NA",
+                        ["server"] = "NA Megaserver",
                         ["reason"] = "manual",
                         ["cp"] = { ["total"] = 3600, ["disciplines"] = {}, ["slotted"] = {} },
                     },
@@ -172,14 +171,15 @@ describe('parseESOTKCompanionSavedVariables', () => {
     expect(snap.stats!.spellDamage).toBe(4500);
     expect(snap.stats!.physicalPen).toBe(18200);
     expect(snap.stats!.weaponCrit).toBe(8000);
-    expect(snap.stats!.critDamage).toBe(125);
+    // Crit damage is never captured (no ESO stat constant) — ESOTK computes it instead.
+    expect(snap.stats!.critDamage).toBeUndefined();
     expect(snap.attributes).toEqual({ magicka: 0, health: 0, stamina: 64 });
   });
 
   it('captures match keys, effects and bars', () => {
     const snap = parseESOTKCompanionSavedVariables(SAMPLE)!.all[0];
     expect(snap.char).toBe('Casts-A-Lot');
-    expect(snap.server).toBe('NA');
+    expect(snap.server).toBe('NA Megaserver');
     expect(snap.ts).toBe(1749384000);
     expect(snap.schemaVersion).toBe(2);
     expect(snap.season).toBe('U51');

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
@@ -30,6 +30,19 @@ const snapshot: CompanionSnapshot = {
   },
   stats: { physicalPen: PVE_PENETRATION_CAP + 3200 },
   effects: [{ id: 13984, name: 'Boon: The Lover', duration: 0 }],
+  scribing: [
+    {
+      abilityId: 217340,
+      name: 'Shattering Knife',
+      bar: 'front',
+      slot: 3,
+      scripts: {
+        1: { id: 1, slot: 1, name: 'Magic Damage' },
+        2: { id: 31, slot: 2, name: 'Class Mastery' },
+        3: { id: 42, slot: 3, name: 'Major Breach' },
+      },
+    },
+  ],
 };
 
 describe('buildCompanionBuildsForReport', () => {
@@ -47,6 +60,7 @@ describe('buildCompanionBuildsForReport', () => {
     expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('warn');
     expect(build.stats).toBe(snapshot.stats);
     expect(build.effects).toBe(snapshot.effects);
+    expect(build.scribing).toBe(snapshot.scribing);
     expect(build.fightId).toBe('f1');
     expect(build.snapshot).toBe(snapshot);
   });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
@@ -29,6 +29,7 @@ const snapshot: CompanionSnapshot = {
     slotted: { 5: 25 },
   },
   stats: { physicalPen: PVE_PENETRATION_CAP + 3200 },
+  effects: [{ id: 13984, name: 'Boon: The Lover', duration: 0 }],
 };
 
 describe('buildCompanionBuildsForReport', () => {
@@ -44,6 +45,8 @@ describe('buildCompanionBuildsForReport', () => {
     expect(build.championPoints!.total).toBe(3600);
     expect(build.championPoints!.allocated[0].name).toBe('Deadly Aim');
     expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('warn');
+    expect(build.stats).toBe(snapshot.stats);
+    expect(build.effects).toBe(snapshot.effects);
     expect(build.fightId).toBe('f1');
     expect(build.snapshot).toBe(snapshot);
   });

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
@@ -57,25 +57,12 @@ describe('buildCompanionBuildsForReport', () => {
     const build = buildCompanionBuildsForReport([snapshot], report).get(1)!;
     expect(build.championPoints!.total).toBe(3600);
     expect(build.championPoints!.allocated[0].name).toBe('Deadly Aim');
-    expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('warn');
+    expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('info');
     expect(build.stats).toBe(snapshot.stats);
     expect(build.effects).toBe(snapshot.effects);
     expect(build.scribing).toBe(snapshot.scribing);
     expect(build.fightId).toBe('f1');
     expect(build.snapshot).toBe(snapshot);
-  });
-
-  it('passes coaching options through (assumed group pen)', () => {
-    const selfPenSnap: CompanionSnapshot = {
-      ts: REPORT_START_S + 60,
-      char: 'Casts-A-Lot',
-      stats: { physicalPen: 7200 },
-    };
-    const build = buildCompanionBuildsForReport([selfPenSnap], report, {
-      coaching: { assumedGroupPen: 11030 },
-    }).get(1)!;
-    // 7200 + 11030 ≈ on cap → good
-    expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('good');
   });
 
   it('passes the target fight through to snapshot matching', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
@@ -13,7 +13,10 @@ const report: MatchableReport = {
     { id: 1, name: 'Casts-A-Lot', server: 'NA' },
     { id: 2, name: 'Tanky', server: 'NA' },
   ],
-  fights: [{ id: 'f1', startTime: 0, endTime: 5 * 60 * 1000 }],
+  fights: [
+    { id: 'f1', startTime: 0, endTime: 5 * 60 * 1000 },
+    { id: 'f2', startTime: 30 * 60 * 1000, endTime: 35 * 60 * 1000 },
+  ],
 };
 
 const snapshot: CompanionSnapshot = {
@@ -56,6 +59,28 @@ describe('buildCompanionBuildsForReport', () => {
     }).get(1)!;
     // 7200 + 11030 ≈ on cap → good
     expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('good');
+  });
+
+  it('passes the target fight through to snapshot matching', () => {
+    const firstFightSnapshot: CompanionSnapshot = {
+      ts: REPORT_START_S + 5 * 60 + 2,
+      char: 'Casts-A-Lot',
+      server: 'NA',
+      stats: { physicalPen: 5000 },
+    };
+    const secondFightSnapshot: CompanionSnapshot = {
+      ts: REPORT_START_S + 35 * 60 + 2,
+      char: 'Casts-A-Lot',
+      server: 'NA',
+      stats: { physicalPen: PVE_PENETRATION_CAP },
+    };
+
+    const build = buildCompanionBuildsForReport([firstFightSnapshot, secondFightSnapshot], report, {
+      targetFightId: 'f2',
+    }).get(1)!;
+
+    expect(build.snapshot).toBe(secondFightSnapshot);
+    expect(build.fightId).toBe('f2');
   });
 
   it('returns an empty map when nothing matches', () => {

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionReportAdapter.test.ts
@@ -1,0 +1,66 @@
+import { buildCompanionBuildsForReport } from '../esotkCompanionReportAdapter';
+import { PVE_PENETRATION_CAP } from '../esotkCompanionCoaching';
+import type { MatchableReport } from '../esotkCompanionMatcher';
+import type { CompanionSnapshot } from '../esotkCompanionParser';
+
+const REPORT_START_MS = 1_749_384_000_000;
+const REPORT_START_S = REPORT_START_MS / 1000;
+
+const report: MatchableReport = {
+  startTime: REPORT_START_MS,
+  endTime: REPORT_START_MS + 60 * 60 * 1000,
+  actors: [
+    { id: 1, name: 'Casts-A-Lot', server: 'NA' },
+    { id: 2, name: 'Tanky', server: 'NA' },
+  ],
+  fights: [{ id: 'f1', startTime: 0, endTime: 5 * 60 * 1000 }],
+};
+
+const snapshot: CompanionSnapshot = {
+  ts: REPORT_START_S + 60,
+  char: 'Casts-A-Lot',
+  server: 'NA',
+  championPoints: {
+    total: 3600,
+    disciplines: { 1: { id: 1, skills: { 25: 50 } } },
+    slotted: { 5: 25 },
+  },
+  stats: { physicalPen: PVE_PENETRATION_CAP + 3200 },
+};
+
+describe('buildCompanionBuildsForReport', () => {
+  it('produces render-ready props for the matched player only', () => {
+    const builds = buildCompanionBuildsForReport([snapshot], report);
+    expect(builds.size).toBe(1);
+    expect(builds.has(1)).toBe(true);
+    expect(builds.has(2)).toBe(false); // no snapshot for Tanky
+  });
+
+  it('builds the champion-point view-model and coaching from the snapshot', () => {
+    const build = buildCompanionBuildsForReport([snapshot], report).get(1)!;
+    expect(build.championPoints!.total).toBe(3600);
+    expect(build.championPoints!.allocated[0].name).toBe('Deadly Aim');
+    expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('warn');
+    expect(build.fightId).toBe('f1');
+    expect(build.snapshot).toBe(snapshot);
+  });
+
+  it('passes coaching options through (assumed group pen)', () => {
+    const selfPenSnap: CompanionSnapshot = {
+      ts: REPORT_START_S + 60,
+      char: 'Casts-A-Lot',
+      stats: { physicalPen: 7200 },
+    };
+    const build = buildCompanionBuildsForReport([selfPenSnap], report, {
+      coaching: { assumedGroupPen: 11030 },
+    }).get(1)!;
+    // 7200 + 11030 ≈ on cap → good
+    expect(build.coaching.find((i) => i.id === 'penetration')!.severity).toBe('good');
+  });
+
+  it('returns an empty map when nothing matches', () => {
+    expect(buildCompanionBuildsForReport([], report).size).toBe(0);
+    const anon: MatchableReport = { ...report, actors: [{ id: 9, name: 'Random 1' }] };
+    expect(buildCompanionBuildsForReport([snapshot], anon).size).toBe(0);
+  });
+});

--- a/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
@@ -48,7 +48,9 @@ export interface ChampionPointsViewModel {
 }
 
 function treeForStar(id: number): ChampionTreeKey {
-  return CHAMPION_POINT_ABILITIES[id as keyof typeof CHAMPION_POINT_ABILITIES]?.tree ?? UNKNOWN_TREE;
+  return (
+    CHAMPION_POINT_ABILITIES[id as keyof typeof CHAMPION_POINT_ABILITIES]?.tree ?? UNKNOWN_TREE
+  );
 }
 
 function emptyByTree(): Record<ChampionTreeKey, AllocatedStar[]> {

--- a/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
@@ -1,0 +1,105 @@
+/**
+ * Champion-point view-model — turns a captured CP snapshot into card-ready data.
+ *
+ * The companion captures the full per-star allocation (the gap ESO Logs can't see);
+ * this groups it by tree, names each star via the existing champion-point map, and
+ * surfaces the slotted stars and totals so a player-card panel can render it directly.
+ */
+
+import {
+  CHAMPION_POINT_ABILITIES,
+  ChampionPointTree,
+  getChampionPointAbilityName,
+  isChampionPointVerified,
+} from '@/types/champion-points';
+
+import type { CompanionChampionPoints } from './esotkCompanionParser';
+
+/** Bucket for stars whose id isn't in the known map yet (new/unmapped). */
+export const UNKNOWN_TREE = 'Unknown' as const;
+export type ChampionTreeKey = ChampionPointTree | typeof UNKNOWN_TREE;
+
+export interface AllocatedStar {
+  id: number;
+  name: string;
+  points: number;
+  tree: ChampionTreeKey;
+  /** Whether the id→name mapping is verified (vs a best-effort/unknown label). */
+  verified: boolean;
+}
+
+export interface SlottedStar {
+  slot: number;
+  id: number;
+  name: string;
+}
+
+export interface ChampionPointsViewModel {
+  /** Total earned champion points (CP rank), if captured. */
+  total?: number;
+  /** Sum of points actually spent across all stars. */
+  totalAllocated: number;
+  /** All stars with points > 0, sorted by points descending. */
+  allocated: AllocatedStar[];
+  /** Allocated stars grouped by tree. */
+  byTree: Record<ChampionTreeKey, AllocatedStar[]>;
+  /** The 12 slotted stars in slot order. */
+  slotted: SlottedStar[];
+}
+
+function treeForStar(id: number): ChampionTreeKey {
+  return CHAMPION_POINT_ABILITIES[id as keyof typeof CHAMPION_POINT_ABILITIES]?.tree ?? UNKNOWN_TREE;
+}
+
+function emptyByTree(): Record<ChampionTreeKey, AllocatedStar[]> {
+  return {
+    [ChampionPointTree.Craft]: [],
+    [ChampionPointTree.Warfare]: [],
+    [ChampionPointTree.Fitness]: [],
+    [UNKNOWN_TREE]: [],
+  };
+}
+
+/**
+ * Build a card-ready champion-point view-model from a captured CP snapshot.
+ * Returns `null` when there's nothing to show.
+ */
+export function buildChampionPointsViewModel(
+  cp: CompanionChampionPoints | undefined,
+): ChampionPointsViewModel | null {
+  if (!cp) return null;
+
+  const allocated: AllocatedStar[] = [];
+  for (const discipline of Object.values(cp.disciplines)) {
+    for (const [skillIdStr, points] of Object.entries(discipline.skills)) {
+      const id = Number(skillIdStr);
+      if (!Number.isFinite(id) || points <= 0) continue;
+      allocated.push({
+        id,
+        name: getChampionPointAbilityName(id),
+        points,
+        tree: treeForStar(id),
+        verified: isChampionPointVerified(id),
+      });
+    }
+  }
+  allocated.sort((a, b) => b.points - a.points || a.id - b.id);
+
+  const byTree = emptyByTree();
+  for (const star of allocated) {
+    byTree[star.tree].push(star);
+  }
+
+  const slotted: SlottedStar[] = Object.entries(cp.slotted)
+    .map(([slotStr, id]) => ({ slot: Number(slotStr), id, name: getChampionPointAbilityName(id) }))
+    .filter((s) => Number.isFinite(s.slot) && Number.isFinite(s.id) && s.id > 0)
+    .sort((a, b) => a.slot - b.slot);
+
+  const totalAllocated = allocated.reduce((sum, s) => sum + s.points, 0);
+
+  if (allocated.length === 0 && slotted.length === 0 && cp.total === undefined) {
+    return null;
+  }
+
+  return { total: cp.total, totalAllocated, allocated, byTree, slotted };
+}

--- a/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionChampionPoints.ts
@@ -71,18 +71,25 @@ export function buildChampionPointsViewModel(
 ): ChampionPointsViewModel | null {
   if (!cp) return null;
 
+  // Prefer ESOTK's canonical (English) name for known ids; otherwise fall back to the
+  // name the addon captured from the client, so even ids the map doesn't know read
+  // cleanly instead of as "Unknown". Only canonical-map hits count as verified.
+  const resolveName = (id: number): { name: string; verified: boolean } => {
+    if (isChampionPointVerified(id)) {
+      return { name: getChampionPointAbilityName(id), verified: true };
+    }
+    const captured = cp.names?.[id];
+    if (captured) return { name: captured, verified: false };
+    return { name: getChampionPointAbilityName(id), verified: false };
+  };
+
   const allocated: AllocatedStar[] = [];
   for (const discipline of Object.values(cp.disciplines)) {
     for (const [skillIdStr, points] of Object.entries(discipline.skills)) {
       const id = Number(skillIdStr);
       if (!Number.isFinite(id) || points <= 0) continue;
-      allocated.push({
-        id,
-        name: getChampionPointAbilityName(id),
-        points,
-        tree: treeForStar(id),
-        verified: isChampionPointVerified(id),
-      });
+      const { name, verified } = resolveName(id);
+      allocated.push({ id, name, points, tree: treeForStar(id), verified });
     }
   }
   allocated.sort((a, b) => b.points - a.points || a.id - b.id);
@@ -93,7 +100,7 @@ export function buildChampionPointsViewModel(
   }
 
   const slotted: SlottedStar[] = Object.entries(cp.slotted)
-    .map(([slotStr, id]) => ({ slot: Number(slotStr), id, name: getChampionPointAbilityName(id) }))
+    .map(([slotStr, id]) => ({ slot: Number(slotStr), id, name: resolveName(id).name }))
     .filter((s) => Number.isFinite(s.slot) && Number.isFinite(s.id) && s.id > 0)
     .sort((a, b) => a.slot - b.slot);
 

--- a/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
@@ -19,8 +19,8 @@ export const PVE_PENETRATION_CAP = 18200;
 export const STANDARD_GROUP_PEN = 11030;
 /** Crit damage hard cap (percent bonus over base); total crit hit = 225%. */
 export const CRIT_DAMAGE_CAP = 125;
-/** Crit rating per 1% crit chance. */
-export const CRIT_RATING_PER_PERCENT = 21918;
+/** Crit rating corresponding to 100 percentage points of crit chance. */
+export const CRIT_RATING_FOR_100_PERCENT = 21918;
 
 export type CoachingSeverity = 'good' | 'info' | 'warn' | 'error';
 
@@ -50,7 +50,7 @@ export interface CoachingOptions {
 }
 
 function critChancePercent(rating: number): number {
-  return Math.round((rating / CRIT_RATING_PER_PERCENT) * 1000) / 10; // one decimal
+  return Math.round((rating / CRIT_RATING_FOR_100_PERCENT) * 1000) / 10; // one decimal
 }
 
 function penetrationInsight(stats: CompanionStats, opts: CoachingOptions): CoachingInsight | null {

--- a/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
@@ -50,7 +50,7 @@ export interface CoachingOptions {
 }
 
 function critChancePercent(rating: number): number {
-  return Math.round((rating / CRIT_RATING_FOR_100_PERCENT) * 1000) / 10; // one decimal
+  return Math.min(100, Math.round((rating / CRIT_RATING_FOR_100_PERCENT) * 1000) / 10); // one decimal
 }
 
 function penetrationInsight(stats: CompanionStats, opts: CoachingOptions): CoachingInsight | null {

--- a/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
@@ -63,7 +63,7 @@ function critChanceInsight(stats: CompanionStats): CoachingInsight | null {
     severity: 'info',
     label: 'Crit chance',
     value: pct,
-    detail: `${pct}% crit chance (${rating.toLocaleString()} rating). Weigh more crit chance vs. weapon/spell damage against your current crit damage.`,
+    detail: `${pct}% crit chance (${rating.toLocaleString()} rating). Weigh more crit chance vs. weapon/spell damage against the crit damage shown on this card.`,
   };
 }
 

--- a/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
@@ -1,0 +1,151 @@
+/**
+ * Stat-aware coaching — the headline insight ESO Logs can't produce.
+ *
+ * Using the companion's *exact* stats (not ESOTK's gear-based estimate), compute how
+ * efficient a build is against ESO's hard caps. The big one is penetration vs the
+ * 18,200 boss-resistance cap; over-pen is wasted, under-pen is lost damage.
+ *
+ * Penetration splits into "self" (on the character sheet, exact) and "effective"
+ * (self + group armour debuffs on the boss, which are NOT on the sheet). Before a log
+ * is available we approximate effective pen with an assumed group contribution; with the
+ * log, ESOTK passes the real debuff value in. See research doc §11.1.1 / §26.
+ */
+
+import type { CompanionStats } from './esotkCompanionParser';
+
+/** Boss/trial/dungeon resistance — the PvE penetration cap. */
+export const PVE_PENETRATION_CAP = 18200;
+/** Standard tank kit (Major+Minor Breach + gold Crusher) supplies ~this much pen to the group. */
+export const STANDARD_GROUP_PEN = 11030;
+/** Crit damage hard cap (percent bonus over base); total crit hit = 225%. */
+export const CRIT_DAMAGE_CAP = 125;
+/** Crit rating per 1% crit chance. */
+export const CRIT_RATING_PER_PERCENT = 21918;
+
+export type CoachingSeverity = 'good' | 'info' | 'warn' | 'error';
+
+export interface CoachingInsight {
+  /** Stable id, e.g. "penetration" | "critChance" | "critDamage". */
+  id: string;
+  label: string;
+  severity: CoachingSeverity;
+  detail: string;
+  /** The headline number (e.g. effective pen), when relevant. */
+  value?: number;
+}
+
+export interface CoachingOptions {
+  /** Target resistance to test penetration against. Defaults to the PvE boss cap. */
+  targetResist?: number;
+  /**
+   * Group armour debuffs assumed present on the target (Breach/Crusher/Alkosh).
+   * 0 = self-only (default). Pass STANDARD_GROUP_PEN for a live pre-pull estimate, or the
+   * exact value derived from the log for an exact effective-pen verdict.
+   */
+  assumedGroupPen?: number;
+  /** How far over/under cap before flagging (avoids nagging over a few points). */
+  slop?: number;
+  /** Whether the group-pen figure is exact (from a log) or an assumption. Tunes wording. */
+  groupPenIsExact?: boolean;
+}
+
+function critChancePercent(rating: number): number {
+  return Math.round((rating / CRIT_RATING_PER_PERCENT) * 1000) / 10; // one decimal
+}
+
+function penetrationInsight(stats: CompanionStats, opts: CoachingOptions): CoachingInsight | null {
+  const self = Math.max(stats.physicalPen ?? 0, stats.spellPen ?? 0);
+  if (self <= 0) return null;
+
+  const target = opts.targetResist ?? PVE_PENETRATION_CAP;
+  const groupPen = opts.assumedGroupPen ?? 0;
+  const slop = opts.slop ?? 100;
+  const effective = self + groupPen;
+
+  const effLabel = opts.groupPenIsExact ? 'effective' : 'estimated effective';
+  const groupNote =
+    groupPen > 0
+      ? ` (${self.toLocaleString()} self + ${groupPen.toLocaleString()} group ${opts.groupPenIsExact ? 'debuffs' : 'debuffs assumed'})`
+      : ' (self only — group debuffs add to this in combat)';
+
+  if (effective > target + slop) {
+    const over = effective - target;
+    return {
+      id: 'penetration',
+      severity: 'warn',
+      label: 'Over the penetration cap',
+      value: effective,
+      detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — ${over.toLocaleString()} over the ${target.toLocaleString()} cap is wasted. Drop a pen source for more damage.`,
+    };
+  }
+  if (effective < target - slop) {
+    const under = target - effective;
+    return {
+      id: 'penetration',
+      severity: groupPen > 0 ? 'warn' : 'info',
+      label: 'Under the penetration cap',
+      value: effective,
+      detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — ${under.toLocaleString()} under the ${target.toLocaleString()} cap is lost damage.`,
+    };
+  }
+  return {
+    id: 'penetration',
+    severity: 'good',
+    label: 'Penetration on cap',
+    value: effective,
+    detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — right on the ${target.toLocaleString()} cap.`,
+  };
+}
+
+function critDamageInsight(stats: CompanionStats): CoachingInsight | null {
+  if (stats.critDamage === undefined) return null;
+  const cd = stats.critDamage;
+  if (cd > CRIT_DAMAGE_CAP) {
+    return {
+      id: 'critDamage',
+      severity: 'warn',
+      label: 'Over the crit damage cap',
+      value: cd,
+      detail: `Crit damage ${cd}% exceeds the ${CRIT_DAMAGE_CAP}% cap by ${cd - CRIT_DAMAGE_CAP}% — that excess is wasted.`,
+    };
+  }
+  return {
+    id: 'critDamage',
+    severity: 'info',
+    label: 'Crit damage headroom',
+    value: cd,
+    detail: `Crit damage ${cd}% of the ${CRIT_DAMAGE_CAP}% cap — ${CRIT_DAMAGE_CAP - cd}% headroom.`,
+  };
+}
+
+function critChanceInsight(stats: CompanionStats): CoachingInsight | null {
+  const rating = Math.max(stats.weaponCrit ?? 0, stats.spellCrit ?? 0);
+  if (rating <= 0) return null;
+  const pct = critChancePercent(rating);
+  return {
+    id: 'critChance',
+    severity: 'info',
+    label: 'Crit chance',
+    value: pct,
+    detail: `${pct}% crit chance (${rating.toLocaleString()} rating). Weigh more crit chance vs. weapon/spell damage against your current crit damage.`,
+  };
+}
+
+/**
+ * Produce coaching insights for a captured stat block. Order: penetration (headline),
+ * crit damage, crit chance. Skips anything we have no data for.
+ */
+export function computeStatCoaching(
+  stats: CompanionStats | undefined,
+  opts: CoachingOptions = {},
+): CoachingInsight[] {
+  if (!stats) return [];
+  const insights: CoachingInsight[] = [];
+  const pen = penetrationInsight(stats, opts);
+  if (pen) insights.push(pen);
+  const cd = critDamageInsight(stats);
+  if (cd) insights.push(cd);
+  const cc = critChanceInsight(stats);
+  if (cc) insights.push(cc);
+  return insights;
+}

--- a/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCoaching.ts
@@ -1,120 +1,56 @@
 /**
- * Stat-aware coaching — the headline insight ESO Logs can't produce.
+ * Stat-aware coaching — build context the ESOTK Companion captures that ESO Logs can't.
  *
- * Using the companion's *exact* stats (not ESOTK's gear-based estimate), compute how
- * efficient a build is against ESO's hard caps. The big one is penetration vs the
- * 18,200 boss-resistance cap; over-pen is wasted, under-pen is lost damage.
+ * Uses the companion's captured character sheet to surface a couple of plain readings:
+ * self penetration and crit chance. These are point-in-time values, read once on leaving
+ * combat with buffs already fading, so they are not comparable across players.
  *
- * Penetration splits into "self" (on the character sheet, exact) and "effective"
- * (self + group armour debuffs on the boss, which are NOT on the sheet). Before a log
- * is available we approximate effective pen with an assumed group contribution; with the
- * log, ESOTK passes the real debuff value in. See research doc §11.1.1 / §26.
+ * Penetration in particular is reported as a plain character-sheet number only. It excludes
+ * the group armour debuffs applied to a target in combat, so it is NOT compared to the
+ * 18,200 resistance cap — we make no over/under-cap verdict here. A real effective-penetration
+ * verdict needs the log's target armour-debuff uptimes (the log-derived penetration engine).
+ * See research doc §11.1.1 / §26.
  */
 
 import type { CompanionStats } from './esotkCompanionParser';
 
-/** Boss/trial/dungeon resistance — the PvE penetration cap. */
+/** Boss/trial/dungeon resistance — the PvE penetration cap. Reference only; no verdict is issued from the snapshot. */
 export const PVE_PENETRATION_CAP = 18200;
-/** Standard tank kit (Major+Minor Breach + gold Crusher) supplies ~this much pen to the group. */
-export const STANDARD_GROUP_PEN = 11030;
-/** Crit damage hard cap (percent bonus over base); total crit hit = 225%. */
-export const CRIT_DAMAGE_CAP = 125;
 /** Crit rating corresponding to 100 percentage points of crit chance. */
 export const CRIT_RATING_FOR_100_PERCENT = 21918;
 
 export type CoachingSeverity = 'good' | 'info' | 'warn' | 'error';
 
 export interface CoachingInsight {
-  /** Stable id, e.g. "penetration" | "critChance" | "critDamage". */
+  /** Stable id, e.g. "penetration" | "critChance". */
   id: string;
   label: string;
   severity: CoachingSeverity;
   detail: string;
-  /** The headline number (e.g. effective pen), when relevant. */
+  /** The headline number (e.g. self penetration), when relevant. */
   value?: number;
-}
-
-export interface CoachingOptions {
-  /** Target resistance to test penetration against. Defaults to the PvE boss cap. */
-  targetResist?: number;
-  /**
-   * Group armour debuffs assumed present on the target (Breach/Crusher/Alkosh).
-   * 0 = self-only (default). Pass STANDARD_GROUP_PEN for a live pre-pull estimate, or the
-   * exact value derived from the log for an exact effective-pen verdict.
-   */
-  assumedGroupPen?: number;
-  /** How far over/under cap before flagging (avoids nagging over a few points). */
-  slop?: number;
-  /** Whether the group-pen figure is exact (from a log) or an assumption. Tunes wording. */
-  groupPenIsExact?: boolean;
 }
 
 function critChancePercent(rating: number): number {
   return Math.min(100, Math.round((rating / CRIT_RATING_FOR_100_PERCENT) * 1000) / 10); // one decimal
 }
 
-function penetrationInsight(stats: CompanionStats, opts: CoachingOptions): CoachingInsight | null {
+/**
+ * Self penetration as read from the character sheet at capture. This is a point-in-time,
+ * self-only figure: group armour debuffs on the target are NOT included and buffs were
+ * already fading when the sheet was read, so it is not comparable across players and we
+ * make no over/under-cap verdict here (the log-derived penetration engine does that).
+ */
+function penetrationInsight(stats: CompanionStats): CoachingInsight | null {
   const self = Math.max(stats.physicalPen ?? 0, stats.spellPen ?? 0);
   if (self <= 0) return null;
 
-  const target = opts.targetResist ?? PVE_PENETRATION_CAP;
-  const groupPen = opts.assumedGroupPen ?? 0;
-  const slop = opts.slop ?? 100;
-  const effective = self + groupPen;
-
-  const effLabel = opts.groupPenIsExact ? 'effective' : 'estimated effective';
-  const groupNote =
-    groupPen > 0
-      ? ` (${self.toLocaleString()} self + ${groupPen.toLocaleString()} group ${opts.groupPenIsExact ? 'debuffs' : 'debuffs assumed'})`
-      : ' (self only — group debuffs add to this in combat)';
-
-  if (effective > target + slop) {
-    const over = effective - target;
-    return {
-      id: 'penetration',
-      severity: 'warn',
-      label: 'Over the penetration cap',
-      value: effective,
-      detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — ${over.toLocaleString()} over the ${target.toLocaleString()} cap is wasted. Drop a pen source for more damage.`,
-    };
-  }
-  if (effective < target - slop) {
-    const under = target - effective;
-    return {
-      id: 'penetration',
-      severity: groupPen > 0 ? 'warn' : 'info',
-      label: 'Under the penetration cap',
-      value: effective,
-      detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — ${under.toLocaleString()} under the ${target.toLocaleString()} cap is lost damage.`,
-    };
-  }
   return {
     id: 'penetration',
-    severity: 'good',
-    label: 'Penetration on cap',
-    value: effective,
-    detail: `${effLabel} penetration ${effective.toLocaleString()}${groupNote} — right on the ${target.toLocaleString()} cap.`,
-  };
-}
-
-function critDamageInsight(stats: CompanionStats): CoachingInsight | null {
-  if (stats.critDamage === undefined) return null;
-  const cd = stats.critDamage;
-  if (cd > CRIT_DAMAGE_CAP) {
-    return {
-      id: 'critDamage',
-      severity: 'warn',
-      label: 'Over the crit damage cap',
-      value: cd,
-      detail: `Crit damage ${cd}% exceeds the ${CRIT_DAMAGE_CAP}% cap by ${cd - CRIT_DAMAGE_CAP}% — that excess is wasted.`,
-    };
-  }
-  return {
-    id: 'critDamage',
     severity: 'info',
-    label: 'Crit damage headroom',
-    value: cd,
-    detail: `Crit damage ${cd}% of the ${CRIT_DAMAGE_CAP}% cap — ${CRIT_DAMAGE_CAP - cd}% headroom.`,
+    label: 'Penetration (character sheet)',
+    value: self,
+    detail: `Character-sheet penetration ${self.toLocaleString()} at capture — a point-in-time reading (buffs fading) that excludes the group armour debuffs applied to a target in combat, so it is not comparable to the resistance cap.`,
   };
 }
 
@@ -133,18 +69,13 @@ function critChanceInsight(stats: CompanionStats): CoachingInsight | null {
 
 /**
  * Produce coaching insights for a captured stat block. Order: penetration (headline),
- * crit damage, crit chance. Skips anything we have no data for.
+ * crit chance. Skips anything we have no data for.
  */
-export function computeStatCoaching(
-  stats: CompanionStats | undefined,
-  opts: CoachingOptions = {},
-): CoachingInsight[] {
+export function computeStatCoaching(stats: CompanionStats | undefined): CoachingInsight[] {
   if (!stats) return [];
   const insights: CoachingInsight[] = [];
-  const pen = penetrationInsight(stats, opts);
+  const pen = penetrationInsight(stats);
   if (pen) insights.push(pen);
-  const cd = critDamageInsight(stats);
-  if (cd) insights.push(cd);
   const cc = critChanceInsight(stats);
   if (cc) insights.push(cc);
   return insights;

--- a/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
@@ -1,0 +1,148 @@
+/**
+ * Match ESOTK Companion snapshots to an ESO Logs report's players/fights.
+ *
+ * The companion's SavedVariables is not stamped with the report code, so we match on
+ * the keys both sides share: character name (+ server) and time. The ESO Logs report
+ * exposes an absolute `startTime` (ms) and per-fight `startTime`/`endTime` as ms offsets
+ * from it, plus the player actors. We attach each actor to the nearest in-window
+ * snapshot. Pure and dependency-free so it can be unit-tested without the app.
+ *
+ * Known gaps handled by the caller, not here: anonymised reports (actor names hidden →
+ * no match → fall back to a manual "attach to player" picker), and the direct-key path
+ * (user supplied the report code) which bypasses matching entirely.
+ */
+
+import type { CompanionSnapshot } from './esotkCompanionParser';
+
+/** Minimal shape of a report player/actor needed for matching. */
+export interface MatchableActor {
+  /** Stable id used as the result key (e.g. ESO Logs actor id). */
+  id: number | string;
+  name: string;
+  /** Optional server/world to disambiguate name collisions. */
+  server?: string;
+}
+
+/** Minimal shape of a report fight needed for matching. */
+export interface MatchableFight {
+  id: number | string;
+  /** ms offset from report start. */
+  startTime: number;
+  /** ms offset from report start. */
+  endTime: number;
+}
+
+/** Minimal report shape required to match snapshots. */
+export interface MatchableReport {
+  /** Absolute report start, UNIX ms. */
+  startTime: number;
+  /** Absolute report end, UNIX ms. Defaults to startTime + 6h if omitted. */
+  endTime?: number;
+  actors: MatchableActor[];
+  fights?: MatchableFight[];
+}
+
+export interface CompanionMatch {
+  actor: MatchableActor;
+  snapshot: CompanionSnapshot;
+  /** The fight whose window best contains/precedes the snapshot, if any. */
+  fightId?: number | string;
+  /** ms between the snapshot and the report window (0 when inside it). */
+  distanceMs: number;
+}
+
+export interface CompanionMatchResult {
+  /** One match per actor that had a usable snapshot, keyed by actor id. */
+  matches: Map<MatchableActor['id'], CompanionMatch>;
+  /** Snapshots that matched no actor (e.g. anonymised report). */
+  unmatched: CompanionSnapshot[];
+}
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+/** Allow a snapshot slightly outside the report window (clock skew / pre-pull capture). */
+const WINDOW_SLOP_MS = 5 * 60 * 1000;
+
+function normalizeName(name: string): string {
+  // ESO names may carry the @ display or a leading icon; compare on the bare name.
+  return name.replace(/^@/, '').trim().toLowerCase();
+}
+
+/** Snapshot ts is UNIX seconds; report times are UNIX ms. */
+function snapshotMs(snapshot: CompanionSnapshot): number {
+  return snapshot.ts * 1000;
+}
+
+function withinWindow(tsMs: number, start: number, end: number): boolean {
+  return tsMs >= start - WINDOW_SLOP_MS && tsMs <= end + WINDOW_SLOP_MS;
+}
+
+function distanceToWindow(tsMs: number, start: number, end: number): number {
+  if (tsMs < start) return start - tsMs;
+  if (tsMs > end) return tsMs - end;
+  return 0;
+}
+
+function findNearestFight(
+  tsMs: number,
+  reportStart: number,
+  fights: MatchableFight[] | undefined,
+): MatchableFight | undefined {
+  if (!fights || fights.length === 0) return undefined;
+  let best: MatchableFight | undefined;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const fight of fights) {
+    const start = reportStart + fight.startTime;
+    const end = reportStart + fight.endTime;
+    const dist = distanceToWindow(tsMs, start, end);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = fight;
+    }
+  }
+  return best;
+}
+
+/**
+ * Match snapshots to report actors. For each actor, picks the in-window snapshot whose
+ * name (and server, when both provide one) matches and which is closest in time; the
+ * combat-end snapshot for that player's fight wins.
+ */
+export function matchCompanionSnapshots(
+  snapshots: CompanionSnapshot[],
+  report: MatchableReport,
+): CompanionMatchResult {
+  const reportStart = report.startTime;
+  const reportEnd = report.endTime ?? reportStart + SIX_HOURS_MS;
+
+  const matches = new Map<MatchableActor['id'], CompanionMatch>();
+  const matchedSnapshots = new Set<CompanionSnapshot>();
+
+  for (const actor of report.actors) {
+    const actorName = normalizeName(actor.name);
+    if (!actorName) continue;
+
+    let best: CompanionMatch | undefined;
+    for (const snapshot of snapshots) {
+      if (normalizeName(snapshot.char) !== actorName) continue;
+      // If both sides declare a server, they must agree.
+      if (actor.server && snapshot.server && actor.server !== snapshot.server) continue;
+
+      const tsMs = snapshotMs(snapshot);
+      if (!withinWindow(tsMs, reportStart, reportEnd)) continue;
+
+      const distanceMs = distanceToWindow(tsMs, reportStart, reportEnd);
+      if (!best || distanceMs < best.distanceMs) {
+        const fight = findNearestFight(tsMs, reportStart, report.fights);
+        best = { actor, snapshot, fightId: fight?.id, distanceMs };
+      }
+    }
+
+    if (best) {
+      matches.set(actor.id, best);
+      matchedSnapshots.add(best.snapshot);
+    }
+  }
+
+  const unmatched = snapshots.filter((s) => !matchedSnapshots.has(s));
+  return { matches, unmatched };
+}

--- a/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
@@ -47,7 +47,7 @@ export interface CompanionMatch {
   snapshot: CompanionSnapshot;
   /** The fight whose window best contains/precedes the snapshot, if any. */
   fightId?: number | string;
-  /** ms between the snapshot and the report window (0 when inside it). */
+  /** ms between the snapshot and the selected fight/report window (0 when inside it). */
   distanceMs: number;
 }
 
@@ -58,6 +58,11 @@ export interface CompanionMatchResult {
   unmatched: CompanionSnapshot[];
 }
 
+export interface MatchCompanionSnapshotsOptions {
+  /** Prefer snapshots for this fight. Use the currently selected report fight when known. */
+  targetFightId?: MatchableFight['id'];
+}
+
 const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
 /** Allow a snapshot slightly outside the report window (clock skew / pre-pull capture). */
 const WINDOW_SLOP_MS = 5 * 60 * 1000;
@@ -65,6 +70,15 @@ const WINDOW_SLOP_MS = 5 * 60 * 1000;
 function normalizeName(name: string): string {
   // ESO names may carry the @ display or a leading icon; compare on the bare name.
   return name.replace(/^@/, '').trim().toLowerCase();
+}
+
+function normalizeServer(server: string | undefined): string | undefined {
+  const normalized = server?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function sameId(a: MatchableFight['id'], b: MatchableFight['id']): boolean {
+  return String(a) === String(b);
 }
 
 /** Snapshot ts is UNIX seconds; report times are UNIX ms. */
@@ -82,13 +96,13 @@ function distanceToWindow(tsMs: number, start: number, end: number): number {
   return 0;
 }
 
-function findNearestFight(
+function findNearestFightCandidate(
   tsMs: number,
   reportStart: number,
   fights: MatchableFight[] | undefined,
-): MatchableFight | undefined {
+): { fight: MatchableFight; distanceMs: number } | undefined {
   if (!fights || fights.length === 0) return undefined;
-  let best: MatchableFight | undefined;
+  let best: { fight: MatchableFight; distanceMs: number } | undefined;
   let bestDist = Number.POSITIVE_INFINITY;
   for (const fight of fights) {
     const start = reportStart + fight.startTime;
@@ -96,10 +110,39 @@ function findNearestFight(
     const dist = distanceToWindow(tsMs, start, end);
     if (dist < bestDist) {
       bestDist = dist;
-      best = fight;
+      best = { fight, distanceMs: dist };
     }
   }
   return best;
+}
+
+function candidateDistance(
+  tsMs: number,
+  report: MatchableReport,
+  opts: MatchCompanionSnapshotsOptions,
+): { fightId?: MatchableFight['id']; distanceMs: number } | null {
+  const reportStart = report.startTime;
+  const reportEnd = report.endTime ?? reportStart + SIX_HOURS_MS;
+
+  const targetFightId = opts.targetFightId;
+  if (targetFightId !== undefined) {
+    const fight = report.fights?.find((f) => sameId(f.id, targetFightId));
+    if (!fight) return null;
+
+    const start = reportStart + fight.startTime;
+    const end = reportStart + fight.endTime;
+    if (!withinWindow(tsMs, start, end)) return null;
+    return { fightId: fight.id, distanceMs: distanceToWindow(tsMs, start, end) };
+  }
+
+  if (!withinWindow(tsMs, reportStart, reportEnd)) return null;
+
+  const fightCandidate = findNearestFightCandidate(tsMs, reportStart, report.fights);
+  if (fightCandidate) {
+    return { fightId: fightCandidate.fight.id, distanceMs: fightCandidate.distanceMs };
+  }
+
+  return { distanceMs: distanceToWindow(tsMs, reportStart, reportEnd) };
 }
 
 /**
@@ -110,10 +153,8 @@ function findNearestFight(
 export function matchCompanionSnapshots(
   snapshots: CompanionSnapshot[],
   report: MatchableReport,
+  opts: MatchCompanionSnapshotsOptions = {},
 ): CompanionMatchResult {
-  const reportStart = report.startTime;
-  const reportEnd = report.endTime ?? reportStart + SIX_HOURS_MS;
-
   const matches = new Map<MatchableActor['id'], CompanionMatch>();
   const matchedSnapshots = new Set<CompanionSnapshot>();
 
@@ -125,15 +166,25 @@ export function matchCompanionSnapshots(
     for (const snapshot of snapshots) {
       if (normalizeName(snapshot.char) !== actorName) continue;
       // If both sides declare a server, they must agree.
-      if (actor.server && snapshot.server && actor.server !== snapshot.server) continue;
+      const actorServer = normalizeServer(actor.server);
+      const snapshotServer = normalizeServer(snapshot.server);
+      if (actorServer && snapshotServer && actorServer !== snapshotServer) continue;
 
       const tsMs = snapshotMs(snapshot);
-      if (!withinWindow(tsMs, reportStart, reportEnd)) continue;
+      const candidate = candidateDistance(tsMs, report, opts);
+      if (!candidate) continue;
 
-      const distanceMs = distanceToWindow(tsMs, reportStart, reportEnd);
-      if (!best || distanceMs < best.distanceMs) {
-        const fight = findNearestFight(tsMs, reportStart, report.fights);
-        best = { actor, snapshot, fightId: fight?.id, distanceMs };
+      if (
+        !best ||
+        candidate.distanceMs < best.distanceMs ||
+        (candidate.distanceMs === best.distanceMs && tsMs > snapshotMs(best.snapshot))
+      ) {
+        best = {
+          actor,
+          snapshot,
+          fightId: candidate.fightId,
+          distanceMs: candidate.distanceMs,
+        };
       }
     }
 

--- a/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
@@ -30,6 +30,8 @@ export interface MatchableFight {
   startTime: number;
   /** ms offset from report start. */
   endTime: number;
+  /** Optional zone id for disambiguating same-character snapshots near the same time. */
+  zoneId?: number;
 }
 
 /** Minimal report shape required to match snapshots. */
@@ -81,6 +83,12 @@ function sameId(a: MatchableFight['id'], b: MatchableFight['id']): boolean {
   return String(a) === String(b);
 }
 
+function zoneMatches(snapshot: CompanionSnapshot, fight: MatchableFight): boolean {
+  return (
+    snapshot.zoneId === undefined || fight.zoneId === undefined || snapshot.zoneId === fight.zoneId
+  );
+}
+
 /** Snapshot ts is UNIX seconds; report times are UNIX ms. */
 function snapshotMs(snapshot: CompanionSnapshot): number {
   return snapshot.ts * 1000;
@@ -100,11 +108,13 @@ function findNearestFightCandidate(
   tsMs: number,
   reportStart: number,
   fights: MatchableFight[] | undefined,
+  snapshot: CompanionSnapshot,
 ): { fight: MatchableFight; distanceMs: number } | undefined {
   if (!fights || fights.length === 0) return undefined;
   let best: { fight: MatchableFight; distanceMs: number } | undefined;
   let bestDist = Number.POSITIVE_INFINITY;
   for (const fight of fights) {
+    if (!zoneMatches(snapshot, fight)) continue;
     const start = reportStart + fight.startTime;
     const end = reportStart + fight.endTime;
     const dist = distanceToWindow(tsMs, start, end);
@@ -119,6 +129,7 @@ function findNearestFightCandidate(
 function candidateDistance(
   tsMs: number,
   report: MatchableReport,
+  snapshot: CompanionSnapshot,
   opts: MatchCompanionSnapshotsOptions,
 ): { fightId?: MatchableFight['id']; distanceMs: number } | null {
   const reportStart = report.startTime;
@@ -128,6 +139,7 @@ function candidateDistance(
   if (targetFightId !== undefined) {
     const fight = report.fights?.find((f) => sameId(f.id, targetFightId));
     if (!fight) return null;
+    if (!zoneMatches(snapshot, fight)) return null;
 
     const start = reportStart + fight.startTime;
     const end = reportStart + fight.endTime;
@@ -137,9 +149,13 @@ function candidateDistance(
 
   if (!withinWindow(tsMs, reportStart, reportEnd)) return null;
 
-  const fightCandidate = findNearestFightCandidate(tsMs, reportStart, report.fights);
+  const fightCandidate = findNearestFightCandidate(tsMs, reportStart, report.fights, snapshot);
   if (fightCandidate) {
     return { fightId: fightCandidate.fight.id, distanceMs: fightCandidate.distanceMs };
+  }
+
+  if (snapshot.zoneId !== undefined && report.fights?.some((fight) => fight.zoneId !== undefined)) {
+    return null;
   }
 
   return { distanceMs: distanceToWindow(tsMs, reportStart, reportEnd) };
@@ -171,7 +187,7 @@ export function matchCompanionSnapshots(
       if (actorServer && snapshotServer && actorServer !== snapshotServer) continue;
 
       const tsMs = snapshotMs(snapshot);
-      const candidate = candidateDistance(tsMs, report, opts);
+      const candidate = candidateDistance(tsMs, report, snapshot, opts);
       if (!candidate) continue;
 
       if (

--- a/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
@@ -7,9 +7,11 @@
  * from it, plus the player actors. We attach each actor to the nearest in-window
  * snapshot. Pure and dependency-free so it can be unit-tested without the app.
  *
- * Known gaps handled by the caller, not here: anonymised reports (actor names hidden →
- * no match → fall back to a manual "attach to player" picker), and the direct-key path
- * (user supplied the report code) which bypasses matching entirely.
+ * Known gaps: on anonymised reports actor names are hidden, so nothing matches and every
+ * snapshot lands in `unmatched` — the caller should surface that (a manual "attach to
+ * player" picker is a planned fallback, not yet implemented; until then, show a notice
+ * rather than silently rendering nothing). The direct-key path (user supplied the report
+ * code) bypasses matching entirely and is handled upstream.
  */
 
 import type { CompanionSnapshot } from './esotkCompanionParser';
@@ -74,9 +76,20 @@ function normalizeName(name: string): string {
   return name.replace(/^@/, '').trim().toLowerCase();
 }
 
-function normalizeServer(server: string | undefined): string | undefined {
-  const normalized = server?.trim().toLowerCase();
-  return normalized || undefined;
+/**
+ * Classify a server/world string to a region. The two sides speak different
+ * vocabularies — the addon's `GetWorldName()` yields "NA Megaserver" / "EU Megaserver"
+ * while ESO Logs actors carry "PC-NA" / "PC-EU" (or console "XB-NA" / "PS-EU") — so a
+ * strict string compare rejects every real match. Returns undefined when the string
+ * carries no recognizable region; callers must then fall through to name + time rather
+ * than reject, so we never drop a match on an unclassifiable server.
+ */
+function toServerRegion(server: string | undefined): 'na' | 'eu' | undefined {
+  if (!server) return undefined;
+  const s = server.toUpperCase();
+  if (s.includes('EU')) return 'eu';
+  if (s.includes('NA')) return 'na';
+  return undefined;
 }
 
 function sameId(a: MatchableFight['id'], b: MatchableFight['id']): boolean {
@@ -181,10 +194,12 @@ export function matchCompanionSnapshots(
     let best: CompanionMatch | undefined;
     for (const snapshot of snapshots) {
       if (normalizeName(snapshot.char) !== actorName) continue;
-      // If both sides declare a server, they must agree.
-      const actorServer = normalizeServer(actor.server);
-      const snapshotServer = normalizeServer(snapshot.server);
-      if (actorServer && snapshotServer && actorServer !== snapshotServer) continue;
+      // If both sides declare a recognizable region, they must agree. The addon
+      // ("NA Megaserver") and ESO Logs ("PC-NA") use different vocabularies, so we
+      // compare by region and only reject on a provable conflict.
+      const actorRegion = toServerRegion(actor.server);
+      const snapshotRegion = toServerRegion(snapshot.server);
+      if (actorRegion && snapshotRegion && actorRegion !== snapshotRegion) continue;
 
       const tsMs = snapshotMs(snapshot);
       const candidate = candidateDistance(tsMs, report, snapshot, opts);

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -1,0 +1,330 @@
+/**
+ * ESOTK Companion saved-variables parser.
+ *
+ * Reads the `ESOTKCompanionSV` file written by the in-game ESOTK Companion add-on
+ * (see `addon/ESOTKCompanion/`) and normalises it into typed build snapshots.
+ *
+ * This is the data ESO Logs structurally cannot provide: the encounter log carries
+ * champion-point *rank* and the slotted stars (as buffs) but never the full point
+ * *allocation*, and the ESO Logs API exposes neither the allocation nor final stats
+ * (crit / penetration / recovery). The add-on captures them live; this parser turns
+ * the on-disk Lua into objects the rest of ESOTK can match to a report and render.
+ */
+
+import { Logger } from '@/utils/logger';
+
+import { parseLuaAssignments, type LuaValue } from './wizardsWardrobeSavedVariables';
+
+const logger = new Logger({ contextPrefix: 'ESOTKCompanionParser' });
+
+/** Champion-point allocation for a single discipline (Craft / Warfare / Fitness). */
+export interface CompanionCpDiscipline {
+  id: number;
+  /** ESO discipline type enum, if captured. */
+  type?: number;
+  /** Total points spent in this discipline. */
+  spent?: number;
+  /** Points spent per champion skill, keyed by skill id. The core gap ESO Logs lacks. */
+  skills: Record<number, number>;
+}
+
+/** Full champion-point state for a snapshot. */
+export interface CompanionChampionPoints {
+  /** Total earned champion points (CP rank). */
+  total?: number;
+  /** Per-discipline allocation, keyed by discipline id. */
+  disciplines: Record<number, CompanionCpDiscipline>;
+  /** The 12 slotted stars, keyed by slot (1-12) → champion skill id. */
+  slotted: Record<number, number>;
+}
+
+/** Final derived stats the log/API never carries. */
+export interface CompanionStats {
+  maxMagicka?: number;
+  maxHealth?: number;
+  maxStamina?: number;
+  spellDamage?: number;
+  weaponDamage?: number;
+  spellCrit?: number;
+  weaponCrit?: number;
+  spellPen?: number;
+  physicalPen?: number;
+  magickaRegen?: number;
+  staminaRegen?: number;
+  healthRegen?: number;
+  physicalResist?: number;
+  spellResist?: number;
+  critResist?: number;
+}
+
+/** Attribute point split. */
+export interface CompanionAttributes {
+  magicka?: number;
+  health?: number;
+  stamina?: number;
+}
+
+/** A long-term effect (mundus is permanent; food/drink is long). */
+export interface CompanionEffect {
+  id: number;
+  name?: string;
+  /** Duration in ms; 0 means permanent (e.g. mundus). */
+  duration?: number;
+}
+
+/** One captured build snapshot, taken on combat end or on demand. */
+export interface CompanionSnapshot {
+  /** UNIX seconds (server/UTC) from GetTimeStamp() — primary match key vs report time. */
+  ts: number;
+  /** Character name — match key vs report masterData actors. */
+  char: string;
+  /** Account (@display) — kept locally, not used for matching (API may not expose it). */
+  account?: string;
+  /** Server / world (e.g. "NA") — disambiguates name collisions. */
+  server?: string;
+  zoneId?: number;
+  classId?: number;
+  raceId?: number;
+  level?: number;
+  cpRank?: number;
+  role?: number;
+  /** How the snapshot was taken: "combatEnd" | "manual". */
+  reason?: string;
+  championPoints?: CompanionChampionPoints;
+  stats?: CompanionStats;
+  attributes?: CompanionAttributes;
+  effects?: CompanionEffect[];
+  bars?: { front?: Record<number, number>; back?: Record<number, number> };
+}
+
+/** Parsed companion file: snapshots grouped by account. */
+export interface CompanionParseResult {
+  schemaVersion: number;
+  season?: string;
+  /** Snapshots keyed by account display name. */
+  byAccount: Record<string, CompanionSnapshot[]>;
+  /** All snapshots flattened, newest last. */
+  all: CompanionSnapshot[];
+}
+
+const SV_TABLE_NAME = 'ESOTKCompanionSV';
+
+function isRecord(v: unknown): v is Record<string, LuaValue> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function asNumber(v: LuaValue | undefined): number | undefined {
+  return typeof v === 'number' ? v : undefined;
+}
+
+function asString(v: LuaValue | undefined): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Lua tables with numeric keys may be parsed as a JS array (1-indexed Lua → 0-indexed
+ * JS) or as an object with numeric-string keys ("1", "2", …), and sparse tables almost
+ * always become objects. Normalise both to `[luaKey, value]` pairs so callers don't
+ * care which representation the parser produced.
+ */
+function numericEntries(v: LuaValue | undefined): Array<[number, LuaValue]> {
+  const out: Array<[number, LuaValue]> = [];
+  if (Array.isArray(v)) {
+    v.forEach((item, i) => {
+      if (item !== null && item !== undefined) out.push([i + 1, item]); // restore Lua 1-index
+    });
+  } else if (isRecord(v)) {
+    for (const [k, val] of Object.entries(v)) {
+      const n = Number(k);
+      if (Number.isFinite(n) && val !== null && val !== undefined) out.push([n, val]);
+    }
+  }
+  return out;
+}
+
+/** Values of a numeric-keyed Lua table, ordered by key. */
+function luaArray(v: LuaValue | undefined): LuaValue[] {
+  return numericEntries(v)
+    .sort((a, b) => a[0] - b[0])
+    .map(([, val]) => val);
+}
+
+/** Build a `{ [numericId]: number }` map from a Lua table of numeric→numeric entries. */
+function numericMap(v: LuaValue | undefined): Record<number, number> {
+  const out: Record<number, number> = {};
+  for (const [id, val] of numericEntries(v)) {
+    const n = asNumber(val);
+    if (typeof n === 'number') out[id] = n;
+  }
+  return out;
+}
+
+function normalizeChampionPoints(v: LuaValue | undefined): CompanionChampionPoints | undefined {
+  if (!isRecord(v)) return undefined;
+  const disciplines: Record<number, CompanionCpDiscipline> = {};
+  for (const [id, d] of numericEntries(v.disciplines)) {
+    if (!isRecord(d)) continue;
+    disciplines[id] = {
+      id: asNumber(d.id) ?? id,
+      type: asNumber(d.type),
+      spent: asNumber(d.spent),
+      skills: numericMap(d.skills),
+    };
+  }
+  return {
+    total: asNumber(v.total),
+    disciplines,
+    slotted: numericMap(v.slotted),
+  };
+}
+
+function normalizeStats(v: LuaValue | undefined): CompanionStats | undefined {
+  if (!isRecord(v)) return undefined;
+  const keys: (keyof CompanionStats)[] = [
+    'maxMagicka', 'maxHealth', 'maxStamina', 'spellDamage', 'weaponDamage',
+    'spellCrit', 'weaponCrit', 'spellPen', 'physicalPen', 'magickaRegen',
+    'staminaRegen', 'healthRegen', 'physicalResist', 'spellResist', 'critResist',
+  ];
+  const out: CompanionStats = {};
+  for (const key of keys) {
+    const n = asNumber(v[key]);
+    if (typeof n === 'number') out[key] = n;
+  }
+  return out;
+}
+
+function normalizeEffects(v: LuaValue | undefined): CompanionEffect[] | undefined {
+  const arr = luaArray(v);
+  if (arr.length === 0) return undefined;
+  const out: CompanionEffect[] = [];
+  for (const item of arr) {
+    if (!isRecord(item)) continue;
+    const id = asNumber(item.id);
+    if (typeof id !== 'number') continue;
+    out.push({ id, name: asString(item.name), duration: asNumber(item.duration) });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeSnapshot(v: LuaValue): CompanionSnapshot | null {
+  if (!isRecord(v)) return null;
+  const ts = asNumber(v.ts);
+  const char = asString(v.char);
+  // ts + char are the match keys; without them the snapshot is unusable.
+  if (typeof ts !== 'number' || !char) return null;
+
+  const attrsRaw = v.attrs;
+  const attributes: CompanionAttributes | undefined = isRecord(attrsRaw)
+    ? {
+        magicka: asNumber(attrsRaw.magicka),
+        health: asNumber(attrsRaw.health),
+        stamina: asNumber(attrsRaw.stamina),
+      }
+    : undefined;
+
+  const barsRaw = v.bars;
+  const bars = isRecord(barsRaw)
+    ? { front: numericMap(barsRaw.front), back: numericMap(barsRaw.back) }
+    : undefined;
+
+  return {
+    ts,
+    char,
+    account: asString(v.account),
+    server: asString(v.server),
+    zoneId: asNumber(v.zoneId),
+    classId: asNumber(v.classId),
+    raceId: asNumber(v.raceId),
+    level: asNumber(v.level),
+    cpRank: asNumber(v.cpRank),
+    role: asNumber(v.role),
+    reason: asString(v.reason),
+    championPoints: normalizeChampionPoints(v.cp),
+    stats: normalizeStats(v.stats),
+    attributes,
+    effects: normalizeEffects(v.effects),
+    bars,
+  };
+}
+
+/** Quick check whether a Lua file looks like an ESOTK Companion save. */
+export function isESOTKCompanionFormat(luaContent: string): boolean {
+  return luaContent.includes(SV_TABLE_NAME);
+}
+
+/**
+ * Parse an `ESOTKCompanionSV` saved-variables file into typed snapshots.
+ * Returns `null` when the file is not an ESOTK Companion save.
+ */
+export function parseESOTKCompanionSavedVariables(luaContent: string): CompanionParseResult | null {
+  let assignments: Record<string, LuaValue>;
+  try {
+    assignments = parseLuaAssignments(luaContent);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.debug('Failed to parse Lua', { error: err.message });
+    return null;
+  }
+
+  const root = assignments[SV_TABLE_NAME];
+  if (!isRecord(root)) {
+    return null;
+  }
+
+  // ZO_SavedVars layout: ESOTKCompanionSV.Default["@account"]["$AccountWide"].snapshots
+  const defaultData = root.Default;
+  if (!isRecord(defaultData)) {
+    return null;
+  }
+
+  const byAccount: Record<string, CompanionSnapshot[]> = {};
+  const all: CompanionSnapshot[] = [];
+  let schemaVersion = 1;
+  let season: string | undefined;
+
+  for (const accountKey of Object.keys(defaultData)) {
+    const accountData = defaultData[accountKey];
+    if (!isRecord(accountData)) continue;
+
+    // Account-wide bucket holds our data; tolerate per-character buckets too.
+    const buckets: LuaValue[] = [];
+    if (isRecord(accountData.$AccountWide)) buckets.push(accountData.$AccountWide);
+    for (const key of Object.keys(accountData)) {
+      if (key !== '$AccountWide' && isRecord(accountData[key])) buckets.push(accountData[key]);
+    }
+
+    const accountSnapshots: CompanionSnapshot[] = [];
+    for (const bucket of buckets) {
+      if (!isRecord(bucket)) continue;
+      const sv = asNumber(bucket.schemaVersion);
+      if (typeof sv === 'number') schemaVersion = sv;
+      const s = asString(bucket.season);
+      if (s) season = s;
+
+      for (const snapRaw of luaArray(bucket.snapshots)) {
+        const snap = normalizeSnapshot(snapRaw);
+        if (snap) accountSnapshots.push(snap);
+      }
+    }
+
+    if (accountSnapshots.length > 0) {
+      accountSnapshots.sort((a, b) => a.ts - b.ts);
+      byAccount[accountKey] = accountSnapshots;
+      all.push(...accountSnapshots);
+    }
+  }
+
+  if (all.length === 0) {
+    logger.info('ESOTKCompanionSV found but contained no usable snapshots');
+    return null;
+  }
+
+  all.sort((a, b) => a.ts - b.ts);
+  logger.info('Parsed ESOTK Companion snapshots', {
+    accounts: Object.keys(byAccount).length,
+    snapshots: all.length,
+    season,
+  });
+
+  return { schemaVersion, season, byAccount, all };
+}

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -47,6 +47,8 @@ export interface CompanionStats {
   weaponDamage?: number;
   spellCrit?: number;
   weaponCrit?: number;
+  /** Crit damage as a percent bonus (base 50). Optional — derived, no single STAT_ constant. */
+  critDamage?: number;
   spellPen?: number;
   physicalPen?: number;
   magickaRegen?: number;
@@ -182,7 +184,7 @@ function normalizeStats(v: LuaValue | undefined): CompanionStats | undefined {
   if (!isRecord(v)) return undefined;
   const keys: (keyof CompanionStats)[] = [
     'maxMagicka', 'maxHealth', 'maxStamina', 'spellDamage', 'weaponDamage',
-    'spellCrit', 'weaponCrit', 'spellPen', 'physicalPen', 'magickaRegen',
+    'spellCrit', 'weaponCrit', 'critDamage', 'spellPen', 'physicalPen', 'magickaRegen',
     'staminaRegen', 'healthRegen', 'physicalResist', 'spellResist', 'critResist',
   ];
   const out: CompanionStats = {};

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -86,7 +86,9 @@ export interface CompanionSnapshot {
   server?: string;
   zoneId?: number;
   classId?: number;
+  className?: string;
   raceId?: number;
+  raceName?: string;
   level?: number;
   cpRank?: number;
   role?: number;
@@ -249,7 +251,9 @@ function normalizeSnapshot(v: LuaValue): CompanionSnapshot | null {
     server: asString(v.server),
     zoneId: asNumber(v.zoneId),
     classId: asNumber(v.classId),
+    className: asString(v.className),
     raceId: asNumber(v.raceId),
+    raceName: asString(v.raceName),
     level: asNumber(v.level),
     cpRank: asNumber(v.cpRank),
     role: asNumber(v.role),

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -47,7 +47,7 @@ export interface CompanionStats {
   weaponDamage?: number;
   spellCrit?: number;
   weaponCrit?: number;
-  /** Crit damage as a percent bonus (base 50). Optional — derived, no single STAT_ constant. */
+  /** Crit damage as a percent bonus (base 50), when the ESO API exposes it. */
   critDamage?: number;
   spellPen?: number;
   physicalPen?: number;
@@ -76,6 +76,8 @@ export interface CompanionEffect {
 
 /** One captured build snapshot, taken on combat end or on demand. */
 export interface CompanionSnapshot {
+  schemaVersion?: number;
+  season?: string;
   /** UNIX seconds (server/UTC) from GetTimeStamp() — primary match key vs report time. */
   ts: number;
   /** Character name — match key vs report masterData actors. */
@@ -223,7 +225,13 @@ function normalizeEffects(v: LuaValue | undefined): CompanionEffect[] | undefine
   return out.length > 0 ? out : undefined;
 }
 
-function normalizeSnapshot(v: LuaValue): CompanionSnapshot | null {
+interface SnapshotDefaults {
+  account?: string;
+  schemaVersion?: number;
+  season?: string;
+}
+
+function normalizeSnapshot(v: LuaValue, defaults: SnapshotDefaults = {}): CompanionSnapshot | null {
   if (!isRecord(v)) return null;
   const ts = asNumber(v.ts);
   const char = asString(v.char);
@@ -245,9 +253,11 @@ function normalizeSnapshot(v: LuaValue): CompanionSnapshot | null {
     : undefined;
 
   return {
+    schemaVersion: asNumber(v.schemaVersion) ?? defaults.schemaVersion,
+    season: asString(v.season) ?? defaults.season,
     ts,
     char,
-    account: asString(v.account),
+    account: asString(v.account) ?? defaults.account,
     server: asString(v.server),
     zoneId: asNumber(v.zoneId),
     classId: asNumber(v.classId),
@@ -268,7 +278,7 @@ function normalizeSnapshot(v: LuaValue): CompanionSnapshot | null {
 
 /** Quick check whether a Lua file looks like an ESOTK Companion save. */
 export function isESOTKCompanionFormat(luaContent: string): boolean {
-  return luaContent.includes(SV_TABLE_NAME);
+  return luaContent.includes(SV_TABLE_NAME) && luaContent.includes('Default');
 }
 
 /**
@@ -321,7 +331,11 @@ export function parseESOTKCompanionSavedVariables(luaContent: string): Companion
       if (s) season = s;
 
       for (const snapRaw of luaArray(bucket.snapshots)) {
-        const snap = normalizeSnapshot(snapRaw);
+        const snap = normalizeSnapshot(snapRaw, {
+          account: accountKey,
+          schemaVersion: sv,
+          season: s,
+        });
         if (snap) accountSnapshots.push(snap);
       }
     }

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -53,12 +53,6 @@ export interface CompanionStats {
   weaponDamage?: number;
   spellCrit?: number;
   weaponCrit?: number;
-  /**
-   * Crit damage percent. NOT captured by the addon — ESO exposes no crit-damage stat
-   * constant, so ESOTK computes it from CP + sets + mundus. Kept optional/defensive in
-   * case a future source provides it; expect it to be undefined from real snapshots.
-   */
-  critDamage?: number;
   spellPen?: number;
   physicalPen?: number;
   magickaRegen?: number;
@@ -236,7 +230,6 @@ function normalizeStats(v: LuaValue | undefined): CompanionStats | undefined {
     'weaponDamage',
     'spellCrit',
     'weaponCrit',
-    'critDamage',
     'spellPen',
     'physicalPen',
     'magickaRegen',

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -36,6 +36,12 @@ export interface CompanionChampionPoints {
   disciplines: Record<number, CompanionCpDiscipline>;
   /** The 12 slotted stars, keyed by slot (1-12) → champion skill id. */
   slotted: Record<number, number>;
+  /**
+   * Client-provided star names, keyed by champion skill id. Ground truth from the game
+   * (localized), used as a fallback when ESOTK's canonical id→name map doesn't know an id
+   * — so even obscure passive stars read cleanly. Absent on pre-name-capture snapshots.
+   */
+  names?: Record<number, string>;
 }
 
 /** Final derived stats the log/API never carries. */
@@ -190,6 +196,15 @@ function numericMap(v: LuaValue | undefined): Record<number, number> {
   return out;
 }
 
+/** Build a `{ [numericId]: string }` map from a Lua table of numeric→string entries. */
+function numericStringMap(v: LuaValue | undefined): Record<number, string> {
+  const out: Record<number, string> = {};
+  for (const [id, val] of numericEntries(v)) {
+    if (typeof val === 'string' && val) out[id] = val;
+  }
+  return out;
+}
+
 function normalizeChampionPoints(v: LuaValue | undefined): CompanionChampionPoints | undefined {
   if (!isRecord(v)) return undefined;
   const disciplines: Record<number, CompanionCpDiscipline> = {};
@@ -202,10 +217,12 @@ function normalizeChampionPoints(v: LuaValue | undefined): CompanionChampionPoin
       skills: numericMap(d.skills),
     };
   }
+  const names = numericStringMap(v.names);
   return {
     total: asNumber(v.total),
     disciplines,
     slotted: numericMap(v.slotted),
+    ...(Object.keys(names).length > 0 ? { names } : {}),
   };
 }
 

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -183,9 +183,22 @@ function normalizeChampionPoints(v: LuaValue | undefined): CompanionChampionPoin
 function normalizeStats(v: LuaValue | undefined): CompanionStats | undefined {
   if (!isRecord(v)) return undefined;
   const keys: (keyof CompanionStats)[] = [
-    'maxMagicka', 'maxHealth', 'maxStamina', 'spellDamage', 'weaponDamage',
-    'spellCrit', 'weaponCrit', 'critDamage', 'spellPen', 'physicalPen', 'magickaRegen',
-    'staminaRegen', 'healthRegen', 'physicalResist', 'spellResist', 'critResist',
+    'maxMagicka',
+    'maxHealth',
+    'maxStamina',
+    'spellDamage',
+    'weaponDamage',
+    'spellCrit',
+    'weaponCrit',
+    'critDamage',
+    'spellPen',
+    'physicalPen',
+    'magickaRegen',
+    'staminaRegen',
+    'healthRegen',
+    'physicalResist',
+    'spellResist',
+    'critResist',
   ];
   const out: CompanionStats = {};
   for (const key of keys) {

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -47,7 +47,11 @@ export interface CompanionStats {
   weaponDamage?: number;
   spellCrit?: number;
   weaponCrit?: number;
-  /** Crit damage as a percent bonus (base 50), when the ESO API exposes it. */
+  /**
+   * Crit damage percent. NOT captured by the addon — ESO exposes no crit-damage stat
+   * constant, so ESOTK computes it from CP + sets + mundus. Kept optional/defensive in
+   * case a future source provides it; expect it to be undefined from real snapshots.
+   */
   critDamage?: number;
   spellPen?: number;
   physicalPen?: number;

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -74,6 +74,26 @@ export interface CompanionEffect {
   duration?: number;
 }
 
+/** One active scribing script slotted on a crafted ability. */
+export interface CompanionScribingScript {
+  id: number;
+  /** Script slot: 1 = focus, 2 = signature, 3 = affix. */
+  slot?: number;
+  name?: string;
+  icon?: string;
+}
+
+/** One scribed skill captured from the local action bars. */
+export interface CompanionScribedSkill {
+  /** Crafted ability / grimoire id from the action slot. */
+  abilityId: number;
+  name?: string;
+  bar?: string;
+  slot?: number;
+  /** Active scripts keyed by script slot. */
+  scripts: Record<number, CompanionScribingScript>;
+}
+
 /** One captured build snapshot, taken on combat end or on demand. */
 export interface CompanionSnapshot {
   schemaVersion?: number;
@@ -101,6 +121,7 @@ export interface CompanionSnapshot {
   attributes?: CompanionAttributes;
   effects?: CompanionEffect[];
   bars?: { front?: Record<number, number>; back?: Record<number, number> };
+  scribing?: CompanionScribedSkill[];
 }
 
 /** Parsed companion file: snapshots grouped by account. */
@@ -225,6 +246,43 @@ function normalizeEffects(v: LuaValue | undefined): CompanionEffect[] | undefine
   return out.length > 0 ? out : undefined;
 }
 
+function normalizeScribing(v: LuaValue | undefined): CompanionScribedSkill[] | undefined {
+  const arr = luaArray(v);
+  if (arr.length === 0) return undefined;
+
+  const out: CompanionScribedSkill[] = [];
+  for (const item of arr) {
+    if (!isRecord(item)) continue;
+    const abilityId = asNumber(item.abilityId);
+    if (typeof abilityId !== 'number') continue;
+
+    const scripts: Record<number, CompanionScribingScript> = {};
+    for (const [scriptSlot, scriptRaw] of numericEntries(item.scripts)) {
+      if (!isRecord(scriptRaw)) continue;
+      const id = asNumber(scriptRaw.id);
+      if (typeof id !== 'number') continue;
+      const slot = asNumber(scriptRaw.slot) ?? scriptSlot;
+      scripts[slot] = {
+        id,
+        slot,
+        name: asString(scriptRaw.name),
+        icon: asString(scriptRaw.icon),
+      };
+    }
+
+    if (Object.keys(scripts).length === 0) continue;
+    out.push({
+      abilityId,
+      name: asString(item.name),
+      bar: asString(item.bar),
+      slot: asNumber(item.slot),
+      scripts,
+    });
+  }
+
+  return out.length > 0 ? out : undefined;
+}
+
 interface SnapshotDefaults {
   account?: string;
   schemaVersion?: number;
@@ -273,6 +331,7 @@ function normalizeSnapshot(v: LuaValue, defaults: SnapshotDefaults = {}): Compan
     attributes,
     effects: normalizeEffects(v.effects),
     bars,
+    scribing: normalizeScribing(v.scribing),
   };
 }
 

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -15,11 +15,7 @@ import {
   buildChampionPointsViewModel,
   type ChampionPointsViewModel,
 } from './esotkCompanionChampionPoints';
-import {
-  computeStatCoaching,
-  type CoachingInsight,
-  type CoachingOptions,
-} from './esotkCompanionCoaching';
+import { computeStatCoaching, type CoachingInsight } from './esotkCompanionCoaching';
 import {
   matchCompanionSnapshots,
   type MatchableActor,
@@ -48,8 +44,6 @@ export interface CompanionBuildForPlayer {
 export interface BuildCompanionBuildsOptions {
   /** Current report fight id. When supplied, picks snapshots nearest to that fight. */
   targetFightId?: number | string;
-  /** Coaching options (penetration target, assumed group pen, …). */
-  coaching?: CoachingOptions;
 }
 
 /**
@@ -70,7 +64,7 @@ export function buildCompanionBuildsForReport(
   for (const [actorId, match] of matches) {
     out.set(actorId, {
       championPoints: buildChampionPointsViewModel(match.snapshot.championPoints),
-      coaching: computeStatCoaching(match.snapshot.stats, opts.coaching),
+      coaching: computeStatCoaching(match.snapshot.stats),
       stats: match.snapshot.stats,
       effects: match.snapshot.effects,
       scribing: match.snapshot.scribing,

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -37,7 +37,9 @@ export interface CompanionBuildForPlayer {
   stats?: CompanionSnapshot['stats'];
   /** Long-term/self effects captured by the add-on (food, mundus, potion clusters). */
   effects?: CompanionSnapshot['effects'];
-  /** The snapshot this was built from (raw stats/effects available for detail views). */
+  /** Scribed skills captured authoritatively from the local action bars. */
+  scribing?: CompanionSnapshot['scribing'];
+  /** The snapshot this was built from (raw stats/effects/scribing available for detail views). */
   snapshot: CompanionSnapshot;
   /** The fight the snapshot best matched, if any. */
   fightId?: number | string;
@@ -71,6 +73,7 @@ export function buildCompanionBuildsForReport(
       coaching: computeStatCoaching(match.snapshot.stats, opts.coaching),
       stats: match.snapshot.stats,
       effects: match.snapshot.effects,
+      scribing: match.snapshot.scribing,
       snapshot: match.snapshot,
       fightId: match.fightId,
     });

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -33,6 +33,10 @@ export interface CompanionBuildForPlayer {
   championPoints: ChampionPointsViewModel | null;
   /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
   coaching: CoachingInsight[];
+  /** Final sheet stats captured by the add-on. */
+  stats?: CompanionSnapshot['stats'];
+  /** Long-term/self effects captured by the add-on (food, mundus, potion clusters). */
+  effects?: CompanionSnapshot['effects'];
   /** The snapshot this was built from (raw stats/effects available for detail views). */
   snapshot: CompanionSnapshot;
   /** The fight the snapshot best matched, if any. */
@@ -65,6 +69,8 @@ export function buildCompanionBuildsForReport(
     out.set(actorId, {
       championPoints: buildChampionPointsViewModel(match.snapshot.championPoints),
       coaching: computeStatCoaching(match.snapshot.stats, opts.coaching),
+      stats: match.snapshot.stats,
+      effects: match.snapshot.effects,
       snapshot: match.snapshot,
       fightId: match.fightId,
     });

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -27,7 +27,7 @@ import type { CompanionSnapshot } from './esotkCompanionParser';
 export interface CompanionBuildForPlayer {
   /** Champion-point view-model, or null when none was captured. */
   championPoints: ChampionPointsViewModel | null;
-  /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
+  /** Stat-aware coaching insights (self penetration + crit chance, point-in-time). */
   coaching: CoachingInsight[];
   /** Final sheet stats captured by the add-on. */
   stats?: CompanionSnapshot['stats'];

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -40,6 +40,8 @@ export interface CompanionBuildForPlayer {
 }
 
 export interface BuildCompanionBuildsOptions {
+  /** Current report fight id. When supplied, picks snapshots nearest to that fight. */
+  targetFightId?: number | string;
   /** Coaching options (penetration target, assumed group pen, …). */
   coaching?: CoachingOptions;
 }
@@ -56,7 +58,9 @@ export function buildCompanionBuildsForReport(
   const out = new Map<MatchableActor['id'], CompanionBuildForPlayer>();
   if (snapshots.length === 0 || report.actors.length === 0) return out;
 
-  const { matches } = matchCompanionSnapshots(snapshots, report);
+  const { matches } = matchCompanionSnapshots(snapshots, report, {
+    targetFightId: opts.targetFightId,
+  });
   for (const [actorId, match] of matches) {
     out.set(actorId, {
       championPoints: buildChampionPointsViewModel(match.snapshot.championPoints),

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -1,0 +1,69 @@
+/**
+ * Report adapter — composes the companion pipeline into per-player render props.
+ *
+ * Given the snapshots parsed from an uploaded `ESOTKCompanionSV` file and an ESO Logs
+ * report, this matches each snapshot to a report actor and produces exactly the shape
+ * `PlayerCard`'s `companionBuild` prop expects: the champion-point view-model + the
+ * stat-aware coaching insights. This is the only wiring the report UI needs — upload a
+ * file, call this, hand each player their entry.
+ *
+ * Pure and dependency-free (no Redux/UI), so the whole match→render mapping is testable
+ * without the running app.
+ */
+
+import {
+  buildChampionPointsViewModel,
+  type ChampionPointsViewModel,
+} from './esotkCompanionChampionPoints';
+import {
+  computeStatCoaching,
+  type CoachingInsight,
+  type CoachingOptions,
+} from './esotkCompanionCoaching';
+import {
+  matchCompanionSnapshots,
+  type MatchableActor,
+  type MatchableReport,
+} from './esotkCompanionMatcher';
+import type { CompanionSnapshot } from './esotkCompanionParser';
+
+/** Render-ready companion build for one matched player. */
+export interface CompanionBuildForPlayer {
+  /** Champion-point view-model, or null when none was captured. */
+  championPoints: ChampionPointsViewModel | null;
+  /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
+  coaching: CoachingInsight[];
+  /** The snapshot this was built from (raw stats/effects available for detail views). */
+  snapshot: CompanionSnapshot;
+  /** The fight the snapshot best matched, if any. */
+  fightId?: number | string;
+}
+
+export interface BuildCompanionBuildsOptions {
+  /** Coaching options (penetration target, assumed group pen, …). */
+  coaching?: CoachingOptions;
+}
+
+/**
+ * Match companion snapshots to a report and build per-actor render props.
+ * Returns a map keyed by actor id; only actors with a matched snapshot appear.
+ */
+export function buildCompanionBuildsForReport(
+  snapshots: CompanionSnapshot[],
+  report: MatchableReport,
+  opts: BuildCompanionBuildsOptions = {},
+): Map<MatchableActor['id'], CompanionBuildForPlayer> {
+  const out = new Map<MatchableActor['id'], CompanionBuildForPlayer>();
+  if (snapshots.length === 0 || report.actors.length === 0) return out;
+
+  const { matches } = matchCompanionSnapshots(snapshots, report);
+  for (const [actorId, match] of matches) {
+    out.set(actorId, {
+      championPoints: buildChampionPointsViewModel(match.snapshot.championPoints),
+      coaching: computeStatCoaching(match.snapshot.stats, opts.coaching),
+      snapshot: match.snapshot,
+      fightId: match.fightId,
+    });
+  }
+  return out;
+}

--- a/src/features/report_details/insights/CompanionBuildPanel.stories.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.stories.tsx
@@ -4,7 +4,6 @@ import { buildChampionPointsViewModel } from '@/features/loadout-manager/utils/e
 import {
   computeStatCoaching,
   PVE_PENETRATION_CAP,
-  STANDARD_GROUP_PEN,
 } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
 
 import { CompanionBuildPanel } from './CompanionBuildPanel';
@@ -25,7 +24,7 @@ const meta: Meta<typeof CompanionBuildPanel> = {
     docs: {
       description: {
         component:
-          'Renders the build data the ESOTK Companion add-on captures that ESO Logs cannot see: the full champion-point allocation (grouped by tree) and stat-aware coaching (penetration vs the 18,200 cap, crit caps).',
+          'Renders the build data the ESOTK Companion add-on captures that ESO Logs cannot see: the full champion-point allocation (grouped by tree) and the character sheet at capture (point-in-time, buff-dependent stats separated from stable ones), plus plain stat readings for penetration and crit chance.',
       },
     },
   },
@@ -34,25 +33,31 @@ const meta: Meta<typeof CompanionBuildPanel> = {
 export default meta;
 type Story = StoryObj<typeof CompanionBuildPanel>;
 
-/** Over-penetration: a DPS wasting stats above the cap. */
-export const OverPenetration: Story = {
+/** High self-penetration reading captured on the character sheet. */
+export const HighPenetration: Story = {
   args: {
     championPoints,
-    coaching: computeStatCoaching(
-      { physicalPen: 12000, critDamage: 130, weaponCrit: 14000 },
-      { assumedGroupPen: STANDARD_GROUP_PEN, groupPenIsExact: false },
-    ),
+    coaching: computeStatCoaching({ physicalPen: PVE_PENETRATION_CAP + 3000, weaponCrit: 14000 }),
+    stats: {
+      physicalPen: PVE_PENETRATION_CAP + 3000,
+      weaponCrit: 14000,
+      spellDamage: 4800,
+      maxMagicka: 38000,
+    },
   },
 };
 
-/** On-cap, healthy build. */
-export const OnCap: Story = {
+/** Typical self-penetration reading captured on the character sheet. */
+export const TypicalPenetration: Story = {
   args: {
     championPoints,
-    coaching: computeStatCoaching(
-      { physicalPen: PVE_PENETRATION_CAP - STANDARD_GROUP_PEN, critDamage: 120, weaponCrit: 12000 },
-      { assumedGroupPen: STANDARD_GROUP_PEN, groupPenIsExact: false },
-    ),
+    coaching: computeStatCoaching({ physicalPen: 9500, weaponCrit: 12000 }),
+    stats: {
+      physicalPen: 9500,
+      weaponCrit: 12000,
+      spellDamage: 4200,
+      maxStamina: 34000,
+    },
   },
 };
 

--- a/src/features/report_details/insights/CompanionBuildPanel.stories.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+import { buildChampionPointsViewModel } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
+import {
+  computeStatCoaching,
+  PVE_PENETRATION_CAP,
+  STANDARD_GROUP_PEN,
+} from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+
+import { CompanionBuildPanel } from './CompanionBuildPanel';
+
+const championPoints = buildChampionPointsViewModel({
+  total: 3600,
+  disciplines: {
+    1: { id: 1, skills: { 25: 50, 27: 50, 8: 50, 12: 50 } }, // Warfare: Deadly Aim, Thaumaturge, Wrathful Strikes, Fighting Finesse
+    3: { id: 3, skills: { 4: 50, 46: 20 } }, // Fitness: Untamed Aggression, Bastion
+  },
+  slotted: { 5: 25, 6: 27, 7: 8, 8: 12 },
+});
+
+const meta: Meta<typeof CompanionBuildPanel> = {
+  title: 'Features/Report Details/Insights/CompanionBuildPanel',
+  component: CompanionBuildPanel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Renders the build data the ESOTK Companion add-on captures that ESO Logs cannot see: the full champion-point allocation (grouped by tree) and stat-aware coaching (penetration vs the 18,200 cap, crit caps).',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CompanionBuildPanel>;
+
+/** Over-penetration: a DPS wasting stats above the cap. */
+export const OverPenetration: Story = {
+  args: {
+    championPoints,
+    coaching: computeStatCoaching(
+      { physicalPen: 12000, critDamage: 130, weaponCrit: 14000 },
+      { assumedGroupPen: STANDARD_GROUP_PEN, groupPenIsExact: false },
+    ),
+  },
+};
+
+/** On-cap, healthy build. */
+export const OnCap: Story = {
+  args: {
+    championPoints,
+    coaching: computeStatCoaching(
+      { physicalPen: PVE_PENETRATION_CAP - STANDARD_GROUP_PEN, critDamage: 120, weaponCrit: 12000 },
+      { assumedGroupPen: STANDARD_GROUP_PEN, groupPenIsExact: false },
+    ),
+  },
+};
+
+/** Champion points only (no stats captured). */
+export const ChampionPointsOnly: Story = {
+  args: { championPoints, coaching: [] },
+};
+
+/** Nothing captured — renders nothing. */
+export const Empty: Story = {
+  args: { championPoints: null, coaching: [] },
+};

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
 import type {
   CompanionEffect,
+  CompanionScribedSkill,
   CompanionStats,
 } from '@/features/loadout-manager/utils/esotkCompanionParser';
 import { MundusStones } from '@/types/abilities';
@@ -40,6 +41,8 @@ export interface CompanionBuildPanelProps {
   stats?: CompanionStats;
   /** Long-term/self effects captured by the add-on. */
   effects?: CompanionEffect[];
+  /** Scribed skills captured directly from the add-on action bar snapshot. */
+  scribing?: CompanionScribedSkill[];
 }
 
 const SECTION_TITLE_SX = {
@@ -132,6 +135,31 @@ function statRows(
   return rows;
 }
 
+function scribedSkillRows(
+  scribing: CompanionScribedSkill[] | undefined,
+): Array<{ id: string; label: string; title: string }> {
+  return (scribing ?? [])
+    .map((skill) => {
+      const scripts = Object.values(skill.scripts)
+        .sort((a, b) => (a.slot ?? 0) - (b.slot ?? 0))
+        .map((script) => script.name || `Script ${script.id}`);
+      if (scripts.length === 0) return null;
+
+      const skillName = skill.name || `Ability ${skill.abilityId}`;
+      const barSlotParts = [
+        skill.bar,
+        skill.slot !== undefined ? `slot ${skill.slot}` : undefined,
+      ].filter(Boolean);
+      const barSlot = barSlotParts.length > 0 ? ` (${barSlotParts.join(' ')})` : '';
+      return {
+        id: `${skill.abilityId}:${skill.bar ?? ''}:${skill.slot ?? ''}`,
+        label: `${skillName}: ${scripts.join(' / ')}`,
+        title: `Scribed skill captured by ESOTK Companion${barSlot} (Ability ID: ${skill.abilityId})`,
+      };
+    })
+    .filter((row): row is { id: string; label: string; title: string } => Boolean(row));
+}
+
 function StarChips({
   stars,
   variant,
@@ -172,9 +200,11 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
   coaching,
   stats,
   effects,
+  scribing,
 }) => {
   const theme = useTheme();
   const rows = React.useMemo(() => statRows(stats), [stats]);
+  const capturedScribing = React.useMemo(() => scribedSkillRows(scribing), [scribing]);
   const auras = React.useMemo(() => effectAuras(effects), [effects]);
   const food = React.useMemo(() => detectFoodFromAuras(auras), [auras]);
   const mundus = React.useMemo(() => detectMundus(effects), [effects]);
@@ -187,12 +217,13 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
   const hasCoaching = coaching.length > 0;
   const hasStats = rows.length > 0;
   const hasConsumables = Boolean(food || mundus || hasPotion);
-  if (!hasCp && !hasCoaching && !hasStats && !hasConsumables) return null;
+  const hasScribing = capturedScribing.length > 0;
+  if (!hasCp && !hasCoaching && !hasStats && !hasConsumables && !hasScribing) return null;
 
   return (
     <Box sx={{ mt: 1 }} data-testid="companion-build-panel">
       {hasCp && championPoints && (
-        <Box sx={{ mb: hasConsumables || hasStats || hasCoaching ? 2 : 0 }}>
+        <Box sx={{ mb: hasConsumables || hasScribing || hasStats || hasCoaching ? 2 : 0 }}>
           <Typography variant="body2" sx={SECTION_TITLE_SX}>
             Champion Points
             {championPoints.total !== undefined && (
@@ -249,7 +280,7 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
       )}
 
       {hasConsumables && (
-        <Box sx={{ mb: hasStats || hasCoaching ? 2 : 0 }}>
+        <Box sx={{ mb: hasScribing || hasStats || hasCoaching ? 2 : 0 }}>
           <Typography variant="body2" sx={SECTION_TITLE_SX}>
             Captured Buffs
           </Typography>
@@ -278,6 +309,26 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
                 sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
               />
             )}
+          </Box>
+        </Box>
+      )}
+
+      {hasScribing && (
+        <Box sx={{ mb: hasStats || hasCoaching ? 2 : 0 }}>
+          <Typography variant="body2" sx={SECTION_TITLE_SX}>
+            Captured Scribing
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {capturedScribing.map((row) => (
+              <Chip
+                key={row.id}
+                size="small"
+                variant="outlined"
+                label={row.label}
+                title={row.title}
+                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+              />
+            ))}
           </Box>
         </Box>
       )}

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -13,7 +13,10 @@ import type {
   ChampionTreeKey,
 } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
 import { UNKNOWN_TREE } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
-import type { CoachingInsight, CoachingSeverity } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+import type {
+  CoachingInsight,
+  CoachingSeverity,
+} from '@/features/loadout-manager/utils/esotkCompanionCoaching';
 import { ChampionPointTree } from '@/types/champion-points';
 import { buildVariantSx } from '@/utils/playerCardStyleUtils';
 
@@ -102,8 +105,13 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
           <Typography variant="body2" sx={SECTION_TITLE_SX}>
             Champion Points
             {championPoints.total !== undefined && (
-              <Typography component="span" variant="caption" sx={{ ml: 1, color: 'text.secondary' }}>
-                {championPoints.total.toLocaleString()} CP · {championPoints.totalAllocated.toLocaleString()} allocated
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{ ml: 1, color: 'text.secondary' }}
+              >
+                {championPoints.total.toLocaleString()} CP ·{' '}
+                {championPoints.totalAllocated.toLocaleString()} allocated
               </Typography>
             )}
           </Typography>

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -51,6 +51,17 @@ const SECTION_TITLE_SX = {
   fontFamily: 'Space Grotesk, sans-serif',
 } as const;
 
+/**
+ * The captured sheet reads once on leaving combat (buffs fading), so most stats are a
+ * volatile point-in-time value. Only max-resource pools are stable at that instant; keep
+ * them in their own group so a reader doesn't compare a volatile chip across players.
+ */
+const STABLE_STAT_IDS = new Set(['maxMagicka', 'maxStamina', 'maxHealth']);
+
+/** Caption/tooltip conveying that these are point-in-time, not comparable across players. */
+const CAPTURED_SHEET_TOOLTIP =
+  'Character sheet at capture — read on leaving combat (buffs fading), point-in-time, not comparable across players.';
+
 // Display order + the chip style variant each tree maps to (matches PlayerCard's CP chips).
 const TREE_ORDER: { tree: ChampionTreeKey; label: string; variant: string }[] = [
   { tree: ChampionPointTree.Warfare, label: 'Warfare', variant: 'championBlue' },
@@ -119,7 +130,6 @@ function statRows(
   add('weaponDamage', 'Weapon Damage', stats.weaponDamage);
   add('spellCrit', 'Spell Crit', stats.spellCrit, critPercent);
   add('weaponCrit', 'Weapon Crit', stats.weaponCrit, critPercent);
-  add('critDamage', 'Crit Damage', stats.critDamage, (value) => `${formatNumber(value)}%`);
   add('spellPen', 'Spell Pen', stats.spellPen);
   add('physicalPen', 'Physical Pen', stats.physicalPen);
   add('maxMagicka', 'Max Magicka', stats.maxMagicka);
@@ -187,6 +197,42 @@ function StarChips({
   );
 }
 
+/** A labeled group of captured-sheet stat chips (volatile vs stable). */
+function SheetStatGroup({
+  caption,
+  rows,
+  volatile: isVolatile,
+}: {
+  caption: string;
+  rows: Array<{ id: string; label: string; value: string }>;
+  volatile: boolean;
+}): React.ReactElement | null {
+  if (rows.length === 0) return null;
+  return (
+    <Box sx={{ mb: 0.75 }}>
+      <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.25 }}>
+        {caption}
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+        {rows.map((row) => (
+          <Chip
+            key={row.id}
+            size="small"
+            variant="outlined"
+            label={`${row.label}: ${row.value}`}
+            title={
+              isVolatile
+                ? `${row.label} — point-in-time character-sheet reading captured by ESOTK Companion (buffs fading)`
+                : `${row.label} captured by ESOTK Companion`
+            }
+            sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
 /**
  * Renders the build data captured by the ESOTK Companion add-on that ESO Logs can't see:
  * the full champion-point allocation (grouped by tree) and stat-aware coaching
@@ -204,6 +250,8 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
 }) => {
   const theme = useTheme();
   const rows = React.useMemo(() => statRows(stats), [stats]);
+  const volatileRows = React.useMemo(() => rows.filter((r) => !STABLE_STAT_IDS.has(r.id)), [rows]);
+  const stableRows = React.useMemo(() => rows.filter((r) => STABLE_STAT_IDS.has(r.id)), [rows]);
   const capturedScribing = React.useMemo(() => scribedSkillRows(scribing), [scribing]);
   const auras = React.useMemo(() => effectAuras(effects), [effects]);
   const food = React.useMemo(() => detectFoodFromAuras(auras), [auras]);
@@ -335,21 +383,17 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
 
       {hasStats && (
         <Box sx={{ mb: hasCoaching ? 2 : 0 }}>
-          <Typography variant="body2" sx={SECTION_TITLE_SX}>
-            Captured Stats
+          <Typography
+            variant="body2"
+            sx={{ ...SECTION_TITLE_SX, display: 'flex', alignItems: 'center', gap: 0.5 }}
+          >
+            Sheet at Capture
+            <Tooltip title={CAPTURED_SHEET_TOOLTIP} placement="top-start">
+              <InfoIcon sx={{ fontSize: '0.9rem', color: 'text.secondary', cursor: 'help' }} />
+            </Tooltip>
           </Typography>
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {rows.map((row) => (
-              <Chip
-                key={row.id}
-                size="small"
-                variant="outlined"
-                label={`${row.label}: ${row.value}`}
-                title={`${row.label} captured by ESOTK Companion`}
-                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
-              />
-            ))}
-          </Box>
+          <SheetStatGroup caption="Volatile (buff-dependent)" rows={volatileRows} volatile />
+          <SheetStatGroup caption="Stable" rows={stableRows} volatile={false} />
         </Box>
       )}
 

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -1,0 +1,184 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircleOutlined';
+import ErrorIcon from '@mui/icons-material/ErrorOutlined';
+import InfoIcon from '@mui/icons-material/InfoOutlined';
+import WarningIcon from '@mui/icons-material/WarningAmberOutlined';
+import { Box, Chip, Tooltip, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import React from 'react';
+
+import type {
+  AllocatedStar,
+  ChampionPointsViewModel,
+  ChampionTreeKey,
+} from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
+import { UNKNOWN_TREE } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
+import type { CoachingInsight, CoachingSeverity } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+import { ChampionPointTree } from '@/types/champion-points';
+import { buildVariantSx } from '@/utils/playerCardStyleUtils';
+
+export interface CompanionBuildPanelProps {
+  /** Champion-point view-model from the ESOTK Companion add-on, or null if none captured. */
+  championPoints: ChampionPointsViewModel | null;
+  /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
+  coaching: CoachingInsight[];
+}
+
+const SECTION_TITLE_SX = {
+  fontWeight: 'bold',
+  mb: 1,
+  fontFamily: 'Space Grotesk, sans-serif',
+} as const;
+
+// Display order + the chip style variant each tree maps to (matches PlayerCard's CP chips).
+const TREE_ORDER: { tree: ChampionTreeKey; label: string; variant: string }[] = [
+  { tree: ChampionPointTree.Warfare, label: 'Warfare', variant: 'championBlue' },
+  { tree: ChampionPointTree.Fitness, label: 'Fitness', variant: 'championRed' },
+  { tree: ChampionPointTree.Craft, label: 'Craft', variant: 'championGreen' },
+  { tree: UNKNOWN_TREE, label: 'Other', variant: 'default' },
+];
+
+const SEVERITY_META: Record<
+  CoachingSeverity,
+  { color: 'success' | 'info' | 'warning' | 'error'; Icon: typeof CheckCircleIcon }
+> = {
+  good: { color: 'success', Icon: CheckCircleIcon },
+  info: { color: 'info', Icon: InfoIcon },
+  warn: { color: 'warning', Icon: WarningIcon },
+  error: { color: 'error', Icon: ErrorIcon },
+};
+
+function StarChips({
+  stars,
+  variant,
+  theme,
+}: {
+  stars: AllocatedStar[];
+  variant: string;
+  theme: Theme;
+}): React.ReactElement {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+      {stars.map((star) => (
+        <Chip
+          key={star.id}
+          size="small"
+          label={`${star.name} ${star.points}`}
+          title={`${star.name} — ${star.points} points (ID: ${star.id})`}
+          sx={{
+            ...(variant === 'default' ? {} : buildVariantSx(variant, theme)),
+            '& .MuiChip-label': { fontSize: '0.58rem' },
+          }}
+        />
+      ))}
+    </Box>
+  );
+}
+
+/**
+ * Renders the build data captured by the ESOTK Companion add-on that ESO Logs can't see:
+ * the full champion-point allocation (grouped by tree) and stat-aware coaching
+ * (penetration vs cap, crit caps). Presentational only — feed it the view-model from
+ * `buildChampionPointsViewModel` and insights from `computeStatCoaching`.
+ *
+ * Renders nothing when there's no companion data, so it's safe to always mount.
+ */
+export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
+  championPoints,
+  coaching,
+}) => {
+  const theme = useTheme();
+
+  const hasCp =
+    championPoints !== null &&
+    (championPoints.allocated.length > 0 || championPoints.slotted.length > 0);
+  const hasCoaching = coaching.length > 0;
+  if (!hasCp && !hasCoaching) return null;
+
+  return (
+    <Box sx={{ mt: 1 }} data-testid="companion-build-panel">
+      {hasCp && championPoints && (
+        <Box sx={{ mb: hasCoaching ? 2 : 0 }}>
+          <Typography variant="body2" sx={SECTION_TITLE_SX}>
+            Champion Points
+            {championPoints.total !== undefined && (
+              <Typography component="span" variant="caption" sx={{ ml: 1, color: 'text.secondary' }}>
+                {championPoints.total.toLocaleString()} CP · {championPoints.totalAllocated.toLocaleString()} allocated
+              </Typography>
+            )}
+          </Typography>
+
+          {TREE_ORDER.map(({ tree, label, variant }) => {
+            const stars = championPoints.byTree[tree];
+            if (!stars || stars.length === 0) return null;
+            return (
+              <Box key={label} sx={{ mb: 0.75 }}>
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'text.secondary', display: 'block', mb: 0.25 }}
+                >
+                  {label}
+                </Typography>
+                <StarChips stars={stars} variant={variant} theme={theme} />
+              </Box>
+            );
+          })}
+
+          {championPoints.slotted.length > 0 && (
+            <Box sx={{ mt: 1 }}>
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', display: 'block', mb: 0.25 }}
+              >
+                Slotted
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                {championPoints.slotted.map((s) => (
+                  <Chip
+                    key={s.slot}
+                    size="small"
+                    variant="outlined"
+                    label={s.name}
+                    title={`Slot ${s.slot}: ${s.name} (ID: ${s.id})`}
+                    sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {hasCoaching && (
+        <Box>
+          <Typography variant="body2" sx={SECTION_TITLE_SX}>
+            Build Coaching
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            {coaching.map((insight) => {
+              const { color, Icon } = SEVERITY_META[insight.severity];
+              return (
+                <Tooltip key={insight.id} title={insight.detail} placement="top-start">
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75 }}>
+                    <Icon fontSize="small" color={color} sx={{ mt: '1px', flexShrink: 0 }} />
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography variant="caption" sx={{ fontWeight: 700, display: 'block' }}>
+                        {insight.label}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{ color: 'text.secondary', display: 'block' }}
+                      >
+                        {insight.detail}
+                      </Typography>
+                    </Box>
+                  </Box>
+                </Tooltip>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -35,7 +35,7 @@ import {
 export interface CompanionBuildPanelProps {
   /** Champion-point view-model from the ESOTK Companion add-on, or null if none captured. */
   championPoints: ChampionPointsViewModel | null;
-  /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
+  /** Stat-aware coaching insights (self penetration + crit chance, point-in-time). */
   coaching: CoachingInsight[];
   /** Final sheet stats captured by the add-on. */
   stats?: CompanionStats;
@@ -235,8 +235,9 @@ function SheetStatGroup({
 
 /**
  * Renders the build data captured by the ESOTK Companion add-on that ESO Logs can't see:
- * the full champion-point allocation (grouped by tree) and stat-aware coaching
- * (penetration vs cap, crit caps). Presentational only — feed it the view-model from
+ * the full champion-point allocation (grouped by tree), the character sheet at capture
+ * (point-in-time, volatile chips separated from stable), and plain stat-reading coaching
+ * (self penetration, crit chance). Presentational only — feed it the view-model from
  * `buildChampionPointsViewModel` and insights from `computeStatCoaching`.
  *
  * Renders nothing when there's no companion data, so it's safe to always mount.

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -17,14 +17,29 @@ import type {
   CoachingInsight,
   CoachingSeverity,
 } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+import type {
+  CompanionEffect,
+  CompanionStats,
+} from '@/features/loadout-manager/utils/esotkCompanionParser';
+import { MundusStones } from '@/types/abilities';
 import { ChampionPointTree } from '@/types/champion-points';
+import { detectFoodFromAuras } from '@/utils/foodDetectionUtils';
 import { buildVariantSx } from '@/utils/playerCardStyleUtils';
+import {
+  detectPotionType,
+  describePotionType,
+  type PotionType,
+} from '@/utils/potionDetectionUtils';
 
 export interface CompanionBuildPanelProps {
   /** Champion-point view-model from the ESOTK Companion add-on, or null if none captured. */
   championPoints: ChampionPointsViewModel | null;
   /** Stat-aware coaching insights (penetration vs cap, crit caps, …). */
   coaching: CoachingInsight[];
+  /** Final sheet stats captured by the add-on. */
+  stats?: CompanionStats;
+  /** Long-term/self effects captured by the add-on. */
+  effects?: CompanionEffect[];
 }
 
 const SECTION_TITLE_SX = {
@@ -50,6 +65,72 @@ const SEVERITY_META: Record<
   warn: { color: 'warning', Icon: WarningIcon },
   error: { color: 'error', Icon: ErrorIcon },
 };
+
+const CRIT_RATING_FOR_100_PERCENT = 21_918;
+const MUNDUS_IDS = new Set(
+  Object.values(MundusStones).filter((value): value is number => typeof value === 'number'),
+);
+const MUNDUS_NAME_RX =
+  /^(?:Boon:|Bonus\s*\(2\):)?\s*The\s+(Warrior|Mage|Serpent|Thief|Lady|Steed|Lord|Apprentice|Ritual|Lover|Atronach|Shadow|Tower)\b/i;
+
+function formatNumber(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function critPercent(rating: number): string {
+  const pct = Math.min(100, Math.round((rating / CRIT_RATING_FOR_100_PERCENT) * 1000) / 10);
+  return `${pct}%`;
+}
+
+function effectAuras(effects: CompanionEffect[] | undefined): Array<{ name: string; id: number }> {
+  return effects?.map((effect) => ({ name: effect.name ?? '', id: effect.id })) ?? [];
+}
+
+function detectMundus(effects: CompanionEffect[] | undefined): { name: string; id: number } | null {
+  for (const effect of effects ?? []) {
+    const name = effect.name ?? '';
+    if (!MUNDUS_IDS.has(effect.id) && !MUNDUS_NAME_RX.test(name)) continue;
+    return {
+      id: effect.id,
+      name: name.replace(/^(?:Boon:|Bonus\s*\(2\):)\s*/i, '').trim() || `Mundus ${effect.id}`,
+    };
+  }
+  return null;
+}
+
+function statRows(
+  stats: CompanionStats | undefined,
+): Array<{ id: string; label: string; value: string }> {
+  if (!stats) return [];
+  const rows: Array<{ id: string; label: string; value: string }> = [];
+  const add = (
+    id: string,
+    label: string,
+    value: number | undefined,
+    formatter = formatNumber,
+  ): void => {
+    if (typeof value === 'number') rows.push({ id, label, value: formatter(value) });
+  };
+
+  add('spellDamage', 'Spell Damage', stats.spellDamage);
+  add('weaponDamage', 'Weapon Damage', stats.weaponDamage);
+  add('spellCrit', 'Spell Crit', stats.spellCrit, critPercent);
+  add('weaponCrit', 'Weapon Crit', stats.weaponCrit, critPercent);
+  add('critDamage', 'Crit Damage', stats.critDamage, (value) => `${formatNumber(value)}%`);
+  add('spellPen', 'Spell Pen', stats.spellPen);
+  add('physicalPen', 'Physical Pen', stats.physicalPen);
+  add('maxMagicka', 'Max Magicka', stats.maxMagicka);
+  add('maxStamina', 'Max Stamina', stats.maxStamina);
+  add('maxHealth', 'Max Health', stats.maxHealth);
+  add('magickaRegen', 'Mag Regen', stats.magickaRegen);
+  add('staminaRegen', 'Stam Regen', stats.staminaRegen);
+  add('healthRegen', 'Health Regen', stats.healthRegen);
+  add('physicalResist', 'Physical Resist', stats.physicalResist);
+  add('spellResist', 'Spell Resist', stats.spellResist);
+  add('critResist', 'Crit Resist', stats.critResist);
+
+  return rows;
+}
 
 function StarChips({
   stars,
@@ -89,19 +170,29 @@ function StarChips({
 export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
   championPoints,
   coaching,
+  stats,
+  effects,
 }) => {
   const theme = useTheme();
+  const rows = React.useMemo(() => statRows(stats), [stats]);
+  const auras = React.useMemo(() => effectAuras(effects), [effects]);
+  const food = React.useMemo(() => detectFoodFromAuras(auras), [auras]);
+  const mundus = React.useMemo(() => detectMundus(effects), [effects]);
+  const potionType = React.useMemo<PotionType>(() => detectPotionType(auras, 0), [auras]);
+  const hasPotion = potionType !== 'none' && potionType !== 'unknown';
 
   const hasCp =
     championPoints !== null &&
     (championPoints.allocated.length > 0 || championPoints.slotted.length > 0);
   const hasCoaching = coaching.length > 0;
-  if (!hasCp && !hasCoaching) return null;
+  const hasStats = rows.length > 0;
+  const hasConsumables = Boolean(food || mundus || hasPotion);
+  if (!hasCp && !hasCoaching && !hasStats && !hasConsumables) return null;
 
   return (
     <Box sx={{ mt: 1 }} data-testid="companion-build-panel">
       {hasCp && championPoints && (
-        <Box sx={{ mb: hasCoaching ? 2 : 0 }}>
+        <Box sx={{ mb: hasConsumables || hasStats || hasCoaching ? 2 : 0 }}>
           <Typography variant="body2" sx={SECTION_TITLE_SX}>
             Champion Points
             {championPoints.total !== undefined && (
@@ -154,6 +245,60 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
               </Box>
             </Box>
           )}
+        </Box>
+      )}
+
+      {hasConsumables && (
+        <Box sx={{ mb: hasStats || hasCoaching ? 2 : 0 }}>
+          <Typography variant="body2" sx={SECTION_TITLE_SX}>
+            Captured Buffs
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {food && (
+              <Chip
+                size="small"
+                label={`Food: ${food.name || food.id}`}
+                title={`Food buff captured by ESOTK Companion (ID: ${food.id})`}
+                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+              />
+            )}
+            {mundus && (
+              <Chip
+                size="small"
+                label={`Mundus: ${mundus.name.replace(/^The\s+/i, '')}`}
+                title={`Mundus captured by ESOTK Companion (ID: ${mundus.id})`}
+                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+              />
+            )}
+            {hasPotion && (
+              <Chip
+                size="small"
+                label={`Potion: ${describePotionType(potionType)}`}
+                title="Potion-type buff cluster captured by ESOTK Companion"
+                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+              />
+            )}
+          </Box>
+        </Box>
+      )}
+
+      {hasStats && (
+        <Box sx={{ mb: hasCoaching ? 2 : 0 }}>
+          <Typography variant="body2" sx={SECTION_TITLE_SX}>
+            Captured Stats
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {rows.map((row) => (
+              <Chip
+                key={row.id}
+                size="small"
+                variant="outlined"
+                label={`${row.label}: ${row.value}`}
+                title={`${row.label} captured by ESOTK Companion`}
+                sx={{ '& .MuiChip-label': { fontSize: '0.58rem' } }}
+              />
+            ))}
+          </Box>
         </Box>
       )}
 

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -58,9 +58,9 @@ const SECTION_TITLE_SX = {
  */
 const STABLE_STAT_IDS = new Set(['maxMagicka', 'maxStamina', 'maxHealth']);
 
-/** Caption/tooltip conveying that these are point-in-time, not comparable across players. */
+/** Caption/tooltip conveying that the volatile group is point-in-time, not comparable across players. */
 const CAPTURED_SHEET_TOOLTIP =
-  'Character sheet at capture — read on leaving combat (buffs fading), point-in-time, not comparable across players.';
+  'Character sheet at capture — read on leaving combat (buffs fading). The volatile group is a point-in-time reading, not comparable across players; the stable group (max resources) is steady.';
 
 // Display order + the chip style variant each tree maps to (matches PlayerCard's CP chips).
 const TREE_ORDER: { tree: ChampionTreeKey; label: string; variant: string }[] = [

--- a/src/features/report_details/insights/LazyPlayerCard.tsx
+++ b/src/features/report_details/insights/LazyPlayerCard.tsx
@@ -72,7 +72,7 @@ export interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
   >;
   /** Test ID for testing */
   'data-testid'?: string;

--- a/src/features/report_details/insights/LazyPlayerCard.tsx
+++ b/src/features/report_details/insights/LazyPlayerCard.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 
 import { PlayerCardSkeleton } from '../../../components/PlayersSkeleton';
 import type { GrimoireData } from '../../../components/ScribingSkillsDisplay';
+import type { CompanionBuildForPlayer } from '../../../features/loadout-manager/utils/esotkCompanionReportAdapter';
 import type { PlayerRoleResult } from '../../../features/role_detection';
 import type { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
 import type { ClassAnalysisResult } from '../../../utils/classDetectionUtils';
@@ -66,6 +67,13 @@ export interface PlayerCardProps {
   detectedRole?: PlayerRoleResult;
   /** Whether the metrics row wraps chips vertically or scrolls horizontally */
   metricsLayout?: MetricsLayout;
+  /**
+   * Build data captured by the ESOTK Companion add-on that ESO Logs can't see.
+   */
+  companionBuild?: Pick<
+    CompanionBuildForPlayer,
+    'championPoints' | 'coaching' | 'stats' | 'effects'
+  >;
   /** Test ID for testing */
   'data-testid'?: string;
 }

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -21,8 +21,7 @@ import type { Theme } from '@mui/material/styles';
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import type { ChampionPointsViewModel } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
-import type { CoachingInsight } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+import type { CompanionBuildForPlayer } from '@/features/loadout-manager/utils/esotkCompanionReportAdapter';
 import { abilityIconUrl } from '@/utils/abilityIconCorrections';
 import { getArmorWeightCounts } from '@/utils/armorUtils';
 import { encodeBuildToURL } from '@/utils/buildEncoding';
@@ -183,7 +182,10 @@ interface PlayerCardProps {
    * stat-aware coaching) that ESO Logs can't see. Optional — when absent the panel
    * renders nothing, so existing cards are unaffected.
    */
-  companionBuild?: { championPoints: ChampionPointsViewModel | null; coaching: CoachingInsight[] };
+  companionBuild?: Pick<
+    CompanionBuildForPlayer,
+    'championPoints' | 'coaching' | 'stats' | 'effects'
+  >;
 }
 
 // Helper function to consolidate build issues
@@ -2028,6 +2030,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                     <CompanionBuildPanel
                       championPoints={companionBuild.championPoints}
                       coaching={companionBuild.coaching}
+                      stats={companionBuild.stats}
+                      effects={companionBuild.effects}
                     />
                   )}
                 </Box>

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -184,7 +184,7 @@ interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
   >;
 }
 
@@ -2032,6 +2032,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                       coaching={companionBuild.coaching}
                       stats={companionBuild.stats}
                       effects={companionBuild.effects}
+                      scribing={companionBuild.scribing}
                     />
                   )}
                 </Box>

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -21,6 +21,8 @@ import type { Theme } from '@mui/material/styles';
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import type { ChampionPointsViewModel } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
+import type { CoachingInsight } from '@/features/loadout-manager/utils/esotkCompanionCoaching';
 import { abilityIconUrl } from '@/utils/abilityIconCorrections';
 import { getArmorWeightCounts } from '@/utils/armorUtils';
 import { encodeBuildToURL } from '@/utils/buildEncoding';
@@ -67,6 +69,7 @@ import { SCRIBING_DETECTION_SCHEMA_VERSION } from '../../scribing/analysis/scrib
 import { ScribedSkillData } from '../../scribing/types';
 
 import { ClassMasteryCluster } from './ClassMasteryCluster';
+import { CompanionBuildPanel } from './CompanionBuildPanel';
 import { MetricsScrollRow } from './MetricsScrollRow';
 import type { StatChipId } from './statChipConfig';
 import { formatStatValue, STAT_CHIP_IDS, STAT_CHIP_META } from './statChipConfig';
@@ -175,6 +178,12 @@ interface PlayerCardProps {
   detectedRole?: PlayerRoleResult;
   /** Whether the metrics row wraps chips vertically or scrolls horizontally */
   metricsLayout?: 'scroll' | 'wrap';
+  /**
+   * Build data captured by the ESOTK Companion add-on (champion-point allocation +
+   * stat-aware coaching) that ESO Logs can't see. Optional — when absent the panel
+   * renders nothing, so existing cards are unaffected.
+   */
+  companionBuild?: { championPoints: ChampionPointsViewModel | null; coaching: CoachingInsight[] };
 }
 
 // Helper function to consolidate build issues
@@ -304,6 +313,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
     visibleChips,
     detectedRole,
     metricsLayout = 'scroll',
+    companionBuild,
   }) => {
     const theme = useTheme();
 
@@ -2012,6 +2022,13 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                         ))}
                       </Box>
                     </Box>
+                  )}
+
+                  {companionBuild && (
+                    <CompanionBuildPanel
+                      championPoints={companionBuild.championPoints}
+                      coaching={companionBuild.coaching}
+                    />
                   )}
                 </Box>
 

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { useLogger } from '@/contexts/LoggerContext';
+import type { MatchableReport } from '@/features/loadout-manager/utils/esotkCompanionMatcher';
+import {
+  parseESOTKCompanionSavedVariables,
+  type CompanionSnapshot,
+} from '@/features/loadout-manager/utils/esotkCompanionParser';
+import {
+  buildCompanionBuildsForReport,
+  type CompanionBuildForPlayer,
+} from '@/features/loadout-manager/utils/esotkCompanionReportAdapter';
 import {
   SCRIBING_DETECTION_SCHEMA_VERSION,
   type CombatEventData,
@@ -42,6 +51,8 @@ import {
   hasPlayerEntries,
 } from '../../../store/player_data/playerDataFallback';
 import type { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
+import { selectReportRegistryEntryForContext } from '../../../store/report/reportSelectors';
+import type { RootState } from '../../../store/storeWithHistory';
 import {
   KnownAbilities,
   MundusStones,
@@ -103,6 +114,52 @@ const formatScribingRecipeForDisplay = (
 
 // This panel now uses report actors from masterData
 
+type CompanionBuildRenderProps = Pick<
+  CompanionBuildForPlayer,
+  'championPoints' | 'coaching' | 'stats' | 'effects'
+>;
+
+interface CompanionUploadState {
+  fileName?: string;
+  snapshotCount: number;
+  error?: string;
+}
+
+function buildMatchableReport(
+  playersById: Record<string | number, PlayerDetailsWithRole>,
+  reportEntry: ReturnType<typeof selectReportRegistryEntryForContext>,
+): MatchableReport | null {
+  const data = reportEntry?.data;
+  if (!data?.startTime) return null;
+
+  const actors = Object.values(playersById)
+    .filter((player) => player.id !== undefined && player.name)
+    .map((player) => ({
+      id: player.id,
+      name: player.name,
+      server: player.server,
+    }));
+  if (actors.length === 0) return null;
+
+  const fights =
+    reportEntry?.fightIds
+      .map((fightId) => reportEntry.fightsById[fightId])
+      .filter((fight): fight is NonNullable<typeof fight> => Boolean(fight))
+      .map((fight) => ({
+        id: fight.id,
+        startTime: fight.startTime,
+        endTime: fight.endTime,
+        zoneId: fight.gameZone?.id,
+      })) ?? [];
+
+  return {
+    startTime: data.startTime,
+    endTime: data.endTime,
+    actors,
+    fights,
+  };
+}
+
 interface PlayersPanelProps {
   context?: ReportFightContextInput;
 }
@@ -116,6 +173,9 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   const fight = useFightForContext(resolvedContext);
   const reportId = resolvedContext.reportCode;
   const fightId = resolvedContext.fightId !== null ? String(resolvedContext.fightId) : null;
+  const reportEntry = useSelector((state: RootState) =>
+    selectReportRegistryEntryForContext(state, resolvedContext),
+  );
 
   // State for storing scribing recipe information
   const [scribingRecipes, setScribingRecipes] = React.useState<
@@ -135,6 +195,10 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       >
     >
   >({});
+  const [companionSnapshots, setCompanionSnapshots] = React.useState<CompanionSnapshot[]>([]);
+  const [companionUpload, setCompanionUpload] = React.useState<CompanionUploadState>({
+    snapshotCount: 0,
+  });
 
   // Use hooks to get data
   const { reportMasterData, isMasterDataLoading } = useReportMasterData();
@@ -192,6 +256,75 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     combatantInfoEvents,
     rolesByPlayerId,
   ]);
+
+  const companionReport = React.useMemo(
+    () => buildMatchableReport(playersById, reportEntry),
+    [playersById, reportEntry],
+  );
+
+  const companionBuildsByPlayer = React.useMemo<Record<string, CompanionBuildRenderProps>>(() => {
+    if (!companionReport || companionSnapshots.length === 0) return {};
+
+    const builds = buildCompanionBuildsForReport(companionSnapshots, companionReport, {
+      targetFightId: resolvedContext.fightId ?? undefined,
+    });
+
+    const byPlayer: Record<string, CompanionBuildRenderProps> = {};
+    builds.forEach((build, actorId) => {
+      byPlayer[String(actorId)] = {
+        championPoints: build.championPoints,
+        coaching: build.coaching,
+        stats: build.stats,
+        effects: build.effects,
+      };
+    });
+    return byPlayer;
+  }, [companionReport, companionSnapshots, resolvedContext.fightId]);
+
+  const handleCompanionFileSelected = React.useCallback(
+    async (file: File): Promise<void> => {
+      try {
+        const text = await file.text();
+        const parsed = parseESOTKCompanionSavedVariables(text);
+        if (!parsed || parsed.all.length === 0) {
+          setCompanionSnapshots([]);
+          setCompanionUpload({
+            fileName: file.name,
+            snapshotCount: 0,
+            error: 'No ESOTK Companion snapshots found',
+          });
+          return;
+        }
+
+        setCompanionSnapshots(parsed.all);
+        setCompanionUpload({
+          fileName: file.name,
+          snapshotCount: parsed.all.length,
+        });
+        logger.info('Loaded ESOTK Companion snapshots', {
+          fileName: file.name,
+          snapshotCount: parsed.all.length,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to read companion file';
+        setCompanionSnapshots([]);
+        setCompanionUpload({
+          fileName: file.name,
+          snapshotCount: 0,
+          error: message,
+        });
+        logger.error(
+          'Failed to load ESOTK Companion snapshots',
+          error instanceof Error ? error : undefined,
+          {
+            fileName: file.name,
+            error: message,
+          },
+        );
+      }
+    },
+    [logger],
+  );
 
   const fightIdNumber = resolvedContext.fightId;
 
@@ -1292,6 +1425,12 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
           barSwapByPlayer={barSwapByPlayer}
           potionResultsByPlayer={potionResultsByPlayer}
           rolesByPlayerId={rolesByPlayerId}
+          companionBuildsByPlayer={companionBuildsByPlayer}
+          companionUpload={{
+            ...companionUpload,
+            matchedCount: Object.keys(companionBuildsByPlayer).length,
+          }}
+          onCompanionFileSelected={handleCompanionFileSelected}
         />
       </div>
     </PlayerAvatarsProvider>

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -441,6 +441,13 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     return byPlayer;
   }, [companionReport, companionSnapshots, resolvedContext.fightId]);
 
+  // Stable reference so PlayersPanelView's React.memo isn't defeated every render
+  // (an inline literal here re-renders the view even on the no-Companion default path).
+  const companionUploadState = React.useMemo(
+    () => ({ ...companionUpload, matchedCount: Object.keys(companionBuildsByPlayer).length }),
+    [companionUpload, companionBuildsByPlayer],
+  );
+
   const handleCompanionFileSelected = React.useCallback(
     async (file: File): Promise<void> => {
       try {
@@ -1677,10 +1684,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
           potionResultsByPlayer={potionResultsByPlayer}
           rolesByPlayerId={rolesByPlayerId}
           companionBuildsByPlayer={companionBuildsByPlayer}
-          companionUpload={{
-            ...companionUpload,
-            matchedCount: Object.keys(companionBuildsByPlayer).length,
-          }}
+          companionUpload={companionUploadState}
           onCompanionFileSelected={handleCompanionFileSelected}
         />
       </div>

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -116,7 +116,7 @@ const formatScribingRecipeForDisplay = (
 
 type CompanionBuildRenderProps = Pick<
   CompanionBuildForPlayer,
-  'championPoints' | 'coaching' | 'stats' | 'effects'
+  'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
 >;
 
 interface CompanionUploadState {
@@ -276,6 +276,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         coaching: build.coaching,
         stats: build.stats,
         effects: build.effects,
+        scribing: build.scribing,
       };
     });
     return byPlayer;

--- a/src/features/report_details/insights/PlayersPanelView.tsx
+++ b/src/features/report_details/insights/PlayersPanelView.tsx
@@ -1,6 +1,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import SortIcon from '@mui/icons-material/Sort';
 import TuneIcon from '@mui/icons-material/Tune';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import ViewStreamIcon from '@mui/icons-material/ViewStream';
 import WrapTextIcon from '@mui/icons-material/WrapText';
 import {
@@ -22,6 +23,7 @@ import React, { useState, useMemo, useCallback } from 'react';
 
 import { PlayersSkeleton } from '../../../components/PlayersSkeleton';
 import { GrimoireData } from '../../../components/ScribingSkillsDisplay';
+import type { CompanionBuildForPlayer } from '../../../features/loadout-manager/utils/esotkCompanionReportAdapter';
 import { DetectedRole, type PlayerRoleResult } from '../../../features/role_detection';
 import { toBroadRole, type BroadRole } from '../../../hooks/useRoleDetection';
 import { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
@@ -81,6 +83,20 @@ interface PlayersPanelViewProps {
   potionResultsByPlayer?: Record<string, PotionStreamResult>;
   /** Detected roles from the role detection algorithm, keyed by player ID */
   rolesByPlayerId?: Record<number, PlayerRoleResult>;
+  /** Per-player companion build data parsed from an uploaded ESOTKCompanion SavedVariables file */
+  companionBuildsByPlayer?: Record<
+    string,
+    Pick<CompanionBuildForPlayer, 'championPoints' | 'coaching' | 'stats' | 'effects'>
+  >;
+  /** Current companion upload status for the toolbar chip */
+  companionUpload?: {
+    fileName?: string;
+    snapshotCount: number;
+    matchedCount: number;
+    error?: string;
+  };
+  /** Called when a user selects an ESOTKCompanion SavedVariables file */
+  onCompanionFileSelected?: (file: File) => Promise<void>;
 }
 
 type SortOption =
@@ -140,6 +156,9 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
     barSwapByPlayer,
     potionResultsByPlayer,
     rolesByPlayerId,
+    companionBuildsByPlayer,
+    companionUpload,
+    onCompanionFileSelected,
   }) => {
     const theme = useTheme();
     const isDarkMode = theme.palette.mode === 'dark';
@@ -152,6 +171,15 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
     const { metricsLayout, toggleMetricsLayout } = useMetricsLayout();
     const handleOpenChipModal = useCallback(() => setChipModalOpen(true), []);
     const handleCloseChipModal = useCallback(() => setChipModalOpen(false), []);
+    const handleCompanionInputChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        event.target.value = '';
+        if (!file || !onCompanionFileSelected) return;
+        void onCompanionFileSelected(file);
+      },
+      [onCompanionFileSelected],
+    );
 
     // Helper: get the effective broad role for a player, preferring detected role
     const getEffectiveBroadRole = useCallback(
@@ -210,6 +238,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
         const totalCritDamage = totalCritDamageByPlayer?.[String(player.id)];
         const critDps = critDpsByPlayer?.[String(player.id)];
         const critChance = critChanceByPlayer?.[String(player.id)];
+        const companionBuild = companionBuildsByPlayer?.[String(player.id)];
 
         return {
           key: player.id,
@@ -239,6 +268,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
           totalCritDamage,
           critDps,
           critChance,
+          companionBuild,
         };
       });
     }, [
@@ -268,6 +298,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
       totalCritDamageByPlayer,
       critDpsByPlayer,
       critChanceByPlayer,
+      companionBuildsByPlayer,
     ]);
 
     // Filter, search, and sort players
@@ -343,6 +374,17 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
         </Box>
       );
     }
+
+    const companionStatusLabel = companionUpload?.error
+      ? 'Companion: error'
+      : companionUpload?.fileName
+        ? `Companion: ${companionUpload.matchedCount} matched`
+        : null;
+    const companionStatusTitle =
+      companionUpload?.error ??
+      (companionUpload?.fileName
+        ? `${companionUpload.snapshotCount.toLocaleString()} snapshots loaded from ${companionUpload.fileName}`
+        : undefined);
 
     return (
       <Box
@@ -521,6 +563,72 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
 
           {/* Action buttons */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {onCompanionFileSelected && (
+              <>
+                <Tooltip title="Upload ESOTK Companion SavedVariables" arrow>
+                  <Button
+                    component="label"
+                    size="small"
+                    startIcon={<UploadFileIcon sx={{ fontSize: '1rem !important' }} />}
+                    aria-label="Upload ESOTK Companion SavedVariables"
+                    sx={{
+                      textTransform: 'none',
+                      whiteSpace: 'nowrap',
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
+                      borderRadius: '10px',
+                      px: 1.5,
+                      py: 0.75,
+                      color: isDarkMode ? '#e2e8f0' : '#334155',
+                      background: isDarkMode
+                        ? alpha(theme.palette.common.white, 0.04)
+                        : alpha(theme.palette.common.black, 0.03),
+                      border: `1px solid ${isDarkMode ? 'rgba(56, 189, 248, 0.12)' : 'rgba(59, 130, 246, 0.1)'}`,
+                      transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                      '&:hover': {
+                        background: isDarkMode
+                          ? 'rgba(56, 189, 248, 0.1)'
+                          : 'rgba(59, 130, 246, 0.08)',
+                        borderColor: isDarkMode
+                          ? 'rgba(56, 189, 248, 0.25)'
+                          : 'rgba(59, 130, 246, 0.2)',
+                        color: isDarkMode ? '#93c5fd' : '#2563eb',
+                      },
+                    }}
+                  >
+                    Companion
+                    <input
+                      hidden
+                      type="file"
+                      accept=".lua,text/plain"
+                      aria-label="ESOTK Companion SavedVariables file"
+                      onChange={handleCompanionInputChange}
+                    />
+                  </Button>
+                </Tooltip>
+                {companionStatusLabel && (
+                  <Chip
+                    size="small"
+                    label={companionStatusLabel}
+                    title={companionStatusTitle}
+                    color={
+                      companionUpload?.error
+                        ? 'error'
+                        : companionUpload?.matchedCount
+                          ? 'success'
+                          : 'warning'
+                    }
+                    variant="outlined"
+                    sx={{
+                      height: 30,
+                      borderRadius: '10px',
+                      '& .MuiChip-label': { fontSize: '0.72rem', fontWeight: 600 },
+                    }}
+                  />
+                )}
+              </>
+            )}
+
             <Tooltip title="Choose which stat chips are shown on each player card" arrow>
               <Badge
                 badgeContent={visibleChips.length}
@@ -756,6 +864,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
                 visibleChips={visibleChips}
                 detectedRole={rolesByPlayerId?.[Number(playerData.player.id)]}
                 metricsLayout={metricsLayout}
+                companionBuild={playerData.companionBuild}
               />
             </Box>
           ))}

--- a/src/features/report_details/insights/PlayersPanelView.tsx
+++ b/src/features/report_details/insights/PlayersPanelView.tsx
@@ -86,7 +86,7 @@ interface PlayersPanelViewProps {
   /** Per-player companion build data parsed from an uploaded ESOTKCompanion SavedVariables file */
   companionBuildsByPlayer?: Record<
     string,
-    Pick<CompanionBuildForPlayer, 'championPoints' | 'coaching' | 'stats' | 'effects'>
+    Pick<CompanionBuildForPlayer, 'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'>
   >;
   /** Current companion upload status for the toolbar chip */
   companionUpload?: {

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -45,6 +45,8 @@ describe('CompanionBuildPanel', () => {
     render(<CompanionBuildPanel championPoints={null} coaching={coaching} />);
     expect(screen.getByText('Build Coaching')).toBeInTheDocument();
     expect(screen.getByText('Penetration (character sheet)')).toBeInTheDocument();
+    // Coaching without a stats prop must not render the captured-sheet section.
+    expect(screen.queryByText('Sheet at Capture')).toBeNull();
   });
 
   it('renders captured consumables and sheet stats from companion effects', () => {
@@ -94,5 +96,28 @@ describe('CompanionBuildPanel', () => {
     // Max-resource pools are grouped as Stable.
     expect(screen.getByText('Stable')).toBeInTheDocument();
     expect(screen.getByText('Max Magicka: 38,000')).toBeInTheDocument();
+    // The point-in-time honesty surface: volatile chips carry a "point-in-time" title.
+    const volatileChips = screen.getAllByTitle(/point-in-time character-sheet reading/i);
+    expect(volatileChips.some((el) => el.textContent?.includes('Physical Pen'))).toBe(true);
+  });
+
+  it('shows only the Stable group when all captured stats are stable', () => {
+    render(
+      <CompanionBuildPanel championPoints={null} coaching={[]} stats={{ maxMagicka: 38000 }} />,
+    );
+    expect(screen.getByText('Sheet at Capture')).toBeInTheDocument();
+    expect(screen.getByText('Stable')).toBeInTheDocument();
+    expect(screen.getByText('Max Magicka: 38,000')).toBeInTheDocument();
+    expect(screen.queryByText('Volatile (buff-dependent)')).toBeNull();
+  });
+
+  it('shows only the Volatile group when all captured stats are volatile', () => {
+    render(
+      <CompanionBuildPanel championPoints={null} coaching={[]} stats={{ physicalPen: 12345 }} />,
+    );
+    expect(screen.getByText('Sheet at Capture')).toBeInTheDocument();
+    expect(screen.getByText('Volatile (buff-dependent)')).toBeInTheDocument();
+    expect(screen.getByText('Physical Pen: 12,345')).toBeInTheDocument();
+    expect(screen.queryByText('Stable')).toBeNull();
   });
 });

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -40,12 +40,11 @@ describe('CompanionBuildPanel', () => {
     expect(screen.getAllByText(/Deadly Aim/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders stat-coaching insights with the failure detail', () => {
+  it('renders stat-coaching insights as point-in-time readings', () => {
     const coaching = computeStatCoaching({ physicalPen: PVE_PENETRATION_CAP + 3200 });
     render(<CompanionBuildPanel championPoints={null} coaching={coaching} />);
     expect(screen.getByText('Build Coaching')).toBeInTheDocument();
-    expect(screen.getByText('Over the penetration cap')).toBeInTheDocument();
-    expect(screen.getByText(/3,200 over/)).toBeInTheDocument();
+    expect(screen.getByText('Penetration (character sheet)')).toBeInTheDocument();
   });
 
   it('renders captured consumables and sheet stats from companion effects', () => {
@@ -53,7 +52,7 @@ describe('CompanionBuildPanel', () => {
       <CompanionBuildPanel
         championPoints={null}
         coaching={[]}
-        stats={{ physicalPen: 12345, weaponCrit: 10959, critDamage: 125 }}
+        stats={{ physicalPen: 12345, weaponCrit: 10959, maxMagicka: 38000 }}
         effects={[
           { id: 13984, name: 'Boon: The Shadow', duration: 0 },
           { id: 9998, name: 'Bewitched Sugar Skulls', duration: 3_600_000 },
@@ -87,9 +86,13 @@ describe('CompanionBuildPanel', () => {
     expect(
       screen.getByText('Shattering Knife: Magic Damage / Class Mastery / Major Breach'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Captured Stats')).toBeInTheDocument();
+    expect(screen.getByText('Sheet at Capture')).toBeInTheDocument();
+    // Volatile (buff-dependent) chips.
+    expect(screen.getByText('Volatile (buff-dependent)')).toBeInTheDocument();
     expect(screen.getByText('Physical Pen: 12,345')).toBeInTheDocument();
     expect(screen.getByText('Weapon Crit: 50%')).toBeInTheDocument();
-    expect(screen.getByText('Crit Damage: 125%')).toBeInTheDocument();
+    // Max-resource pools are grouped as Stable.
+    expect(screen.getByText('Stable')).toBeInTheDocument();
+    expect(screen.getByText('Max Magicka: 38,000')).toBeInTheDocument();
   });
 });

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -47,4 +47,32 @@ describe('CompanionBuildPanel', () => {
     expect(screen.getByText('Over the penetration cap')).toBeInTheDocument();
     expect(screen.getByText(/3,200 over/)).toBeInTheDocument();
   });
+
+  it('renders captured consumables and sheet stats from companion effects', () => {
+    render(
+      <CompanionBuildPanel
+        championPoints={null}
+        coaching={[]}
+        stats={{ physicalPen: 12345, weaponCrit: 10959, critDamage: 125 }}
+        effects={[
+          { id: 13984, name: 'Boon: The Shadow', duration: 0 },
+          { id: 9998, name: 'Bewitched Sugar Skulls', duration: 3_600_000 },
+          { id: 68405, name: 'Major Fortitude', duration: 47_000 },
+          { id: 68406, name: 'Major Intellect', duration: 47_000 },
+          { id: 68408, name: 'Major Endurance', duration: 47_000 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Captured Buffs')).toBeInTheDocument();
+    expect(screen.getByText('Food: Bewitched Sugar Skulls')).toBeInTheDocument();
+    expect(screen.getByText('Mundus: Shadow')).toBeInTheDocument();
+    expect(
+      screen.getByText('Potion: Tri-Stat Potion (Health, Magicka & Stamina)'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Captured Stats')).toBeInTheDocument();
+    expect(screen.getByText('Physical Pen: 12,345')).toBeInTheDocument();
+    expect(screen.getByText('Weapon Crit: 50%')).toBeInTheDocument();
+    expect(screen.getByText('Crit Damage: 125%')).toBeInTheDocument();
+  });
 });

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -61,6 +61,19 @@ describe('CompanionBuildPanel', () => {
           { id: 68406, name: 'Major Intellect', duration: 47_000 },
           { id: 68408, name: 'Major Endurance', duration: 47_000 },
         ]}
+        scribing={[
+          {
+            abilityId: 217340,
+            name: 'Shattering Knife',
+            bar: 'front',
+            slot: 3,
+            scripts: {
+              1: { id: 1, slot: 1, name: 'Magic Damage' },
+              2: { id: 31, slot: 2, name: 'Class Mastery' },
+              3: { id: 42, slot: 3, name: 'Major Breach' },
+            },
+          },
+        ]}
       />,
     );
 
@@ -69,6 +82,10 @@ describe('CompanionBuildPanel', () => {
     expect(screen.getByText('Mundus: Shadow')).toBeInTheDocument();
     expect(
       screen.getByText('Potion: Tri-Stat Potion (Health, Magicka & Stamina)'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Captured Scribing')).toBeInTheDocument();
+    expect(
+      screen.getByText('Shattering Knife: Magic Damage / Class Mastery / Major Breach'),
     ).toBeInTheDocument();
     expect(screen.getByText('Captured Stats')).toBeInTheDocument();
     expect(screen.getByText('Physical Pen: 12,345')).toBeInTheDocument();

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { buildChampionPointsViewModel } from '@/features/loadout-manager/utils/esotkCompanionChampionPoints';
+import {
+  computeStatCoaching,
+  PVE_PENETRATION_CAP,
+} from '@/features/loadout-manager/utils/esotkCompanionCoaching';
+
+import { CompanionBuildPanel } from '../CompanionBuildPanel';
+
+// 25 = Deadly Aim (Warfare), 27 = Thaumaturge (Warfare)
+const cpViewModel = buildChampionPointsViewModel({
+  total: 3600,
+  disciplines: { 1: { id: 1, skills: { 25: 50, 27: 20 } } },
+  slotted: { 5: 25 },
+});
+
+describe('CompanionBuildPanel', () => {
+  it('renders nothing when there is no companion data', () => {
+    const { container } = render(<CompanionBuildPanel championPoints={null} coaching={[]} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('companion-build-panel')).toBeNull();
+  });
+
+  it('renders champion-point allocation grouped by tree with totals', () => {
+    render(<CompanionBuildPanel championPoints={cpViewModel} coaching={[]} />);
+    expect(screen.getByText('Champion Points')).toBeInTheDocument();
+    expect(screen.getByText(/3,600 CP/)).toBeInTheDocument();
+    expect(screen.getByText(/70 allocated/)).toBeInTheDocument(); // 50 + 20
+    expect(screen.getByText('Warfare')).toBeInTheDocument();
+    expect(screen.getByText('Deadly Aim 50')).toBeInTheDocument();
+    expect(screen.getByText('Thaumaturge 20')).toBeInTheDocument();
+  });
+
+  it('renders slotted stars', () => {
+    render(<CompanionBuildPanel championPoints={cpViewModel} coaching={[]} />);
+    expect(screen.getByText('Slotted')).toBeInTheDocument();
+    // slot 5 = skill 25 = Deadly Aim (appears as an allocated chip and a slotted chip)
+    expect(screen.getAllByText(/Deadly Aim/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders stat-coaching insights with the failure detail', () => {
+    const coaching = computeStatCoaching({ physicalPen: PVE_PENETRATION_CAP + 3200 });
+    render(<CompanionBuildPanel championPoints={null} coaching={coaching} />);
+    expect(screen.getByText('Build Coaching')).toBeInTheDocument();
+    expect(screen.getByText('Over the penetration cap')).toBeInTheDocument();
+    expect(screen.getByText(/3,200 over/)).toBeInTheDocument();
+  });
+});

--- a/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
+++ b/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
@@ -56,6 +56,7 @@ function makeProps(overrides: Partial<PlayersPanelViewProps> = {}): PlayersPanel
     scribingSkillsByPlayer: {},
     buildIssuesByPlayer: {},
     classAnalysisByPlayer: {},
+    kalpaBuildEvidenceByPlayer: {},
     deathsByPlayer: {},
     resurrectsByPlayer: {},
     cpmByPlayer: {},

--- a/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
+++ b/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import type { CompanionBuildForPlayer } from '@/features/loadout-manager/utils/esotkCompanionReportAdapter';
+import type { PlayerDetailsWithRole } from '@/store/player_data/playerDataSlice';
+
+import { PlayersPanelView } from '../PlayersPanelView';
+
+interface MockLazyPlayerCardProps {
+  player: Pick<PlayerDetailsWithRole, 'id'>;
+  companionBuild?: Pick<
+    CompanionBuildForPlayer,
+    'championPoints' | 'coaching' | 'stats' | 'effects'
+  >;
+}
+
+jest.mock('../LazyPlayerCard', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    LazyPlayerCard: ({ player, companionBuild }: MockLazyPlayerCardProps): React.ReactElement =>
+      ReactActual.createElement(
+        'div',
+        { 'data-testid': `mock-player-card-${player.id}` },
+        companionBuild?.stats?.physicalPen ?? 'no companion',
+      ),
+  };
+});
+
+type PlayersPanelViewProps = React.ComponentProps<typeof PlayersPanelView>;
+
+function makePlayer(): PlayerDetailsWithRole {
+  return {
+    id: 1,
+    guid: 1,
+    name: 'Casts-A-Lot',
+    displayName: 'Casts-A-Lot',
+    type: 'Player',
+    server: 'NA',
+    anonymous: false,
+    icon: '',
+    specs: [],
+    potionUse: 0,
+    healthstoneUse: 0,
+    combatantInfo: { stats: [], talents: [], gear: [] },
+    role: 'dps',
+  };
+}
+
+function makeProps(overrides: Partial<PlayersPanelViewProps> = {}): PlayersPanelViewProps {
+  const player = makePlayer();
+  return {
+    playerActors: { 1: player },
+    mundusBuffsByPlayer: {},
+    championPointsByPlayer: {},
+    aurasByPlayer: {},
+    scribingSkillsByPlayer: {},
+    buildIssuesByPlayer: {},
+    classAnalysisByPlayer: {},
+    deathsByPlayer: {},
+    resurrectsByPlayer: {},
+    cpmByPlayer: {},
+    maxHealthByPlayer: {},
+    maxStaminaByPlayer: {},
+    maxMagickaByPlayer: {},
+    distanceByPlayer: {},
+    isLoading: false,
+    playerGear: {},
+    ...overrides,
+  };
+}
+
+describe('PlayersPanelView companion builds', () => {
+  it('passes parsed companion builds through to player cards', () => {
+    render(
+      <PlayersPanelView
+        {...makeProps({
+          companionBuildsByPlayer: {
+            1: {
+              championPoints: null,
+              coaching: [],
+              stats: { physicalPen: 12345 },
+              effects: [],
+            },
+          },
+          companionUpload: {
+            fileName: 'ESOTKCompanion.lua',
+            snapshotCount: 1,
+            matchedCount: 1,
+          },
+          onCompanionFileSelected: jest.fn(async (_file: File): Promise<void> => {}),
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('mock-player-card-1')).toHaveTextContent('12345');
+    expect(screen.getByText('Companion: 1 matched')).toBeInTheDocument();
+  });
+
+  it('invokes the companion file callback when a file is selected', () => {
+    const onCompanionFileSelected = jest.fn(async (_file: File): Promise<void> => {});
+    const { container } = render(
+      <PlayersPanelView
+        {...makeProps({
+          onCompanionFileSelected,
+        })}
+      />,
+    );
+
+    const input = container.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected companion file input');
+    }
+
+    const file = new File(['ESOTKCompanionSV = {}'], 'ESOTKCompanion.lua', {
+      type: 'text/plain',
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onCompanionFileSelected).toHaveBeenCalledWith(file);
+  });
+});

--- a/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
+++ b/src/features/report_details/insights/__tests__/PlayersPanelView.test.tsx
@@ -10,7 +10,7 @@ interface MockLazyPlayerCardProps {
   player: Pick<PlayerDetailsWithRole, 'id'>;
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
   >;
 }
 
@@ -80,6 +80,7 @@ describe('PlayersPanelView companion builds', () => {
               coaching: [],
               stats: { physicalPen: 12345 },
               effects: [],
+              scribing: [],
             },
           },
           companionUpload: {


### PR DESCRIPTION
## What

Fills the data **ESO Logs structurally cannot provide** — champion-point allocation, exact final stats (penetration/crit/recovery), attributes, mundus/food — via an in-game add-on, and surfaces it on ESOTK player cards with cap-aware coaching. Includes the full strategy research that shaped it.

## End-to-end pipeline (all built + tested)

`add-on (verified API) → SavedVariables → parser → report matcher → CP view-model + stat coaching → CompanionBuildPanel → PlayerCard`

- **In-game add-on** (`addon/ESOTKCompanion/`): captures full CP allocation, slotted stars, final stats, attributes, mundus/food, bars. Read-only/ToS-safe; every call `pcall`-guarded.
- **`esotkCompanionParser`**: parses `ESOTKCompanionSV` into typed per-fight snapshots (handles array/object Lua key representations).
- **`esotkCompanionMatcher`**: pure snapshot↔report matcher (character + server + time window, nearest fight; manual-attach fallback for anonymised reports).
- **`esotkCompanionChampionPoints`**: card-ready CP view-model (allocation grouped by tree, named via existing `champion-points.ts`, slotted, totals).
- **`esotkCompanionCoaching`**: penetration vs the 18,200 cap (self vs effective), crit-damage vs 125% cap, crit chance — the insight ESO Logs can't give.
- **`CompanionBuildPanel`** + wiring into `PlayerCard` via an optional, null-safe `companionBuild` prop (existing cards unaffected when absent). RTL tests + Storybook story.

## API correctness — verified against source, not guessed

Checked against the official ZOS source (`esoui/.../championdatamanager.lua`) and the DynamicCP add-on, which caught **three real bugs**: `GetNumPointsSpentOnChampionSkill` is single-arg; `GetNumChampionDisciplineSkills`/`GetChampionSkillId` take the discipline **index** not the id; `GetChampionDisciplineType` takes the id. `STAT_*` names and gear/mundus/quickslot reads also source-verified (see add-on README + research doc §26.2).

## Verification

- `npm run validate` (typecheck + lint `--max-warnings 0` + prettier) — clean
- Full test suite: **209 suites, 3157 tests, 0 failures** (44 new companion/panel tests)
- Production `npm run build` — succeeds
- Lua syntax validated

## Known limits (honest)

- The Lua add-on couldn't be run against a live ESO client here — function names/arities are source-verified; a one-time in-game value check remains.
- No live browser screenshot (no Chrome in CI env); the panel is covered by RTL tests + a Storybook story.
- The `companionBuild` prop is wired and null-safe but not yet fed by a production upload/store pipeline — that's the next feature (upload companion SavedVariables in the report view → match → render).

## Docs

Full strategy in `documentation/features/addons/ESOTK_COMPANION_ADDON_RESEARCH.md` (26 sections: gap analysis, stat-coaching accuracy, group-share transport, ruleset/compliance engine, 2026 meta, verified API tables).

https://claude.ai/code/session_01WkZVf1ZNVLgPCHWChRWDvG