### PR TITLE
feat(reports): hide empty logs from Latest Reports, badge them in personal/profile lists

### DIFF
--- a/src/features/latest_reports/LatestReports.tsx
+++ b/src/features/latest_reports/LatestReports.tsx
@@ -36,12 +36,14 @@ import {
   formatReportDateTime,
   formatReportDuration,
   getReportVisibilityColor,
-  isReportEmpty,
+  partitionReportsByData,
 } from '../reports/reportFormatting';
 import { useReportPageLayout } from '../reports/useReportPageLayout';
 
 interface LatestReportsState {
   reports: UserReportSummaryFragment[];
+  /** Reports on the current page hidden because they contain no combat data. */
+  hiddenEmptyCount: number;
   loading: boolean;
   error: string | null;
   pagination: {
@@ -67,6 +69,7 @@ export const LatestReports: React.FC = () => {
 
   const [state, setState] = useState<LatestReportsState>({
     reports: [],
+    hiddenEmptyCount: 0,
     loading: true,
     error: null,
     pagination: {
@@ -109,12 +112,18 @@ export const LatestReports: React.FC = () => {
           return;
         }
 
+        const fetchedReports = (reportPagination.data || []).filter(
+          (report: UserReportSummaryFragment | null): report is UserReportSummaryFragment =>
+            report !== null,
+        );
+        // Hide logs with no combat data (failed uploads/parses on ESO Logs) —
+        // there is nothing to view, so listing them is just a dead end.
+        const { reportsWithData, emptyCount } = partitionReportsByData(fetchedReports);
+
         setState((prev) => ({
           ...prev,
-          reports: (reportPagination.data || []).filter(
-            (report: UserReportSummaryFragment | null): report is UserReportSummaryFragment =>
-              report !== null,
-          ),
+          reports: reportsWithData,
+          hiddenEmptyCount: emptyCount,
           loading: false,
           pagination: {
             currentPage: reportPagination.current_page || 1,
@@ -290,31 +299,54 @@ export const LatestReports: React.FC = () => {
             )}
           </Box>
 
-          {state.reports.length > 0 ? (
-            <>
-              <Box
-                sx={{
-                  flexDirection: isDesktop ? 'row' : 'column',
-                  justifyContent: 'space-between',
-                  gap: isDesktop ? 2 : 1.5,
-                  alignItems: isDesktop ? 'center' : 'flex-start',
-                  display: 'flex',
-                  mb: isDesktop ? 3 : 2,
-                }}
-              >
+          {(state.reports.length > 0 || state.hiddenEmptyCount > 0) && (
+            <Box
+              sx={{
+                flexDirection: isDesktop ? 'row' : 'column',
+                justifyContent: 'space-between',
+                gap: isDesktop ? 2 : 1.5,
+                alignItems: isDesktop ? 'center' : 'flex-start',
+                display: 'flex',
+                mb: isDesktop ? 3 : 2,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, flexWrap: 'wrap' }}>
                 <Typography variant="body1" sx={{ color: 'text.secondary' }}>
                   Page {state.pagination.currentPage}
                   {state.pagination.hasMorePages ? '+' : ` of ${state.pagination.totalPages}`}
                 </Typography>
-
-                <Chip
-                  variant="outlined"
-                  color="primary"
-                  label={`${state.pagination.perPage} per page`}
-                  sx={{ fontWeight: 500 }}
-                />
+                {state.hiddenEmptyCount > 0 && (
+                  <Tooltip
+                    title="Logs with no combat data — usually caused by an upload or parsing issue on ESO Logs — are hidden from this list because there is nothing to view"
+                    arrow
+                  >
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        cursor: 'help',
+                        textDecoration: 'underline dotted',
+                        textUnderlineOffset: '3px',
+                      }}
+                    >
+                      {state.hiddenEmptyCount} empty {state.hiddenEmptyCount === 1 ? 'log' : 'logs'}{' '}
+                      hidden
+                    </Typography>
+                  </Tooltip>
+                )}
               </Box>
 
+              <Chip
+                variant="outlined"
+                color="primary"
+                label={`${state.pagination.perPage} per page`}
+                sx={{ fontWeight: 500 }}
+              />
+            </Box>
+          )}
+
+          {state.reports.length > 0 ? (
+            <>
               {isDesktop ? (
                 <TableContainer
                   component={Paper}
@@ -406,20 +438,6 @@ export const LatestReports: React.FC = () => {
                                 >
                                   {report.title || 'Untitled Report'}
                                 </Typography>
-                                {isReportEmpty(report) && (
-                                  <Tooltip
-                                    title="This log may contain no fight data due to an upload or parsing issue on ESO Logs"
-                                    arrow
-                                  >
-                                    <Chip
-                                      label="Empty Log"
-                                      size="small"
-                                      color="warning"
-                                      variant="outlined"
-                                      sx={{ flexShrink: 0, fontSize: '0.7rem', height: 20 }}
-                                    />
-                                  </Tooltip>
-                                )}
                               </Box>
                               <Typography
                                 variant="caption"
@@ -482,26 +500,35 @@ export const LatestReports: React.FC = () => {
               ) : (
                 <ReportListMobile reports={state.reports} onSelect={handleReportClick} showOwner />
               )}
-
-              {/* Pagination */}
-              <Box sx={{ mt: isDesktop ? 3 : 2, justifyContent: 'center', display: 'flex' }}>
-                <Pagination
-                  count={state.pagination.totalPages}
-                  page={state.pagination.currentPage}
-                  onChange={handlePageChange}
-                  disabled={state.loading}
-                  color="primary"
-                  size={isDesktop ? 'large' : 'medium'}
-                  sx={{
-                    '& .MuiPaginationItem-root': {
-                      borderRadius: 2,
-                    },
-                  }}
-                />
-              </Box>
             </>
           ) : (
-            !state.loading && <Alert severity="info">No reports found.</Alert>
+            !state.loading && (
+              <Alert severity="info">
+                {state.hiddenEmptyCount > 0
+                  ? 'Every report on this page contains no combat data, so they were all hidden. Try another page.'
+                  : 'No reports found.'}
+              </Alert>
+            )
+          )}
+
+          {/* Pagination — kept visible even when a page has nothing to show, so
+              users can still navigate away from a fully-hidden page. */}
+          {state.pagination.totalPages > 1 && (
+            <Box sx={{ mt: isDesktop ? 3 : 2, justifyContent: 'center', display: 'flex' }}>
+              <Pagination
+                count={state.pagination.totalPages}
+                page={state.pagination.currentPage}
+                onChange={handlePageChange}
+                disabled={state.loading}
+                color="primary"
+                size={isDesktop ? 'large' : 'medium'}
+                sx={{
+                  '& .MuiPaginationItem-root': {
+                    borderRadius: 2,
+                  },
+                }}
+              />
+            </Box>
           )}
 
           {/* Loading overlay */}

--- a/src/features/profile_logs/ProfileLogsPanel.test.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../hooks/useViewTransitionNavigate', () => ({
 }));
 
 jest.mock('../reports/reportFormatting', () => ({
+  ...jest.requireActual('../reports/reportFormatting'),
   formatReportDateTime: () => 'Jan 01, 2024 10:00',
   formatReportDuration: () => '6m',
 }));
@@ -44,14 +45,19 @@ const renderPanel = (overrides: Partial<UseProfileUploadedReportsResult> = {}) =
   );
 };
 
-const makeReport = (code: string): ProfileReportSummary => ({
+const makeReport = (
+  code: string,
+  overrides: Partial<ProfileReportSummary> = {},
+): ProfileReportSummary => ({
   code,
   title: `My ${code} run`,
   startTime: 1_700_000_000_000,
   endTime: 1_700_000_360_000,
   visibility: 'public',
+  segments: 3,
   zone: { name: 'Rockgrove' },
   owner: { id: 42, name: 'Tester' },
+  ...overrides,
 });
 
 beforeEach(() => {
@@ -109,6 +115,18 @@ describe('ProfileLogsPanel', () => {
     const btn = screen.getByRole('button', { name: /show more logs/i });
     fireEvent.click(btn);
     expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('flags logs with no combat data with an "Empty Log" chip', () => {
+    renderPanel({
+      reports: [makeReport('ABC123'), makeReport('EMPTY1', { segments: 0 })],
+      total: 2,
+    });
+
+    const chips = screen.getAllByText('Empty Log');
+    expect(chips).toHaveLength(1);
+    // The healthy log row must not be flagged.
+    expect(screen.getByText('My ABC123 run')).toBeInTheDocument();
   });
 
   it('shows an error state with a retry that calls reload', () => {

--- a/src/features/profile_logs/ProfileLogsPanel.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.tsx
@@ -11,7 +11,11 @@ import { useTheme } from '@mui/material/styles';
 import React from 'react';
 
 import { useViewTransitionNavigate } from '../../hooks/useViewTransitionNavigate';
-import { formatReportDateTime, formatReportDuration } from '../reports/reportFormatting';
+import {
+  formatReportDateTime,
+  formatReportDuration,
+  isReportEmpty,
+} from '../reports/reportFormatting';
 
 import type { ProfileReportSummary } from './profileLogsQueries';
 import { useProfileUploadedReports } from './useProfileUploadedReports';
@@ -168,18 +172,36 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
       />
 
       <Box sx={{ minWidth: 0, flex: 1, position: 'relative', pointerEvents: 'none' }}>
-        <Typography
-          sx={{
-            fontWeight: 600,
-            fontSize: '0.9rem',
-            color: theme.palette.text.primary,
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {title}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+          <Typography
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.9rem',
+              color: theme.palette.text.primary,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {title}
+          </Typography>
+          {isReportEmpty(report) && (
+            <Tooltip
+              title="This log contains no combat data, likely due to an upload or parsing issue on ESO Logs"
+              arrow
+            >
+              {/* Re-enable pointer events (the parent disables them for the
+                  full-bleed row button) so the tooltip is reachable. */}
+              <Chip
+                label="Empty Log"
+                size="small"
+                color="warning"
+                variant="outlined"
+                sx={{ flexShrink: 0, fontSize: '0.65rem', height: 18, pointerEvents: 'auto' }}
+              />
+            </Tooltip>
+          )}
+        </Box>
         <Box
           sx={{
             display: 'flex',

--- a/src/features/profile_logs/profileLogsQueries.ts
+++ b/src/features/profile_logs/profileLogsQueries.ts
@@ -34,6 +34,7 @@ export const GET_PROFILE_UPLOADED_REPORTS = gql`
     startTime
     endTime
     visibility
+    segments
     zone {
       name
     }
@@ -51,6 +52,8 @@ export interface ProfileReportSummary {
   startTime: number;
   endTime: number;
   visibility: string;
+  /** Number of uploaded log segments; 0 means the log contains no data. */
+  segments: number;
   zone: { name: string } | null;
   owner: { id: number; name: string } | null;
 }

--- a/src/features/profile_logs/useProfileUploadedReports.test.tsx
+++ b/src/features/profile_logs/useProfileUploadedReports.test.tsx
@@ -24,6 +24,7 @@ const makeReport = (code: string, visibility = 'public'): ProfileReportSummary =
   startTime: 1_700_000_000_000,
   endTime: 1_700_000_360_000,
   visibility,
+  segments: 3,
   zone: { name: 'Rockgrove' },
   owner: { id: 42, name: 'Tester' },
 });

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -826,15 +826,39 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
           </Box>
           <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
             This log contains no fight data, likely due to an upload or parsing issue on ESO Logs.
+            Re-uploading the log on ESO Logs usually fixes it.
           </Typography>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={() => navigate(-1)}
-            sx={{ textTransform: 'none' }}
-          >
-            Go back
-          </Button>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate(-1)}
+              sx={{ textTransform: 'none' }}
+            >
+              Go back
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate('/latest-reports')}
+              sx={{ textTransform: 'none' }}
+            >
+              Browse latest reports
+            </Button>
+            {reportId && (
+              <Button
+                variant="text"
+                size="small"
+                component="a"
+                href={`https://www.esologs.com/reports/${reportId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ textTransform: 'none' }}
+              >
+                View on ESO Logs
+              </Button>
+            )}
+          </Box>
         </CardContent>
       </Card>
     );

--- a/src/features/reports/reportFormatting.test.ts
+++ b/src/features/reports/reportFormatting.test.ts
@@ -1,0 +1,58 @@
+import { isReportEmpty, partitionReportsByData } from './reportFormatting';
+
+const baseReport = {
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  segments: 3,
+};
+
+describe('isReportEmpty', () => {
+  it('returns false for a report with segments and a real duration', () => {
+    expect(isReportEmpty(baseReport)).toBe(false);
+  });
+
+  it('returns true when the report has zero segments', () => {
+    expect(isReportEmpty({ ...baseReport, segments: 0 })).toBe(true);
+  });
+
+  it('returns true when start and end time are identical (zero duration)', () => {
+    expect(isReportEmpty({ ...baseReport, endTime: baseReport.startTime })).toBe(true);
+  });
+
+  it('falls back to the duration check when segments is not selected by the query', () => {
+    expect(isReportEmpty({ startTime: 1, endTime: 2 })).toBe(false);
+    expect(isReportEmpty({ startTime: 1, endTime: 1 })).toBe(true);
+  });
+});
+
+describe('partitionReportsByData', () => {
+  it('separates reports with data from empty ones and counts the empties', () => {
+    const healthy = { ...baseReport, code: 'A' };
+    const noSegments = { ...baseReport, code: 'B', segments: 0 };
+    const zeroDuration = { ...baseReport, code: 'C', endTime: baseReport.startTime };
+
+    const { reportsWithData, emptyCount } = partitionReportsByData([
+      healthy,
+      noSegments,
+      zeroDuration,
+    ]);
+
+    expect(reportsWithData).toEqual([healthy]);
+    expect(emptyCount).toBe(2);
+  });
+
+  it('returns everything with a zero count when no reports are empty', () => {
+    const reports = [
+      { ...baseReport, code: 'A' },
+      { ...baseReport, code: 'B' },
+    ];
+    expect(partitionReportsByData(reports)).toEqual({
+      reportsWithData: reports,
+      emptyCount: 0,
+    });
+  });
+
+  it('handles an empty list', () => {
+    expect(partitionReportsByData([])).toEqual({ reportsWithData: [], emptyCount: 0 });
+  });
+});

--- a/src/features/reports/reportFormatting.ts
+++ b/src/features/reports/reportFormatting.ts
@@ -1,8 +1,6 @@
 import type { ChipProps } from '@mui/material';
 import { format } from 'date-fns';
 
-import type { UserReportSummaryFragment } from '../../graphql/gql/graphql';
-
 export const formatReportDateTime = (timestamp: number): string => {
   return format(new Date(timestamp), 'MMM dd, yyyy HH:mm');
 };
@@ -33,8 +31,32 @@ export const getReportVisibilityColor = (visibility: string): ChipProps['color']
   }
 };
 
-export const isReportEmpty = (report: UserReportSummaryFragment): boolean => {
+/**
+ * Minimal report shape needed to decide whether a log has any combat data.
+ * Structural so it works with any report summary type (generated fragments,
+ * profile log summaries, etc.) — `segments` is optional because not every
+ * query selects it.
+ */
+export interface ReportEmptinessFields {
+  startTime: number;
+  endTime: number;
+  segments?: number | null;
+}
+
+export const isReportEmpty = (report: ReportEmptinessFields): boolean => {
   if (report.segments === 0) return true;
   if (report.startTime === report.endTime) return true;
   return false;
+};
+
+/**
+ * Splits a report list into reports that contain combat data and a count of
+ * empty ones, so list surfaces can hide broken logs while telling the user
+ * how many were hidden.
+ */
+export const partitionReportsByData = <T extends ReportEmptinessFields>(
+  reports: T[],
+): { reportsWithData: T[]; emptyCount: number } => {
+  const reportsWithData = reports.filter((report) => !isReportEmpty(report));
+  return { reportsWithData, emptyCount: reports.length - reportsWithData.length };
 };

--- a/src/hooks/useLatestReport.test.tsx
+++ b/src/hooks/useLatestReport.test.tsx
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import type { UserReportSummaryFragment } from '../graphql/gql/graphql';
+
+import { useLatestReport } from './useLatestReport';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockClient = { query: jest.fn() };
+
+jest.mock('../EsoLogsClientContext', () => ({
+  useEsoLogsClientInstance: () => mockClient,
+}));
+
+const mockUseAuth = jest.fn();
+
+jest.mock('../features/auth/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeReport = (
+  code: string,
+  overrides: Partial<UserReportSummaryFragment> = {},
+): UserReportSummaryFragment => ({
+  code,
+  title: `Report ${code}`,
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  visibility: 'public',
+  segments: 3,
+  zone: { name: 'Rockgrove' },
+  owner: { name: 'Tester' },
+  ...overrides,
+});
+
+const reportsResult = (reports: UserReportSummaryFragment[]) => ({
+  reportData: { reports: { data: reports } },
+});
+
+beforeEach(() => {
+  mockClient.query.mockReset();
+  mockUseAuth.mockReturnValue({ isLoggedIn: true, currentUser: { id: 42 } });
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useLatestReport', () => {
+  it('returns null without querying when logged out', async () => {
+    mockUseAuth.mockReturnValue({ isLoggedIn: false, currentUser: null });
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report).toBeNull();
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('returns the newest report when it has combat data', async () => {
+    mockClient.query.mockResolvedValue(reportsResult([makeReport('AAA'), makeReport('BBB')]));
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report?.code).toBe('AAA');
+  });
+
+  it('skips empty logs and returns the newest report with data', async () => {
+    mockClient.query.mockResolvedValue(
+      reportsResult([
+        makeReport('EMPTY1', { segments: 0 }),
+        makeReport('EMPTY2', { endTime: 1_700_000_000_000 }),
+        makeReport('GOOD'),
+      ]),
+    );
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report?.code).toBe('GOOD');
+  });
+
+  it('falls back to the newest report when every recent report is empty', async () => {
+    mockClient.query.mockResolvedValue(
+      reportsResult([makeReport('EMPTY1', { segments: 0 }), makeReport('EMPTY2', { segments: 0 })]),
+    );
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report?.code).toBe('EMPTY1');
+  });
+
+  it('returns null when the user has no reports at all', async () => {
+    mockClient.query.mockResolvedValue(reportsResult([]));
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.report).toBeNull();
+  });
+});

--- a/src/hooks/useLatestReport.ts
+++ b/src/hooks/useLatestReport.ts
@@ -2,11 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useEsoLogsClientInstance } from '../EsoLogsClientContext';
 import { useAuth } from '../features/auth/AuthContext';
+import { isReportEmpty } from '../features/reports/reportFormatting';
 import {
   UserReportSummaryFragment,
   GetUserReportsQuery,
   GetUserReportsDocument,
 } from '../graphql/gql/graphql';
+
+// Fetch a handful of recent reports so we can skip over empty logs (failed
+// uploads/parses with no combat data) when picking the "latest report" link.
+const LATEST_REPORT_FETCH_LIMIT = 10;
 
 interface LatestReportState {
   report: UserReportSummaryFragment | null;
@@ -47,17 +52,23 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
       const reportsResult: GetUserReportsQuery = await client.query({
         query: GetUserReportsDocument,
         variables: {
-          limit: 1, // Only fetch the latest report
+          limit: LATEST_REPORT_FETCH_LIMIT,
           page: 1,
           userID,
         },
       });
 
       const reportPagination = reportsResult.reportData?.reports;
-      const latestReport = reportPagination?.data?.[0] || null;
+      const candidates = (reportPagination?.data ?? []).filter(
+        (report): report is UserReportSummaryFragment => report !== null,
+      );
+      // Prefer the newest report that has combat data; if every recent report
+      // is empty, fall back to the newest one so the link still exists.
+      const latestReport = candidates.find((report) => !isReportEmpty(report)) ?? null;
+      const fallbackReport = candidates[0] ?? null;
 
       setState({
-        report: latestReport,
+        report: latestReport ?? fallbackReport,
         loading: false,
         error: null,
       });


### PR DESCRIPTION
## Summary

Follow-up to the earlier "Empty Log" chip work: empty logs (failed uploads/parses on ESO Logs with `segments === 0` or zero duration) were still listed everywhere, and clicking one led to a dead end. This PR hides them from community-facing discovery surfaces and keeps them — clearly badged — in the user's own lists so owners can see a log is broken.

### Latest Reports (`/latest-reports`)
- Empty logs are now **filtered out entirely** — there is nothing to view, so listing them was just a dead-end click.
- A small "N empty logs hidden" note (with explanatory tooltip) appears next to the page indicator so the shorter page count isn't mysterious.
- If an entire page consists of empty logs, an informative alert explains why it's blank — and pagination now stays rendered so users can navigate away (previously it disappeared with the table).
- Removed the now-unreachable "Empty Log" chip from this page's table.

### Landing page "latest report" shortcut
- `useLatestReport` now fetches the 10 most recent reports and links the newest one that **actually has data**, falling back to the newest report only when all of them are empty. Previously it blind-linked the single newest report, which could point at an empty log.

### Profile "Recent Logs" panel
- Added `segments` to the profile reports query so emptiness is detectable at list time.
- Empty logs stay visible (they're the user's own uploads) but are flagged with the standard "Empty Log" warning chip + tooltip.

### My Reports
- Unchanged by design: personal logs keep showing with the warning chip so owners can see something went wrong with the upload.

### Report page empty state
- The "No fights available" card now offers **Browse latest reports** and **View on ESO Logs** alongside "Go back", plus a hint that re-uploading on ESO Logs usually fixes the log.

### Sample reports
- Verified both bundled sample reports are healthy (57 and 72 fights); the earlier "sample report looks empty" symptom was the base-path bug already fixed in #1161 — no changes needed.

## Implementation notes
- `isReportEmpty` now takes a structural `ReportEmptinessFields` type so it works with any report summary shape (generated fragments, profile summaries).
- New `partitionReportsByData` helper splits a list into reports-with-data + hidden count.

## Testing
- New unit tests: `reportFormatting.test.ts` (emptiness detection + partitioning) and `useLatestReport.test.tsx` (skips empty logs, fallback behavior, logged-out short-circuit).
- New `ProfileLogsPanel` test for the Empty Log chip; fixtures updated for the required `segments` field.
- `npm run validate` ✅ and full suite `jest --watchAll=false` ✅ (206 suites, 3,137 tests passing).

https://claude.ai/code/session_01Kb1S4LCKNEsf9PhJDqS26W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb1S4LCKNEsf9PhJDqS26W)_