### PR TITLE
feat(fight-replay): add/edit/delete custom map markers with persistence, drag-to-move &amp; undo

### DIFF
--- a/src/features/fight_replay/FightReplay.tsx
+++ b/src/features/fight_replay/FightReplay.tsx
@@ -1,15 +1,14 @@
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import EditLocationAltIcon from '@mui/icons-material/EditLocationAlt';
 import PlaceIcon from '@mui/icons-material/Place';
 import { Alert, Box, Button, Chip, Snackbar, Typography } from '@mui/material';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import type { FightFragment } from '@/graphql/gql/graphql';
 import { useCurrentFight, useReportFightParams } from '@/hooks';
-import { ZONE_SCALE_DATA, ZoneScaleData } from '@/types/zoneScaleData';
-import { detectMapFromCoordinates } from '@/utils/mapMarkersUtils';
 
 import { useFriendlyBuffEvents } from '../../hooks/events/useFriendlyBuffEvents';
 import { useHostileBuffEvents } from '../../hooks/events/useHostileBuffEvents';
@@ -18,16 +17,11 @@ import { useActorPositionsTask } from '../../hooks/workerTasks/useActorPositions
 
 import { FightReplay3D } from './components/FightReplay3D';
 import { MapMarkersModal } from './components/MapMarkersModal';
+import { MarkerEditDialog } from './components/MarkerEditDialog';
+import { MarkersPanel } from './components/MarkersPanel';
 import { ReplayStatePanel } from './components/ReplayStatePanel';
-import { MapMarkersState } from './types/mapMarkers';
-import {
-  createMarkerFromElmsIcon,
-  encodeMarkersToElms,
-  encodeMarkersToMor,
-  parseMarkersInput,
-  withNewMarker,
-  withoutMarker,
-} from './utils/mapMarkerConverters';
+import { useMapMarkersManager } from './hooks/useMapMarkersManager';
+import { encodeMarkersToElms, encodeMarkersToMor } from './utils/mapMarkerConverters';
 
 function formatDuration(milliseconds: number): string {
   const totalSeconds = Math.floor(milliseconds / 1000);
@@ -36,38 +30,14 @@ function formatDuration(milliseconds: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
-function resolveActiveMapData(
-  fight: FightFragment | null,
-  markersState: MapMarkersState | null,
-): ZoneScaleData | null {
-  if (!fight?.gameZone?.id) {
-    return null;
+/** True when the keydown target is a text-entry element (don't steal undo/redo from inputs). */
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
   }
-
-  const zoneId = fight.gameZone.id;
-  const zoneMaps = ZONE_SCALE_DATA[zoneId];
-
-  if (!zoneMaps || zoneMaps.length === 0) {
-    return null;
-  }
-
-  const fightMapId = fight.maps?.[0]?.id;
-  if (fightMapId) {
-    const map = zoneMaps.find((candidate) => candidate.mapId === fightMapId);
-    if (map) {
-      return map;
-    }
-  }
-
-  const marker = markersState?.markers[0];
-  if (marker) {
-    const detected = detectMapFromCoordinates(zoneId, marker.x, marker.z);
-    if (detected) {
-      return detected;
-    }
-  }
-
-  return zoneMaps[0] ?? null;
+  return (
+    target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true
+  );
 }
 
 export const FightReplay: React.FC = () => {
@@ -80,89 +50,86 @@ export const FightReplay: React.FC = () => {
     document.title = 'Fight Replay | ESO Toolkit';
   }, []);
 
-  // Map Markers state (M0R or Elms format)
-  const [markersState, setMarkersState] = useState<MapMarkersState | null>(null);
   const [markersModalOpen, setMarkersModalOpen] = useState(false);
   const [copySnackbar, setCopySnackbar] = useState<{
-    type: 'success' | 'error';
+    type: 'success' | 'error' | 'info';
     message: string;
   } | null>(null);
 
+  const handleMarkersError = useCallback((message: string) => {
+    setCopySnackbar({ type: 'error', message });
+  }, []);
+
+  // Map Markers (M0R or Elms format): CRUD + per-zone persistence + undo/redo.
+  const {
+    markersState,
+    restoredCount,
+    canUndo,
+    canRedo,
+    loadFromString,
+    clearMarkers,
+    addMarkerAt,
+    removeMarker,
+    moveMarker,
+    editMarker,
+    undo,
+    redo,
+  } = useMapMarkersManager({ fight, onError: handleMarkersError });
+
+  // Marker edit mode: enables plain right-click placement, drag-to-move, and right-click editing
+  // in the 3D arena (the Alt+right-click chords keep working regardless, for muscle memory).
+  const [markersEditMode, setMarkersEditMode] = useState(false);
+
+  // The marker currently open in the edit dialog (from the context menu or the panel list).
+  const [editingMarkerId, setEditingMarkerId] = useState<string | null>(null);
+  const editingMarker = useMemo(
+    () => markersState?.markers.find((marker) => marker.id === editingMarkerId) ?? null,
+    [markersState, editingMarkerId],
+  );
+
+  // Surface restored-from-storage marker sets so users know why markers appeared.
+  useEffect(() => {
+    if (restoredCount > 0) {
+      setCopySnackbar({
+        type: 'info',
+        message: `Restored ${restoredCount} saved marker${restoredCount === 1 ? '' : 's'} for this zone.`,
+      });
+    }
+  }, [restoredCount]);
+
+  // Undo/redo keyboard shortcuts while edit mode is on (Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z or Ctrl+Y).
+  useEffect(() => {
+    if (!markersEditMode) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (!(event.ctrlKey || event.metaKey) || isTextEntryTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === 'z' && !event.shiftKey) {
+        event.preventDefault();
+        undo();
+      } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+        event.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [markersEditMode, undo, redo]);
+
   // Handle loading markers from modal
-  const handleLoadMarkers = useCallback((markersString: string): void => {
-    const parsed = parseMarkersInput(markersString);
-    setMarkersState(parsed);
-    setMarkersModalOpen(false);
-  }, []);
-
-  // Handle clearing markers
-  const handleClearMarkers = useCallback((): void => {
-    setMarkersState(null);
-  }, []);
-
-  const activeMapData = useMemo(
-    () => resolveActiveMapData(fight ?? null, markersState),
-    [fight, markersState],
-  );
-
-  const handleAddMarkerAt = useCallback(
-    (iconKey: number, arenaPoint: { x: number; y: number; z: number }) => {
-      if (!fight?.gameZone?.id) {
-        setCopySnackbar({ type: 'error', message: 'Fight zone information is unavailable.' });
-        return;
-      }
-
-      const mapData = activeMapData;
-      if (!mapData) {
-        setCopySnackbar({
-          type: 'error',
-          message: 'Map scale data is unavailable for this fight.',
-        });
-        return;
-      }
-
-      const zoneId = markersState?.zoneId ?? fight.gameZone.id;
-
-      const clamp = (value: number): number => Math.min(100, Math.max(0, value));
-      const clampedX = clamp(arenaPoint.x);
-      const clampedZ = clamp(arenaPoint.z);
-
-      const normalizedX = (100 - clampedX) / 100;
-      const normalizedZ = (100 - clampedZ) / 100;
-
-      const x = normalizedX * (mapData.maxX - mapData.minX) + mapData.minX;
-      const z = normalizedZ * (mapData.maxZ - mapData.minZ) + mapData.minZ;
-      const y = mapData.y ?? markersState?.markers[0]?.y ?? 0;
-
-      try {
-        const newMarker = createMarkerFromElmsIcon(iconKey, { x, y, z });
-
-        setMarkersState((prev) => {
-          const baseState: MapMarkersState = prev ?? {
-            format: 'elms',
-            zoneId,
-            markers: [],
-            originalEncodedString: undefined,
-          };
-
-          const adjustedState =
-            baseState.zoneId === zoneId ? baseState : { ...baseState, zoneId, markers: [] };
-
-          return withNewMarker(adjustedState, newMarker, 'elms');
-        });
-      } catch (error) {
-        setCopySnackbar({
-          type: 'error',
-          message: error instanceof Error ? error.message : 'Failed to add marker.',
-        });
-      }
+  const handleLoadMarkers = useCallback(
+    (markersString: string): void => {
+      loadFromString(markersString);
+      setMarkersModalOpen(false);
     },
-    [activeMapData, fight, markersState],
+    [loadFromString],
   );
-
-  const handleRemoveMarker = useCallback((markerId: string) => {
-    setMarkersState((prev) => (prev ? withoutMarker(prev, markerId) : prev));
-  }, []);
 
   const handleExportMarkers = useCallback(
     async (format: 'elms' | 'mor') => {
@@ -357,6 +324,17 @@ export const FightReplay: React.FC = () => {
             {markersState ? 'Manage Map Markers' : 'Import Map Markers'}
           </Button>
 
+          <Button
+            variant={markersEditMode ? 'contained' : 'outlined'}
+            color="secondary"
+            startIcon={<EditLocationAltIcon />}
+            onClick={() => setMarkersEditMode((prev) => !prev)}
+            type="button"
+            aria-pressed={markersEditMode}
+          >
+            {markersEditMode ? 'Done Editing' : 'Edit Markers'}
+          </Button>
+
           {markersState && markersState.markers.length > 0 && (
             <>
               <Button
@@ -381,6 +359,14 @@ export const FightReplay: React.FC = () => {
           )}
         </Box>
 
+        {/* Edit-mode hint: surfaces the gestures, which are otherwise invisible. */}
+        {markersEditMode && (
+          <Typography variant="caption" color="text.secondary">
+            Right-click the map to place a marker · drag a marker to move it · right-click a marker
+            to edit or remove it · Ctrl+Z to undo
+          </Typography>
+        )}
+
         {/* Marker Statistics */}
         {markersState && markerStats.success && (
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
@@ -403,6 +389,21 @@ export const FightReplay: React.FC = () => {
             )}
           </Box>
         )}
+
+        {/* Marker management list: edit/delete each marker, undo/redo, clear all. */}
+        {(markersEditMode || (markersState && markersState.markers.length > 0)) && (
+          <MarkersPanel
+            markersState={markersState}
+            editMode={markersEditMode}
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onUndo={undo}
+            onRedo={redo}
+            onEditMarker={setEditingMarkerId}
+            onRemoveMarker={removeMarker}
+            onClearMarkers={clearMarkers}
+          />
+        )}
       </Box>
 
       {/* Map Markers Modal (M0R and Elms formats) */}
@@ -412,9 +413,17 @@ export const FightReplay: React.FC = () => {
         fight={fight || ({} as FightFragment)}
         markersState={markersState}
         onLoadMarkers={handleLoadMarkers}
-        onClearMarkers={handleClearMarkers}
+        onClearMarkers={clearMarkers}
         onExportElms={() => handleExportMarkers('elms')}
         onExportMor={() => handleExportMarkers('mor')}
+      />
+
+      {/* Per-marker edit dialog (icon / label / colour / size, plus delete) */}
+      <MarkerEditDialog
+        marker={editingMarker}
+        onClose={() => setEditingMarkerId(null)}
+        onApply={editMarker}
+        onDelete={removeMarker}
       />
 
       {/* 3D Arena */}
@@ -423,8 +432,11 @@ export const FightReplay: React.FC = () => {
         allBuffEvents={allBuffEvents}
         showActorNames={true}
         markersState={markersState}
-        onAddMarker={handleAddMarkerAt}
-        onRemoveMarker={handleRemoveMarker}
+        onAddMarker={addMarkerAt}
+        onRemoveMarker={removeMarker}
+        markersEditMode={markersEditMode}
+        onMarkerMove={moveMarker}
+        onEditMarker={setEditingMarkerId}
         showPlayerPaths={true}
         initialSelectedPlayerIds={[]} // Empty initially, user can select via HUD
       />

--- a/src/features/fight_replay/FightReplay.tsx
+++ b/src/features/fight_replay/FightReplay.tsx
@@ -20,6 +20,7 @@ import { MapMarkersModal } from './components/MapMarkersModal';
 import { MarkerEditDialog } from './components/MarkerEditDialog';
 import { MarkersPanel } from './components/MarkersPanel';
 import { ReplayStatePanel } from './components/ReplayStatePanel';
+import { useIsMobileReplay } from './hooks/useIsMobileReplay';
 import { useMapMarkersManager } from './hooks/useMapMarkersManager';
 import { encodeMarkersToElms, encodeMarkersToMor } from './utils/mapMarkerConverters';
 
@@ -78,7 +79,10 @@ export const FightReplay: React.FC = () => {
 
   // Marker edit mode: enables plain right-click placement, drag-to-move, and right-click editing
   // in the 3D arena (the Alt+right-click chords keep working regardless, for muscle memory).
+  // On touch the same mode maps to long-press gestures instead of right-clicks.
   const [markersEditMode, setMarkersEditMode] = useState(false);
+  const toggleMarkersEditMode = useCallback(() => setMarkersEditMode((prev) => !prev), []);
+  const isMobileReplay = useIsMobileReplay();
 
   // The marker currently open in the edit dialog (from the context menu or the panel list).
   const [editingMarkerId, setEditingMarkerId] = useState<string | null>(null);
@@ -328,7 +332,7 @@ export const FightReplay: React.FC = () => {
             variant={markersEditMode ? 'contained' : 'outlined'}
             color="secondary"
             startIcon={<EditLocationAltIcon />}
-            onClick={() => setMarkersEditMode((prev) => !prev)}
+            onClick={toggleMarkersEditMode}
             type="button"
             aria-pressed={markersEditMode}
           >
@@ -359,11 +363,13 @@ export const FightReplay: React.FC = () => {
           )}
         </Box>
 
-        {/* Edit-mode hint: surfaces the gestures, which are otherwise invisible. */}
+        {/* Edit-mode hint: surfaces the gestures, which are otherwise invisible. Touch and
+            mouse get their own wording — right-click and Ctrl+Z don't exist on a phone. */}
         {markersEditMode && (
           <Typography variant="caption" color="text.secondary">
-            Right-click the map to place a marker · drag a marker to move it · right-click a marker
-            to edit or remove it · Ctrl+Z to undo
+            {isMobileReplay
+              ? 'Press and hold the map to place a marker · drag a marker to move it · press and hold a marker to edit or remove it'
+              : 'Right-click the map to place a marker · drag a marker to move it · right-click a marker to edit or remove it · Ctrl+Z to undo'}
           </Typography>
         )}
 
@@ -435,8 +441,11 @@ export const FightReplay: React.FC = () => {
         onAddMarker={addMarkerAt}
         onRemoveMarker={removeMarker}
         markersEditMode={markersEditMode}
+        onToggleMarkersEditMode={toggleMarkersEditMode}
         onMarkerMove={moveMarker}
         onEditMarker={setEditingMarkerId}
+        canUndoMarkers={canUndo}
+        onUndoMarkers={undo}
         showPlayerPaths={true}
         initialSelectedPlayerIds={[]} // Empty initially, user can select via HUD
       />

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -748,6 +748,16 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         // Fill the fullscreen container's height; otherwise the responsive 16:9-ish clamp.
         height: isFullscreen ? '100%' : ARENA_HEIGHT,
         position: 'relative',
+        // Mobile: suppress the OS long-press behaviors (text-selection loupe, Copy/Look Up
+        // callout) across the whole replay block — they hijack the marker long-press/drag
+        // gestures on iOS Safari and select the HUD chrome's text.
+        ...(isMobile
+          ? {
+              userSelect: 'none' as const,
+              WebkitUserSelect: 'none' as const,
+              WebkitTouchCallout: 'none' as const,
+            }
+          : null),
       }}
       role="img"
       aria-label="3D fight replay arena showing player positions over time"
@@ -966,6 +976,12 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
                       event.stopPropagation();
                     },
                   },
+                  // Portaled past the replay container, so it needs its own selection
+                  // suppression: iOS otherwise text-selects the menu items the long-press
+                  // gesture lands on and covers them with the Copy/Look Up callout.
+                  paper: {
+                    sx: { userSelect: 'none', WebkitTouchCallout: 'none' },
+                  },
                 }}
                 onContextMenu={(event) => {
                   event.preventDefault();
@@ -1037,7 +1053,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
                   },
                   paper: {
                     onMouseLeave: handleGroupMouseLeave,
-                    sx: { pointerEvents: 'auto' },
+                    sx: { pointerEvents: 'auto', userSelect: 'none', WebkitTouchCallout: 'none' },
                   },
                   root: {
                     sx: { pointerEvents: 'none' },

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -37,7 +37,7 @@ import { DEFAULT_ACTOR_SCALE, computeActorScaleFromMapData } from '../utils/mapS
 import { getVisiblePlayerIds } from '../utils/pathUtils';
 import { decidePreviewMode } from '../utils/previewMode';
 
-import { Arena3DScene, GroundContextMenuPayload } from './Arena3DScene';
+import { ADD_MARKER_AT_CENTER_EVENT, Arena3DScene, GroundContextMenuPayload } from './Arena3DScene';
 import { BossHealthPanel } from './BossHealthPanel';
 import { LockedPlayerStatsPanel } from './LockedPlayerStatsPanel';
 import { MarkerContextMenuPayload } from './Marker3D';
@@ -1394,6 +1394,11 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           onToggleStats={() => setStatsPanelEnabled((prev) => !prev)}
           markersEditMode={markersEditMode}
           onToggleMarkersEditMode={onToggleMarkersEditMode}
+          onAddMarkerAtCenter={
+            onAddMarker
+              ? () => window.dispatchEvent(new CustomEvent(ADD_MARKER_AT_CENTER_EVENT))
+              : undefined
+          }
           canUndoMarkers={canUndoMarkers}
           onUndoMarkers={onUndoMarkers}
         />

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -107,6 +107,12 @@ interface Arena3DProps {
   markersState?: MapMarkersState | null;
   onAddMarker?: (iconKey: number, arenaPoint: { x: number; y: number; z: number }) => void;
   onRemoveMarker?: (markerId: string) => void;
+  /** Marker edit mode: plain right-click context menus + draggable markers (no Alt chord). */
+  markersEditMode?: boolean;
+  /** Drag-to-move commit for a marker (arena-space coordinates). */
+  onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
+  /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
+  onEditMarker?: (markerId: string) => void;
   /** Fight data for zone/map information (required for map markers coordinate transformation) */
   fight: FightFragment;
   /** Selected player IDs for path visualization */
@@ -156,6 +162,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   markersState,
   onAddMarker,
   onRemoveMarker,
+  markersEditMode = false,
+  onMarkerMove,
+  onEditMarker,
   fight,
   selectedPlayerIds,
   onPlayerSelectionChange,
@@ -278,7 +287,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
 
   const handleMarkerContextMenu = useCallback(
     (payload: MarkerContextMenuPayload) => {
-      if (!onRemoveMarker) {
+      if (!onRemoveMarker && !onEditMarker) {
         return;
       }
 
@@ -289,7 +298,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         markerId: payload.markerId,
       });
     },
-    [onRemoveMarker],
+    [onRemoveMarker, onEditMarker],
   );
 
   const handleCloseContextMenu = useCallback(() => {
@@ -352,6 +361,15 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
     onRemoveMarker(contextMenu.markerId);
     setContextMenu(null);
   }, [contextMenu, onRemoveMarker]);
+
+  const handleEditMarkerClick = useCallback(() => {
+    if (!contextMenu || contextMenu.type !== 'marker' || !onEditMarker) {
+      return;
+    }
+
+    onEditMarker(contextMenu.markerId);
+    setContextMenu(null);
+  }, [contextMenu, onEditMarker]);
 
   const markerForMenu =
     contextMenu?.type === 'marker' ? (markerLookup.get(contextMenu.markerId) ?? null) : null;
@@ -795,6 +813,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             markersState={markersState}
             onGroundContextMenu={handleGroundContextMenu}
             onMarkerContextMenu={handleMarkerContextMenu}
+            markersEditMode={markersEditMode}
+            onMarkerMove={onMarkerMove}
             fight={fight}
             initialTarget={initialCameraTarget}
             initialPosition={initialCameraPosition}
@@ -974,6 +994,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
                       <ChevronRightIcon fontSize="small" />
                     </MenuItem>
                   ))}
+                {contextMenu?.type === 'marker' && onEditMarker && (
+                  <MenuItem onClick={handleEditMarkerClick}>Edit marker…</MenuItem>
+                )}
                 {contextMenu?.type === 'marker' && (
                   <MenuItem onClick={handleRemoveMarkerClick} disabled={!onRemoveMarker}>
                     {markerRemoveLabel}

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -109,10 +109,15 @@ interface Arena3DProps {
   onRemoveMarker?: (markerId: string) => void;
   /** Marker edit mode: plain right-click context menus + draggable markers (no Alt chord). */
   markersEditMode?: boolean;
+  /** Toggle marker edit mode — surfaced in the mobile tools sheet (no page toolbar in immersive). */
+  onToggleMarkersEditMode?: () => void;
   /** Drag-to-move commit for a marker (arena-space coordinates). */
   onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
   /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
   onEditMarker?: (markerId: string) => void;
+  /** Marker undo (mobile tools sheet — Ctrl+Z has no touch equivalent). */
+  canUndoMarkers?: boolean;
+  onUndoMarkers?: () => void;
   /** Fight data for zone/map information (required for map markers coordinate transformation) */
   fight: FightFragment;
   /** Selected player IDs for path visualization */
@@ -163,8 +168,11 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   onAddMarker,
   onRemoveMarker,
   markersEditMode = false,
+  onToggleMarkersEditMode,
   onMarkerMove,
   onEditMarker,
+  canUndoMarkers = false,
+  onUndoMarkers,
   fight,
   selectedPlayerIds,
   onPlayerSelectionChange,
@@ -1368,7 +1376,39 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           following={followingActorId != null}
           statsPanelEnabled={statsPanelEnabled}
           onToggleStats={() => setStatsPanelEnabled((prev) => !prev)}
+          markersEditMode={markersEditMode}
+          onToggleMarkersEditMode={onToggleMarkersEditMode}
+          canUndoMarkers={canUndoMarkers}
+          onUndoMarkers={onUndoMarkers}
         />
+      )}
+
+      {/* Marker edit-mode hint — touch gestures are invisible, so name them while the mode is on.
+          Top-center, clear of the Close (top-right) and the boss HUD; non-interactive. */}
+      {mobileImmersive && markersEditMode && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 12,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 2,
+            pointerEvents: 'none',
+            px: 1.5,
+            py: 0.5,
+            borderRadius: '999px',
+            backgroundColor: 'rgba(13,20,48,0.85)',
+            border: '1px solid rgba(148,210,255,0.35)',
+            maxWidth: 'calc(100% - 140px)',
+          }}
+        >
+          <Typography
+            variant="caption"
+            sx={{ color: 'rgba(226,232,240,0.92)', whiteSpace: 'nowrap', fontSize: '0.68rem' }}
+          >
+            Hold map: add · drag marker: move · hold marker: edit
+          </Typography>
+        </Box>
       )}
     </div>
   );

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -66,6 +66,28 @@ export interface GroundContextMenuPayload {
 }
 
 /**
+ * iOS Safari fires its NATIVE long-press behaviors (text-selection loupe, Copy/Look Up
+ * callout, image sheet) for touches on the canvas, hijacking the marker long-press and
+ * cancelling drags mid-gesture. CSS `touch-action`/`user-select` don't fully cover this —
+ * the supported escape hatch is preventDefault on a NON-passive touchstart. Pointer events
+ * (which drive all replay interaction, camera and pinch included) are unaffected. Mounted
+ * only inside the mobile immersive overlay, so desktop and the inline preview keep stock
+ * browser behavior.
+ */
+const SuppressNativeTouchDefaults: React.FC = () => {
+  const { gl } = useThree();
+
+  useEffect(() => {
+    const dom = gl.domElement;
+    const prevent = (event: TouchEvent): void => event.preventDefault();
+    dom.addEventListener('touchstart', prevent, { passive: false });
+    return () => dom.removeEventListener('touchstart', prevent);
+  }, [gl]);
+
+  return null;
+};
+
+/**
  * Actor renderer. Each actor is a standing figure (capsule body + role-glyph cap) with a
  * ground anchor ring, facing wedge, and state rings; bosses/enemies stand larger so they
  * read above the player crowd. Name cards float above and can be toggled off (N key).
@@ -694,6 +716,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           touch pinch, which CanvasWheelZoom re-implements minimally so mobile pinch is preserved.
           enablePan is gated by the touch policy: off on mobile-immersive so the two-finger gesture is
           pinch-only (no OrbitControls pan colliding with CanvasWheelZoom on the same touchmove). */}
+      {mobileImmersive && <SuppressNativeTouchDefaults />}
       <OrbitControls
         enablePan={touchPolicy.enablePan}
         enableZoom={false}

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -9,6 +9,7 @@ import { Logger, LogLevel } from '../../../utils/logger';
 import { MapTimeline } from '../../../utils/mapTimelineUtils';
 import { TimestampPositionLookup } from '../../../workers/calculations/CalculateActorPositions';
 import { MapMarkersState } from '../types/mapMarkers';
+import { LongPressTracker } from '../utils/longPress';
 import { DEFAULT_ACTOR_SCALE, computeActorScaleFromMapData } from '../utils/mapScaling';
 import { extractPlayerPaths, DEFAULT_PATH_SAMPLING } from '../utils/pathUtils';
 import { getPlayerPathColor } from '../utils/playerColors';
@@ -305,6 +306,30 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
     renderBudgetRef.current = RENDER_TAIL_FRAMES;
   }, []);
 
+  // Touch path for placing markers: press-and-hold on the ground (edit mode only) opens the
+  // same add-marker menu desktop gets from right-click. The arena point is captured at
+  // pointer-down; any movement past the slop (drag/rotate/pinch) cancels the press.
+  const groundPressPointRef = useRef<{ x: number; y: number; z: number } | null>(null);
+  const onGroundContextMenuRef = useRef(onGroundContextMenu);
+  onGroundContextMenuRef.current = onGroundContextMenu;
+  const groundLongPressRef = useRef<LongPressTracker | null>(null);
+  if (groundLongPressRef.current === null) {
+    groundLongPressRef.current = new LongPressTracker((start) => {
+      const arenaPoint = groundPressPointRef.current;
+      if (!arenaPoint) {
+        return;
+      }
+      onGroundContextMenuRef.current?.({
+        arenaPoint,
+        screenPosition: { left: start.clientX, top: start.clientY },
+      });
+    });
+  }
+  const groundLongPress = groundLongPressRef.current;
+  useEffect(() => {
+    return () => groundLongPress.cancel();
+  }, [groundLongPress]);
+
   // Player visibility is now owned by Arena3D and passed in as a prop, so the DOM
   // PlayerListPanel overlay (which renders the toggle controls) and these in-canvas actors
   // share one source of truth.
@@ -580,8 +605,8 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           visible={showPlayerTrails}
         />
       )}
-      {/* Interaction plane for context menu support (Alt + Right Click, or plain Right Click in
-          marker edit mode) */}
+      {/* Interaction plane for the add-marker context menu: Alt+Right-Click (always), plain
+          Right-Click in marker edit mode, and press-and-hold on touch in edit mode. */}
       <mesh
         position={[arenaDimensions.centerX, -0.019, arenaDimensions.centerZ]}
         rotation={[-Math.PI / 2, 0, 0]}
@@ -601,8 +626,45 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
                 top: event.nativeEvent.clientY,
               },
             });
+            return;
+          }
+
+          // Touch path: arm a long-press at the touched ground point. Camera rotate cancels it
+          // via the movement slop, so holding still is the only way it fires.
+          if (
+            event.button === 0 &&
+            event.nativeEvent.pointerType !== 'mouse' &&
+            markersEditMode &&
+            onGroundContextMenu
+          ) {
+            groundPressPointRef.current = {
+              x: event.point.x,
+              y: event.point.y,
+              z: event.point.z,
+            };
+            groundLongPress.begin({
+              pointerId: event.pointerId,
+              clientX: event.nativeEvent.clientX,
+              clientY: event.nativeEvent.clientY,
+            });
           }
         }}
+        onPointerMove={(event) => {
+          groundLongPress.move({
+            pointerId: event.pointerId,
+            clientX: event.nativeEvent.clientX,
+            clientY: event.nativeEvent.clientY,
+          });
+        }}
+        onPointerUp={(event) => {
+          groundLongPress.end({
+            pointerId: event.pointerId,
+            clientX: event.nativeEvent.clientX,
+            clientY: event.nativeEvent.clientY,
+          });
+        }}
+        onPointerCancel={() => groundLongPress.cancel()}
+        onPointerLeave={() => groundLongPress.cancel()}
       >
         <planeGeometry args={[arenaDimensions.size, arenaDimensions.size]} />
         <meshBasicMaterial visible={false} transparent opacity={0} />

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -1,6 +1,7 @@
 import { Grid, OrbitControls } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import React, { Suspense, useMemo, useCallback, useRef, useEffect } from 'react';
+import * as THREE from 'three';
 
 import { FightFragment } from '@/graphql/gql/graphql';
 
@@ -64,6 +65,43 @@ export interface GroundContextMenuPayload {
   arenaPoint: { x: number; y: number; z: number };
   screenPosition: { left: number; top: number };
 }
+
+/**
+ * Event the mobile tools sheet dispatches to place a marker without any gesture: the
+ * in-canvas bridge below raycasts the SCREEN CENTER onto the arena floor and opens the
+ * add-marker menu there. Long-press is the fast path; this is the always-works path.
+ */
+export const ADD_MARKER_AT_CENTER_EVENT = 'replay:add-marker-at-center';
+
+const GROUND_PLANE = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0.019);
+
+const CenterAddMarkerBridge: React.FC<{
+  onGroundContextMenu: (payload: GroundContextMenuPayload) => void;
+}> = ({ onGroundContextMenu }) => {
+  const { camera, gl } = useThree();
+  const callbackRef = useRef(onGroundContextMenu);
+  callbackRef.current = onGroundContextMenu;
+
+  useEffect(() => {
+    const handler = (): void => {
+      const raycaster = new THREE.Raycaster();
+      raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
+      const hit = new THREE.Vector3();
+      if (!raycaster.ray.intersectPlane(GROUND_PLANE, hit)) {
+        return;
+      }
+      const rect = gl.domElement.getBoundingClientRect();
+      callbackRef.current({
+        arenaPoint: { x: hit.x, y: hit.y, z: hit.z },
+        screenPosition: { left: rect.left + rect.width / 2, top: rect.top + rect.height / 2 },
+      });
+    };
+    window.addEventListener(ADD_MARKER_AT_CENTER_EVENT, handler);
+    return () => window.removeEventListener(ADD_MARKER_AT_CENTER_EVENT, handler);
+  }, [camera, gl]);
+
+  return null;
+};
 
 /**
  * iOS Safari fires its NATIVE long-press behaviors (text-selection loupe, Copy/Look Up
@@ -330,31 +368,88 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
 
   // Touch path for placing markers: press-and-hold on the ground (edit mode only) opens the
   // same add-marker menu desktop gets from right-click. The arena point is captured at
-  // pointer-down; any movement past the slop (drag/rotate/pinch) cancels the press. The menu
+  // pointer-down; movement past the slop (drag/rotate/pinch) cancels the press. The menu
   // itself opens on RELEASE (deferred a tick) — opening it under a still-down finger would let
-  // the gesture's trailing click land on the menu backdrop and close it immediately.
+  // the gesture's trailing click land on the menu backdrop and close it immediately. The
+  // gesture is tracked on WINDOW listeners (see the plane's onPointerDown for why).
   const groundPressPointRef = useRef<{ x: number; y: number; z: number } | null>(null);
   const pendingGroundMenuRef = useRef<GroundContextMenuPayload | null>(null);
   const onGroundContextMenuRef = useRef(onGroundContextMenu);
   onGroundContextMenuRef.current = onGroundContextMenu;
+  const groundGestureCleanupRef = useRef<(() => void) | null>(null);
   const groundLongPressRef = useRef<LongPressTracker | null>(null);
   if (groundLongPressRef.current === null) {
-    groundLongPressRef.current = new LongPressTracker((start) => {
-      const arenaPoint = groundPressPointRef.current;
-      if (!arenaPoint) {
-        return;
-      }
-      pendingGroundMenuRef.current = {
-        arenaPoint,
-        screenPosition: { left: start.clientX, top: start.clientY },
-      };
-      // Subtle confirmation that the hold registered (no-op where unsupported).
-      navigator.vibrate?.(30);
-    });
+    groundLongPressRef.current = new LongPressTracker(
+      (start) => {
+        const arenaPoint = groundPressPointRef.current;
+        if (!arenaPoint) {
+          return;
+        }
+        pendingGroundMenuRef.current = {
+          arenaPoint,
+          screenPosition: { left: start.clientX, top: start.clientY },
+        };
+        // Subtle confirmation that the hold registered (no-op where unsupported).
+        navigator.vibrate?.(30);
+      },
+      // A resting fingertip drifts more than a mouse — keep the hold forgiving (iOS's own
+      // long-press recognizer tolerates roughly this much travel).
+      { slopPx: 18 },
+    );
   }
   const groundLongPress = groundLongPressRef.current;
+
+  const beginGroundLongPress = useCallback(
+    (pointerId: number, clientX: number, clientY: number) => {
+      groundGestureCleanupRef.current?.();
+      groundLongPress.begin({ pointerId, clientX, clientY });
+
+      const onMove = (ev: PointerEvent): void => {
+        if (ev.pointerId !== pointerId) return;
+        groundLongPress.move({ pointerId: ev.pointerId, clientX: ev.clientX, clientY: ev.clientY });
+      };
+      const cleanup = (): void => {
+        groundGestureCleanupRef.current = null;
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        window.removeEventListener('pointercancel', onCancel);
+      };
+      const onUp = (ev: PointerEvent): void => {
+        if (ev.pointerId !== pointerId) return;
+        const fired = groundLongPress.end({
+          pointerId: ev.pointerId,
+          clientX: ev.clientX,
+          clientY: ev.clientY,
+        });
+        cleanup();
+
+        const payload = pendingGroundMenuRef.current;
+        pendingGroundMenuRef.current = null;
+        if (fired && payload) {
+          // After this gesture's trailing click has been dispatched.
+          setTimeout(() => onGroundContextMenuRef.current?.(payload), 0);
+        }
+      };
+      const onCancel = (ev: PointerEvent): void => {
+        if (ev.pointerId !== pointerId) return;
+        pendingGroundMenuRef.current = null;
+        groundLongPress.cancel();
+        cleanup();
+      };
+
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', onCancel);
+      groundGestureCleanupRef.current = cleanup;
+    },
+    [groundLongPress],
+  );
+
   useEffect(() => {
-    return () => groundLongPress.cancel();
+    return () => {
+      groundGestureCleanupRef.current?.();
+      groundLongPress.cancel();
+    };
   }, [groundLongPress]);
 
   // Player visibility is now owned by Arena3D and passed in as a prop, so the DOM
@@ -656,8 +751,12 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
             return;
           }
 
-          // Touch path: arm a long-press at the touched ground point. Camera rotate cancels it
-          // via the movement slop, so holding still is the only way it fires.
+          // Touch path: arm a long-press at the touched ground point. The REST of the gesture
+          // is tracked on WINDOW listeners, not on this mesh: R3F only delivers move/up/leave
+          // to the plane while the ray still hits it un-occluded, and in edit mode every marker
+          // carries a fat invisible grab proxy — one pixel of finger jitter re-raycasts onto a
+          // proxy, fires pointerleave on the plane, and would silently cancel the hold
+          // (field-reported on iPhone as "nothing happens when I hold").
           if (
             event.button === 0 &&
             event.nativeEvent.pointerType !== 'mouse' &&
@@ -669,41 +768,12 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
               y: event.point.y,
               z: event.point.z,
             };
-            groundLongPress.begin({
-              pointerId: event.pointerId,
-              clientX: event.nativeEvent.clientX,
-              clientY: event.nativeEvent.clientY,
-            });
+            beginGroundLongPress(
+              event.pointerId,
+              event.nativeEvent.clientX,
+              event.nativeEvent.clientY,
+            );
           }
-        }}
-        onPointerMove={(event) => {
-          groundLongPress.move({
-            pointerId: event.pointerId,
-            clientX: event.nativeEvent.clientX,
-            clientY: event.nativeEvent.clientY,
-          });
-        }}
-        onPointerUp={(event) => {
-          const fired = groundLongPress.end({
-            pointerId: event.pointerId,
-            clientX: event.nativeEvent.clientX,
-            clientY: event.nativeEvent.clientY,
-          });
-
-          const payload = pendingGroundMenuRef.current;
-          pendingGroundMenuRef.current = null;
-          if (fired && payload) {
-            // After this gesture's trailing click has been dispatched.
-            setTimeout(() => onGroundContextMenuRef.current?.(payload), 0);
-          }
-        }}
-        onPointerCancel={() => {
-          pendingGroundMenuRef.current = null;
-          groundLongPress.cancel();
-        }}
-        onPointerLeave={() => {
-          pendingGroundMenuRef.current = null;
-          groundLongPress.cancel();
         }}
       >
         <planeGeometry args={[arenaDimensions.size, arenaDimensions.size]} />
@@ -717,6 +787,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           enablePan is gated by the touch policy: off on mobile-immersive so the two-finger gesture is
           pinch-only (no OrbitControls pan colliding with CanvasWheelZoom on the same touchmove). */}
       {mobileImmersive && <SuppressNativeTouchDefaults />}
+      {markersEditMode && onGroundContextMenu && (
+        <CenterAddMarkerBridge onGroundContextMenu={onGroundContextMenu} />
+      )}
       <OrbitControls
         enablePan={touchPolicy.enablePan}
         enableZoom={false}

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -213,6 +213,10 @@ export interface Arena3DSceneProps {
   markersState?: MapMarkersState | null;
   onGroundContextMenu?: (payload: GroundContextMenuPayload) => void;
   onMarkerContextMenu?: (payload: MarkerContextMenuPayload) => void;
+  /** Marker edit mode: plain right-click context menus + draggable markers (no Alt chord). */
+  markersEditMode?: boolean;
+  /** Drag-to-move commit for a marker (arena-space coordinates). */
+  onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
   fight: FightFragment;
   initialTarget?: [number, number, number];
   /**
@@ -263,6 +267,8 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   markersState,
   onGroundContextMenu,
   onMarkerContextMenu,
+  markersEditMode = false,
+  onMarkerMove,
   fight,
   initialTarget,
   initialPosition,
@@ -558,6 +564,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           markersState={markersState}
           fight={fight}
           onMarkerContextMenu={onMarkerContextMenu}
+          editable={markersEditMode}
+          onMarkerMove={onMarkerMove}
+          markDirty={markSceneDirty}
         />
       )}
       {/* Player Path Trails - Animated trails for selected players */}
@@ -571,12 +580,17 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           visible={showPlayerTrails}
         />
       )}
-      {/* Interaction plane for context menu support (Alt + Right Click) */}
+      {/* Interaction plane for context menu support (Alt + Right Click, or plain Right Click in
+          marker edit mode) */}
       <mesh
         position={[arenaDimensions.centerX, -0.019, arenaDimensions.centerZ]}
         rotation={[-Math.PI / 2, 0, 0]}
         onPointerDown={(event) => {
-          if (event.button === 2 && event.nativeEvent.altKey && onGroundContextMenu) {
+          if (
+            event.button === 2 &&
+            (event.nativeEvent.altKey || markersEditMode) &&
+            onGroundContextMenu
+          ) {
             event.stopPropagation();
             event.nativeEvent.preventDefault();
 

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -308,8 +308,11 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
 
   // Touch path for placing markers: press-and-hold on the ground (edit mode only) opens the
   // same add-marker menu desktop gets from right-click. The arena point is captured at
-  // pointer-down; any movement past the slop (drag/rotate/pinch) cancels the press.
+  // pointer-down; any movement past the slop (drag/rotate/pinch) cancels the press. The menu
+  // itself opens on RELEASE (deferred a tick) — opening it under a still-down finger would let
+  // the gesture's trailing click land on the menu backdrop and close it immediately.
   const groundPressPointRef = useRef<{ x: number; y: number; z: number } | null>(null);
+  const pendingGroundMenuRef = useRef<GroundContextMenuPayload | null>(null);
   const onGroundContextMenuRef = useRef(onGroundContextMenu);
   onGroundContextMenuRef.current = onGroundContextMenu;
   const groundLongPressRef = useRef<LongPressTracker | null>(null);
@@ -319,10 +322,12 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
       if (!arenaPoint) {
         return;
       }
-      onGroundContextMenuRef.current?.({
+      pendingGroundMenuRef.current = {
         arenaPoint,
         screenPosition: { left: start.clientX, top: start.clientY },
-      });
+      };
+      // Subtle confirmation that the hold registered (no-op where unsupported).
+      navigator.vibrate?.(30);
     });
   }
   const groundLongPress = groundLongPressRef.current;
@@ -657,14 +662,27 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           });
         }}
         onPointerUp={(event) => {
-          groundLongPress.end({
+          const fired = groundLongPress.end({
             pointerId: event.pointerId,
             clientX: event.nativeEvent.clientX,
             clientY: event.nativeEvent.clientY,
           });
+
+          const payload = pendingGroundMenuRef.current;
+          pendingGroundMenuRef.current = null;
+          if (fired && payload) {
+            // After this gesture's trailing click has been dispatched.
+            setTimeout(() => onGroundContextMenuRef.current?.(payload), 0);
+          }
         }}
-        onPointerCancel={() => groundLongPress.cancel()}
-        onPointerLeave={() => groundLongPress.cancel()}
+        onPointerCancel={() => {
+          pendingGroundMenuRef.current = null;
+          groundLongPress.cancel();
+        }}
+        onPointerLeave={() => {
+          pendingGroundMenuRef.current = null;
+          groundLongPress.cancel();
+        }}
       >
         <planeGeometry args={[arenaDimensions.size, arenaDimensions.size]} />
         <meshBasicMaterial visible={false} transparent opacity={0} />

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -384,6 +384,15 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // transport is hidden (the canvas is a non-interactive teaser); it returns once the user expands.
   const mobilePreview = isMobile && !isImmersive;
 
+  // Marker editing needs the interactive overlay — the inline mobile preview is a
+  // pointer-events:none teaser, so enabling edit mode from the page toolbar would otherwise
+  // look broken (holds select page text, drags do nothing). Auto-expand instead.
+  useEffect(() => {
+    if (markersEditMode && isMobile) {
+      setMobilePseudoFullscreen(true);
+    }
+  }, [markersEditMode, isMobile]);
+
   const toggleFullscreen = useCallback(() => {
     // Mobile: flip the CSS pseudo-fullscreen overlay (the native API can't fullscreen a div on iOS).
     if (isMobile) {
@@ -668,6 +677,11 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
               paddingLeft: 'env(safe-area-inset-left)',
               paddingRight: 'env(safe-area-inset-right)',
               boxSizing: 'border-box',
+              // iOS: the overlay is an app surface, not a document — suppress the OS
+              // long-press text-selection/callout that hijacks marker gestures.
+              userSelect: 'none',
+              WebkitUserSelect: 'none',
+              WebkitTouchCallout: 'none',
               '& > .MuiPaper-root': { height: '100%', borderRadius: 0 },
             }
           : null),

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -33,10 +33,15 @@ interface FightReplay3DProps {
   onRemoveMarker?: (markerId: string) => void;
   /** Marker edit mode: plain right-click context menus + draggable markers (no Alt chord). */
   markersEditMode?: boolean;
+  /** Toggle marker edit mode — surfaced in the mobile tools sheet inside the immersive overlay. */
+  onToggleMarkersEditMode?: () => void;
   /** Drag-to-move commit for a marker (arena-space coordinates). */
   onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
   /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
   onEditMarker?: (markerId: string) => void;
+  /** Marker undo for the mobile tools sheet (Ctrl+Z has no touch equivalent). */
+  canUndoMarkers?: boolean;
+  onUndoMarkers?: () => void;
   /** Whether to show player paths toolkit */
   showPlayerPaths?: boolean;
   /** Initial selected player IDs for path visualization */
@@ -51,8 +56,11 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   onAddMarker,
   onRemoveMarker,
   markersEditMode = false,
+  onToggleMarkersEditMode,
   onMarkerMove,
   onEditMarker,
+  canUndoMarkers = false,
+  onUndoMarkers,
   showPlayerPaths = false,
   initialSelectedPlayerIds = [],
 }) => {
@@ -682,8 +690,11 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           onAddMarker={onAddMarker}
           onRemoveMarker={onRemoveMarker}
           markersEditMode={markersEditMode}
+          onToggleMarkersEditMode={onToggleMarkersEditMode}
           onMarkerMove={onMarkerMove}
           onEditMarker={onEditMarker}
+          canUndoMarkers={canUndoMarkers}
+          onUndoMarkers={onUndoMarkers}
           fight={selectedFight}
           selectedPlayerIds={selectedPlayerIds}
           onPlayerSelectionChange={setSelectedPlayerIds}

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -14,6 +14,7 @@ import { BuffEvent } from '../../../types/combatlogEvents';
 import { TRANSPORT_IDLE_MS, TRANSPORT_RESERVED, HAIRLINE_H } from '../constants/replayDesign';
 import { useIsMobileReplay } from '../hooks/useIsMobileReplay';
 import { MapMarkersState } from '../types/mapMarkers';
+import { lockDocumentSelection } from '../utils/documentSelectionLock';
 import { clampReplayTime } from '../utils/replayTime';
 
 import { Arena3D } from './Arena3D';
@@ -524,6 +525,16 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
       body.style.overflow = prevOverflow;
       body.style.overscrollBehavior = prevOverscroll;
     };
+  }, [mobilePseudoFullscreen]);
+
+  // Document-WIDE selection lock while the overlay is open. iOS Safari's long-press selection
+  // hit-test is not confined to the touched element: with the overlay unselectable, WebKit
+  // selects the nearest selectable text — i.e. the PAGE BEHIND the overlay (field-reported on
+  // iPhone). Scoped CSS can't fix that, so every element goes unselectable for the overlay's
+  // lifetime (text inputs stay editable — see documentSelectionLock).
+  useEffect(() => {
+    if (!mobilePseudoFullscreen) return;
+    return lockDocumentSelection();
   }, [mobilePseudoFullscreen]);
 
   // Keyboard shortcuts: playback transport + player-path toggles. Camera keys (WASD, r reset,

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -31,6 +31,12 @@ interface FightReplay3DProps {
   markersState?: MapMarkersState | null;
   onAddMarker?: (iconKey: number, arenaPoint: { x: number; y: number; z: number }) => void;
   onRemoveMarker?: (markerId: string) => void;
+  /** Marker edit mode: plain right-click context menus + draggable markers (no Alt chord). */
+  markersEditMode?: boolean;
+  /** Drag-to-move commit for a marker (arena-space coordinates). */
+  onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
+  /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
+  onEditMarker?: (markerId: string) => void;
   /** Whether to show player paths toolkit */
   showPlayerPaths?: boolean;
   /** Initial selected player IDs for path visualization */
@@ -44,6 +50,9 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   markersState,
   onAddMarker,
   onRemoveMarker,
+  markersEditMode = false,
+  onMarkerMove,
+  onEditMarker,
   showPlayerPaths = false,
   initialSelectedPlayerIds = [],
 }) => {
@@ -672,6 +681,9 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           markersState={markersState}
           onAddMarker={onAddMarker}
           onRemoveMarker={onRemoveMarker}
+          markersEditMode={markersEditMode}
+          onMarkerMove={onMarkerMove}
+          onEditMarker={onEditMarker}
           fight={selectedFight}
           selectedPlayerIds={selectedPlayerIds}
           onPlayerSelectionChange={setSelectedPlayerIds}

--- a/src/features/fight_replay/components/MapMarkers.tsx
+++ b/src/features/fight_replay/components/MapMarkers.tsx
@@ -25,6 +25,12 @@ interface MapMarkersProps {
   scale?: number;
   /** Callback when a marker context menu is requested */
   onMarkerContextMenu?: (payload: MarkerContextMenuPayload) => void;
+  /** Edit mode: markers become draggable and context menus open without the Alt chord */
+  editable?: boolean;
+  /** Drag-to-move commit (arena-space coordinates) */
+  onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
+  /** Repaint signal for the on-demand render loop (drag mutates the scene outside React commits) */
+  markDirty?: () => void;
 }
 
 export const MapMarkers: React.FC<MapMarkersProps> = ({
@@ -32,6 +38,9 @@ export const MapMarkers: React.FC<MapMarkersProps> = ({
   fight,
   scale = 1,
   onMarkerContextMenu,
+  editable = false,
+  onMarkerMove,
+  markDirty,
 }) => {
   const resolvedMarkers = useMemo<MapMarkersState | null>(() => {
     if (!markersState || markersState.markers.length === 0) {
@@ -253,6 +262,9 @@ export const MapMarkers: React.FC<MapMarkersProps> = ({
           markerId={marker.id}
           scale={effectiveScale}
           onContextMenu={onMarkerContextMenu}
+          editable={editable}
+          onMove={onMarkerMove}
+          markDirty={markDirty}
         />
       ))}
     </group>

--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three';
 
 import { MorMarker } from '../../../types/mapMarkers';
+import { LongPressTracker } from '../utils/longPress';
 
 import { MarkerShape } from './MarkerShape';
 
@@ -75,7 +76,22 @@ interface DragState {
   plane: THREE.Plane;
   /** Last intersection point, committed on release. */
   point: THREE.Vector3 | null;
+  /** Screen position at pointer-down — drags only engage beyond a slop from here. */
+  startClient: { x: number; y: number };
+  /** True once the pointer travelled past the slop: the gesture is a real drag, not a tap. */
+  engaged: boolean;
+  /** Arena point under the pointer at pointer-down (long-press menu payload). */
+  arenaStart: { x: number; y: number; z: number };
+  /** The element holding the pointer capture (needed to release outside an event handler). */
+  captureTarget: Element | null;
 }
+
+/**
+ * Pointer travel (px) before a press becomes a drag. Below this a touch is a long-press
+ * candidate and a mouse release is a click — either way the marker must not move, so a
+ * shaky tap never commits a position change.
+ */
+const DRAG_SLOP_PX = 8;
 
 /** Minimal shape of the default OrbitControls instance we toggle while dragging. */
 interface ToggleableControls {
@@ -122,22 +138,22 @@ export const Marker3D: React.FC<Marker3DProps> = ({
     [gl],
   );
 
-  const endDrag = useCallback(
-    (event: ThreeEvent<PointerEvent>, commit: boolean) => {
+  const releaseDrag = useCallback(
+    (commit: boolean) => {
       const drag = dragRef.current;
-      if (!drag || drag.pointerId !== event.pointerId) {
+      if (!drag) {
         return;
       }
       dragRef.current = null;
 
-      (event.target as Element | null)?.releasePointerCapture?.(event.pointerId);
+      drag.captureTarget?.releasePointerCapture?.(drag.pointerId);
       const orbit = controls as unknown as ToggleableControls | null;
       if (orbit) {
         orbit.enabled = true;
       }
       setCursor(editable ? 'grab' : 'auto');
 
-      if (commit && drag.point && onMove) {
+      if (commit && drag.engaged && drag.point && onMove) {
         onMove(markerId, { x: drag.point.x, z: drag.point.z });
       } else {
         setDragPosition(null);
@@ -146,6 +162,38 @@ export const Marker3D: React.FC<Marker3DProps> = ({
     },
     [controls, editable, markDirty, markerId, onMove, setCursor],
   );
+
+  // Latest-callback refs so the long-press tracker (created once) never goes stale.
+  const releaseDragRef = useRef(releaseDrag);
+  releaseDragRef.current = releaseDrag;
+  const onContextMenuRef = useRef(onContextMenu);
+  onContextMenuRef.current = onContextMenu;
+
+  // Touch path to the context menu: press and hold without moving. Firing aborts the
+  // pending drag (no commit) and opens the same menu right-click opens on desktop.
+  const longPressRef = useRef<LongPressTracker | null>(null);
+  if (longPressRef.current === null) {
+    longPressRef.current = new LongPressTracker(
+      (start) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== start.pointerId) {
+          return;
+        }
+        const arenaPoint = drag.arenaStart;
+        releaseDragRef.current(false);
+        onContextMenuRef.current?.({
+          markerId,
+          screenPosition: { left: start.clientX, top: start.clientY },
+          arenaPoint,
+        });
+      },
+      { slopPx: DRAG_SLOP_PX },
+    );
+  }
+  useEffect(() => {
+    const tracker = longPressRef.current;
+    return () => tracker?.cancel();
+  }, []);
 
   const handlePointerDown = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
@@ -168,9 +216,12 @@ export const Marker3D: React.FC<Marker3DProps> = ({
         return;
       }
 
-      // Left-drag to move (edit mode only).
+      // Primary press in edit mode: a drag candidate — and on touch, also a long-press
+      // candidate. The slop disambiguates: move past it = drag; hold still = context menu.
       if (event.button === 0 && editable && onMove) {
         event.stopPropagation();
+
+        const { clientX, clientY, pointerType } = event.nativeEvent;
 
         // Drag along the horizontal plane at the marker's height so the marker tracks the
         // pointer ray without jumping vertically. Plane: y = position[1] → constant = -y.
@@ -178,6 +229,10 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           pointerId: event.pointerId,
           plane: new THREE.Plane(new THREE.Vector3(0, 1, 0), -position[1]),
           point: null,
+          startClient: { x: clientX, y: clientY },
+          engaged: false,
+          arenaStart: { x: event.point.x, y: event.point.y, z: event.point.z },
+          captureTarget: event.target as Element | null,
         };
 
         (event.target as Element | null)?.setPointerCapture?.(event.pointerId);
@@ -186,6 +241,10 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           orbit.enabled = false;
         }
         setCursor('grabbing');
+
+        if (pointerType !== 'mouse' && onContextMenu) {
+          longPressRef.current?.begin({ pointerId: event.pointerId, clientX, clientY });
+        }
       }
     },
     [controls, editable, markerId, onContextMenu, onMove, position, setCursor],
@@ -200,6 +259,18 @@ export const Marker3D: React.FC<Marker3DProps> = ({
 
       event.stopPropagation();
 
+      const { clientX, clientY } = event.nativeEvent;
+      longPressRef.current?.move({ pointerId: event.pointerId, clientX, clientY });
+
+      if (!drag.engaged) {
+        const dx = clientX - drag.startClient.x;
+        const dy = clientY - drag.startClient.y;
+        if (dx * dx + dy * dy <= DRAG_SLOP_PX * DRAG_SLOP_PX) {
+          return; // still a tap/long-press candidate — don't move the marker yet
+        }
+        drag.engaged = true;
+      }
+
       const hit = new THREE.Vector3();
       if (event.ray.intersectPlane(drag.plane, hit)) {
         drag.point = hit;
@@ -212,19 +283,27 @@ export const Marker3D: React.FC<Marker3DProps> = ({
 
   const handlePointerUp = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
-      if (dragRef.current) {
+      const { clientX, clientY } = event.nativeEvent;
+      longPressRef.current?.end({ pointerId: event.pointerId, clientX, clientY });
+
+      const drag = dragRef.current;
+      if (drag && drag.pointerId === event.pointerId) {
         event.stopPropagation();
-        endDrag(event, true);
+        releaseDrag(true);
       }
     },
-    [endDrag],
+    [releaseDrag],
   );
 
   const handlePointerCancel = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
-      endDrag(event, false);
+      longPressRef.current?.cancel();
+      const drag = dragRef.current;
+      if (drag && drag.pointerId === event.pointerId) {
+        releaseDrag(false);
+      }
     },
-    [endDrag],
+    [releaseDrag],
   );
 
   const handlePointerOver = useCallback(

--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -75,9 +75,11 @@ interface Marker3DProps {
 /**
  * Pointer travel (px) before a press becomes a drag. Below this a touch is a long-press
  * candidate and a mouse release is a click — either way the marker must not move, so a
- * shaky tap never commits a position change.
+ * shaky tap never commits a position change. Touch gets a larger budget: a resting
+ * fingertip drifts several px, and an 8px threshold made real-device holds cancel.
  */
 const DRAG_SLOP_PX = 8;
+const TOUCH_SLOP_PX = 14;
 
 /** Minimal shape of the default OrbitControls instance we toggle while dragging. */
 interface ToggleableControls {
@@ -92,6 +94,8 @@ interface DragState {
   point: THREE.Vector3 | null;
   /** Screen position at pointer-down — drags only engage beyond a slop from here. */
   startClient: { x: number; y: number };
+  /** Pointer-type-dependent engagement slop (px) — touch gets a larger budget than mouse. */
+  slopPx: number;
   /** True once the pointer travelled past the slop: the gesture is a real drag, not a tap. */
   engaged: boolean;
   /** Arena point under the pointer at pointer-down (long-press menu payload). */
@@ -203,7 +207,8 @@ export const Marker3D: React.FC<Marker3DProps> = ({
         // Subtle confirmation that the hold registered (no-op where unsupported).
         navigator.vibrate?.(30);
       },
-      { slopPx: DRAG_SLOP_PX },
+      // The tracker only ever arms for touch/pen — use the finger-sized slop.
+      { slopPx: TOUCH_SLOP_PX },
     );
   }
   useEffect(() => {
@@ -274,7 +279,7 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           if (!drag.engaged) {
             const dx = ev.clientX - drag.startClient.x;
             const dy = ev.clientY - drag.startClient.y;
-            if (dx * dx + dy * dy <= DRAG_SLOP_PX * DRAG_SLOP_PX) {
+            if (dx * dx + dy * dy <= drag.slopPx * drag.slopPx) {
               return; // still a tap/long-press candidate — don't move the marker yet
             }
             drag.engaged = true;
@@ -340,6 +345,7 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           plane: new THREE.Plane(new THREE.Vector3(0, 1, 0), -markerY),
           point: null,
           startClient: { x: clientX, y: clientY },
+          slopPx: pointerType === 'mouse' ? DRAG_SLOP_PX : TOUCH_SLOP_PX,
           engaged: false,
           arenaStart: { x: event.point.x, y: event.point.y, z: event.point.z },
           removeListeners: () => {

--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -321,9 +321,17 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           releaseDragRef.current(false);
         };
 
+        // While a touch drag is live, claim the gesture outright: without this Safari can
+        // reinterpret the touch as scroll/selection mid-drag and fire pointercancel.
+        const onWindowTouchMove =
+          pointerType !== 'mouse' ? (ev: TouchEvent): void => ev.preventDefault() : null;
+
         window.addEventListener('pointermove', onWindowMove);
         window.addEventListener('pointerup', onWindowUp);
         window.addEventListener('pointercancel', onWindowCancel);
+        if (onWindowTouchMove) {
+          window.addEventListener('touchmove', onWindowTouchMove, { passive: false });
+        }
 
         // Drag along the horizontal plane at the marker's height so the marker tracks the
         // pointer ray without jumping vertically. Plane: y = markerY → constant = -markerY.
@@ -338,6 +346,9 @@ export const Marker3D: React.FC<Marker3DProps> = ({
             window.removeEventListener('pointermove', onWindowMove);
             window.removeEventListener('pointerup', onWindowUp);
             window.removeEventListener('pointercancel', onWindowCancel);
+            if (onWindowTouchMove) {
+              window.removeEventListener('touchmove', onWindowTouchMove);
+            }
           },
         };
 

--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -3,7 +3,8 @@
  * Supports both M0R and Elms marker formats
  */
 import { Billboard } from '@react-three/drei';
-import React, { useEffect, useMemo } from 'react';
+import { ThreeEvent, useThree } from '@react-three/fiber';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 
 import { MorMarker } from '../../../types/mapMarkers';
@@ -55,6 +56,30 @@ interface Marker3DProps {
   scale?: number;
   markerId: string;
   onContextMenu?: (payload: MarkerContextMenuPayload) => void;
+  /**
+   * Edit mode: left-drag moves the marker (commit via onMove) and the context menu opens on a
+   * plain right-click (no Alt chord). Off by default so playback interaction is unchanged.
+   */
+  editable?: boolean;
+  /** Drag-to-move commit: final arena-space position after the pointer is released. */
+  onMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
+  /**
+   * Tells the on-demand render loop to repaint (drag mutates the scene from pointer events,
+   * outside any React commit of the scene root — invisible while paused otherwise).
+   */
+  markDirty?: () => void;
+}
+
+interface DragState {
+  pointerId: number;
+  plane: THREE.Plane;
+  /** Last intersection point, committed on release. */
+  point: THREE.Vector3 | null;
+}
+
+/** Minimal shape of the default OrbitControls instance we toggle while dragging. */
+interface ToggleableControls {
+  enabled: boolean;
 }
 
 /**
@@ -69,12 +94,156 @@ export const Marker3D: React.FC<Marker3DProps> = ({
   scale = 1,
   markerId,
   onContextMenu,
+  editable = false,
+  onMove,
+  markDirty,
 }) => {
+  const { controls, gl } = useThree();
+
   // Coordinates are already in meters and normalized to arena space
   const position: [number, number, number] = useMemo(
     () => [marker.x, marker.y, marker.z],
     [marker.x, marker.y, marker.z],
   );
+
+  // While dragging, the live position overrides the prop-driven one; cleared on commit.
+  const [dragPosition, setDragPosition] = useState<[number, number, number] | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+
+  // Clear any stale drag override when the upstream position changes (commit landed).
+  useEffect(() => {
+    setDragPosition(null);
+  }, [position]);
+
+  const setCursor = useCallback(
+    (cursor: string) => {
+      gl.domElement.style.cursor = cursor;
+    },
+    [gl],
+  );
+
+  const endDrag = useCallback(
+    (event: ThreeEvent<PointerEvent>, commit: boolean) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) {
+        return;
+      }
+      dragRef.current = null;
+
+      (event.target as Element | null)?.releasePointerCapture?.(event.pointerId);
+      const orbit = controls as unknown as ToggleableControls | null;
+      if (orbit) {
+        orbit.enabled = true;
+      }
+      setCursor(editable ? 'grab' : 'auto');
+
+      if (commit && drag.point && onMove) {
+        onMove(markerId, { x: drag.point.x, z: drag.point.z });
+      } else {
+        setDragPosition(null);
+        markDirty?.();
+      }
+    },
+    [controls, editable, markDirty, markerId, onMove, setCursor],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      // Right-click: context menu. Requires Alt during playback; plain right-click in edit mode.
+      if (event.button === 2) {
+        if (!onContextMenu || (!event.nativeEvent.altKey && !editable)) {
+          return;
+        }
+
+        event.stopPropagation();
+        event.nativeEvent.preventDefault();
+
+        const { clientX, clientY } = event.nativeEvent;
+
+        onContextMenu({
+          markerId,
+          screenPosition: { left: clientX, top: clientY },
+          arenaPoint: { x: event.point.x, y: event.point.y, z: event.point.z },
+        });
+        return;
+      }
+
+      // Left-drag to move (edit mode only).
+      if (event.button === 0 && editable && onMove) {
+        event.stopPropagation();
+
+        // Drag along the horizontal plane at the marker's height so the marker tracks the
+        // pointer ray without jumping vertically. Plane: y = position[1] → constant = -y.
+        dragRef.current = {
+          pointerId: event.pointerId,
+          plane: new THREE.Plane(new THREE.Vector3(0, 1, 0), -position[1]),
+          point: null,
+        };
+
+        (event.target as Element | null)?.setPointerCapture?.(event.pointerId);
+        const orbit = controls as unknown as ToggleableControls | null;
+        if (orbit) {
+          orbit.enabled = false;
+        }
+        setCursor('grabbing');
+      }
+    },
+    [controls, editable, markerId, onContextMenu, onMove, position, setCursor],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) {
+        return;
+      }
+
+      event.stopPropagation();
+
+      const hit = new THREE.Vector3();
+      if (event.ray.intersectPlane(drag.plane, hit)) {
+        drag.point = hit;
+        setDragPosition([hit.x, position[1], hit.z]);
+        markDirty?.();
+      }
+    },
+    [markDirty, position],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (dragRef.current) {
+        event.stopPropagation();
+        endDrag(event, true);
+      }
+    },
+    [endDrag],
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      endDrag(event, false);
+    },
+    [endDrag],
+  );
+
+  const handlePointerOver = useCallback(
+    (event: ThreeEvent<PointerEvent>) => {
+      if (editable && onMove) {
+        event.stopPropagation();
+        if (!dragRef.current) {
+          setCursor('grab');
+        }
+      }
+    },
+    [editable, onMove, setCursor],
+  );
+
+  const handlePointerOut = useCallback(() => {
+    if (editable && !dragRef.current) {
+      setCursor('auto');
+    }
+  }, [editable, setCursor]);
 
   // Convert RGBA color (0-1 range) to Three.js color
   const color = useMemo(() => {
@@ -102,96 +271,56 @@ export const Marker3D: React.FC<Marker3DProps> = ({
   // Determine if marker should be a billboard (always face camera) or have orientation
   const isFloating = marker.orientation === undefined;
 
-  if (isFloating) {
-    // Floating marker - always faces camera
-    return (
-      <group
-        position={position}
-        onPointerDown={(event) => {
-          if (event.button === 2) {
-            if (!onContextMenu || !event.nativeEvent.altKey) {
-              return;
-            }
+  const renderedPosition = dragPosition ?? position;
 
-            event.stopPropagation();
-            event.nativeEvent.preventDefault();
+  const content = (
+    <>
+      {/* Shape based on bgTexture (only if provided) */}
+      {marker.bgTexture && (
+        <MarkerShape
+          texturePath={marker.bgTexture}
+          size={markerSize}
+          color={color}
+          opacity={marker.colour[3]}
+        />
+      )}
 
-            const { clientX, clientY } = event.nativeEvent;
+      {/* Text label if provided */}
+      {textTexture && (
+        <sprite position={[0, 0, 0.01]} scale={[markerSize * 0.8, markerSize * 0.4, 1]}>
+          <spriteMaterial map={textTexture} transparent depthTest={false} />
+        </sprite>
+      )}
+    </>
+  );
 
-            onContextMenu({
-              markerId,
-              screenPosition: { left: clientX, top: clientY },
-              arenaPoint: { x: event.point.x, y: event.point.y, z: event.point.z },
-            });
-          }
-        }}
-      >
+  return (
+    <group
+      position={renderedPosition}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+    >
+      {isFloating ? (
+        // Floating marker - always faces camera
         <Billboard follow={true} lockX={false} lockY={false} lockZ={false}>
-          {/* Shape based on bgTexture (only if provided) */}
-          {marker.bgTexture && (
-            <MarkerShape
-              texturePath={marker.bgTexture}
-              size={markerSize}
-              color={color}
-              opacity={marker.colour[3]}
-            />
-          )}
-
-          {/* Text label if provided */}
-          {textTexture && (
-            <sprite position={[0, 0, 0.01]} scale={[markerSize * 0.8, markerSize * 0.4, 1]}>
-              <spriteMaterial map={textTexture} transparent depthTest={false} />
-            </sprite>
-          )}
+          {content}
         </Billboard>
-      </group>
-    );
-  } else {
-    // Ground-facing marker with specific orientation
-    // We know orientation is defined because isFloating is false
-    const [pitch, yaw] = marker.orientation as [number, number];
-
-    return (
-      <group
-        position={position}
-        onPointerDown={(event) => {
-          if (event.button === 2) {
-            if (!onContextMenu || !event.nativeEvent.altKey) {
-              return;
-            }
-
-            event.stopPropagation();
-            event.nativeEvent.preventDefault();
-
-            const { clientX, clientY } = event.nativeEvent;
-
-            onContextMenu({
-              markerId,
-              screenPosition: { left: clientX, top: clientY },
-              arenaPoint: { x: event.point.x, y: event.point.y, z: event.point.z },
-            });
-          }
-        }}
-      >
-        <group rotation={[pitch, yaw, 0]}>
-          {/* Shape based on bgTexture (only if provided) */}
-          {marker.bgTexture && (
-            <MarkerShape
-              texturePath={marker.bgTexture}
-              size={markerSize}
-              color={color}
-              opacity={marker.colour[3]}
-            />
-          )}
-
-          {/* Text label if provided - slightly above the marker plane */}
-          {textTexture && (
-            <sprite position={[0, 0, 0.01]} scale={[markerSize * 0.8, markerSize * 0.4, 1]}>
-              <spriteMaterial map={textTexture} transparent depthTest={false} />
-            </sprite>
-          )}
+      ) : (
+        // Ground-facing marker with specific orientation (defined because isFloating is false)
+        <group
+          rotation={[
+            (marker.orientation as [number, number])[0],
+            (marker.orientation as [number, number])[1],
+            0,
+          ]}
+        >
+          {content}
         </group>
-      </group>
-    );
-  }
+      )}
+    </group>
+  );
 };

--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -58,8 +58,9 @@ interface Marker3DProps {
   markerId: string;
   onContextMenu?: (payload: MarkerContextMenuPayload) => void;
   /**
-   * Edit mode: left-drag moves the marker (commit via onMove) and the context menu opens on a
-   * plain right-click (no Alt chord). Off by default so playback interaction is unchanged.
+   * Edit mode: left-drag moves the marker (commit via onMove), the context menu opens on a
+   * plain right-click (no Alt chord), and press-and-hold opens it on touch. Off by default
+   * so playback interaction is unchanged.
    */
   editable?: boolean;
   /** Drag-to-move commit: final arena-space position after the pointer is released. */
@@ -69,21 +70,6 @@ interface Marker3DProps {
    * outside any React commit of the scene root — invisible while paused otherwise).
    */
   markDirty?: () => void;
-}
-
-interface DragState {
-  pointerId: number;
-  plane: THREE.Plane;
-  /** Last intersection point, committed on release. */
-  point: THREE.Vector3 | null;
-  /** Screen position at pointer-down — drags only engage beyond a slop from here. */
-  startClient: { x: number; y: number };
-  /** True once the pointer travelled past the slop: the gesture is a real drag, not a tap. */
-  engaged: boolean;
-  /** Arena point under the pointer at pointer-down (long-press menu payload). */
-  arenaStart: { x: number; y: number; z: number };
-  /** The element holding the pointer capture (needed to release outside an event handler). */
-  captureTarget: Element | null;
 }
 
 /**
@@ -98,12 +84,32 @@ interface ToggleableControls {
   enabled: boolean;
 }
 
+interface DragState {
+  pointerId: number;
+  /** Horizontal plane at the marker's height the pointer ray is intersected with. */
+  plane: THREE.Plane;
+  /** Last intersection point, committed on release. */
+  point: THREE.Vector3 | null;
+  /** Screen position at pointer-down — drags only engage beyond a slop from here. */
+  startClient: { x: number; y: number };
+  /** True once the pointer travelled past the slop: the gesture is a real drag, not a tap. */
+  engaged: boolean;
+  /** Arena point under the pointer at pointer-down (long-press menu payload). */
+  arenaStart: { x: number; y: number; z: number };
+  /** Removes the window listeners driving this drag. */
+  removeListeners: () => void;
+}
+
 /**
  * Renders a single marker in 3D space
  * - If orientation is undefined, marker is "floating" (billboard that always faces camera)
  * - If orientation is defined, marker is ground-facing with specific pitch/yaw
  *
  * NOTE: Expects coordinates in meters (already converted from centimeters by MapMarkers parent)
+ *
+ * Drag-to-move runs on WINDOW pointer listeners with a manual raycast (not R3F per-object
+ * events): once the pointer leaves the marker's tiny hit area mid-drag, object-scoped events
+ * stop arriving and DOM pointer capture is unreliable across browsers/synthetic pointers.
  */
 export const Marker3D: React.FC<Marker3DProps> = ({
   marker,
@@ -114,7 +120,7 @@ export const Marker3D: React.FC<Marker3DProps> = ({
   onMove,
   markDirty,
 }) => {
-  const { controls, gl } = useThree();
+  const { controls, gl, camera } = useThree();
 
   // Coordinates are already in meters and normalized to arena space
   const position: [number, number, number] = useMemo(
@@ -145,8 +151,8 @@ export const Marker3D: React.FC<Marker3DProps> = ({
         return;
       }
       dragRef.current = null;
+      drag.removeListeners();
 
-      drag.captureTarget?.releasePointerCapture?.(drag.pointerId);
       const orbit = controls as unknown as ToggleableControls | null;
       if (orbit) {
         orbit.enabled = true;
@@ -163,14 +169,19 @@ export const Marker3D: React.FC<Marker3DProps> = ({
     [controls, editable, markDirty, markerId, onMove, setCursor],
   );
 
-  // Latest-callback refs so the long-press tracker (created once) never goes stale.
+  // Latest-callback refs so the long-press tracker and window listeners never go stale.
   const releaseDragRef = useRef(releaseDrag);
   releaseDragRef.current = releaseDrag;
   const onContextMenuRef = useRef(onContextMenu);
   onContextMenuRef.current = onContextMenu;
+  const markDirtyRef = useRef(markDirty);
+  markDirtyRef.current = markDirty;
 
-  // Touch path to the context menu: press and hold without moving. Firing aborts the
-  // pending drag (no commit) and opens the same menu right-click opens on desktop.
+  // Touch path to the context menu: press and hold without moving. Firing neutralizes the
+  // pending drag (no commit, camera restored) but KEEPS the window listeners — the menu opens
+  // on RELEASE (deferred a tick), because opening it while the finger is still down would let
+  // this gesture's trailing click land on the menu backdrop and close it immediately.
+  const pendingMenuRef = useRef<MarkerContextMenuPayload | null>(null);
   const longPressRef = useRef<LongPressTracker | null>(null);
   if (longPressRef.current === null) {
     longPressRef.current = new LongPressTracker(
@@ -179,13 +190,18 @@ export const Marker3D: React.FC<Marker3DProps> = ({
         if (!drag || drag.pointerId !== start.pointerId) {
           return;
         }
-        const arenaPoint = drag.arenaStart;
-        releaseDragRef.current(false);
-        onContextMenuRef.current?.({
+        pendingMenuRef.current = {
           markerId,
           screenPosition: { left: start.clientX, top: start.clientY },
-          arenaPoint,
-        });
+          arenaPoint: drag.arenaStart,
+        };
+        // Neutralize the drag without tearing down the gesture's listeners.
+        drag.engaged = false;
+        drag.point = null;
+        setDragPosition(null);
+        markDirtyRef.current?.();
+        // Subtle confirmation that the hold registered (no-op where unsupported).
+        navigator.vibrate?.(30);
       },
       { slopPx: DRAG_SLOP_PX },
     );
@@ -194,6 +210,25 @@ export const Marker3D: React.FC<Marker3DProps> = ({
     const tracker = longPressRef.current;
     return () => tracker?.cancel();
   }, []);
+
+  /** Raycast the pointer's current screen position onto the drag plane. */
+  const raycastToPlane = useCallback(
+    (clientX: number, clientY: number, plane: THREE.Plane): THREE.Vector3 | null => {
+      const rect = gl.domElement.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return null;
+      }
+      const ndc = new THREE.Vector2(
+        ((clientX - rect.left) / rect.width) * 2 - 1,
+        -((clientY - rect.top) / rect.height) * 2 + 1,
+      );
+      const raycaster = new THREE.Raycaster();
+      raycaster.setFromCamera(ndc, camera);
+      const hit = new THREE.Vector3();
+      return raycaster.ray.intersectPlane(plane, hit) ? hit : null;
+    },
+    [camera, gl],
+  );
 
   const handlePointerDown = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
@@ -218,24 +253,94 @@ export const Marker3D: React.FC<Marker3DProps> = ({
 
       // Primary press in edit mode: a drag candidate — and on touch, also a long-press
       // candidate. The slop disambiguates: move past it = drag; hold still = context menu.
-      if (event.button === 0 && editable && onMove) {
+      if (event.button === 0 && editable && onMove && !dragRef.current) {
         event.stopPropagation();
 
-        const { clientX, clientY, pointerType } = event.nativeEvent;
+        const { clientX, clientY, pointerType, pointerId } = event.nativeEvent;
+        const markerY = position[1];
+
+        const onWindowMove = (ev: PointerEvent): void => {
+          const drag = dragRef.current;
+          if (!drag || ev.pointerId !== drag.pointerId || pendingMenuRef.current) {
+            return;
+          }
+
+          longPressRef.current?.move({
+            pointerId: ev.pointerId,
+            clientX: ev.clientX,
+            clientY: ev.clientY,
+          });
+
+          if (!drag.engaged) {
+            const dx = ev.clientX - drag.startClient.x;
+            const dy = ev.clientY - drag.startClient.y;
+            if (dx * dx + dy * dy <= DRAG_SLOP_PX * DRAG_SLOP_PX) {
+              return; // still a tap/long-press candidate — don't move the marker yet
+            }
+            drag.engaged = true;
+          }
+
+          const hit = raycastToPlane(ev.clientX, ev.clientY, drag.plane);
+          if (hit) {
+            drag.point = hit;
+            setDragPosition([hit.x, markerY, hit.z]);
+            markDirtyRef.current?.();
+          }
+        };
+
+        const onWindowUp = (ev: PointerEvent): void => {
+          const drag = dragRef.current;
+          if (!drag || ev.pointerId !== drag.pointerId) {
+            return;
+          }
+
+          longPressRef.current?.end({
+            pointerId: ev.pointerId,
+            clientX: ev.clientX,
+            clientY: ev.clientY,
+          });
+
+          const payload = pendingMenuRef.current;
+          pendingMenuRef.current = null;
+          releaseDragRef.current(payload === null);
+
+          // Long-press: open the menu AFTER this gesture's trailing click has been
+          // dispatched, so it can't immediately close the menu via its backdrop.
+          if (payload) {
+            setTimeout(() => onContextMenuRef.current?.(payload), 0);
+          }
+        };
+
+        const onWindowCancel = (ev: PointerEvent): void => {
+          const drag = dragRef.current;
+          if (!drag || ev.pointerId !== drag.pointerId) {
+            return;
+          }
+          longPressRef.current?.cancel();
+          pendingMenuRef.current = null;
+          releaseDragRef.current(false);
+        };
+
+        window.addEventListener('pointermove', onWindowMove);
+        window.addEventListener('pointerup', onWindowUp);
+        window.addEventListener('pointercancel', onWindowCancel);
 
         // Drag along the horizontal plane at the marker's height so the marker tracks the
-        // pointer ray without jumping vertically. Plane: y = position[1] → constant = -y.
+        // pointer ray without jumping vertically. Plane: y = markerY → constant = -markerY.
         dragRef.current = {
-          pointerId: event.pointerId,
-          plane: new THREE.Plane(new THREE.Vector3(0, 1, 0), -position[1]),
+          pointerId,
+          plane: new THREE.Plane(new THREE.Vector3(0, 1, 0), -markerY),
           point: null,
           startClient: { x: clientX, y: clientY },
           engaged: false,
           arenaStart: { x: event.point.x, y: event.point.y, z: event.point.z },
-          captureTarget: event.target as Element | null,
+          removeListeners: () => {
+            window.removeEventListener('pointermove', onWindowMove);
+            window.removeEventListener('pointerup', onWindowUp);
+            window.removeEventListener('pointercancel', onWindowCancel);
+          },
         };
 
-        (event.target as Element | null)?.setPointerCapture?.(event.pointerId);
         const orbit = controls as unknown as ToggleableControls | null;
         if (orbit) {
           orbit.enabled = false;
@@ -243,68 +348,19 @@ export const Marker3D: React.FC<Marker3DProps> = ({
         setCursor('grabbing');
 
         if (pointerType !== 'mouse' && onContextMenu) {
-          longPressRef.current?.begin({ pointerId: event.pointerId, clientX, clientY });
+          longPressRef.current?.begin({ pointerId, clientX, clientY });
         }
       }
     },
-    [controls, editable, markerId, onContextMenu, onMove, position, setCursor],
+    [controls, editable, markerId, onContextMenu, onMove, position, raycastToPlane, setCursor],
   );
 
-  const handlePointerMove = useCallback(
-    (event: ThreeEvent<PointerEvent>) => {
-      const drag = dragRef.current;
-      if (!drag || drag.pointerId !== event.pointerId) {
-        return;
-      }
-
-      event.stopPropagation();
-
-      const { clientX, clientY } = event.nativeEvent;
-      longPressRef.current?.move({ pointerId: event.pointerId, clientX, clientY });
-
-      if (!drag.engaged) {
-        const dx = clientX - drag.startClient.x;
-        const dy = clientY - drag.startClient.y;
-        if (dx * dx + dy * dy <= DRAG_SLOP_PX * DRAG_SLOP_PX) {
-          return; // still a tap/long-press candidate — don't move the marker yet
-        }
-        drag.engaged = true;
-      }
-
-      const hit = new THREE.Vector3();
-      if (event.ray.intersectPlane(drag.plane, hit)) {
-        drag.point = hit;
-        setDragPosition([hit.x, position[1], hit.z]);
-        markDirty?.();
-      }
-    },
-    [markDirty, position],
-  );
-
-  const handlePointerUp = useCallback(
-    (event: ThreeEvent<PointerEvent>) => {
-      const { clientX, clientY } = event.nativeEvent;
-      longPressRef.current?.end({ pointerId: event.pointerId, clientX, clientY });
-
-      const drag = dragRef.current;
-      if (drag && drag.pointerId === event.pointerId) {
-        event.stopPropagation();
-        releaseDrag(true);
-      }
-    },
-    [releaseDrag],
-  );
-
-  const handlePointerCancel = useCallback(
-    (event: ThreeEvent<PointerEvent>) => {
-      longPressRef.current?.cancel();
-      const drag = dragRef.current;
-      if (drag && drag.pointerId === event.pointerId) {
-        releaseDrag(false);
-      }
-    },
-    [releaseDrag],
-  );
+  // Abort any in-flight drag on unmount (restores OrbitControls + removes window listeners).
+  useEffect(() => {
+    return () => {
+      releaseDragRef.current(false);
+    };
+  }, []);
 
   const handlePointerOver = useCallback(
     (event: ThreeEvent<PointerEvent>) => {
@@ -352,6 +408,11 @@ export const Marker3D: React.FC<Marker3DProps> = ({
 
   const renderedPosition = dragPosition ?? position;
 
+  // Generous invisible grab target for edit mode. Markers are world-faithful (a 1m marker on a
+  // 1km map is a couple of pixels), which makes them impossible to grab precisely — especially
+  // on touch. The proxy disc never renders (opacity 0) but participates in raycasts.
+  const hitRadius = Math.max(markerSize * 0.8, 0.6);
+
   const content = (
     <>
       {/* Shape based on bgTexture (only if provided) */}
@@ -370,6 +431,14 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           <spriteMaterial map={textTexture} transparent depthTest={false} />
         </sprite>
       )}
+
+      {/* Edit-mode grab proxy (invisible, raycast-only) */}
+      {editable && (
+        <mesh position={[0, 0, 0.02]}>
+          <circleGeometry args={[hitRadius, 16]} />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
+      )}
     </>
   );
 
@@ -377,9 +446,6 @@ export const Marker3D: React.FC<Marker3DProps> = ({
     <group
       position={renderedPosition}
       onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerCancel}
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
     >

--- a/src/features/fight_replay/components/MarkerEditDialog.test.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.test.tsx
@@ -99,3 +99,25 @@ describe('MarkerEditDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 });
+
+describe('MarkerEditDialog — out-of-range sizes', () => {
+  it('preserves a size outside the slider range on a label-only edit', () => {
+    const onApply = jest.fn();
+    render(
+      <MarkerEditDialog
+        marker={marker({ size: 33.5, elmsIconKey: undefined })}
+        onClose={noop}
+        onApply={onApply}
+        onDelete={noop}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'big AoE' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      'm1',
+      expect.objectContaining({ text: 'big AoE', size: 33.5 }),
+    );
+  });
+});

--- a/src/features/fight_replay/components/MarkerEditDialog.test.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ReplayMarker } from '../types/mapMarkers';
+
+import { MarkerEditDialog } from './MarkerEditDialog';
+
+function marker(overrides: Partial<ReplayMarker> = {}): ReplayMarker {
+  return {
+    id: 'm1',
+    source: 'manual',
+    x: 80000,
+    y: 15000,
+    z: 70000,
+    size: 1.5,
+    colour: [1, 1, 1, 1],
+    bgTexture: 'M0RMarkers/textures/blank.dds',
+    text: '1',
+    orientation: undefined,
+    elmsIconKey: 1,
+    ...overrides,
+  };
+}
+
+const noop = (): void => undefined;
+
+describe('MarkerEditDialog', () => {
+  it('does not render when there is no marker', () => {
+    render(<MarkerEditDialog marker={null} onClose={noop} onApply={noop} onDelete={noop} />);
+    expect(screen.queryByText('Edit Marker')).not.toBeInTheDocument();
+  });
+
+  it('seeds the form from the marker and applies a label edit', () => {
+    const onApply = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <MarkerEditDialog marker={marker()} onClose={onClose} onApply={onApply} onDelete={noop} />,
+    );
+
+    const label = screen.getByLabelText('Label');
+    expect(label).toHaveValue('1');
+
+    fireEvent.change(label, { target: { value: 'Portal group' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      'm1',
+      expect.objectContaining({
+        iconKey: 1,
+        text: 'Portal group',
+        size: 1.5,
+        colour: [1, 1, 1, 1],
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('picking an icon previews its template values before saving', () => {
+    const onApply = jest.fn();
+    render(<MarkerEditDialog marker={marker()} onClose={noop} onApply={onApply} onDelete={noop} />);
+
+    // MT Hex (icon 21): red, text 'MT', default size 1.
+    fireEvent.click(screen.getByRole('button', { name: /use icon mt hex/i }));
+    expect(screen.getByLabelText('Label')).toHaveValue('MT');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onApply).toHaveBeenCalledWith(
+      'm1',
+      expect.objectContaining({ iconKey: 21, text: 'MT', size: 1, colour: [1, 0, 0, 1] }),
+    );
+  });
+
+  it('selecting a swatch changes the submitted colour while keeping the alpha', () => {
+    const onApply = jest.fn();
+    render(
+      <MarkerEditDialog
+        marker={marker({ colour: [1, 1, 1, 0.5] })}
+        onClose={noop}
+        onApply={onApply}
+        onDelete={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set colour Red' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onApply).toHaveBeenCalledWith('m1', expect.objectContaining({ colour: [1, 0, 0, 0.5] }));
+  });
+
+  it('deletes the marker and closes', () => {
+    const onDelete = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <MarkerEditDialog marker={marker()} onClose={onClose} onApply={noop} onDelete={onDelete} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onDelete).toHaveBeenCalledWith('m1');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/fight_replay/components/MarkerEditDialog.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.tsx
@@ -81,7 +81,10 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
   const [rgb, setRgb] = useState<[number, number, number]>([1, 1, 1]);
   const [size, setSize] = useState(1);
 
-  // Seed the form whenever a (different) marker opens the dialog.
+  // Seed the form whenever a (different) marker opens the dialog. Size is seeded UNclamped:
+  // imported M0R markers can legitimately sit outside the slider range (e.g. 0.3 or 33.5),
+  // and a label-only edit must not silently rewrite them. Only the slider track display is
+  // clamped; the value submits as-is unless the user actually drags the slider.
   useEffect(() => {
     if (!marker) {
       return;
@@ -89,7 +92,7 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
     setIconKey(marker.elmsIconKey);
     setText(marker.text ?? '');
     setRgb([marker.colour[0], marker.colour[1], marker.colour[2]]);
-    setSize(Math.min(MAX_SIZE_METERS, Math.max(MIN_SIZE_METERS, marker.size)));
+    setSize(marker.size);
   }, [marker]);
 
   // Picking an icon previews its template values in the form; the user can then override them.
@@ -253,7 +256,9 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
             Size: {size.toFixed(2)}m
           </Typography>
           <Slider
-            value={size}
+            // Display clamps an out-of-range size to the track edge; `size` itself stays
+            // untouched until the user drags, so Save preserves the original value.
+            value={Math.min(MAX_SIZE_METERS, Math.max(MIN_SIZE_METERS, size))}
             onChange={(_event, value) => setSize(value as number)}
             min={MIN_SIZE_METERS}
             max={MAX_SIZE_METERS}

--- a/src/features/fight_replay/components/MarkerEditDialog.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.tsx
@@ -13,6 +13,8 @@ import {
   TextField,
   Tooltip,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -71,6 +73,9 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
   onApply,
   onDelete,
 }) => {
+  const theme = useTheme();
+  // Full-screen on phones (same breakpoint as MapMarkersModal) — the icon grid needs the room.
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const [iconKey, setIconKey] = useState<number | undefined>(undefined);
   const [text, setText] = useState('');
   const [rgb, setRgb] = useState<[number, number, number]>([1, 1, 1]);
@@ -124,7 +129,13 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
   }, [marker, onClose, onDelete]);
 
   return (
-    <Dialog open={Boolean(marker)} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog
+      open={Boolean(marker)}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      fullScreen={fullScreen}
+    >
       <DialogTitle>Edit Marker</DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1 }}>
         {/* Icon picker */}
@@ -197,8 +208,9 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
                     aria-label={`Set colour ${swatch.label}`}
                     aria-pressed={selected}
                     sx={{
-                      width: 28,
-                      height: 28,
+                      // 36px hits the comfortable touch-target floor without crowding desktop.
+                      width: 36,
+                      height: 36,
                       borderRadius: '50%',
                       border: '2px solid',
                       borderColor: selected ? 'primary.main' : 'divider',
@@ -222,8 +234,8 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
               }}
               aria-label="Custom colour"
               sx={{
-                width: 36,
-                height: 28,
+                width: 48,
+                height: 36,
                 p: 0,
                 border: '1px solid',
                 borderColor: 'divider',

--- a/src/features/fight_replay/components/MarkerEditDialog.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.tsx
@@ -1,0 +1,268 @@
+/**
+ * Dialog for editing a single map marker: icon (Elms template), label, colour, and size.
+ * Submits one atomic MarkerEdit so the change is a single undo step.
+ */
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Slider,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { MorMarker } from '@/types/mapMarkers';
+import { ELMS_ICON_MAP } from '@/utils/elmsMarkersDecoder';
+
+import { ReplayMarker } from '../types/mapMarkers';
+import { COMMON_MARKER_GROUPS, MarkerEdit } from '../utils/mapMarkerConverters';
+
+import { MarkerSpritePreview } from './MarkerSpritePreview';
+
+const MIN_SIZE_METERS = 0.5;
+const MAX_SIZE_METERS = 5;
+
+/** Quick-pick swatches mirroring the Elms marker palette. */
+const COLOUR_SWATCHES: Array<{ label: string; rgb: [number, number, number] }> = [
+  { label: 'White', rgb: [1, 1, 1] },
+  { label: 'Blue', rgb: [0, 0, 1] },
+  { label: 'Green', rgb: [0, 1, 0] },
+  { label: 'Orange', rgb: [1, 0.5, 0] },
+  { label: 'Pink', rgb: [1, 0, 0.9] },
+  { label: 'Red', rgb: [1, 0, 0] },
+  { label: 'Yellow', rgb: [1, 0.8, 0] },
+];
+
+function rgbToHexInput([r, g, b]: [number, number, number]): string {
+  const toHex = (value: number): string =>
+    Math.max(0, Math.min(255, Math.round(value * 255)))
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexInputToRgb(hex: string): [number, number, number] | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) {
+    return null;
+  }
+  const value = parseInt(match[1], 16);
+  return [((value >> 16) & 0xff) / 255, ((value >> 8) & 0xff) / 255, (value & 0xff) / 255];
+}
+
+interface MarkerEditDialogProps {
+  /** The marker being edited; null closes the dialog. */
+  marker: ReplayMarker | null;
+  onClose: () => void;
+  /** Apply the edit (single undo step) and close. */
+  onApply: (markerId: string, edit: MarkerEdit) => void;
+  /** Delete the marker and close. */
+  onDelete: (markerId: string) => void;
+}
+
+export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
+  marker,
+  onClose,
+  onApply,
+  onDelete,
+}) => {
+  const [iconKey, setIconKey] = useState<number | undefined>(undefined);
+  const [text, setText] = useState('');
+  const [rgb, setRgb] = useState<[number, number, number]>([1, 1, 1]);
+  const [size, setSize] = useState(1);
+
+  // Seed the form whenever a (different) marker opens the dialog.
+  useEffect(() => {
+    if (!marker) {
+      return;
+    }
+    setIconKey(marker.elmsIconKey);
+    setText(marker.text ?? '');
+    setRgb([marker.colour[0], marker.colour[1], marker.colour[2]]);
+    setSize(Math.min(MAX_SIZE_METERS, Math.max(MIN_SIZE_METERS, marker.size)));
+  }, [marker]);
+
+  // Picking an icon previews its template values in the form; the user can then override them.
+  const handlePickIcon = useCallback((nextIconKey: number) => {
+    const template: Partial<MorMarker> | undefined = ELMS_ICON_MAP[nextIconKey];
+    if (!template) {
+      return;
+    }
+    setIconKey(nextIconKey);
+    setText(template.text ?? '');
+    const colour = template.colour ?? [1, 1, 1, 1];
+    setRgb([colour[0], colour[1], colour[2]]);
+    setSize(template.size ?? 1);
+  }, []);
+
+  const handleApply = useCallback(() => {
+    if (!marker) {
+      return;
+    }
+
+    const alpha = marker.colour[3];
+    onApply(marker.id, {
+      iconKey,
+      text,
+      colour: [rgb[0], rgb[1], rgb[2], alpha],
+      size,
+    });
+    onClose();
+  }, [iconKey, marker, onApply, onClose, rgb, size, text]);
+
+  const handleDelete = useCallback(() => {
+    if (!marker) {
+      return;
+    }
+    onDelete(marker.id);
+    onClose();
+  }, [marker, onClose, onDelete]);
+
+  return (
+    <Dialog open={Boolean(marker)} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Edit Marker</DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1 }}>
+        {/* Icon picker */}
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Icon
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {COMMON_MARKER_GROUPS.map((group) => (
+              <Box key={group.key} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ width: 110, flexShrink: 0 }}
+                >
+                  {group.label}
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                  {group.options.map((option) => (
+                    <Box
+                      key={option.iconKey}
+                      component="button"
+                      type="button"
+                      onClick={() => handlePickIcon(option.iconKey)}
+                      aria-label={`Use icon ${option.label}`}
+                      aria-pressed={iconKey === option.iconKey}
+                      sx={{
+                        p: 0.25,
+                        background: 'none',
+                        border: '2px solid',
+                        borderColor: iconKey === option.iconKey ? 'primary.main' : 'transparent',
+                        borderRadius: 1,
+                        cursor: 'pointer',
+                        display: 'inline-flex',
+                      }}
+                    >
+                      <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* Label */}
+        <TextField
+          label="Label"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          size="small"
+          fullWidth
+          helperText="Shown on the marker. Custom labels export via the M0R format only."
+        />
+
+        {/* Colour */}
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Colour
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+            {COLOUR_SWATCHES.map((swatch) => {
+              const selected = rgbToHexInput(swatch.rgb) === rgbToHexInput(rgb);
+              return (
+                <Tooltip key={swatch.label} title={swatch.label}>
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={() => setRgb(swatch.rgb)}
+                    aria-label={`Set colour ${swatch.label}`}
+                    aria-pressed={selected}
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: '50%',
+                      border: '2px solid',
+                      borderColor: selected ? 'primary.main' : 'divider',
+                      backgroundColor: rgbToHexInput(swatch.rgb),
+                      cursor: 'pointer',
+                      p: 0,
+                    }}
+                  />
+                </Tooltip>
+              );
+            })}
+            <Box
+              component="input"
+              type="color"
+              value={rgbToHexInput(rgb)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const parsed = hexInputToRgb(e.target.value);
+                if (parsed) {
+                  setRgb(parsed);
+                }
+              }}
+              aria-label="Custom colour"
+              sx={{
+                width: 36,
+                height: 28,
+                p: 0,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                cursor: 'pointer',
+                backgroundColor: 'transparent',
+              }}
+            />
+          </Box>
+        </Box>
+
+        {/* Size */}
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Size: {size.toFixed(2)}m
+          </Typography>
+          <Slider
+            value={size}
+            onChange={(_event, value) => setSize(value as number)}
+            min={MIN_SIZE_METERS}
+            max={MAX_SIZE_METERS}
+            step={0.25}
+            valueLabelDisplay="auto"
+            aria-label="Marker size in meters"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleDelete} color="error" type="button">
+          Delete
+        </Button>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button onClick={onClose} color="inherit" type="button">
+          Cancel
+        </Button>
+        <Button onClick={handleApply} variant="contained" type="button">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/features/fight_replay/components/MarkersPanel.test.tsx
+++ b/src/features/fight_replay/components/MarkersPanel.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
+
+import { MarkersPanel } from './MarkersPanel';
+
+function marker(overrides: Partial<ReplayMarker> = {}): ReplayMarker {
+  return {
+    id: 'm1',
+    source: 'manual',
+    x: 80000,
+    y: 15000,
+    z: 70000,
+    size: 1.5,
+    colour: [1, 1, 1, 1],
+    bgTexture: 'M0RMarkers/textures/blank.dds',
+    text: '1',
+    orientation: undefined,
+    elmsIconKey: 1,
+    ...overrides,
+  };
+}
+
+function stateOf(markers: ReplayMarker[]): MapMarkersState {
+  return { format: 'elms', zoneId: 636, markers };
+}
+
+const noop = (): void => undefined;
+
+function renderPanel(
+  markersState: MapMarkersState | null,
+  overrides: Partial<React.ComponentProps<typeof MarkersPanel>> = {},
+): ReturnType<typeof render> {
+  return render(
+    <MarkersPanel
+      markersState={markersState}
+      editMode={true}
+      canUndo={false}
+      canRedo={false}
+      onUndo={noop}
+      onRedo={noop}
+      onEditMarker={noop}
+      onRemoveMarker={noop}
+      onClearMarkers={noop}
+      {...overrides}
+    />,
+  );
+}
+
+describe('MarkersPanel', () => {
+  it('renders nothing with no markers and no history', () => {
+    const { container } = renderPanel(null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists markers with their label and position summary', () => {
+    renderPanel(stateOf([marker(), marker({ id: 'm2', text: 'Kite here', elmsIconKey: 21 })]));
+
+    expect(screen.getByText('Markers (2)')).toBeInTheDocument();
+    expect(screen.getByText('Kite here')).toBeInTheDocument();
+    // 80000cm/100 = 800m, 70000cm/100 = 700m, size 1.5m
+    expect(screen.getAllByText('800m, 700m · 1.5m')).toHaveLength(2);
+  });
+
+  it('fires edit/remove callbacks with the marker id', () => {
+    const onEditMarker = jest.fn();
+    const onRemoveMarker = jest.fn();
+    renderPanel(stateOf([marker()]), { onEditMarker, onRemoveMarker });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit 1/i }));
+    expect(onEditMarker).toHaveBeenCalledWith('m1');
+
+    fireEvent.click(screen.getByRole('button', { name: /delete 1/i }));
+    expect(onRemoveMarker).toHaveBeenCalledWith('m1');
+  });
+
+  it('wires undo/redo buttons to their callbacks and disables them when unavailable', () => {
+    const onUndo = jest.fn();
+    const onRedo = jest.fn();
+    renderPanel(stateOf([marker()]), { canUndo: true, canRedo: false, onUndo, onRedo });
+
+    const undoButton = screen.getByRole('button', { name: 'Undo' });
+    const redoButton = screen.getByRole('button', { name: 'Redo' });
+
+    expect(redoButton).toBeDisabled();
+    fireEvent.click(undoButton);
+    expect(onUndo).toHaveBeenCalled();
+  });
+
+  it('clears all markers via the Clear all action', () => {
+    const onClearMarkers = jest.fn();
+    renderPanel(stateOf([marker()]), { onClearMarkers });
+
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    expect(onClearMarkers).toHaveBeenCalled();
+  });
+
+  it('labels markers without text by their source', () => {
+    renderPanel(stateOf([marker({ text: undefined, elmsIconKey: undefined, source: 'imported' })]));
+    expect(screen.getByText('Imported marker')).toBeInTheDocument();
+  });
+});

--- a/src/features/fight_replay/components/MarkersPanel.test.tsx
+++ b/src/features/fight_replay/components/MarkersPanel.test.tsx
@@ -49,9 +49,14 @@ function renderPanel(
 }
 
 describe('MarkersPanel', () => {
-  it('renders nothing with no markers and no history', () => {
-    const { container } = renderPanel(null);
+  it('renders nothing with no markers, no history, and edit mode off', () => {
+    const { container } = renderPanel(null, { editMode: false });
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the empty-state guidance while edit mode is on', () => {
+    renderPanel(null, { editMode: true });
+    expect(screen.getByText(/no markers yet/i)).toBeInTheDocument();
   });
 
   it('lists markers with their label and position summary', () => {

--- a/src/features/fight_replay/components/MarkersPanel.tsx
+++ b/src/features/fight_replay/components/MarkersPanel.tsx
@@ -1,0 +1,199 @@
+/**
+ * Compact management panel listing the loaded map markers with per-marker edit/delete,
+ * plus undo/redo and clear-all. Rendered on the fight replay page while markers exist
+ * or marker edit mode is active.
+ */
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import EditIcon from '@mui/icons-material/Edit';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RedoIcon from '@mui/icons-material/Redo';
+import UndoIcon from '@mui/icons-material/Undo';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { MorMarker } from '@/types/mapMarkers';
+
+import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
+
+import { MarkerSpritePreview } from './MarkerSpritePreview';
+
+function toCssColour(colour: MorMarker['colour']): string {
+  const [r, g, b, a] = colour;
+  return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${Math.max(
+    0,
+    Math.min(1, a),
+  ).toFixed(3)})`;
+}
+
+/** Sprite preview for template markers; a colour chip with the label for fully custom ones. */
+const MarkerGlyph: React.FC<{ marker: ReplayMarker }> = ({ marker }) => {
+  if (typeof marker.elmsIconKey === 'number') {
+    return <MarkerSpritePreview iconKey={marker.elmsIconKey} label={marker.text} />;
+  }
+
+  return (
+    <span
+      role="img"
+      aria-label={marker.text ? `Marker ${marker.text}` : 'Custom marker'}
+      style={{
+        width: 32,
+        height: 32,
+        minWidth: 32,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 8,
+        background: toCssColour(marker.colour),
+        border: '1px solid rgba(12, 12, 18, 0.6)',
+        color: 'rgba(255, 255, 255, 0.95)',
+        fontWeight: 700,
+        fontSize: '0.7rem',
+        overflow: 'hidden',
+        userSelect: 'none',
+      }}
+    >
+      {marker.text?.slice(0, 3) ?? null}
+    </span>
+  );
+};
+
+function describeMarker(marker: ReplayMarker): string {
+  if (marker.text && marker.text.trim().length > 0) {
+    return marker.text.trim();
+  }
+  return marker.source === 'imported' ? 'Imported marker' : 'Marker';
+}
+
+function describePosition(marker: ReplayMarker): string {
+  // World coordinates are centimeters; meters are the human-scale unit used everywhere else.
+  return `${Math.round(marker.x / 100)}m, ${Math.round(marker.z / 100)}m · ${marker.size.toFixed(1)}m`;
+}
+
+interface MarkersPanelProps {
+  markersState: MapMarkersState | null;
+  /** Auto-expand while edit mode is on. */
+  editMode: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onEditMarker: (markerId: string) => void;
+  onRemoveMarker: (markerId: string) => void;
+  onClearMarkers: () => void;
+}
+
+export const MarkersPanel: React.FC<MarkersPanelProps> = ({
+  markersState,
+  editMode,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  onEditMarker,
+  onRemoveMarker,
+  onClearMarkers,
+}) => {
+  const markers = markersState?.markers ?? [];
+
+  if (markers.length === 0 && !canUndo && !canRedo) {
+    return null;
+  }
+
+  return (
+    <Accordion
+      disableGutters
+      elevation={0}
+      defaultExpanded={editMode}
+      sx={{ bgcolor: 'action.hover', border: 1, borderColor: 'divider', borderRadius: 1 }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle2">Markers ({markers.length})</Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ pt: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+          <Tooltip title="Undo (Ctrl+Z)">
+            <span>
+              <IconButton size="small" onClick={onUndo} disabled={!canUndo} aria-label="Undo">
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Redo (Ctrl+Shift+Z)">
+            <span>
+              <IconButton size="small" onClick={onRedo} disabled={!canRedo} aria-label="Redo">
+                <RedoIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Box sx={{ flexGrow: 1 }} />
+          {markers.length > 0 && (
+            <Button size="small" color="secondary" onClick={onClearMarkers} type="button">
+              Clear all
+            </Button>
+          )}
+        </Box>
+
+        <List dense disablePadding sx={{ maxHeight: 260, overflowY: 'auto' }}>
+          {markers.map((marker) => (
+            <ListItem
+              key={marker.id}
+              disableGutters
+              secondaryAction={
+                <Box sx={{ display: 'flex', gap: 0.25 }}>
+                  <Tooltip title="Edit marker">
+                    <IconButton
+                      size="small"
+                      onClick={() => onEditMarker(marker.id)}
+                      aria-label={`Edit ${describeMarker(marker)}`}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete marker">
+                    <IconButton
+                      size="small"
+                      onClick={() => onRemoveMarker(marker.id)}
+                      aria-label={`Delete ${describeMarker(marker)}`}
+                    >
+                      <DeleteOutlineIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              }
+              sx={{ pr: 9 }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0 }}>
+                <MarkerGlyph marker={marker} />
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                    {describeMarker(marker)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {describePosition(marker)}
+                  </Typography>
+                </Box>
+              </Box>
+            </ListItem>
+          ))}
+        </List>
+
+        {markers.length === 0 && (
+          <Typography variant="caption" color="text.secondary">
+            No markers yet. Right-click the map in edit mode to place one.
+          </Typography>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};

--- a/src/features/fight_replay/components/MarkersPanel.tsx
+++ b/src/features/fight_replay/components/MarkersPanel.tsx
@@ -106,7 +106,9 @@ export const MarkersPanel: React.FC<MarkersPanelProps> = ({
 }) => {
   const markers = markersState?.markers ?? [];
 
-  if (markers.length === 0 && !canUndo && !canRedo) {
+  // Outside edit mode an empty panel is noise; in edit mode it carries the empty-state
+  // guidance ("right-click / long-press to place"), so it stays.
+  if (markers.length === 0 && !canUndo && !canRedo && !editMode) {
     return null;
   }
 
@@ -190,7 +192,7 @@ export const MarkersPanel: React.FC<MarkersPanelProps> = ({
 
         {markers.length === 0 && (
           <Typography variant="caption" color="text.secondary">
-            No markers yet. Right-click the map in edit mode to place one.
+            No markers yet. Right-click (or press and hold) the map to place one.
           </Typography>
         )}
       </AccordionDetails>

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -256,6 +256,9 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
               backgroundColor: alpha(theme.palette.background.paper, 0.96),
               backdropFilter: 'blur(12px)',
               border: '1px solid rgba(148,210,255,0.25)',
+              // iOS: keep long-presses from text-selecting the sheet rows.
+              userSelect: 'none',
+              WebkitTouchCallout: 'none',
             }),
           },
         }}

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -1,3 +1,4 @@
+import AddLocationAlt from '@mui/icons-material/AddLocationAlt';
 import Bolt from '@mui/icons-material/Bolt';
 import CenterFocusStrong from '@mui/icons-material/CenterFocusStrong';
 import Close from '@mui/icons-material/Close';
@@ -55,6 +56,8 @@ export interface MobileReplayControlsProps {
   /** Marker edit mode (long-press to place/edit, drag to move). Omitted = no markers row. */
   markersEditMode?: boolean;
   onToggleMarkersEditMode?: () => void;
+  /** Gesture-free marker placement: opens the add-marker menu at the screen center. */
+  onAddMarkerAtCenter?: () => void;
   /** Undo the last marker change — only shown while edit mode is on. */
   canUndoMarkers?: boolean;
   onUndoMarkers?: () => void;
@@ -87,6 +90,7 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
   onToggleStats,
   markersEditMode = false,
   onToggleMarkersEditMode,
+  onAddMarkerAtCenter,
   canUndoMarkers = false,
   onUndoMarkers,
 }) => {
@@ -131,6 +135,19 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
             icon: <EditLocationAlt fontSize="small" />,
             active: markersEditMode,
             onTap: onToggleMarkersEditMode,
+            closesOnTap: true,
+          } as ToolItem,
+        ]
+      : []),
+    // Gesture-free placement: long-press is the fast path, this row always works.
+    ...(markersEditMode && onAddMarkerAtCenter
+      ? [
+          {
+            key: 'addMarker',
+            label: 'Add marker here',
+            icon: <AddLocationAlt fontSize="small" />,
+            active: false,
+            onTap: onAddMarkerAtCenter,
             closesOnTap: true,
           } as ToolItem,
         ]

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -1,6 +1,7 @@
 import Bolt from '@mui/icons-material/Bolt';
 import CenterFocusStrong from '@mui/icons-material/CenterFocusStrong';
 import Close from '@mui/icons-material/Close';
+import EditLocationAlt from '@mui/icons-material/EditLocationAlt';
 import Insights from '@mui/icons-material/Insights';
 import Label from '@mui/icons-material/Label';
 import LabelOff from '@mui/icons-material/LabelOff';
@@ -8,6 +9,7 @@ import People from '@mui/icons-material/People';
 import RestartAlt from '@mui/icons-material/RestartAlt';
 import Route from '@mui/icons-material/Route';
 import Tune from '@mui/icons-material/Tune';
+import Undo from '@mui/icons-material/Undo';
 import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import React, { useState } from 'react';
@@ -50,6 +52,12 @@ export interface MobileReplayControlsProps {
   following: boolean;
   statsPanelEnabled: boolean;
   onToggleStats: () => void;
+  /** Marker edit mode (long-press to place/edit, drag to move). Omitted = no markers row. */
+  markersEditMode?: boolean;
+  onToggleMarkersEditMode?: () => void;
+  /** Undo the last marker change — only shown while edit mode is on. */
+  canUndoMarkers?: boolean;
+  onUndoMarkers?: () => void;
 }
 
 /** A row in the tools sheet. `closesOnTap` items open another on-screen panel, so the sheet dismisses
@@ -61,6 +69,7 @@ interface ToolItem {
   active: boolean;
   onTap: () => void;
   closesOnTap?: boolean;
+  disabled?: boolean;
 }
 
 export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
@@ -76,6 +85,10 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
   following,
   statsPanelEnabled,
   onToggleStats,
+  markersEditMode = false,
+  onToggleMarkersEditMode,
+  canUndoMarkers = false,
+  onUndoMarkers,
 }) => {
   // The tools sheet anchor — null = closed.
   const [toolsAnchor, setToolsAnchor] = useState<HTMLElement | null>(null);
@@ -106,6 +119,34 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
       active: namesEnabled,
       onTap: onToggleNames,
     },
+    // Marker editing: the touch home for the desktop "Edit Markers" toggle. While on,
+    // long-press the map to place a marker, drag a marker to move it, long-press a marker
+    // to edit/remove it. Undo rides along for recovering from a mis-drag without leaving
+    // the overlay.
+    ...(onToggleMarkersEditMode
+      ? [
+          {
+            key: 'editMarkers',
+            label: markersEditMode ? 'Stop editing markers' : 'Edit markers',
+            icon: <EditLocationAlt fontSize="small" />,
+            active: markersEditMode,
+            onTap: onToggleMarkersEditMode,
+            closesOnTap: true,
+          } as ToolItem,
+        ]
+      : []),
+    ...(markersEditMode && onUndoMarkers
+      ? [
+          {
+            key: 'undoMarkers',
+            label: 'Undo marker change',
+            icon: <Undo fontSize="small" />,
+            active: false,
+            onTap: onUndoMarkers,
+            disabled: !canUndoMarkers,
+          } as ToolItem,
+        ]
+      : []),
     {
       key: 'reset',
       label: 'Reset view',
@@ -224,6 +265,7 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
             key={item.key}
             onClick={() => handleTap(item)}
             aria-pressed={item.active}
+            disabled={item.disabled}
             sx={{
               minHeight: 44,
               color: item.active ? 'primary.main' : 'text.primary',

--- a/src/features/fight_replay/hooks/useMapMarkersManager.test.tsx
+++ b/src/features/fight_replay/hooks/useMapMarkersManager.test.tsx
@@ -1,0 +1,265 @@
+import { act, renderHook } from '@testing-library/react';
+
+import type { FightFragment } from '@/graphql/gql/graphql';
+
+import { ReplayMarker } from '../types/mapMarkers';
+
+import { useMapMarkersManager } from './useMapMarkersManager';
+
+const STORAGE_KEY = 'replay.mapMarkers.v1';
+
+// Hel Ra Citadel: zone 636, map 614 — bounds minX 32030, maxX 133200, minZ 18939, maxZ 120109.
+const HEL_RA_FIGHT = {
+  name: 'The Warrior',
+  gameZone: { id: 636 },
+  maps: [{ id: 614, name: 'Hel Ra Citadel' }],
+} as unknown as FightFragment;
+
+function savedMarker(overrides: Partial<ReplayMarker> = {}): ReplayMarker {
+  return {
+    id: 'saved-1',
+    source: 'manual',
+    x: 80000,
+    y: 15000,
+    z: 70000,
+    size: 1.5,
+    colour: [1, 1, 1, 1],
+    bgTexture: 'M0RMarkers/textures/blank.dds',
+    text: '1',
+    orientation: undefined,
+    elmsIconKey: 1,
+    ...overrides,
+  };
+}
+
+function seedStorage(markers: ReplayMarker[], zoneId = 636): void {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      [String(zoneId)]: { format: 'elms', zoneId, markers, savedAt: Date.now() },
+    }),
+  );
+}
+
+function readStorage(): Record<string, { markers: ReplayMarker[] }> {
+  return JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}');
+}
+
+describe('useMapMarkersManager', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts empty when nothing is stored for the zone', () => {
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    expect(result.current.markersState).toBeNull();
+    expect(result.current.restoredCount).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("restores the zone's saved markers and reports the restored count", () => {
+    seedStorage([savedMarker()]);
+
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    expect(result.current.markersState?.markers).toHaveLength(1);
+    expect(result.current.markersState?.markers[0].text).toBe('1');
+    expect(result.current.markersState?.zoneId).toBe(636);
+    expect(result.current.restoredCount).toBe(1);
+  });
+
+  it('ignores corrupt stored blobs instead of throwing', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not valid json');
+
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+    expect(result.current.markersState).toBeNull();
+  });
+
+  it('drops malformed stored markers but keeps the valid ones', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        '636': {
+          format: 'elms',
+          zoneId: 636,
+          markers: [savedMarker(), { id: 'bad', x: 'NaN-ish' }],
+          savedAt: 1,
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+    expect(result.current.markersState?.markers).toHaveLength(1);
+    expect(result.current.markersState?.markers[0].id).toBe('saved-1');
+  });
+
+  it('does not restore markers saved for a different zone', () => {
+    seedStorage([savedMarker()], 638); // Aetherian Archive
+
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+    expect(result.current.markersState).toBeNull();
+  });
+
+  it('addMarkerAt places a marker at the world coordinates for the arena point and persists it', () => {
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.addMarkerAt(1, { x: 50, y: 0, z: 50 });
+    });
+
+    const marker = result.current.markersState?.markers[0];
+    expect(marker).toBeDefined();
+    // Arena center (50, 50) → midpoint of the Hel Ra bounding box.
+    expect(marker?.x).toBeCloseTo((32030 + 133200) / 2, 0);
+    expect(marker?.z).toBeCloseTo((18939 + 120109) / 2, 0);
+    expect(marker?.elmsIconKey).toBe(1);
+    expect(marker?.source).toBe('manual');
+
+    expect(readStorage()['636'].markers).toHaveLength(1);
+  });
+
+  it('moveMarker rewrites the world position from an arena point', () => {
+    seedStorage([savedMarker()]);
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    const id = result.current.markersState!.markers[0].id;
+    act(() => {
+      result.current.moveMarker(id, { x: 100, z: 100 });
+    });
+
+    const moved = result.current.markersState!.markers[0];
+    // Arena (100, 100) → normalized 0 → the map's min corner.
+    expect(moved.x).toBeCloseTo(32030, 0);
+    expect(moved.z).toBeCloseTo(18939, 0);
+    expect(readStorage()['636'].markers[0].x).toBeCloseTo(32030, 0);
+  });
+
+  it('removeMarker deletes the marker and clears the storage slot when none remain', () => {
+    seedStorage([savedMarker()]);
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.removeMarker('saved-1');
+    });
+
+    expect(result.current.markersState?.markers).toHaveLength(0);
+    expect(readStorage()['636']).toBeUndefined();
+  });
+
+  it('editMarker applies label/colour/size and an icon swap as ONE undo step', () => {
+    seedStorage([savedMarker()]);
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.editMarker('saved-1', {
+        iconKey: 20, // red square template
+        text: 'Stack here',
+        colour: [0.5, 0.25, 1, 1],
+        size: 3,
+      });
+    });
+
+    const edited = result.current.markersState!.markers[0];
+    expect(edited.text).toBe('Stack here');
+    expect(edited.colour).toEqual([0.5, 0.25, 1, 1]);
+    expect(edited.size).toBe(3);
+    // Custom text/colour/size diverge from the template → no longer claims Elms fidelity.
+    expect(edited.elmsIconKey).toBeUndefined();
+
+    // Single undo restores the original marker entirely.
+    act(() => {
+      result.current.undo();
+    });
+    const restored = result.current.markersState!.markers[0];
+    expect(restored.text).toBe('1');
+    expect(restored.size).toBe(1.5);
+    expect(restored.elmsIconKey).toBe(1);
+  });
+
+  it('undo/redo walk the history and keep storage in sync', () => {
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.addMarkerAt(1, { x: 50, y: 0, z: 50 });
+    });
+    act(() => {
+      result.current.addMarkerAt(2, { x: 25, y: 0, z: 25 });
+    });
+    expect(result.current.markersState?.markers).toHaveLength(2);
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.markersState?.markers).toHaveLength(1);
+    expect(result.current.canRedo).toBe(true);
+    expect(readStorage()['636'].markers).toHaveLength(1);
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.markersState?.markers).toHaveLength(2);
+    expect(readStorage()['636'].markers).toHaveLength(2);
+  });
+
+  it('a new mutation clears the redo branch', () => {
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.addMarkerAt(1, { x: 50, y: 0, z: 50 });
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.addMarkerAt(3, { x: 10, y: 0, z: 10 });
+    });
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('loadFromString imports an Elms string and clearMarkers wipes state + storage', () => {
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.loadFromString('/636//80000,15000,70000,21//636//90000,15000,80000,18/');
+    });
+    expect(result.current.markersState?.markers).toHaveLength(2);
+    expect(result.current.markersState?.format).toBe('elms');
+    expect(readStorage()['636'].markers).toHaveLength(2);
+
+    act(() => {
+      result.current.clearMarkers();
+    });
+    expect(result.current.markersState).toBeNull();
+    expect(readStorage()['636']).toBeUndefined();
+  });
+
+  it('reports decode failures through onError instead of throwing', () => {
+    const onError = jest.fn();
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT, onError }));
+
+    act(() => {
+      result.current.loadFromString('definitely-not-a-markers-string');
+    });
+
+    expect(onError).toHaveBeenCalled();
+    expect(result.current.markersState).toBeNull();
+  });
+
+  it('preserves other zones in storage when writing this zone', () => {
+    seedStorage([savedMarker({ x: 50000, z: 50000 })], 638);
+    const { result } = renderHook(() => useMapMarkersManager({ fight: HEL_RA_FIGHT }));
+
+    act(() => {
+      result.current.addMarkerAt(1, { x: 50, y: 0, z: 50 });
+    });
+
+    const stored = readStorage();
+    expect(stored['636'].markers).toHaveLength(1);
+    expect(stored['638'].markers).toHaveLength(1);
+  });
+});

--- a/src/features/fight_replay/hooks/useMapMarkersManager.ts
+++ b/src/features/fight_replay/hooks/useMapMarkersManager.ts
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { FightFragment } from '@/graphql/gql/graphql';
+import { MorMarker } from '@/types/mapMarkers';
+import { ZONE_SCALE_DATA, ZoneScaleData } from '@/types/zoneScaleData';
+import { detectMapFromCoordinates } from '@/utils/mapMarkersUtils';
+
+import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
+import {
+  MarkerEdit,
+  arenaPointToWorld,
+  createMarkerFromElmsIcon,
+  parseMarkersInput,
+  withMarkerEdit,
+  withMarkerPosition,
+  withNewMarker,
+  withoutMarker,
+} from '../utils/mapMarkerConverters';
+
+/**
+ * useMapMarkersManager
+ *
+ * Owns the fight replay's map-markers state and everything around it:
+ *  - CRUD: import (M0R/Elms strings), place, move, edit, remove, clear
+ *  - Per-zone persistence in localStorage, auto-restored when a fight in that zone opens,
+ *    so a raid lead's marker set survives reloads and carries across pulls in the same trial.
+ *  - Undo/redo history (bounded) over every mutation.
+ *
+ * Persistence shape (versioned key): { [zoneId]: { format, zoneId, markers, savedAt } }.
+ * Reads are sanitized field-by-field so a corrupt blob degrades to "nothing saved" instead of
+ * injecting garbage into the 3D scene. All storage access is try/caught (private mode, quota).
+ */
+
+const VERSION = 1;
+const STORAGE_KEY = `replay.mapMarkers.v${VERSION}`;
+const HISTORY_LIMIT = 50;
+
+interface PersistedZoneMarkers {
+  format: MapMarkersState['format'];
+  zoneId: number;
+  markers: ReplayMarker[];
+  savedAt: number;
+}
+
+type PersistedMarkersByZone = Record<string, PersistedZoneMarkers>;
+
+const isFiniteNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+const isColour = (v: unknown): v is [number, number, number, number] =>
+  Array.isArray(v) && v.length === 4 && v.every(isFiniteNumber);
+
+const isOrientation = (v: unknown): v is [number, number] =>
+  Array.isArray(v) && v.length === 2 && v.every(isFiniteNumber);
+
+function sanitizeMarker(raw: unknown): ReplayMarker | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  if (
+    typeof obj.id !== 'string' ||
+    !isFiniteNumber(obj.x) ||
+    !isFiniteNumber(obj.y) ||
+    !isFiniteNumber(obj.z) ||
+    !isFiniteNumber(obj.size) ||
+    obj.size <= 0 ||
+    !isColour(obj.colour)
+  ) {
+    return null;
+  }
+
+  return {
+    id: obj.id,
+    source: obj.source === 'imported' ? 'imported' : 'manual',
+    x: obj.x,
+    y: obj.y,
+    z: obj.z,
+    size: obj.size,
+    colour: [...obj.colour] as [number, number, number, number],
+    bgTexture: typeof obj.bgTexture === 'string' ? obj.bgTexture : undefined,
+    text: typeof obj.text === 'string' ? obj.text : undefined,
+    orientation: isOrientation(obj.orientation)
+      ? ([...obj.orientation] as [number, number])
+      : undefined,
+    elmsIconKey: isFiniteNumber(obj.elmsIconKey) ? obj.elmsIconKey : undefined,
+  };
+}
+
+function sanitizeZoneEntry(raw: unknown): PersistedZoneMarkers | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  if (!isFiniteNumber(obj.zoneId) || !Array.isArray(obj.markers)) return null;
+
+  const markers = obj.markers
+    .map(sanitizeMarker)
+    .filter((marker): marker is ReplayMarker => marker !== null);
+
+  if (markers.length === 0) return null;
+
+  return {
+    format: obj.format === 'mor' ? 'mor' : 'elms',
+    zoneId: obj.zoneId,
+    markers,
+    savedAt: isFiniteNumber(obj.savedAt) ? obj.savedAt : 0,
+  };
+}
+
+function readStored(): PersistedMarkersByZone {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    const out: PersistedMarkersByZone = {};
+    for (const [zoneKey, entry] of Object.entries(parsed as Record<string, unknown>)) {
+      const sanitized = sanitizeZoneEntry(entry);
+      if (sanitized) {
+        out[zoneKey] = sanitized;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Read-merge-write of one zone's slot, so other zones' saved sets are never clobbered. */
+function persistZone(zoneId: number, state: MapMarkersState | null): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const stored = readStored();
+    const key = String(zoneId);
+
+    if (!state || state.markers.length === 0) {
+      delete stored[key];
+    } else {
+      stored[key] = {
+        format: state.format,
+        zoneId: state.zoneId,
+        markers: state.markers,
+        savedAt: Date.now(),
+      };
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage disabled / quota exceeded — markers simply won't survive a reload.
+  }
+}
+
+/**
+ * Resolve the scale data for the map the markers should be placed on: the fight's own map when
+ * known, else the map whose bounding box contains the first marker, else the zone's first map.
+ */
+function resolveActiveMapData(
+  fight: FightFragment | null | undefined,
+  markersState: MapMarkersState | null,
+): ZoneScaleData | null {
+  if (!fight?.gameZone?.id) {
+    return null;
+  }
+
+  const zoneId = fight.gameZone.id;
+  const zoneMaps = ZONE_SCALE_DATA[zoneId];
+
+  if (!zoneMaps || zoneMaps.length === 0) {
+    return null;
+  }
+
+  const fightMapId = fight.maps?.[0]?.id;
+  if (fightMapId) {
+    const map = zoneMaps.find((candidate) => candidate.mapId === fightMapId);
+    if (map) {
+      return map;
+    }
+  }
+
+  const marker = markersState?.markers[0];
+  if (marker) {
+    const detected = detectMapFromCoordinates(zoneId, marker.x, marker.z);
+    if (detected) {
+      return detected;
+    }
+  }
+
+  return zoneMaps[0] ?? null;
+}
+
+export interface UseMapMarkersManagerOptions {
+  fight: FightFragment | null | undefined;
+  /** Surface user-facing errors (e.g. snackbar). */
+  onError?: (message: string) => void;
+}
+
+export interface UseMapMarkersManagerResult {
+  markersState: MapMarkersState | null;
+  /** Scale data for the map markers are placed on (also used by the page for map info). */
+  activeMapData: ZoneScaleData | null;
+  /** Number of markers restored from a previous session for this zone (0 when none). */
+  restoredCount: number;
+  canUndo: boolean;
+  canRedo: boolean;
+  loadFromString: (markersString: string) => void;
+  clearMarkers: () => void;
+  addMarkerAt: (iconKey: number, arenaPoint: { x: number; y: number; z: number }) => void;
+  removeMarker: (markerId: string) => void;
+  /** Commit a drag-to-move: arena-space point → world coords for the active map. */
+  moveMarker: (markerId: string, arenaPoint: { x: number; z: number }) => void;
+  /** Apply one edit-dialog submission (icon/label/colour/size) as a single undo step. */
+  editMarker: (markerId: string, edit: MarkerEdit) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+export const useMapMarkersManager = ({
+  fight,
+  onError,
+}: UseMapMarkersManagerOptions): UseMapMarkersManagerResult => {
+  const zoneId = fight?.gameZone?.id ?? null;
+
+  const [markersState, setMarkersState] = useState<MapMarkersState | null>(null);
+  const [restoredCount, setRestoredCount] = useState(0);
+
+  const activeMapData = useMemo(
+    () => resolveActiveMapData(fight, markersState),
+    [fight, markersState],
+  );
+
+  // Undo/redo stacks hold full state snapshots (markers states are small — ≤200 markers).
+  // Refs (not state) for the stacks themselves; canUndo/canRedo mirror into state for the UI.
+  const pastRef = useRef<(MapMarkersState | null)[]>([]);
+  const futureRef = useRef<(MapMarkersState | null)[]>([]);
+  const [historyVersion, setHistoryVersion] = useState(0);
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  // Restore this zone's saved markers when the fight (zone) changes. Replaces in-memory state
+  // wholesale: marker sets are zone-scoped, so carrying one zone's set into another is never right.
+  const restoredZoneRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (zoneId === null || restoredZoneRef.current === zoneId) {
+      return;
+    }
+    restoredZoneRef.current = zoneId;
+    pastRef.current = [];
+    futureRef.current = [];
+    setHistoryVersion((v) => v + 1);
+
+    const saved = readStored()[String(zoneId)];
+    if (saved) {
+      setMarkersState({ format: saved.format, zoneId: saved.zoneId, markers: saved.markers });
+      setRestoredCount(saved.markers.length);
+    } else {
+      setMarkersState(null);
+      setRestoredCount(0);
+    }
+  }, [zoneId]);
+
+  // Single mutation gateway: snapshots history, applies the update, persists the zone slot.
+  const commit = useCallback(
+    (updater: (prev: MapMarkersState | null) => MapMarkersState | null) => {
+      setMarkersState((prev) => {
+        const next = updater(prev);
+        if (next === prev) {
+          return prev;
+        }
+
+        pastRef.current = [...pastRef.current.slice(-(HISTORY_LIMIT - 1)), prev];
+        futureRef.current = [];
+        setHistoryVersion((v) => v + 1);
+
+        if (zoneId !== null) {
+          persistZone(next?.zoneId ?? zoneId, next);
+        }
+        return next;
+      });
+    },
+    [zoneId],
+  );
+
+  const loadFromString = useCallback(
+    (markersString: string) => {
+      try {
+        const parsed = parseMarkersInput(markersString);
+        commit(() => parsed);
+      } catch (error) {
+        onErrorRef.current?.(
+          error instanceof Error ? error.message : 'Unable to decode markers string.',
+        );
+      }
+    },
+    [commit],
+  );
+
+  const clearMarkers = useCallback(() => {
+    commit((prev) => (prev === null ? prev : null));
+  }, [commit]);
+
+  const addMarkerAt = useCallback(
+    (iconKey: number, arenaPoint: { x: number; y: number; z: number }) => {
+      if (zoneId === null) {
+        onErrorRef.current?.('Fight zone information is unavailable.');
+        return;
+      }
+      if (!activeMapData) {
+        onErrorRef.current?.('Map scale data is unavailable for this fight.');
+        return;
+      }
+
+      const world = arenaPointToWorld(activeMapData, arenaPoint);
+
+      try {
+        setRestoredCount(0);
+        commit((prev) => {
+          const targetZone = prev?.zoneId ?? zoneId;
+          const y = activeMapData.y ?? prev?.markers[0]?.y ?? 0;
+          const newMarker: MorMarker = createMarkerFromElmsIcon(iconKey, {
+            x: world.x,
+            y,
+            z: world.z,
+          });
+
+          const baseState: MapMarkersState = prev ?? {
+            format: 'elms',
+            zoneId: targetZone,
+            markers: [],
+          };
+
+          const adjusted =
+            baseState.zoneId === targetZone
+              ? baseState
+              : { ...baseState, zoneId: targetZone, markers: [] };
+
+          return withNewMarker(adjusted, newMarker, 'elms');
+        });
+      } catch (error) {
+        onErrorRef.current?.(error instanceof Error ? error.message : 'Failed to add marker.');
+      }
+    },
+    [activeMapData, commit, zoneId],
+  );
+
+  const removeMarker = useCallback(
+    (markerId: string) => {
+      commit((prev) => (prev ? withoutMarker(prev, markerId) : prev));
+    },
+    [commit],
+  );
+
+  const moveMarker = useCallback(
+    (markerId: string, arenaPoint: { x: number; z: number }) => {
+      if (!activeMapData) {
+        onErrorRef.current?.('Map scale data is unavailable for this fight.');
+        return;
+      }
+
+      const world = arenaPointToWorld(activeMapData, arenaPoint);
+      commit((prev) => (prev ? withMarkerPosition(prev, markerId, world) : prev));
+    },
+    [activeMapData, commit],
+  );
+
+  const editMarker = useCallback(
+    (markerId: string, edit: MarkerEdit) => {
+      commit((prev) => {
+        if (!prev) return prev;
+        try {
+          return withMarkerEdit(prev, markerId, edit);
+        } catch (error) {
+          onErrorRef.current?.(error instanceof Error ? error.message : 'Failed to edit marker.');
+          return prev;
+        }
+      });
+    },
+    [commit],
+  );
+
+  const undo = useCallback(() => {
+    setMarkersState((current) => {
+      if (pastRef.current.length === 0) {
+        return current;
+      }
+      const previous = pastRef.current[pastRef.current.length - 1];
+      pastRef.current = pastRef.current.slice(0, -1);
+      futureRef.current = [...futureRef.current, current];
+      setHistoryVersion((v) => v + 1);
+
+      if (zoneId !== null) {
+        persistZone(previous?.zoneId ?? zoneId, previous);
+      }
+      return previous;
+    });
+  }, [zoneId]);
+
+  const redo = useCallback(() => {
+    setMarkersState((current) => {
+      if (futureRef.current.length === 0) {
+        return current;
+      }
+      const next = futureRef.current[futureRef.current.length - 1];
+      futureRef.current = futureRef.current.slice(0, -1);
+      pastRef.current = [...pastRef.current, current];
+      setHistoryVersion((v) => v + 1);
+
+      if (zoneId !== null) {
+        persistZone(next?.zoneId ?? zoneId, next);
+      }
+      return next;
+    });
+  }, [zoneId]);
+
+  const canUndo = useMemo(() => {
+    void historyVersion;
+    return pastRef.current.length > 0;
+  }, [historyVersion]);
+
+  const canRedo = useMemo(() => {
+    void historyVersion;
+    return futureRef.current.length > 0;
+  }, [historyVersion]);
+
+  return {
+    markersState,
+    activeMapData,
+    restoredCount,
+    canUndo,
+    canRedo,
+    loadFromString,
+    clearMarkers,
+    addMarkerAt,
+    removeMarker,
+    moveMarker,
+    editMarker,
+    undo,
+    redo,
+  };
+};

--- a/src/features/fight_replay/utils/documentSelectionLock.test.ts
+++ b/src/features/fight_replay/utils/documentSelectionLock.test.ts
@@ -1,0 +1,79 @@
+import { lockDocumentSelection } from './documentSelectionLock';
+
+const LOCK_CLASS = 'replay-touch-selection-lock';
+
+function fireSelectStart(target: EventTarget): Event {
+  const event = new Event('selectstart', { bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe('lockDocumentSelection', () => {
+  afterEach(() => {
+    // Reset any leaked lock state between tests.
+    document.documentElement.classList.remove(LOCK_CLASS);
+  });
+
+  it('adds the lock class and stylesheet while held, removes the class on release', () => {
+    const release = lockDocumentSelection();
+
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(true);
+    const style = document.getElementById('replay-touch-selection-lock-style');
+    expect(style).not.toBeNull();
+    expect(style?.textContent).toContain('-webkit-touch-callout: none');
+    expect(style?.textContent).toContain('user-select: text'); // inputs stay editable
+
+    release();
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(false);
+  });
+
+  it('prevents selectstart on regular elements while locked', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    const release = lockDocumentSelection();
+    const blocked = fireSelectStart(div);
+    expect(blocked.defaultPrevented).toBe(true);
+
+    release();
+    const allowed = fireSelectStart(div);
+    expect(allowed.defaultPrevented).toBe(false);
+
+    div.remove();
+  });
+
+  it('allows selectstart inside text inputs (typing/caret must keep working)', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const release = lockDocumentSelection();
+    const event = fireSelectStart(input);
+    expect(event.defaultPrevented).toBe(false);
+
+    release();
+    input.remove();
+  });
+
+  it('is re-entrant: the lock lifts only when every holder releases', () => {
+    const releaseA = lockDocumentSelection();
+    const releaseB = lockDocumentSelection();
+
+    releaseA();
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(true);
+
+    releaseB();
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(false);
+  });
+
+  it('release is idempotent (double-release cannot unlock another holder)', () => {
+    const releaseA = lockDocumentSelection();
+    const releaseB = lockDocumentSelection();
+
+    releaseA();
+    releaseA(); // double release of the same holder
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(true);
+
+    releaseB();
+    expect(document.documentElement.classList.contains(LOCK_CLASS)).toBe(false);
+  });
+});

--- a/src/features/fight_replay/utils/documentSelectionLock.ts
+++ b/src/features/fight_replay/utils/documentSelectionLock.ts
@@ -1,0 +1,91 @@
+/**
+ * Document-wide text-selection lock for the mobile immersive replay overlay.
+ *
+ * Why document-wide: iOS Safari's long-press selection hit-test is NOT confined to the touched
+ * element — when that element is unselectable, WebKit searches for the nearest *selectable*
+ * content, including text visually BEHIND a fixed overlay. So scoping `user-select: none` to
+ * the overlay makes Safari select the page underneath instead (observed in the field). Since
+ * iOS 15 the loupe/callout can also appear despite element-level `-webkit-user-select: none`
+ * (WebKit bug 231161). The reliable pattern is the PWA-grade one: while the app surface is
+ * active, EVERY element is unselectable, with text inputs explicitly re-enabled (under
+ * `user-select: none` iOS makes fields uneditable — WebKit bug 82692).
+ *
+ * The lock also installs a `selectstart` preventer (programmatic backstop for the CSS) and
+ * clears any selection that existed when the lock engaged.
+ */
+
+const LOCK_CLASS = 'replay-touch-selection-lock';
+const STYLE_ID = 'replay-touch-selection-lock-style';
+
+const LOCK_CSS = `
+.${LOCK_CLASS}, .${LOCK_CLASS} * {
+  -webkit-user-select: none !important;
+  user-select: none !important;
+  -webkit-touch-callout: none !important;
+}
+.${LOCK_CLASS} input, .${LOCK_CLASS} textarea, .${LOCK_CLASS} [contenteditable] {
+  -webkit-user-select: text !important;
+  user-select: text !important;
+}
+`;
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true
+  );
+}
+
+function ensureStyleSheet(): void {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = LOCK_CSS;
+  document.head.appendChild(style);
+}
+
+const preventSelectStart = (event: Event): void => {
+  if (!isTextEntryTarget(event.target)) {
+    event.preventDefault();
+  }
+};
+
+// Re-entrant: multiple concurrent lockers (e.g. fast unmount/remount) share one document state.
+let lockCount = 0;
+
+/**
+ * Engage the document-wide selection lock. Returns a release function; the lock lifts when
+ * every outstanding holder has released.
+ */
+export function lockDocumentSelection(): () => void {
+  if (typeof document === 'undefined') {
+    return () => undefined;
+  }
+
+  lockCount += 1;
+  if (lockCount === 1) {
+    ensureStyleSheet();
+    document.documentElement.classList.add(LOCK_CLASS);
+    document.addEventListener('selectstart', preventSelectStart);
+    // Drop any selection that existed before the lock — it would otherwise keep its
+    // grab handles/callout alive on iOS.
+    document.getSelection?.()?.removeAllRanges();
+  }
+
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    lockCount -= 1;
+    if (lockCount === 0) {
+      document.documentElement.classList.remove(LOCK_CLASS);
+      document.removeEventListener('selectstart', preventSelectStart);
+    }
+  };
+}

--- a/src/features/fight_replay/utils/longPress.test.ts
+++ b/src/features/fight_replay/utils/longPress.test.ts
@@ -1,0 +1,97 @@
+import { LongPressTracker, PointerSample } from './longPress';
+
+function sample(overrides: Partial<PointerSample> = {}): PointerSample {
+  return { pointerId: 1, clientX: 100, clientY: 100, ...overrides };
+}
+
+describe('LongPressTracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires after the hold delay with the starting sample', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500 });
+
+    tracker.begin(sample());
+    jest.advanceTimersByTime(499);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onLongPress).toHaveBeenCalledWith(sample());
+  });
+
+  it('cancels when the pointer travels beyond the slop (drag/rotate)', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500, slopPx: 10 });
+
+    tracker.begin(sample());
+    tracker.move(sample({ clientX: 115 })); // 15px > 10px slop
+    jest.advanceTimersByTime(1000);
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(tracker.pending).toBe(false);
+  });
+
+  it('tolerates jitter within the slop', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500, slopPx: 10 });
+
+    tracker.begin(sample());
+    tracker.move(sample({ clientX: 104, clientY: 103 }));
+    jest.advanceTimersByTime(500);
+
+    expect(onLongPress).toHaveBeenCalled();
+  });
+
+  it('ignores movement from other pointers', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500, slopPx: 10 });
+
+    tracker.begin(sample());
+    tracker.move(sample({ pointerId: 2, clientX: 300 }));
+    jest.advanceTimersByTime(500);
+
+    expect(onLongPress).toHaveBeenCalled();
+  });
+
+  it('end() reports whether the press fired so callers can suppress the tap', () => {
+    const tracker = new LongPressTracker(jest.fn(), { delayMs: 500 });
+
+    tracker.begin(sample());
+    expect(tracker.end(sample())).toBe(false); // released early — a tap
+
+    tracker.begin(sample());
+    jest.advanceTimersByTime(500);
+    expect(tracker.end(sample())).toBe(true); // released after the press fired
+  });
+
+  it('end() for a different pointer leaves the gesture armed', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500 });
+
+    tracker.begin(sample());
+    expect(tracker.end(sample({ pointerId: 9 }))).toBe(false);
+    jest.advanceTimersByTime(500);
+    expect(onLongPress).toHaveBeenCalled();
+  });
+
+  it('begin() rearms cleanly over a previous gesture', () => {
+    const onLongPress = jest.fn();
+    const tracker = new LongPressTracker(onLongPress, { delayMs: 500 });
+
+    tracker.begin(sample());
+    jest.advanceTimersByTime(300);
+    tracker.begin(sample({ pointerId: 2 }));
+    jest.advanceTimersByTime(300);
+    expect(onLongPress).not.toHaveBeenCalled(); // first was replaced; second not elapsed
+
+    jest.advanceTimersByTime(200);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onLongPress).toHaveBeenCalledWith(sample({ pointerId: 2 }));
+  });
+});

--- a/src/features/fight_replay/utils/longPress.ts
+++ b/src/features/fight_replay/utils/longPress.ts
@@ -1,0 +1,96 @@
+/**
+ * Long-press gesture tracker for touch/pen pointers.
+ *
+ * Touch has no right-click, so the marker context menus use the platform idiom instead:
+ * press and hold without moving. The tracker arms on pointer-down, cancels if the pointer
+ * travels beyond a screen-space slop (that's a drag or a camera rotate, not a press), and
+ * fires the callback once the hold delay elapses. Pure and timer-based so it is unit-testable
+ * and shared by the marker and ground-plane gestures.
+ */
+
+export interface PointerSample {
+  pointerId: number;
+  clientX: number;
+  clientY: number;
+}
+
+export interface LongPressOptions {
+  /** Hold time before the press fires. 500ms matches the iOS/Android context-menu delay. */
+  delayMs?: number;
+  /** Max pointer travel (px) before the gesture is reinterpreted as a drag/rotate. */
+  slopPx?: number;
+}
+
+const DEFAULT_DELAY_MS = 500;
+const DEFAULT_SLOP_PX = 10;
+
+export class LongPressTracker {
+  private readonly onLongPress: (start: PointerSample) => void;
+  private readonly delayMs: number;
+  private readonly slopPx: number;
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private start: PointerSample | null = null;
+  private fired = false;
+
+  constructor(onLongPress: (start: PointerSample) => void, options: LongPressOptions = {}) {
+    this.onLongPress = onLongPress;
+    this.delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+    this.slopPx = options.slopPx ?? DEFAULT_SLOP_PX;
+  }
+
+  /** Arm the tracker for a new pointer-down. Replaces any in-flight gesture. */
+  begin(sample: PointerSample): void {
+    this.cancel();
+    this.start = { ...sample };
+    this.fired = false;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.fired = true;
+      if (this.start) {
+        this.onLongPress(this.start);
+      }
+    }, this.delayMs);
+  }
+
+  /** Feed pointer movement; cancels the press once travel exceeds the slop. */
+  move(sample: PointerSample): void {
+    if (!this.start || sample.pointerId !== this.start.pointerId) {
+      return;
+    }
+
+    const dx = sample.clientX - this.start.clientX;
+    const dy = sample.clientY - this.start.clientY;
+    if (dx * dx + dy * dy > this.slopPx * this.slopPx) {
+      this.cancel();
+    }
+  }
+
+  /**
+   * End the gesture (pointer-up/cancel). Returns true when the long-press already fired,
+   * so the caller can suppress the tap/commit that would otherwise follow.
+   */
+  end(sample: PointerSample): boolean {
+    if (!this.start || sample.pointerId !== this.start.pointerId) {
+      return false;
+    }
+
+    const hadFired = this.fired;
+    this.cancel();
+    return hadFired;
+  }
+
+  /** True while a press is armed but has not fired or been cancelled. */
+  get pending(): boolean {
+    return this.timer !== null;
+  }
+
+  cancel(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.start = null;
+    this.fired = false;
+  }
+}

--- a/src/features/fight_replay/utils/mapMarkerConverters.test.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.test.ts
@@ -3,12 +3,17 @@ import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
 import {
   COMMON_MARKER_GROUPS,
   COMMON_MARKER_OPTIONS,
+  applyElmsIconTemplate,
+  arenaPointToWorld,
   createMarkerFromElmsIcon,
   encodeMarkersToElms,
   encodeMarkersToMor,
   ensureFormat,
   parseMarkersInput,
   updateMarker,
+  withMarkerEdit,
+  withMarkerPatch,
+  withMarkerPosition,
   withNewMarker,
   withoutMarker,
 } from './mapMarkerConverters';
@@ -190,5 +195,117 @@ describe('marker menu metadata', () => {
     const numbers = COMMON_MARKER_GROUPS.find((g) => g.key === 'numbers');
     expect(numbers?.label).toBe('Numbers');
     expect(numbers?.options.map((o) => o.iconKey)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+});
+
+describe('arenaPointToWorld', () => {
+  // Hel Ra Citadel main map bounds.
+  const helRa = {
+    name: 'Hel Ra Citadel',
+    mapId: 614,
+    zoneId: 636,
+    scaleFactor: 0.0000098844,
+    minX: 32030,
+    maxX: 133200,
+    minZ: 18939,
+    maxZ: 120109,
+  };
+
+  it('maps the arena center to the bounding-box midpoint', () => {
+    const world = arenaPointToWorld(helRa, { x: 50, z: 50 });
+    expect(world.x).toBeCloseTo((helRa.minX + helRa.maxX) / 2, 5);
+    expect(world.z).toBeCloseTo((helRa.minZ + helRa.maxZ) / 2, 5);
+  });
+
+  it('inverts the render transform exactly (world -> arena -> world round trip)', () => {
+    // Forward transform used by MapMarkers: arena = 100 - normalized * 100.
+    const worldX = 80000;
+    const worldZ = 70000;
+    const arenaX = 100 - ((worldX - helRa.minX) / (helRa.maxX - helRa.minX)) * 100;
+    const arenaZ = 100 - ((worldZ - helRa.minZ) / (helRa.maxZ - helRa.minZ)) * 100;
+
+    const world = arenaPointToWorld(helRa, { x: arenaX, z: arenaZ });
+    expect(world.x).toBeCloseTo(worldX, 5);
+    expect(world.z).toBeCloseTo(worldZ, 5);
+  });
+
+  it('clamps out-of-range arena points into the map bounds', () => {
+    const past = arenaPointToWorld(helRa, { x: 150, z: -10 });
+    expect(past.x).toBe(helRa.minX); // arena x > 100 clamps to the min-X edge
+    expect(past.z).toBe(helRa.maxZ); // arena z < 0 clamps to the max-Z edge
+  });
+});
+
+describe('withMarkerPosition', () => {
+  it('moves only the matching marker and keeps Y by default', () => {
+    const a = manualMarker(1, { x: 100, y: 42, z: 200 });
+    const b = { ...manualMarker(2), id: 'other' };
+    const next = withMarkerPosition(stateFromMarkers([a, b]), a.id, { x: 999, z: 888 });
+
+    expect(next.markers[0]).toMatchObject({ x: 999, y: 42, z: 888 });
+    expect(next.markers[1]).toMatchObject({ x: 100, z: 200 });
+  });
+});
+
+describe('withMarkerPatch', () => {
+  it('keeps elmsIconKey when the patch matches the template values', () => {
+    const a = manualMarker(1); // template: text '1', size 1.5, white
+    const next = withMarkerPatch(stateFromMarkers([a]), a.id, {
+      text: '1',
+      size: 1.5,
+      colour: [1, 1, 1, 1],
+    });
+    expect(next.markers[0].elmsIconKey).toBe(1);
+  });
+
+  it('drops elmsIconKey when the patch diverges from the template', () => {
+    const a = manualMarker(1);
+    const next = withMarkerPatch(stateFromMarkers([a]), a.id, { text: 'custom label' });
+    expect(next.markers[0].text).toBe('custom label');
+    expect(next.markers[0].elmsIconKey).toBeUndefined();
+  });
+
+  it('clears the label when given blank text', () => {
+    const a = manualMarker(1);
+    const next = withMarkerPatch(stateFromMarkers([a]), a.id, { text: '   ' });
+    expect(next.markers[0].text).toBeUndefined();
+  });
+
+  it('ignores non-positive sizes', () => {
+    const a = manualMarker(1);
+    const next = withMarkerPatch(stateFromMarkers([a]), a.id, { size: -2 });
+    expect(next.markers[0].size).toBe(1.5);
+  });
+});
+
+describe('applyElmsIconTemplate / withMarkerEdit', () => {
+  it('re-skins a marker from a template while keeping its position and id', () => {
+    const a = manualMarker(1, { x: 11, y: 22, z: 33 });
+    const reskinned = applyElmsIconTemplate(a, 21); // MT hex: red, text 'MT'
+    expect(reskinned).toMatchObject({ id: a.id, x: 11, y: 22, z: 33, text: 'MT' });
+    expect(reskinned.colour).toEqual([1, 0, 0, 1]);
+    expect(reskinned.elmsIconKey).toBe(21);
+  });
+
+  it('throws on an unknown icon key', () => {
+    expect(() => applyElmsIconTemplate(manualMarker(1), 99999)).toThrow(/Unknown Elms icon/);
+  });
+
+  it('withMarkerEdit applies icon swap then field overrides in one transition', () => {
+    const a = manualMarker(1);
+    const next = withMarkerEdit(stateFromMarkers([a]), a.id, {
+      iconKey: 21,
+      text: 'MT',
+      colour: [1, 0, 0, 1],
+      size: 1,
+    });
+    // Overrides equal the template → still a faithful icon 21.
+    expect(next.markers[0].elmsIconKey).toBe(21);
+    expect(next.markers[0].text).toBe('MT');
+  });
+
+  it('withMarkerEdit is a no-op for an unknown marker id', () => {
+    const state = stateFromMarkers([manualMarker(1)]);
+    expect(withMarkerEdit(state, 'nope', { text: 'x' })).toBe(state);
   });
 });

--- a/src/features/fight_replay/utils/mapMarkerConverters.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { MorMarker, TEXTURE_LOOKUP } from '@/types/mapMarkers';
+import { ZoneScaleData } from '@/types/zoneScaleData';
 import {
   DecodedElmsMarkers,
   ELMS_ICON_MAP,
@@ -498,6 +499,158 @@ export function encodeMarkersToMor(state: MapMarkersState): string {
   ];
 
   return `<${sections.join(']')}>`;
+}
+
+/**
+ * Convert an arena-space point (the 0-100 coordinate system the 3D scene uses) back into
+ * world-space centimeters for the given map. Exact inverse of the transform MapMarkers applies
+ * when rendering, so a marker dropped/dragged at an arena point round-trips to the same spot.
+ */
+export function arenaPointToWorld(
+  mapData: ZoneScaleData,
+  arenaPoint: { x: number; z: number },
+): { x: number; z: number } {
+  const clamp = (value: number): number => Math.min(100, Math.max(0, value));
+
+  const normalizedX = (100 - clamp(arenaPoint.x)) / 100;
+  const normalizedZ = (100 - clamp(arenaPoint.z)) / 100;
+
+  return {
+    x: normalizedX * (mapData.maxX - mapData.minX) + mapData.minX,
+    z: normalizedZ * (mapData.maxZ - mapData.minZ) + mapData.minZ,
+  };
+}
+
+/**
+ * Re-skin an existing marker with a different Elms icon template (shape/text/colour/size),
+ * keeping its position and identity. Used by the marker edit dialog's icon picker.
+ */
+export function applyElmsIconTemplate(marker: ReplayMarker, iconKey: number): ReplayMarker {
+  const template = ELMS_ICON_MAP[iconKey];
+
+  if (!template) {
+    throw new Error(`Unknown Elms icon key: ${iconKey}`);
+  }
+
+  const colour: [number, number, number, number] = template.colour
+    ? ([...template.colour] as [number, number, number, number])
+    : [1, 1, 1, 1];
+
+  return {
+    ...marker,
+    size: template.size ?? 1,
+    bgTexture: template.bgTexture,
+    colour,
+    text: template.text,
+    elmsIconKey: iconKey,
+  };
+}
+
+/** Fields of a marker the edit dialog can change. */
+export interface MarkerEditPatch {
+  text?: string;
+  colour?: [number, number, number, number];
+  size?: number;
+}
+
+/** One edit-dialog submission: optional icon re-skin plus field overrides, applied atomically. */
+export interface MarkerEdit extends MarkerEditPatch {
+  /** When set, re-skin from this Elms template first; patch fields then override the template. */
+  iconKey?: number;
+}
+
+/**
+ * Apply a partial edit (label/colour/size) to one marker by id. Clearing the label and diverging
+ * from the icon template drops `elmsIconKey` so stats/exports stop claiming template fidelity.
+ */
+export function withMarkerPatch(
+  state: MapMarkersState,
+  markerId: string,
+  patch: MarkerEditPatch,
+): MapMarkersState {
+  return {
+    ...state,
+    markers: state.markers.map((marker) => {
+      if (marker.id !== markerId) {
+        return marker;
+      }
+
+      const next: ReplayMarker = { ...cloneMarker(marker), id: marker.id, source: marker.source };
+
+      if (patch.text !== undefined) {
+        next.text = patch.text.trim().length > 0 ? patch.text : undefined;
+      }
+      if (patch.colour !== undefined) {
+        next.colour = [...patch.colour] as [number, number, number, number];
+      }
+      if (patch.size !== undefined && Number.isFinite(patch.size) && patch.size > 0) {
+        next.size = patch.size;
+      }
+
+      // If the marker no longer matches its Elms template, it can only round-trip via M0R.
+      if (typeof next.elmsIconKey === 'number') {
+        const template = ELMS_ICON_MAP[next.elmsIconKey];
+        const stillMatches =
+          template !== undefined &&
+          next.text === template.text &&
+          sizesMatch(next.size, template.size ?? 1) &&
+          coloursMatch(
+            next.colour,
+            (template.colour ?? [1, 1, 1, 1]) as [number, number, number, number],
+          );
+
+        if (!stillMatches) {
+          next.elmsIconKey = undefined;
+        }
+      }
+
+      return next;
+    }),
+  };
+}
+
+/**
+ * Apply one edit-dialog submission to a marker in the state: optional icon template re-skin,
+ * then label/colour/size overrides — as a SINGLE state transition (one undo step).
+ */
+export function withMarkerEdit(
+  state: MapMarkersState,
+  markerId: string,
+  edit: MarkerEdit,
+): MapMarkersState {
+  const target = state.markers.find((marker) => marker.id === markerId);
+  if (!target) {
+    return state;
+  }
+
+  let base = state;
+  if (edit.iconKey !== undefined && edit.iconKey !== target.elmsIconKey) {
+    base = updateMarker(state, applyElmsIconTemplate(target, edit.iconKey));
+  }
+
+  const { iconKey: _iconKey, ...patch } = edit;
+  return withMarkerPatch(base, markerId, patch);
+}
+
+/** Move one marker to new world-space coordinates (drag-to-move commit). */
+export function withMarkerPosition(
+  state: MapMarkersState,
+  markerId: string,
+  position: { x: number; z: number; y?: number },
+): MapMarkersState {
+  return {
+    ...state,
+    markers: state.markers.map((marker) =>
+      marker.id === markerId
+        ? {
+            ...marker,
+            x: position.x,
+            z: position.z,
+            y: position.y ?? marker.y,
+          }
+        : marker,
+    ),
+  };
 }
 
 export function withNewMarker(


### PR DESCRIPTION
# Custom map markers: full add / edit / delete system

## Background

The fight replay already understood both ESO marker addon formats — **Elm's Markers / EnchantedMapsLite** (`/zone//x,y,z,iconKey/`) and **M0RMarkers** (`<zone]timestamp]…>`) — via the existing decoders, and could place/remove markers behind a hidden **Alt+right-click** chord. But:

- markers lived in transient `useState` → **lost on every reload / navigation**
- there was **no way to edit** a marker (move, relabel, recolor, resize) — `updateMarker` existed but was unused
- the add/remove gestures were undiscoverable, and there was no overview of what's placed

## What this adds

### Persistence & state (`useMapMarkersManager`)
- Per-zone **localStorage persistence** (versioned key, field-level sanitization, read-merge-write so zones never clobber each other) — marker sets auto-restore when you reopen any fight in that zone, with an info snackbar
- **Undo/redo** (bounded history) over every mutation — buttons in the panel plus `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` while editing
- All CRUD funneled through one commit gateway, so every action is exactly one undo step

### Edit mode (toggle next to "Import Map Markers")
- **Plain right-click** on the map places a marker (the Alt chord still works during playback, unchanged)
- **Drag a marker** to move it — runs on window-level pointer listeners with a manual plane raycast (object-scoped events/pointer capture drop the gesture once the pointer leaves the tiny mesh), OrbitControls suspended for the drag, slop-gated so a shaky click never commits, committed through the exact inverse (`arenaPointToWorld`) of the render transform; edit mode adds an invisible raycast-only grab disc so small markers have a humane hit target
- **Right-click a marker → Edit marker… / Remove**

### Marker editing (`MarkerEditDialog`)
- Swap the Elms icon template (grouped picker with previews), custom label, colour (Elms palette swatches + free color input), size slider
- Applied atomically (`withMarkerEdit`) = a single undo step
- Edits that diverge from an Elms template drop `elmsIconKey`, so **Copy Elms** fails honestly and **Copy M0R** (which supports arbitrary text/colour/size) becomes the export path
- Out-of-range imported sizes (e.g. 0.3m / 33.5m M0R markers) are preserved on label-only edits — only the slider display clamps

### Management panel (`MarkersPanel`)
- Collapsible list of all loaded markers (sprite/colour glyph, label, world position in meters, size) with per-row edit/delete, undo/redo, and clear-all

### Full native touch support (mobile, iterated against real-iPhone field testing)
- **Long-press** (500 ms) on the map places a marker; long-press a marker to edit/remove — both gestures tracked on **window-level listeners** (immune to raycast churn/occlusion mid-hold) via a shared unit-tested `LongPressTracker`, with finger-realistic slop (18 px ground / 14 px marker; mouse drag stays 8 px). Menus open on **release**, deferred past the gesture's trailing click so they can't self-dismiss
- **Gesture-free fallback:** the tools sheet gains **"Add marker here"** — raycasts the screen center onto the floor and opens the icon menu, so placement never depends on a hold
- **iOS Safari gesture-steal countermeasures** (researched against WebKit bugs 231161 / 82692): non-passive `touchstart` preventDefault on the canvas in the overlay, a **document-wide selection lock** while the overlay is open (iOS's long-press hit-test otherwise selects page text *behind* the overlay; inputs stay editable), `touchmove` preventDefault during marker drags so Safari can't cancel them mid-gesture, and selection suppression on the portaled menus
- Enabling "Edit Markers" on mobile auto-expands the immersive overlay (the inline preview is a non-interactive teaser); tools sheet also gains "Edit markers" / "Undo marker change" rows and an in-overlay hint chip
- `MarkerEditDialog` goes full-screen on phones with touch-sized swatches; page hints use touch wording on mobile

## Coexistence with in-flight replay PRs

#1194, #1192, #1189 and #1165 all touch the replay. All new behavior lives in **new files** plus `Marker3D.tsx`/`MapMarkers.tsx` (untouched by those PRs); the contested files (`FightReplay.tsx`, `FightReplay3D.tsx`, `Arena3D.tsx`, `Arena3DScene.tsx`, `MobileReplayControls.tsx`) only gained additive props/pass-throughs, to keep rebases in either direction cheap. `FightReplay.tsx`'s inline marker handlers moved into the hook, which also shrinks the surface #1194/#1165 conflict with.

## Tests & verification

- `useMapMarkersManager`: restore/sanitize/zone-isolation, add/move/remove/edit round-trips through real Hel Ra Citadel scale data, undo/redo incl. redo-branch clearing, multi-zone storage isolation
- `mapMarkerConverters`: `arenaPointToWorld` exact-inverse round trip + clamping, `withMarkerPosition/Patch/Edit`, `applyElmsIconTemplate`
- `LongPressTracker` (fire/slop-cancel/multi-pointer/suppression under fake timers) and `documentSelectionLock` (class/stylesheet lifecycle, selectstart blocking with input exemption, re-entrancy)
- Component tests for `MarkersPanel` and `MarkerEditDialog` (incl. out-of-range size preservation)
- **Live-browser verified** (mocked-GraphQL harness driving the real 3D replay, desktop + emulated touch with simulated finger jitter): place via right-click / long-press / tools sheet, drag commit on both input types, slop no-ops, edit dialog, undo/redo, per-zone persistence across reloads

`npm run validate` ✅ · `npm test -- --watchAll=false` ✅ (209 suites, 3,175 tests)

https://claude.ai/code/session_01GX4Yr4wNDwY7WGk8ybPKJb