### PR TITLE
Round HUD corner accent brackets to match fight card border radius

### DIFF
--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -1019,6 +1019,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               height: 6,
               borderTop: `1px solid ${accentBarColor}60`,
               borderLeft: `1px solid ${accentBarColor}60`,
+              borderTopLeftRadius: '3px',
               zIndex: 3,
               pointerEvents: 'none',
             }}
@@ -1033,6 +1034,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               height: 6,
               borderBottom: `1px solid ${accentBarColor}40`,
               borderRight: `1px solid ${accentBarColor}40`,
+              borderBottomRightRadius: '3px',
               zIndex: 3,
               pointerEvents: 'none',
             }}

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -1024,21 +1024,6 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               pointerEvents: 'none',
             }}
           />
-          {/* HUD corner accents — top-right */}
-          <Box
-            sx={{
-              position: 'absolute',
-              top: 3,
-              right: 5,
-              width: 6,
-              height: 6,
-              borderTop: `1px solid ${accentBarColor}40`,
-              borderRight: `1px solid ${accentBarColor}40`,
-              borderTopRightRadius: '3px',
-              zIndex: 3,
-              pointerEvents: 'none',
-            }}
-          />
           {/* Interior content */}
           <Box
             sx={{

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -1024,17 +1024,17 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               pointerEvents: 'none',
             }}
           />
-          {/* HUD corner accents — bottom-right */}
+          {/* HUD corner accents — top-right */}
           <Box
             sx={{
               position: 'absolute',
-              bottom: 3,
+              top: 3,
               right: 5,
               width: 6,
               height: 6,
-              borderBottom: `1px solid ${accentBarColor}40`,
+              borderTop: `1px solid ${accentBarColor}40`,
               borderRight: `1px solid ${accentBarColor}40`,
-              borderBottomRightRadius: '3px',
+              borderTopRightRadius: '3px',
               zIndex: 3,
               pointerEvents: 'none',
             }}


### PR DESCRIPTION
## Summary

- Fight cards have `borderRadius: 8px` but the inner HUD corner accent brackets (top-left and bottom-right) were sharp/straight-edged
- Added `borderTopLeftRadius: 3px` to the top-left accent and `borderBottomRightRadius: 3px` to the bottom-right accent so the brackets follow the card's rounded shape

## Test plan

- [ ] Open a report with multiple fights and confirm the corner accent brackets visually curve with the card corners
- [ ] Check in both dark and light mode
- [ ] Verify selected/hover states still look correct

https://claude.ai/code/session_018hVLAb6K9CU2UNoMwj5QpP

---
_Generated by [Claude Code](https://claude.ai/code/session_018hVLAb6K9CU2UNoMwj5QpP)_