### PR TITLE
Audit of #1197 + #1193: fight detection fixes for mixed/chaotic logs, dungeon metadata integration, conflict resolution with main

### DIFF
--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -239,3 +239,61 @@ dungeons/arenas should be a follow-up coordinated with those PRs.
 - **Rendered in headless Chromium** against both real reports: grouped
   attempt-heavy encounters with "Show all N attempts", the "Group attempts"
   toggle, and correct "Veteran HM" headers.
+
+---
+
+## Follow-up audit (2026-06-09)
+
+A second review pass plus in-browser verification against a synthetic
+**chaotic mixed log** (DSR run → Bal Sunnar dungeon → Sanity's Edge → DSR
+re-entry, with no-`gameZone` trash sprinkled in) surfaced four more issues, all
+fixed and unit-tested:
+
+### 12. Report-level zone fallback shattered mixed-log runs — _High_
+
+`resolveFightZone` falls back to the **report-level** zone name for fights with
+no `gameZone`. That zone is report-wide, so in a mixed log it is wrong for every
+fight outside the "main" zone: a no-`gameZone` trash pull inside the Bal Sunnar
+segment of a Dreadsail-Reef-rooted report resolved to *Dreadsail Reef* and split
+the dungeon run in half (observed directly in the browser as
+`DSR → Bal Sunnar → DSR → Bal Sunnar`).
+
+**Fix:** report-fallback zones are now flagged (`fromReportFallback`) and treated
+as **weak evidence** in `groupFightsIntoRuns` — they can seed or label a run but
+never force a split away from one. A name-keyed fallback also no longer splits
+from an id-keyed run of the same content (`zone:1564` vs `name:bal sunnar`).
+
+### 13. Runs with no difficulty data were asserted as "Veteran" — _Medium_
+
+`determineRunDifficulty`'s final fallback returned **"Veteran"** when no fight
+carried a difficulty code — mislabeling dungeons (whose fights commonly have
+`difficulty: null`) and legacy logs. It now returns a **null label** (no badge)
+when there is no difficulty signal at all.
+
+### 14. Per-encounter difficulty badge used the *first* attempt, not the kill — _Medium_
+
+The boss-header badge took the difficulty of the first fight that had one, so a
+Veteran wipe followed by an HM kill displayed "(Veteran)". It now uses
+`encounterResultDifficulty` (highest difficulty among kills, falling back to
+best attempt) — consistent with the run-level HM logic.
+
+### 15. Chaotic-log headers were indistinguishable — _UX_
+
+With multiple runs of the same zone (re-entries, second lockouts) the headers
+were identical. Run headers now show:
+
+- a **time range** (wall-clock start–end of the run),
+- a **"Run N" badge** when the same zone appears more than once, and
+- a **"Dungeon" / "Arena" tag** for non-trial content.
+
+Dead `isFalsePositive` plumbing in `ReportFightsView` was also removed, and the
+kill-card background now keys off `isBossFight` rather than `difficulty != null`.
+
+### Verification (follow-up)
+
+- `npm run validate` — clean; full `report_details` suite green (40+ detection
+  tests including new regressions for findings 12–14).
+- **Chrome (CDP) end-to-end**: both real sample reports plus the synthetic mixed
+  chaos log render correctly in dark and light mode — correct run separation,
+  "Run 1/2" badges, dungeon tagging, attempt grouping/expansion, and reset
+  chips.

--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -1,0 +1,137 @@
+# Fight / Trial / Dungeon Detection Audit — 2026-06-08
+
+Audit of the system that detects **which fight, and which trial/dungeon**, each
+combat log belongs to — the data behind the **Report Fights** page
+(`src/features/report_details/ReportFightsView.tsx`), which lists every
+individual fight grouped by encounter and run.
+
+The goal was to make detection "as good as possible in June 2026," with special
+attention to logs that **mix multiple trials and/or dungeons** in a single
+report.
+
+---
+
+## TL;DR
+
+The previous detection was almost entirely **heuristic** and **ignored
+authoritative data the ESO Logs API already returns on every fight**
+(`encounterID`, `originalEncounterID`, per-fight `gameZone {id,name}`, and
+`kill`). It worked for clean single-trial logs but degraded badly on mixed logs
+and had no dungeon support at all.
+
+This audit replaces the heuristics with the authoritative API signals, extracted
+into a pure, unit-tested module (`src/features/report_details/fightGrouping.ts`)
+plus a canonical content-zone table (`src/data/esoContentZones.ts`). Boss-name
+matching is retained only as a fallback for legacy logs.
+
+---
+
+## Findings
+
+### 1. Boss vs. trash decided by `difficulty`, not `encounterID` — _Medium_
+
+`ReportFightsView` split bosses from trash with `fight.difficulty != null`.
+The API's authoritative signal is **`encounterID !== 0`** (schema: _"If the ID
+is 0, the fight is considered a trash fight."_). It also exposes
+`originalEncounterID` for bosses that ESO Logs demotes to trash — which the old
+code could not represent at all.
+
+**Fix:** `isBossFight()` uses `effectiveEncounterId(fight) !== 0`, unioned with
+the old `difficulty` check as a safety net so no current boss is dropped.
+
+### 2. Trial detection by boss-name string matching — _High_
+
+`getTrialNameFromBoss()` matched **boss-name substrings** against hardcoded
+per-trial lists, falling back to the report-level zone **name**. Every fight
+already carries a per-fight `gameZone {id, name}` (an in-game zone ID, e.g.
+`1121` = Sunspire) and an `encounterID`, none of which were used. Name matching
+is fragile (breaks on renames/variants) and, crucially, cannot distinguish two
+zones that share a boss-name token.
+
+**Fix:** `resolveFightZone()` resolves by `gameZone.id` against a canonical table
+(`CONTENT_ZONES`, derived from the existing `ZONE_NAMES` + `TRIAL_ENCOUNTERS`
+data, so there is no duplicated zone list). Boss-name matching survives **only**
+as a fallback when `gameZone` is missing (older logs).
+
+### 3. Mixed trials/dungeons split only on trial-name change — _High_
+
+The old grouping started a new "run" only when the **derived trial-name string**
+changed between consecutive bosses (with an explicit _"don't try to separate
+trial instances"_ comment). Consequences:
+
+- **Two runs of the same trial** in one log merged into one.
+- A **trial → dungeon → trial** sequence mis-grouped (dungeons weren't detected).
+- Back-to-back re-clears of the same content merged.
+
+**Fix:** `groupFightsIntoRuns()` groups by the resolved per-fight zone identity
+(chronologically), starting a new run when the zone changes **or** when a boss
+encounter that was already _killed_ in the current run reappears (re-clear /
+second lockout). Inter-zone trash with no `gameZone` attaches to the current run
+instead of forcing a spurious split.
+
+### 4. No dungeon detection at all — _High_
+
+Only the 13–15 trials were handled; any dungeon fell through to
+`"Unknown Trial"`. `dungeonPulls` and dungeon `gameZone`s were fetched but unused.
+
+**Fix (scoped):** dungeons now **detect, separate, and label correctly** from the
+API's `gameZone` (no static table needed), so mixed trial+dungeon logs group
+properly and dungeons show their real name instead of "Unknown Trial".
+Richer per-dungeon metadata (expected boss counts, HM rules) is intentionally
+**deferred** to coordinate with the in-flight loadout-manager dungeon work
+(PR #1193) rather than introduce a competing hardcoded dungeon table here.
+
+### 5. Kill/wipe via `bossPercentage` + a hand-tuned heuristic — _Medium_
+
+The UI inferred kills from `bossPercentage <= 1%` and then ran a brittle
+`isFalsePositiveWipe()` heuristic (duration/percentage thresholds) to undo ESO
+Logs' "100% wipe" mislabels. The API exposes an authoritative **`kill: Boolean`**
+that makes the heuristic unnecessary.
+
+**Fix:** `wasKill()` uses `fight.kill`, falling back to `bossPercentage` only when
+`kill` is null (some legacy logs). `isFalsePositiveWipe()` is removed.
+
+### 6. Report query under-fetches the zone — _Low_
+
+`reports.graphql`'s `Report` fragment requests only `zone { name }` (not `id`,
+`encounters`, or `difficulties`), so even the report-level zone was name-only.
+Not changed here because per-fight `gameZone` already supplies a more reliable,
+per-fight signal; noted for future enrichment.
+
+---
+
+## What changed
+
+| File                                                | Change                                                                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/data/esoContentZones.ts`                       | **New.** Canonical content-zone table keyed by in-game zone ID, derived from existing `ZONE_NAMES` + `TRIAL_ENCOUNTERS` (no duplicated data).                            |
+| `src/features/report_details/fightGrouping.ts`      | **New.** Pure detection module: `isBossFight`, `wasKill`, `effectiveEncounterId`, `resolveFightZone`, `groupFightsIntoRuns`, `buildRunEncounters`, `uncategorizedTrash`. |
+| `src/features/report_details/fightGrouping.test.ts` | **New.** 18 unit tests covering boss/trash, kill detection, zone resolution, mixed-trial/dungeon separation, re-clear detection, and trash association.                  |
+| `src/features/report_details/ReportFightsView.tsx`  | Refactored to consume the module. Removed `getTrialNameFromBoss` and `isFalsePositiveWipe`; boss/trash + kill now use the authoritative helpers. UI/rendering unchanged. |
+
+No GraphQL schema or codegen changes were required — every field used
+(`encounterID`, `originalEncounterID`, `gameZone`, `kill`, `bossPercentage`,
+`difficulty`) is already in the `Fight` fragment.
+
+---
+
+## Deferred / future work
+
+- **Dungeon metadata** (expected boss counts, veteran-HM rules) — coordinate with
+  PR #1193's dungeon data once merged; plug into `CONTENT_ZONES`.
+- **Completion-ring boss counts** in `ReportFightsView` are still the original
+  zone-name-keyed constants (kept to avoid regressing variable-boss trials like
+  Cloudrest/Asylum). Some look stale (e.g. Sanctum Ophidia listed as 5; it has 4
+  main bosses) and could be re-derived from `expectedBossCount` once
+  optional-boss semantics are encoded.
+- **Arena detection** (Maelstrom / Vateshran / DSA / BRP) would benefit from
+  adding `size` and `fightPercentage` to the `Fight` fragment.
+
+---
+
+## Verification
+
+- `npm run validate` (typecheck + lint + format) — clean.
+- `npx jest src/features/report_details src/store/report/reportSelectors.test.ts`
+  — 157 passed, 14 snapshots passed.
+- New `fightGrouping.test.ts` — 18 passed.

--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -179,6 +179,37 @@ This also lays the groundwork for trifecta reasoning (Veteran HM + speed +
 no-death). Per-boss badges are unchanged (a mini still correctly shows
 "Veteran").
 
+### 11. Normal-mode trials mislabeled as "Veteran"; arenas called "dungeons" — _Medium_
+
+Difficulty codes are Normal ≤ 120, Veteran 121, Veteran HM 122 (+1/+2/+3 →
+123–125). The code only treated `< 10` as Normal, so a Normal clear (code ~120)
+fell through to "Veteran". Arenas (Maelstrom, Vateshran, Dragonstar, Blackrose)
+were also lumped in as "dungeons".
+
+**Fix:** Normal is now `0 < code < 121` in both the run label and the per-boss
+badge; `classifyUnknownZone()` tags the four arenas as `type: 'arena'`.
+
+### Full edge-case matrix (now covered by tests)
+
+`fightGrouping.test.ts` + `runDifficulty.test.ts` exercise: single trial; two
+different trials; **three** distinct trials in order; **A → B → A** re-entry
+(three runs); trial → dungeon; same-zone re-clears (one run by default, opt-in
+split); 5+ / 45+ attempt encounters with reset detection; inter-zone trash with
+no `gameZone`; out-of-order input; legacy logs with **no `gameZone`** (boss-name
+resolution); **arenas**; **Normal** difficulty; demoted (`encounterID 0`) fights;
+trash-only runs; empty/null input; zero-duration/invalid fights; per-boss vs
+final-boss-only vs Cloudrest/Asylum +N HM; mini-boss HM exclusion; and two
+**real** reports end-to-end.
+
+### Maps — intentionally untouched
+
+The fight-replay map/coordinate system (`zoneScaleData`, `mapScaling`,
+`mapMarkersUtils`) only has data for the 15 trials, so dungeons/arenas lack
+replay map scaling. That area is being actively reworked in several open PRs
+(#1192 map scaling, #1189 mid-fight map switching, #1194 continuous replay), so
+to avoid conflicts this PR does **not** modify it. Extending map coverage to
+dungeons/arenas should be a follow-up coordinated with those PRs.
+
 ---
 
 ## Deferred / future work
@@ -199,7 +230,7 @@ no-death). Per-boss badges are unchanged (a mini still correctly shows
 
 - `npm run validate` (typecheck + lint + format) — clean.
 - `npx jest src/features/report_details src/store/report/reportSelectors.test.ts`
-  — 175 passed, 14 snapshots passed.
+  — 184 passed, 14 snapshots passed.
 - `fightGrouping.test.ts` (26) + `runDifficulty.test.ts` (10) include
   **end-to-end checks against the two real committed reports**: the DSR farm
   resolves to one run with multi-kill grouped encounters; the VSE log resolves to

--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -214,13 +214,20 @@ dungeons/arenas should be a follow-up coordinated with those PRs.
 
 ## Deferred / future work
 
-- **Dungeon metadata** (expected boss counts, veteran-HM rules) — coordinate with
-  PR #1193's dungeon data once merged; plug into `CONTENT_ZONES`.
+- ~~**Dungeon metadata** (expected boss counts) — coordinate with PR #1193's
+  dungeon data once merged; plug into `CONTENT_ZONES`.~~ **Done** — #1193's
+  curated dungeon rosters are merged into this branch and consumed by name
+  (`getDungeonBossCount`), giving dungeon runs an expected boss count for the
+  completion ring. Dungeon **HM rules** remain future work (dungeon fights
+  commonly carry `difficulty: null`, so no difficulty badge is shown).
 - **Completion-ring boss counts** in `ReportFightsView` are still the original
-  zone-name-keyed constants (kept to avoid regressing variable-boss trials like
-  Cloudrest/Asylum). Some look stale (e.g. Sanctum Ophidia listed as 5; it has 4
-  main bosses) and could be re-derived from `expectedBossCount` once
-  optional-boss semantics are encoded.
+  zone-name-keyed constants for trials (kept to avoid regressing variable-boss
+  trials like Cloudrest/Asylum). Some look stale (e.g. Sanctum Ophidia listed as
+  5; it has 4 main bosses) and could be re-derived from `expectedBossCount` once
+  optional-boss semantics are encoded. Dungeon counts come from the curated
+  rosters; note these enumerate *achievement* bosses, which may exceed what ESO
+  Logs tracks as encounters in some dungeons — the ring degrades to yellow, not
+  green, in that case.
 - **Arena detection** (Maelstrom / Vateshran / DSA / BRP) would benefit from
   adding `size` and `fightPercentage` to the `Fight` fragment.
 
@@ -289,11 +296,29 @@ were identical. Run headers now show:
 Dead `isFalsePositive` plumbing in `ReportFightsView` was also removed, and the
 kill-card background now keys off `isBossFight` rather than `difficulty != null`.
 
+### 16. Dungeon expected-boss-counts wired in from PR #1193 — _Enhancement_
+
+PR #1193's 58 curated, achievement-verified dungeon boss rosters
+(`loadout-manager/data/trialConfigs.ts`) are merged into this branch and
+consumed by `resolveFightZone` via `getDungeonBossCount` (name-keyed — the ESO
+Logs `gameZone` for dungeons gives a name but our canonical zone table only
+enumerates trials). Dungeon runs now get a real `expectedBossCount`, so the
+completion ring shows e.g. **2/3 yellow** for a partial Bal Sunnar clear
+instead of a misleading green "all encountered bosses killed". Lookups degrade
+gracefully: an unmatched dungeon name simply shows no expected count, exactly
+as before. The ring's colour thresholds were generalised to *all-killed =
+green, ≥half = yellow* (identical behaviour for the 3/4/5-boss trial cases it
+previously special-cased).
+
 ### Verification (follow-up)
 
 - `npm run validate` — clean; full `report_details` suite green (40+ detection
-  tests including new regressions for findings 12–14).
+  tests including new regressions for findings 12–14, plus dungeon boss-count
+  resolution tests for finding 16).
 - **Chrome (CDP) end-to-end**: both real sample reports plus the synthetic mixed
   chaos log render correctly in dark and light mode — correct run separation,
-  "Run 1/2" badges, dungeon tagging, attempt grouping/expansion, and reset
-  chips.
+  "Run 1/2" badges, dungeon tagging, attempt grouping/expansion, reset chips,
+  and the Bal Sunnar segment showing 2/3 expected bosses (yellow ring). The
+  loadout-manager activity selector (from #1193) was also verified: sectioned
+  General/Trials/Dungeons/Arenas/Substitutes headers with all 58 dungeons
+  alphabetised.

--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -36,8 +36,9 @@ is 0, the fight is considered a trash fight."_). It also exposes
 `originalEncounterID` for bosses that ESO Logs demotes to trash — which the old
 code could not represent at all.
 
-**Fix:** `isBossFight()` uses `effectiveEncounterId(fight) !== 0`, unioned with
-the old `difficulty` check as a safety net so no current boss is dropped.
+**Fix:** `isBossFight()` uses the live `encounterID !== 0`, unioned with the old
+`difficulty` check as a safety net so no current boss is dropped. (See finding 7
+for the demoted-fight refinement.)
 
 ### 2. Trial detection by boss-name string matching — _High_
 
@@ -115,6 +116,52 @@ No GraphQL schema or codegen changes were required — every field used
 
 ---
 
+## Validation against real logs (2026-06-09)
+
+Re-ran the detection over the two committed real ESO Logs reports in
+`public/sample-reports/` — both are **single-zone attempt farms**, which is
+exactly the hard case for grouping. They drove three follow-up corrections:
+
+### 7. Demoted fights were being counted as phantom boss attempts — _Medium_
+
+Real logs are full of `encounterID: 0, originalEncounterID: <boss>, kill: null`
+fights — post-kill cleanup and instant resets that ESO Logs deliberately
+demoted to trash. The first pass counted them as boss attempts (inflating
+attempt counts and adding empty cards).
+
+**Fix:** `isBossFight()` now follows the _live_ `encounterID` (demoted ⇒ trash),
+matching ESO Logs' intent. `originalEncounterID` is still recoverable via
+`effectiveEncounterId()`.
+
+### 8. Re-clear auto-split shattered farm/reset logs — _High (self-regression)_
+
+The DSR sample (`F4f2bMwWtgVKxjB9`, "DSR Day 34 Reef Resets") kills the same
+bosses repeatedly (Lylanar ×7 attempts / 3 kills, Bow Breaker ×4). The initial
+re-clear rule started a brand-new run on every repeat, fragmenting one farm
+night into ~6 messy runs.
+
+**Fix:** same-zone re-clears now stay in **one run by default**; per-clear
+splitting is opt-in via `groupFightsIntoRuns(…, { splitReclears: true })`.
+Zone-change splitting (the real mixed-log fix) is unchanged.
+
+### 9. Attempt-heavy encounters were unreadable — _High (UX)_
+
+The VSE sample (`YArFDbq7BdhwL691`, "FAST VSE HM") has **45 attempts on a single
+boss** (Exarchanic Yaseyla) before the kill — an unusable wall of 45 cards.
+About half are quick "reset" re-pulls (very short, boss left near full health).
+
+**Fix (the requested organisation toggle):**
+
+- `summarizeEncounter()` / `isResetPull()` derive per-encounter stats: attempts,
+  real attempts vs. resets, kill count, and best pull %.
+- `ReportFightsView` gained a **"Group attempts"** toggle (default on, shown only
+  when some encounter exceeds the threshold). When on, attempt-heavy encounters
+  collapse to the **kill(s) + best pull**, with the remaining attempts behind a
+  "Show all N attempts" expander, and the header shows summary chips
+  (`3 kills` / `Best 12%` / `20 resets`).
+
+---
+
 ## Deferred / future work
 
 - **Dungeon metadata** (expected boss counts, veteran-HM rules) — coordinate with
@@ -133,5 +180,8 @@ No GraphQL schema or codegen changes were required — every field used
 
 - `npm run validate` (typecheck + lint + format) — clean.
 - `npx jest src/features/report_details src/store/report/reportSelectors.test.ts`
-  — 157 passed, 14 snapshots passed.
-- New `fightGrouping.test.ts` — 18 passed.
+  — 165 passed, 14 snapshots passed.
+- `fightGrouping.test.ts` — 26 passed, including **end-to-end checks against the
+  two real committed reports**: the DSR farm resolves to one run with multi-kill
+  grouped encounters, and the VSE log resolves to one run with 30+ Yaseyla
+  attempts (resets detected, eventual kill).

--- a/FIGHT-DETECTION-AUDIT-2026-06-08.md
+++ b/FIGHT-DETECTION-AUDIT-2026-06-08.md
@@ -160,6 +160,25 @@ About half are quick "reset" re-pulls (very short, boss left near full health).
   "Show all N attempts" expander, and the header shows summary chips
   (`3 kills` / `Best 12%` / `20 resets`).
 
+### 10. Mini-bosses wrongly downgraded HM clears to "Partial Veteran HM" — _High_
+
+ESO mini-bosses (Spiral Descender, Bow Breaker, Sail Ripper, Haj Mota, …) **have
+no Hard Mode** — they are always Veteran. The old `calculateTrialDifficulty`
+counted every fight at difficulty 121 (including those minis, and including
+_wipes_) as a "Veteran boss", so a full-HM clear showed as **"Partial Veteran
+HM"** (confirmed on both real logs). HM status is also a kill property, not a
+wipe property — wiping a boss on Veteran then killing it on HM is an HM kill.
+
+**Fix:** new `runDifficulty.ts` (`determineRunDifficulty`) judges HM only on
+**HM-capable bosses** (minis excluded via `isHmCapableBoss`) and only on the
+**kill** difficulty (highest difficulty among kills; falls back to best attempt
+for in-progress runs). Linear trials use per-boss / final-boss-only rules;
+Cloudrest & Asylum (the "skip to the final boss" trials) use the +0..+3 codes
+(122–125) from the final-boss kill. Both real logs now read **"Veteran HM"**.
+This also lays the groundwork for trifecta reasoning (Veteran HM + speed +
+no-death). Per-boss badges are unchanged (a mini still correctly shows
+"Veteran").
+
 ---
 
 ## Deferred / future work
@@ -180,8 +199,12 @@ About half are quick "reset" re-pulls (very short, boss left near full health).
 
 - `npm run validate` (typecheck + lint + format) — clean.
 - `npx jest src/features/report_details src/store/report/reportSelectors.test.ts`
-  — 165 passed, 14 snapshots passed.
-- `fightGrouping.test.ts` — 26 passed, including **end-to-end checks against the
-  two real committed reports**: the DSR farm resolves to one run with multi-kill
-  grouped encounters, and the VSE log resolves to one run with 30+ Yaseyla
-  attempts (resets detected, eventual kill).
+  — 175 passed, 14 snapshots passed.
+- `fightGrouping.test.ts` (26) + `runDifficulty.test.ts` (10) include
+  **end-to-end checks against the two real committed reports**: the DSR farm
+  resolves to one run with multi-kill grouped encounters; the VSE log resolves to
+  one run with 30+ Yaseyla attempts (resets detected, eventual kill); and both
+  read as **Veteran HM** (mini-bosses no longer force "Partial").
+- **Rendered in headless Chromium** against both real reports: grouped
+  attempt-heavy encounters with "Show all N attempts", the "Group attempts"
+  toggle, and correct "Veteran HM" headers.

--- a/src/data/esoContentZones.ts
+++ b/src/data/esoContentZones.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical ESO content-zone metadata, keyed by the in-game zone ID that the
+ * ESO Logs API reports on every fight as `fight.gameZone.id`.
+ *
+ * This is the authoritative key used to detect *which* trial / dungeon / arena a
+ * fight belongs to. It is far more reliable than matching boss-name strings,
+ * because:
+ *   - it is per-fight (so it correctly separates logs that mix several
+ *     trials/dungeons in one report), and
+ *   - it does not break when ZeniMax renames a boss or adds name variants.
+ *
+ * Trial entries are derived from the existing single sources of truth
+ * (`ZONE_NAMES` for the id↔name mapping and `TRIAL_ENCOUNTERS` for boss counts)
+ * so there is no duplicated zone list to keep in sync.
+ *
+ * Dungeons are intentionally *not* enumerated here. Detection of dungeons relies
+ * purely on the API-provided `gameZone` (id + name), which needs no static table,
+ * and richer per-dungeon metadata is being curated separately (see the loadout
+ * manager dungeon work). Unknown zones therefore still get correct grouping and a
+ * human-readable label — they simply have no `expectedBossCount`.
+ */
+
+import { TRIAL_ENCOUNTERS } from '../types/trial-encounters';
+import { ZONE_NAMES } from '../types/zoneScaleData';
+
+export type ContentType = 'trial' | 'dungeon' | 'arena' | 'unknown';
+
+export interface ContentZone {
+  /** In-game zone ID (matches `fight.gameZone.id`). */
+  zoneId: number;
+  /** Canonical display name. */
+  name: string;
+  /** Content category. */
+  type: ContentType;
+  /** Short acronym (e.g. "vAA", "KA"). Trials only. */
+  shortName?: string;
+  /**
+   * Number of *main* bosses expected for a full clear (excludes optional
+   * mini-bosses). Used only to colour the completion indicator. Trials only.
+   */
+  expectedBossCount?: number;
+}
+
+/**
+ * Normalise a zone name for matching across our data sources. `ZONE_NAMES`
+ * (zoneScaleData) and `TRIAL_ENCOUNTERS` are curated independently and disagree
+ * on apostrophe style (e.g. straight "Kyne's Aegis" vs typographic
+ * "Kyne’s Aegis"), so the join is done on an apostrophe-insensitive key.
+ */
+function normalizeZoneName(name: string): string {
+  return name.replace(/[‘’]/g, "'");
+}
+
+/** Build a name → trial metadata index from the verified trial encounter data. */
+const TRIAL_BY_NAME = new Map(
+  TRIAL_ENCOUNTERS.map((trial) => [
+    normalizeZoneName(trial.name),
+    {
+      shortName: trial.shortName,
+      // "Main" bosses only — mini-bosses are optional and skew completion colour.
+      bossCount: trial.encounters.filter((e) => e.type === 'boss').length,
+    },
+  ]),
+);
+
+/**
+ * Canonical content zones keyed by in-game zone ID.
+ * Seeded with every trial (the 12-player content the site fully supports).
+ */
+export const CONTENT_ZONES: Record<number, ContentZone> = Object.fromEntries(
+  Object.entries(ZONE_NAMES).map(([id, name]) => {
+    const zoneId = Number(id);
+    const trial = TRIAL_BY_NAME.get(normalizeZoneName(name));
+    return [
+      zoneId,
+      {
+        zoneId,
+        name,
+        type: 'trial' as const,
+        shortName: trial?.shortName,
+        expectedBossCount: trial?.bossCount,
+      },
+    ];
+  }),
+);
+
+/** Look up canonical metadata for an in-game zone ID. */
+export function getContentZone(zoneId: number | null | undefined): ContentZone | undefined {
+  if (zoneId == null) return undefined;
+  return CONTENT_ZONES[zoneId];
+}
+
+/** True when the zone ID is a known 12-player trial. */
+export function isTrialZone(zoneId: number | null | undefined): boolean {
+  return getContentZone(zoneId)?.type === 'trial';
+}

--- a/src/data/esoContentZones.ts
+++ b/src/data/esoContentZones.ts
@@ -20,6 +20,7 @@
  * human-readable label — they simply have no `expectedBossCount`.
  */
 
+import { TRIALS } from '../features/loadout-manager/data/trialConfigs';
 import { TRIAL_ENCOUNTERS } from '../types/trial-encounters';
 import { ZONE_NAMES } from '../types/zoneScaleData';
 
@@ -93,4 +94,26 @@ export function getContentZone(zoneId: number | null | undefined): ContentZone |
 /** True when the zone ID is a known 12-player trial. */
 export function isTrialZone(zoneId: number | null | undefined): boolean {
   return getContentZone(zoneId)?.type === 'trial';
+}
+
+/**
+ * Dungeon metadata keyed by lowercased dungeon name, derived from the
+ * loadout-manager activity configs (the curated per-dungeon boss rosters).
+ *
+ * The ESO Logs API gives dungeons a per-fight `gameZone {id, name}` but our
+ * canonical zone table only enumerates trials, so dungeons are matched by
+ * *name*. Lookups degrade gracefully: an unmatched name simply has no
+ * `expectedBossCount`.
+ */
+const DUNGEON_BY_NAME = new Map(
+  TRIALS.filter((activity) => activity.type === 'dungeon').map((activity) => [
+    activity.name.toLowerCase(),
+    activity,
+  ]),
+);
+
+/** Expected boss count (completion-achievement bosses) for a dungeon name. */
+export function getDungeonBossCount(name: string | null | undefined): number | undefined {
+  if (!name) return undefined;
+  return DUNGEON_BY_NAME.get(name.toLowerCase())?.bosses.length;
 }

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -29,6 +29,15 @@ import {
 } from '../../utils/trialClassification';
 
 import { BossAvatar } from './BossAvatar';
+import {
+  bossHealthRemaining,
+  buildRunEncounters,
+  groupFightsIntoRuns,
+  isBossFight,
+  uncategorizedTrash,
+  wasKill,
+  type RunEncounter,
+} from './fightGrouping';
 
 function formatTimestamp(fightStartTime: number, reportStartTime: number): string {
   // Convert fight timestamp (relative ms) + report startTime (Unix timestamp) to actual clock time
@@ -230,14 +239,6 @@ interface ReportFightsViewProps {
   reportData: ReportFragment | null | undefined;
 }
 
-interface Encounter {
-  id: string;
-  name: string;
-  bossFights: FightFragment[];
-  preTrash: FightFragment[];
-  postTrash: FightFragment[];
-}
-
 export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
   fights,
   loading,
@@ -324,214 +325,51 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
   );
 
   const encounters = React.useMemo(() => {
-    if (!fights) return [];
+    // Group fights into trial/dungeon runs using authoritative API data
+    // (per-fight gameZone + encounterID). See ./fightGrouping.
+    const runs = groupFightsIntoRuns(fights, reportData);
 
-    // First, filter and sort all valid fights by start time
-    const validFights = fights
-      .filter((fight) => fight.startTime && fight.endTime && fight.endTime > fight.startTime)
-      .sort((a, b) => a.startTime - b.startTime);
+    return runs.map((run) => {
+      const runEncounters = buildRunEncounters(run);
+      const leftover = uncategorizedTrash(run, runEncounters);
 
-    // Separate boss fights and trash fights
-    const bossFights = validFights.filter((fight) => fight.difficulty != null);
-    const trashFights = validFights.filter((fight) => fight.difficulty == null);
-
-    // Track boss progression to detect trial resets
-    const bossProgressionOrder: string[] = [];
-    const bossInstancesSeen: Set<string> = new Set();
-    let currentRunNumber = 1;
-
-    // Group bosses by zone and detect trial runs
-    const trialRuns: Array<{
-      id: string;
-      name: string;
-      encounters: Encounter[];
-      startTime: number;
-      endTime: number;
-      difficulty: number | null;
-      difficultyLabel: string | null;
-      fights: FightFragment[];
-      trialName: string;
-      isComplete: boolean;
-    }> = [];
-
-    // Process each fight
-    const trialNamesByRun: Record<number, string> = {};
-
-    for (let i = 0; i < bossFights.length; i++) {
-      const currentBoss = bossFights[i];
-      const nextBoss = bossFights[i + 1];
-      const bossName = currentBoss.name || 'Unknown Boss';
-      // Instance count should only be used for encounter IDs, not for determining resets
-      const bossProgressionKey = bossName; // Just the boss name, not including instance count
-
-      // Determine trial name from boss name
-      const trialName = getTrialNameFromBoss(bossName, reportData);
-
-      // SIMPLIFIED APPROACH: Don't try to separate trial instances
-      // Just group all bosses from the same trial together
-      // This avoids all the complex edge cases and false separations
-      let shouldStartNewRun = false;
-
-      // Only separate if this is a completely different trial
-      const currentRunTrialName = trialNamesByRun[currentRunNumber];
-      if (currentRunTrialName && currentRunTrialName !== trialName) {
-        shouldStartNewRun = true;
-      }
-
-      if (shouldStartNewRun) {
-        // Reset progression tracking
-        currentRunNumber++;
-        bossInstancesSeen.clear();
-        bossProgressionOrder.length = 0;
-      }
-
-      // Track boss progression and trial name for this run
-      bossProgressionOrder.push(bossProgressionKey);
-      bossInstancesSeen.add(bossProgressionKey);
-
-      // Set the trial name for this run
-      trialNamesByRun[currentRunNumber] = trialName;
-
-      const trialRunId = `${trialName}-run-${currentRunNumber}`;
-      const trialRunName = `${trialName}`;
-
-      // Find or create the trial run
-      let currentTrialRun = trialRuns.find((run) => run.id === trialRunId);
-
-      if (!currentTrialRun) {
-        // For now, use the current boss difficulty as initial difficulty
-        // This will be updated later when we finalize the trial run
-        const initialDifficulty = currentBoss.difficulty ?? 0;
-        const initialDifficultyLabel = getDifficultyLabel(initialDifficulty, trialName);
-
-        const nameWithDifficulty = initialDifficultyLabel
-          ? `${trialRunName} (${initialDifficultyLabel})`
-          : trialRunName;
-
-        const newTrialRun = {
-          id: trialRunId,
-          name: nameWithDifficulty,
-          startTime: currentBoss.startTime,
-          endTime: currentBoss.endTime,
-          difficulty: initialDifficulty,
-          difficultyLabel: initialDifficultyLabel,
-          fights: [currentBoss],
-          trialName: trialName,
-          isComplete: false,
-          encounters: [],
-        };
-
-        trialRuns.push(newTrialRun);
-        currentTrialRun = newTrialRun;
-      }
-
-      // Find trash before this boss (after previous boss or from start)
-      const prevBossEnd = i > 0 ? bossFights[i - 1].endTime : 0;
-      const preTrash = trashFights.filter(
-        (trash) => trash.startTime >= prevBossEnd && trash.startTime < currentBoss.startTime,
-      );
-
-      // Find trash after this boss (before next boss or until end)
-      const nextBossStart = nextBoss ? nextBoss.startTime : Number.MAX_SAFE_INTEGER;
-      const postTrash = trashFights.filter(
-        (trash) => trash.startTime > currentBoss.endTime && trash.startTime < nextBossStart,
-      );
-
-      // Ensure currentTrialRun is defined before proceeding
-      if (!currentTrialRun) {
-        // Skip to next boss if no trial run is available
-        continue;
-      }
-
-      // Group all attempts of the same boss into one encounter
-      // Use only boss name (without instance count) for encounter grouping
-      const encounterKey = `${trialRunId}-${bossName.replace(/\s+/g, '-').toLowerCase()}`;
-      let bossEncounter = currentTrialRun.encounters.find((enc) => enc.id === encounterKey);
-
-      if (!bossEncounter) {
-        // Create display name without instance numbers
-        const displayName = bossName;
-
-        const newEncounter: Encounter = {
-          id: encounterKey,
-          name: displayName,
-          bossFights: [],
-          preTrash: [],
-          postTrash: [],
-        };
-        currentTrialRun.encounters.push(newEncounter);
-        bossEncounter = newEncounter;
-      }
-
-      // Add boss and pre-trash to the encounter
-      bossEncounter.bossFights.push(currentBoss);
-      bossEncounter.preTrash.push(...preTrash);
-
-      // Update the trial run's fights array to include all bosses
-      if (!currentTrialRun.fights.some((f) => f.id === currentBoss.id)) {
-        currentTrialRun.fights.push(currentBoss);
-      }
-
-      // Only add post-trash if there's a next boss (not the final boss)
-      if (nextBoss) {
-        bossEncounter.postTrash.push(...postTrash);
-      }
-    }
-
-    // Handle any remaining trash that doesn't fit near bosses
-    const allCategorizedTrash = trialRuns.flatMap((run) =>
-      run.encounters.flatMap((enc) => [...enc.preTrash, ...enc.postTrash]),
-    );
-    const uncategorizedTrash = trashFights.filter(
-      (trash) => !allCategorizedTrash.some((cat) => cat.id === trash.id),
-    );
-
-    if (uncategorizedTrash.length > 0) {
-      trialRuns.push({
-        id: 'misc-trash',
-        name: 'Miscellaneous Trash',
-        startTime: uncategorizedTrash[0]?.startTime || 0,
-        endTime: uncategorizedTrash[uncategorizedTrash.length - 1]?.endTime || 0,
-        difficulty: null,
-        difficultyLabel: null,
-        fights: [],
-        trialName: 'Miscellaneous',
-        isComplete: true,
-        encounters: [
-          {
-            id: 'misc-trash-encounter',
-            name: 'Miscellaneous Trash',
+      // Surface trash that isn't tied to a boss (e.g. trailing trash, or a
+      // trash-only segment) so it stays reachable via the trash toggle.
+      const encountersForRun: RunEncounter[] = [...runEncounters];
+      if (leftover.length > 0) {
+        if (encountersForRun.length === 0) {
+          encountersForRun.push({
+            id: `${run.id}-misc-trash`,
+            name: 'Trash',
             bossFights: [],
-            preTrash: uncategorizedTrash,
+            preTrash: leftover,
             postTrash: [],
-          },
-        ],
-      });
-    }
+          });
+        } else {
+          const last = encountersForRun.length - 1;
+          encountersForRun[last] = {
+            ...encountersForRun[last],
+            postTrash: [...encountersForRun[last].postTrash, ...leftover],
+          };
+        }
+      }
 
-    // Update trial run names to remove any existing run numbers
-    const updatedTrialRuns = trialRuns?.map((run) => {
-      const baseName = run.name.replace(/#\d+$/, '');
-
-      return {
-        ...run,
-        name: baseName,
-      };
-    });
-
-    // Calculate trial difficulty for each individual run based on its own fights
-    const finalizedTrialRuns = updatedTrialRuns.map((run, _index) => {
-      const baseName = run.name.replace(/#\d+/, '').trim(); // Remove run number for calculation
-      const trialDifficulty = calculateTrialDifficulty(run.fights, baseName);
+      const hasBosses = runEncounters.length > 0;
+      const trialDifficulty = hasBosses
+        ? calculateTrialDifficulty(run.fights, run.zone.name)
+        : { difficulty: 0, label: null as string | null };
 
       return {
-        ...run,
+        id: run.id,
+        name: run.zone.name,
+        trialName: run.zone.name,
+        contentType: run.zone.type,
+        expectedBossCount: run.zone.expectedBossCount,
         difficulty: trialDifficulty.difficulty,
         difficultyLabel: trialDifficulty.label,
+        encounters: encountersForRun,
       };
     });
-
-    return finalizedTrialRuns;
   }, [fights, reportData]);
 
   const [showTrashForEncounter, setShowTrashForEncounter] = React.useState<Set<string>>(new Set());
@@ -620,43 +458,33 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
   }
 
   const renderFightCard = (fight: FightFragment, idx: number): React.ReactNode => {
-    // Handle both boss fights and trash fights
-    const isBossFight = fight.difficulty != null;
+    // Handle both boss fights and trash fights (encounterID-based, see fightGrouping.isBossFight)
+    const fightIsBoss = isBossFight(fight);
 
     let bossWasKilled: boolean;
-    let rawIsWipe: boolean;
     let isFalsePositive: boolean;
     let isWipe: boolean;
     let bossHealthPercent: number;
     let backgroundFillPercent: number;
 
-    if (isBossFight) {
-      // Boss fight logic - consider anything <= 1% as a kill (not just 0.01%)
-      bossWasKilled =
-        fight.bossPercentage !== null &&
-        fight.bossPercentage !== undefined &&
-        fight.bossPercentage <= 1.0;
-      rawIsWipe =
-        fight.bossPercentage !== null &&
-        fight.bossPercentage !== undefined &&
-        fight.bossPercentage > 1.0;
-      isFalsePositive = rawIsWipe && isFalsePositiveWipe(fight);
-      isWipe = rawIsWipe && !isFalsePositive;
-      bossHealthPercent =
-        fight.bossPercentage !== null && fight.bossPercentage !== undefined
-          ? Math.round(fight.bossPercentage)
-          : 0;
+    if (fightIsBoss) {
+      // Boss fight logic — use the API's authoritative `kill` flag (see fightGrouping.wasKill).
+      // This replaces the old `bossPercentage`-based heuristic + false-positive detection.
+      bossWasKilled = wasKill(fight);
+      isFalsePositive = false;
+      isWipe = !bossWasKilled;
+      const remaining = bossHealthRemaining(fight);
+      bossHealthPercent = remaining != null ? Math.round(remaining) : 0;
 
       // Fill represents progress (damage dealt): kills = full, wipes = 100 - health remaining
-      backgroundFillPercent = bossWasKilled ? 100 : isWipe ? 100 - bossHealthPercent : 100;
+      backgroundFillPercent = bossWasKilled ? 100 : 100 - bossHealthPercent;
     } else {
       // Trash fight logic - use the kill field to determine success/wipe
       // kill === true means success, kill === false means wipe, kill === null means unknown (treat as successful)
       const wasKilled = fight.kill === true || fight.kill === null;
       bossWasKilled = false; // Trash fights don't have a "boss"
-      rawIsWipe = fight.kill === false;
       isFalsePositive = false; // No false positive detection for trash
-      isWipe = rawIsWipe;
+      isWipe = fight.kill === false;
       bossHealthPercent = 0;
       backgroundFillPercent = wasKilled ? 100 : 0; // Full bar if successful, empty if wipe
     }
@@ -839,7 +667,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                 #{idx + 1}
               </Typography>
               {/* Status badge — hidden for false positives */}
-              {isBossFight && !isFalsePositive && (
+              {fightIsBoss && !isFalsePositive && (
                 <Box
                   sx={{
                     display: 'inline-flex',
@@ -1131,28 +959,14 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                     }}
                   >
                     {(() => {
-                      // Count killed bosses (boss percentage <= 0.01 or false positive wipes)
+                      // Count killed encounters using the authoritative kill detection.
                       const killedBosses = trialRun.encounters.reduce((count, encounter) => {
-                        const hasKill = encounter.bossFights.some((fight) => {
-                          // Use the same kill logic as individual fight cards
-                          const isBossFight = fight.difficulty != null;
-                          if (isBossFight) {
-                            const bossWasKilled =
-                              fight.bossPercentage !== null &&
-                              fight.bossPercentage !== undefined &&
-                              fight.bossPercentage <= 1.0;
-                            const rawIsWipe =
-                              fight.bossPercentage !== null &&
-                              fight.bossPercentage !== undefined &&
-                              fight.bossPercentage > 1.0;
-                            const isFalsePositive = rawIsWipe && isFalsePositiveWipe(fight);
-                            return bossWasKilled || isFalsePositive; // Kill if boss was killed or false positive wipe
-                          } else {
-                            // For trash fights, use the kill field to determine success
-                            // kill === true means success, kill === null means unknown (treat as successful)
-                            return fight.kill === true || fight.kill === null;
-                          }
-                        });
+                        const hasKill = encounter.bossFights.some((fight) =>
+                          isBossFight(fight)
+                            ? wasKill(fight)
+                            : // Trash: kill === null means unknown (treat as successful)
+                              fight.kill === true || fight.kill === null,
+                        );
                         return count + (hasKill ? 1 : 0);
                       }, 0);
 

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -34,6 +34,8 @@ import {
   buildRunEncounters,
   groupFightsIntoRuns,
   isBossFight,
+  isResetPull,
+  summarizeEncounter,
   uncategorizedTrash,
   wasKill,
   type RunEncounter,
@@ -384,6 +386,95 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
       }
       return newSet;
     });
+  };
+
+  // Attempt organisation: on farm/progression logs an encounter can have dozens
+  // of attempts (real logs show 45+ on a single boss). When "Group attempts" is
+  // on, those collapse to the kills + best pull, with the rest behind a toggle.
+  const [groupAttempts, setGroupAttempts] = React.useState(true);
+  const [expandedAttempts, setExpandedAttempts] = React.useState<Set<string>>(new Set());
+
+  const toggleExpandedAttempts = (encounterId: string): void => {
+    setExpandedAttempts((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(encounterId)) {
+        newSet.delete(encounterId);
+      } else {
+        newSet.add(encounterId);
+      }
+      return newSet;
+    });
+  };
+
+  // Boss-fight grid styling, shared between grouped and ungrouped rendering.
+  const bossGridSx = {
+    display: 'grid',
+    gridTemplateColumns: {
+      xs: 'repeat(auto-fill, minmax(100px, 1fr))',
+      sm: 'repeat(auto-fill, minmax(120px, 1fr))',
+      md: 'repeat(auto-fill, minmax(140px, 1fr))',
+      lg: 'repeat(auto-fill, minmax(160px, 1fr))',
+    },
+    gap: { xs: 0.5, sm: 1 },
+    overflow: 'visible',
+  } as const;
+
+  // Encounters with more than this many attempts get collapsed when grouping.
+  const ATTEMPT_GROUP_THRESHOLD = 4;
+
+  const renderBossAttempts = (encounter: RunEncounter): React.ReactNode => {
+    const fights = encounter.bossFights;
+    // Stable attempt numbers (#1, #2, …) by chronological order.
+    const attemptIndex = new Map(fights.map((f, i) => [f.id, i]));
+
+    const useGrouping = groupAttempts && fights.length > ATTEMPT_GROUP_THRESHOLD;
+    if (!useGrouping) {
+      return (
+        <List sx={bossGridSx}>
+          {fights.map((fight) => renderFightCard(fight, attemptIndex.get(fight.id) ?? 0))}
+        </List>
+      );
+    }
+
+    // Pin the kill(s) and the single best non-reset wipe; collapse the rest.
+    const killIds = new Set(fights.filter((f) => wasKill(f)).map((f) => f.id));
+    const measurableWipes = fights.filter(
+      (f) => !wasKill(f) && !isResetPull(f) && bossHealthRemaining(f) != null,
+    );
+    const bestWipeId = measurableWipes.length
+      ? measurableWipes.reduce((a, b) =>
+          (bossHealthRemaining(a) ?? 100) <= (bossHealthRemaining(b) ?? 100) ? a : b,
+        ).id
+      : null;
+    const isHighlight = (f: FightFragment): boolean => killIds.has(f.id) || f.id === bestWipeId;
+
+    const highlight = fights.filter(isHighlight);
+    const rest = fights.filter((f) => !isHighlight(f));
+    const expanded = expandedAttempts.has(encounter.id);
+
+    return (
+      <>
+        <List sx={bossGridSx}>
+          {highlight.map((fight) => renderFightCard(fight, attemptIndex.get(fight.id) ?? 0))}
+        </List>
+        {rest.length > 0 && (
+          <>
+            <Button
+              size="small"
+              onClick={() => toggleExpandedAttempts(encounter.id)}
+              sx={{ textTransform: 'none', mt: 0.5 }}
+            >
+              {expanded ? 'Show fewer' : `Show all ${fights.length} attempts`}
+            </Button>
+            <Collapse in={expanded}>
+              <List sx={{ ...bossGridSx, mt: 0.5 }}>
+                {rest.map((fight) => renderFightCard(fight, attemptIndex.get(fight.id) ?? 0))}
+              </List>
+            </Collapse>
+          </>
+        )}
+      </>
+    );
   };
 
   if (loading) {
@@ -840,6 +931,24 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
           }}
         >
           {encounters.length === 0 && <Typography> No Fights Found </Typography>}
+          {encounters.some((run) =>
+            run.encounters.some((e) => e.bossFights.length > ATTEMPT_GROUP_THRESHOLD),
+          ) && (
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={groupAttempts}
+                    onChange={(e) => setGroupAttempts(e.target.checked)}
+                    size="small"
+                  />
+                }
+                label="Group attempts"
+                slotProps={{ typography: { variant: 'body2', sx: { color: 'text.secondary' } } }}
+                data-testid="group-attempts-toggle"
+              />
+            </Box>
+          )}
           <Box data-testid="fight-list">
             {encounters.map((trialRun) => (
               <Box
@@ -1125,6 +1234,50 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                               ({encounter.bossFights.length})
                             </Box>
                           </Typography>
+                          {(() => {
+                            // Aggregate attempt summary — only meaningful with >1 attempt.
+                            const summary = summarizeEncounter(encounter);
+                            if (summary.attempts <= 1) return null;
+                            const chips: Array<{ label: string; color: string }> = [];
+                            if (summary.kills > 1) {
+                              chips.push({
+                                label: `${summary.kills} kills`,
+                                color: getThemeColors.circleGreen,
+                              });
+                            }
+                            if (!summary.killed && summary.bestPercent != null) {
+                              chips.push({
+                                label: `Best ${Math.round(summary.bestPercent)}%`,
+                                color: getThemeColors.circleOrange,
+                              });
+                            }
+                            if (summary.resets > 0) {
+                              chips.push({
+                                label: `${summary.resets} reset${summary.resets > 1 ? 's' : ''}`,
+                                color: darkMode ? '#94a3b8' : '#64748b',
+                              });
+                            }
+                            if (chips.length === 0) return null;
+                            return (
+                              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                                {chips.map((chip) => (
+                                  <Chip
+                                    key={chip.label}
+                                    label={chip.label}
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{
+                                      height: 18,
+                                      fontSize: '0.62rem',
+                                      color: chip.color,
+                                      borderColor: `${chip.color}66`,
+                                      '& .MuiChip-label': { px: 0.75 },
+                                    }}
+                                  />
+                                ))}
+                              </Box>
+                            );
+                          })()}
                         </Box>
                         {(encounter.preTrash.length > 0 || encounter.postTrash.length > 0) && (
                           <FormControlLabel
@@ -1187,22 +1340,8 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                         </Box>
                       </Collapse>
 
-                      {/* Boss fights */}
-                      <List
-                        sx={{
-                          display: 'grid',
-                          gridTemplateColumns: {
-                            xs: 'repeat(auto-fill, minmax(100px, 1fr))',
-                            sm: 'repeat(auto-fill, minmax(120px, 1fr))',
-                            md: 'repeat(auto-fill, minmax(140px, 1fr))',
-                            lg: 'repeat(auto-fill, minmax(160px, 1fr))',
-                          },
-                          gap: { xs: 0.5, sm: 1 },
-                          overflow: 'visible',
-                        }}
-                      >
-                        {encounter.bossFights.map((fight, idx) => renderFightCard(fight, idx))}
-                      </List>
+                      {/* Boss fights (grouped/collapsed for attempt-heavy encounters) */}
+                      {renderBossAttempts(encounter)}
 
                       {/* Post-encounter trash */}
                       <Collapse

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -1031,7 +1031,9 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                       // Determine expected total bosses based on zone name
                       const zoneName = trialRun.name.replace(/#\d+/, '').trim();
 
-                      let expectedTotalBosses = encounteredBosses; // default fallback
+                      // Default: the resolved zone's expected count (covers
+                      // dungeons via the curated rosters), else what we saw.
+                      let expectedTotalBosses = trialRun.expectedBossCount ?? encounteredBosses;
 
                       // Known trial boss counts
                       if (zoneName.includes("Kyne's Aegis")) expectedTotalBosses = 3;
@@ -1064,14 +1066,10 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
 
                       // Determine color based on completion against expected total
                       let color = getThemeColors.circleOrange; // orange - default for low completion
-                      if (killedBosses === expectedTotalBosses) {
+                      if (killedBosses >= expectedTotalBosses) {
                         color = getThemeColors.circleGreen; // green - ALL expected bosses killed
-                      } else if (expectedTotalBosses === 5 && killedBosses >= 3) {
-                        color = getThemeColors.circleYellow; // yellow - 3-4 kills in 5-boss trial
-                      } else if (expectedTotalBosses === 4 && killedBosses >= 2) {
-                        color = getThemeColors.circleYellow; // yellow - 2-3 kills in 4-boss trial
-                      } else if (expectedTotalBosses === 3 && killedBosses >= 2) {
-                        color = getThemeColors.circleYellow; // yellow - 2 kills in 3-boss trial
+                      } else if (killedBosses >= Math.ceil(expectedTotalBosses / 2)) {
+                        color = getThemeColors.circleYellow; // yellow - at least half cleared
                       }
 
                       return (

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -40,6 +40,7 @@ import {
   wasKill,
   type RunEncounter,
 } from './fightGrouping';
+import { determineRunDifficulty } from './runDifficulty';
 
 function formatTimestamp(fightStartTime: number, reportStartTime: number): string {
   // Convert fight timestamp (relative ms) + report startTime (Unix timestamp) to actual clock time
@@ -127,109 +128,6 @@ function getWipeHealthGradientBackground(percentage: number, darkMode: boolean):
   const [lr, lg, lb] = mixRgb(rgb, [255, 255, 255], 0.78);
   const [lr2, lg2, lb2] = mixRgb(rgb, [255, 255, 255], 0.68);
   return `linear-gradient(135deg, rgba(${lr}, ${lg}, ${lb}, 0.85) 0%, rgba(${lr2}, ${lg2}, ${lb2}, 0.65) 100%)`;
-}
-
-// Helper function to determine if a trial has per-boss HM or final-boss-only HM
-function getTrialHMType(trialName: string): 'per-boss' | 'final-boss-only' | 'special' {
-  const perBossHMTrials = [
-    'Sunspire',
-    "Kyne's Aegis",
-    'Rockgrove',
-    'Dreadsail Reef',
-    "Sanity's Edge",
-    'Lucent Citadel',
-    'Ossein Cage',
-    'Opulent Ordeal',
-  ];
-
-  const specialTrials = ['Cloudrest', 'Asylum'];
-
-  if (specialTrials.some((trial) => trialName.includes(trial))) {
-    return 'special';
-  }
-
-  if (perBossHMTrials.some((trial) => trialName.includes(trial))) {
-    return 'per-boss';
-  }
-
-  return 'final-boss-only';
-}
-
-function calculateTrialDifficulty(
-  fights: FightFragment[],
-  trialName: string,
-): { difficulty: number; label: string } {
-  // Get HM type for this trial
-  const hmType = getTrialHMType(trialName);
-  const nonHMBosses = ['Basks-In-Snakes', 'Basks-in-Snakes', 'Ash Titan'];
-
-  if (hmType === 'per-boss') {
-    // For per-boss HM trials, analyze all HM-capable bosses in this run
-    const hmCapableFights = fights.filter((fight) => !nonHMBosses.includes(fight.name));
-
-    if (hmCapableFights.length === 0) {
-      return { difficulty: 121, label: 'Veteran' };
-    }
-
-    const hmBosses = hmCapableFights.filter((fight) => fight.difficulty === 122);
-    const vetBosses = hmCapableFights.filter((fight) => fight.difficulty === 121);
-    const normalBosses = hmCapableFights.filter((fight) => (fight.difficulty ?? 0) < 10);
-
-    // Determine difficulty pattern for this run
-    if (normalBosses.length > 0 && hmBosses.length === 0 && vetBosses.length === 0) {
-      return { difficulty: 0, label: 'Normal' };
-    } else if (hmBosses.length > 0 && vetBosses.length === 0) {
-      return { difficulty: 122, label: 'Veteran HM' };
-    } else if (hmBosses.length === 0 && vetBosses.length > 0) {
-      return { difficulty: 121, label: 'Veteran' };
-    } else if (hmBosses.length > 0 && vetBosses.length > 0) {
-      return { difficulty: 122, label: 'Partial Veteran HM' };
-    } else {
-      // Mixed with normal - default to veteran
-      return { difficulty: 121, label: 'Veteran' };
-    }
-  } else if (hmType === 'final-boss-only') {
-    // For final-boss-only HM trials, check if ANY boss in this run was HM
-    // This handles cases where the final boss was done in HM
-    const hasHM = fights.some((fight) => fight.difficulty === 122);
-    const hasVet = fights.some((fight) => fight.difficulty === 121);
-    const hasNormal = fights.some((fight) => (fight.difficulty ?? 0) < 10);
-
-    if (hasHM) {
-      return { difficulty: 122, label: 'Veteran HM' };
-    } else if (hasVet) {
-      return { difficulty: 121, label: 'Veteran' };
-    } else if (hasNormal) {
-      return { difficulty: 0, label: 'Normal' };
-    } else {
-      return { difficulty: 121, label: 'Veteran' };
-    }
-  } else if (hmType === 'special') {
-    // For Cloudrest and Asylum Sanctorium, use difficulty codes for HM detection
-    // Difficulty codes: 121=Veteran, 122=Standard HM, 123=+1, 124=+2, 125=+3
-    const difficulties = fights.map((fight) => fight.difficulty ?? 0).filter((d) => d > 0);
-    const maxDifficulty = Math.max(...difficulties, 0);
-    const hasNormal = fights.some((fight) => (fight.difficulty ?? 0) < 10);
-
-    if (maxDifficulty >= 125) {
-      return { difficulty: 125, label: 'Veteran HM +3' };
-    } else if (maxDifficulty >= 124) {
-      return { difficulty: 124, label: 'Veteran HM +2' };
-    } else if (maxDifficulty >= 123) {
-      return { difficulty: 123, label: 'Veteran HM +1' };
-    } else if (maxDifficulty >= 122) {
-      return { difficulty: 122, label: 'Veteran HM' };
-    } else if (maxDifficulty >= 121) {
-      return { difficulty: 121, label: 'Veteran' };
-    } else if (hasNormal) {
-      return { difficulty: 0, label: 'Normal' };
-    } else {
-      return { difficulty: 121, label: 'Veteran' };
-    }
-  } else {
-    // Fallback for any unhandled trial types
-    return { difficulty: 121, label: 'Veteran' };
-  }
 }
 
 interface ReportFightsViewProps {
@@ -358,7 +256,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
 
       const hasBosses = runEncounters.length > 0;
       const trialDifficulty = hasBosses
-        ? calculateTrialDifficulty(run.fights, run.zone.name)
+        ? determineRunDifficulty(encountersForRun, run.zone.name)
         : { difficulty: 0, label: null as string | null };
 
       return {

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -40,7 +40,7 @@ import {
   wasKill,
   type RunEncounter,
 } from './fightGrouping';
-import { determineRunDifficulty } from './runDifficulty';
+import { determineRunDifficulty, encounterResultDifficulty } from './runDifficulty';
 
 function formatTimestamp(fightStartTime: number, reportStartTime: number): string {
   // Convert fight timestamp (relative ms) + report startTime (Unix timestamp) to actual clock time
@@ -162,8 +162,6 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
         trashGradient:
           'linear-gradient(135deg, rgba(100, 116, 139, 0.3) 0%, rgba(71, 85, 105, 0.2) 100%)',
         trashShadow: 'none',
-        falsePositiveGradient:
-          'linear-gradient(135deg, rgba(251, 191, 36, 0.6) 0%, rgba(245, 158, 11, 0.45) 100%)',
         wipeShadow: 'none',
         hoverBg: 'rgba(255,255,255,0.08)',
         badgeBorder: '1px solid rgba(255,255,255,0.18)',
@@ -190,8 +188,6 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
         trashGradient:
           'linear-gradient(135deg, rgba(236, 239, 243, 0.6) 0%, rgba(241, 243, 245, 0.4) 100%)',
         trashShadow: 'none',
-        falsePositiveGradient:
-          'linear-gradient(135deg, rgba(236, 239, 243, 0.6) 0%, rgba(241, 243, 245, 0.4) 100%)',
         wipeShadow: 'none',
         hoverBg: 'rgba(30, 41, 59, 0.04)',
         badgeBorder: '1px solid rgba(100, 116, 139, 0.4)',
@@ -229,6 +225,15 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
     // (per-fight gameZone + encounterID). See ./fightGrouping.
     const runs = groupFightsIntoRuns(fights, reportData);
 
+    // When the same zone appears as several separate runs (left and re-entered,
+    // or multiple instances in a chaotic log), number them so headers stay
+    // distinguishable: "Dreadsail Reef · Run 2".
+    const zoneRunTotals = new Map<string, number>();
+    for (const run of runs) {
+      zoneRunTotals.set(run.zone.name, (zoneRunTotals.get(run.zone.name) ?? 0) + 1);
+    }
+    const zoneRunSeen = new Map<string, number>();
+
     return runs.map((run) => {
       const runEncounters = buildRunEncounters(run);
       const leftover = uncategorizedTrash(run, runEncounters);
@@ -259,6 +264,9 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
         ? determineRunDifficulty(encountersForRun, run.zone.name)
         : { difficulty: 0, label: null as string | null };
 
+      const ordinal = (zoneRunSeen.get(run.zone.name) ?? 0) + 1;
+      zoneRunSeen.set(run.zone.name, ordinal);
+
       return {
         id: run.id,
         name: run.zone.name,
@@ -268,6 +276,9 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
         difficulty: trialDifficulty.difficulty,
         difficultyLabel: trialDifficulty.label,
         encounters: encountersForRun,
+        startTime: run.startTime,
+        endTime: run.endTime,
+        runLabel: (zoneRunTotals.get(run.zone.name) ?? 1) > 1 ? `Run ${ordinal}` : null,
       };
     });
   }, [fights, reportData]);
@@ -450,8 +461,6 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
     // Handle both boss fights and trash fights (encounterID-based, see fightGrouping.isBossFight)
     const fightIsBoss = isBossFight(fight);
 
-    let bossWasKilled: boolean;
-    let isFalsePositive: boolean;
     let isWipe: boolean;
     let bossHealthPercent: number;
     let backgroundFillPercent: number;
@@ -459,8 +468,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
     if (fightIsBoss) {
       // Boss fight logic — use the API's authoritative `kill` flag (see fightGrouping.wasKill).
       // This replaces the old `bossPercentage`-based heuristic + false-positive detection.
-      bossWasKilled = wasKill(fight);
-      isFalsePositive = false;
+      const bossWasKilled = wasKill(fight);
       isWipe = !bossWasKilled;
       const remaining = bossHealthRemaining(fight);
       bossHealthPercent = remaining != null ? Math.round(remaining) : 0;
@@ -471,8 +479,6 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
       // Trash fight logic - use the kill field to determine success/wipe
       // kill === true means success, kill === false means wipe, kill === null means unknown (treat as successful)
       const wasKilled = fight.kill === true || fight.kill === null;
-      bossWasKilled = false; // Trash fights don't have a "boss"
-      isFalsePositive = false; // No false positive detection for trash
       isWipe = fight.kill === false;
       bossHealthPercent = 0;
       backgroundFillPercent = wasKilled ? 100 : 0; // Full bar if successful, empty if wipe
@@ -482,35 +488,25 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
     // green for kills (green = complete).
     const accentBarColor = isWipe
       ? getWipeHealthGradientColor(bossHealthPercent)
-      : isFalsePositive
-        ? darkMode
-          ? '#64748b'
-          : '#94a3b8'
-        : darkMode
-          ? '#4ade80'
-          : '#10b981';
+      : darkMode
+        ? '#4ade80'
+        : '#10b981';
 
     const accentGlow = accentBarColor + '66';
 
     // Status color — for wipes, match the smooth accent gradient so the %
-    // text gradually shifts from red (high boss HP left) to green (almost killed)
+    // text gradually shifts with boss HP remaining
     const statusColor = isWipe
       ? getWipeHealthGradientColor(bossHealthPercent)
-      : isFalsePositive
-        ? darkMode
-          ? '#64748b'
-          : '#94a3b8'
-        : darkMode
-          ? '#4ade80'
-          : '#059669';
+      : darkMode
+        ? '#4ade80'
+        : '#059669';
 
     // Glass background tint based on status
     const glassBg = darkMode
       ? isWipe
         ? 'rgba(255, 60, 60, 0.06)'
-        : isFalsePositive
-          ? 'rgba(100, 116, 139, 0.06)'
-          : 'rgba(74, 222, 128, 0.06)'
+        : 'rgba(74, 222, 128, 0.06)'
       : 'rgba(255, 255, 255, 0.6)';
 
     const borderColor = darkMode ? `${accentBarColor}30` : `${accentBarColor}20`;
@@ -584,7 +580,7 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               right: `${100 - backgroundFillPercent}%`,
               background: isWipe
                 ? getWipeHealthGradientBackground(bossHealthPercent, darkMode)
-                : fight.difficulty == null || isFalsePositive
+                : !fightIsBoss
                   ? getThemeColors.trashGradient
                   : getThemeColors.killGradient,
               borderRadius: '8px',
@@ -655,8 +651,8 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
               >
                 #{idx + 1}
               </Typography>
-              {/* Status badge — hidden for false positives */}
-              {fightIsBoss && !isFalsePositive && (
+              {/* Status badge — boss fights only */}
+              {fightIsBoss && (
                 <Box
                   sx={{
                     display: 'inline-flex',
@@ -952,10 +948,63 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                                 {difficultyLabel}
                               </Box>
                             )}
+                            {(trialRun.contentType === 'dungeon' ||
+                              trialRun.contentType === 'arena') && (
+                              <Box
+                                component="span"
+                                sx={{
+                                  fontWeight: 600,
+                                  color: 'text.secondary',
+                                  border: (t: Theme) => `1px solid ${t.palette.divider}`,
+                                  px: 0.75,
+                                  py: 0.25,
+                                  borderRadius: 1,
+                                  fontSize: '0.7em',
+                                  letterSpacing: '0.06em',
+                                  textTransform: 'uppercase',
+                                  flexShrink: 0,
+                                }}
+                              >
+                                {trialRun.contentType === 'dungeon' ? 'Dungeon' : 'Arena'}
+                              </Box>
+                            )}
+                            {trialRun.runLabel && (
+                              <Box
+                                component="span"
+                                sx={{
+                                  fontWeight: 600,
+                                  color: 'text.secondary',
+                                  backgroundColor: (t: Theme) =>
+                                    t.palette.mode === 'dark'
+                                      ? 'rgba(255,255,255,0.08)'
+                                      : 'rgba(15,23,42,0.06)',
+                                  px: 0.75,
+                                  py: 0.25,
+                                  borderRadius: 1,
+                                  fontSize: '0.75em',
+                                  flexShrink: 0,
+                                }}
+                              >
+                                {trialRun.runLabel}
+                              </Box>
+                            )}
                           </>
                         );
                       })()}
                     </Typography>
+                    {reportStartTime != null && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+                          letterSpacing: '0.03em',
+                        }}
+                      >
+                        {formatTimestamp(trialRun.startTime, reportStartTime)} –{' '}
+                        {formatTimestamp(trialRun.endTime, reportStartTime)}
+                      </Typography>
+                    )}
                   </Box>
                   <Box
                     sx={{
@@ -1099,14 +1148,14 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
                           >
                             {encounter.name}{' '}
                             {(() => {
-                              // Get difficulty from the first boss fight
-                              const bossFight = encounter.bossFights.find(
-                                (f) => f.difficulty != null,
-                              );
-                              if (bossFight && bossFight.difficulty != null) {
+                              // Difficulty this boss was completed at — the kill's
+                              // difficulty, not the first attempt's (a Veteran wipe
+                              // before an HM kill must still read "Veteran HM").
+                              const difficultyCode = encounterResultDifficulty(encounter);
+                              if (difficultyCode > 0) {
                                 const trialName = trialRun.trialName || '';
                                 const difficultyLabel = getDifficultyLabel(
-                                  bossFight.difficulty,
+                                  difficultyCode,
                                   trialName,
                                 );
                                 return (

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -22,11 +22,7 @@ import { ReportActionBar } from '../../components/ReportActionBar';
 import { ReportFightsSkeleton } from '../../components/ReportFightsSkeleton';
 import { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
 import { RootState } from '../../store/storeWithHistory';
-import {
-  getDifficultyLabel,
-  getTrialNameFromBoss,
-  isFalsePositiveWipe,
-} from '../../utils/trialClassification';
+import { getDifficultyLabel } from '../../utils/trialClassification';
 
 import { BossAvatar } from './BossAvatar';
 import {

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -117,6 +117,30 @@ describe('resolveFightZone', () => {
     expect(zone.name).toBe('Fungal Grotto I');
     expect(zone.zoneId).toBe(ZONE_DUNGEON);
   });
+
+  it('prefers the raw gameZone over the boss-name fallback (dungeon boss with a trial token)', () => {
+    // "The Mage's Twin Serpent" hits several trial tokens ('the mage',
+    // 'serpent', 'twins') — but the fight carries a real dungeon gameZone, and
+    // the per-fight API signal must win.
+    const zone = resolveFightZone(
+      makeFight({
+        gameZone: { id: ZONE_DUNGEON, name: 'Fungal Grotto I' },
+        name: "The Mage's Twin Serpent",
+        encounterID: 500,
+      }),
+    );
+    expect(zone.type).toBe('dungeon');
+    expect(zone.name).toBe('Fungal Grotto I');
+    expect(zone.zoneId).toBe(ZONE_DUNGEON);
+  });
+
+  it('resolves a name-only gameZone that matches a canonical trial', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: { id: null, name: 'Sunspire' }, encounterID: 21 }),
+    );
+    expect(zone.type).toBe('trial');
+    expect(zone.zoneId).toBe(ZONE_SUNSPIRE);
+  });
 });
 
 describe('groupFightsIntoRuns', () => {

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -1,0 +1,259 @@
+import type { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
+
+import {
+  buildRunEncounters,
+  effectiveEncounterId,
+  groupFightsIntoRuns,
+  isBossFight,
+  resolveFightZone,
+  trialNameFromBossName,
+  uncategorizedTrash,
+  wasKill,
+} from './fightGrouping';
+
+// In-game zone IDs from ZONE_NAMES / zoneScaleData.
+const ZONE_SUNSPIRE = 1121;
+const ZONE_CLOUDREST = 1051;
+const ZONE_KYNES_AEGIS = 1196;
+const ZONE_DUNGEON = 999999; // not a known trial → treated as dungeon
+
+let nextId = 1;
+
+function makeFight(overrides: Partial<FightFragment> = {}): FightFragment {
+  const id = overrides.id ?? nextId++;
+  return {
+    __typename: 'ReportFight',
+    id,
+    name: 'Boss',
+    difficulty: 121,
+    startTime: 0,
+    endTime: 60_000,
+    kill: true,
+    encounterID: 21,
+    originalEncounterID: null,
+    bossPercentage: 0,
+    gameZone: { __typename: 'GameZone', id: ZONE_SUNSPIRE, name: 'Sunspire' },
+    ...overrides,
+  } as FightFragment;
+}
+
+const reportData = { zone: { name: 'Sunspire' } } as ReportFragment;
+
+describe('boss vs trash classification', () => {
+  it('treats encounterID !== 0 as a boss', () => {
+    expect(isBossFight(makeFight({ encounterID: 21, difficulty: null }))).toBe(true);
+  });
+
+  it('treats encounterID 0 with no difficulty as trash', () => {
+    expect(isBossFight(makeFight({ encounterID: 0, difficulty: null }))).toBe(false);
+  });
+
+  it('treats a boss demoted to trash (originalEncounterID) as a boss', () => {
+    expect(
+      isBossFight(makeFight({ encounterID: 0, originalEncounterID: 21, difficulty: null })),
+    ).toBe(true);
+    expect(effectiveEncounterId(makeFight({ encounterID: 0, originalEncounterID: 21 }))).toBe(21);
+  });
+
+  it('keeps difficulty-tagged bosses even if encounterID is 0', () => {
+    expect(isBossFight(makeFight({ encounterID: 0, difficulty: 122 }))).toBe(true);
+  });
+});
+
+describe('kill detection', () => {
+  it('uses the authoritative kill flag', () => {
+    expect(wasKill(makeFight({ kill: true, bossPercentage: 100 }))).toBe(true);
+    expect(wasKill(makeFight({ kill: false, bossPercentage: 0 }))).toBe(false);
+  });
+
+  it('falls back to bossPercentage when kill is null', () => {
+    expect(wasKill(makeFight({ kill: null, bossPercentage: 0.5 }))).toBe(true);
+    expect(wasKill(makeFight({ kill: null, bossPercentage: 40 }))).toBe(false);
+  });
+});
+
+describe('trialNameFromBossName', () => {
+  it('matches known bosses with instance suffixes', () => {
+    expect(trialNameFromBossName('Lord Falgravn #2')).toBe("Kyne's Aegis");
+    expect(trialNameFromBossName('Yolnahkriin')).toBe('Sunspire');
+  });
+
+  it('returns null for unknown bosses', () => {
+    expect(trialNameFromBossName('Some Dungeon Boss')).toBeNull();
+    expect(trialNameFromBossName('')).toBeNull();
+  });
+});
+
+describe('resolveFightZone', () => {
+  it('resolves a known trial by gameZone id', () => {
+    const zone = resolveFightZone(makeFight({ gameZone: { id: ZONE_KYNES_AEGIS, name: 'x' } }));
+    expect(zone.name).toBe("Kyne's Aegis");
+    expect(zone.type).toBe('trial');
+    expect(zone.expectedBossCount).toBe(3);
+  });
+
+  it('falls back to boss-name when gameZone is missing', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: null, name: 'Nahviintaas', encounterID: 21 }),
+    );
+    expect(zone.name).toBe('Sunspire');
+    expect(zone.type).toBe('trial');
+  });
+
+  it('treats an unknown gameZone as a dungeon and labels it from the API name', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: { id: ZONE_DUNGEON, name: 'Fungal Grotto I' }, encounterID: 500 }),
+    );
+    expect(zone.type).toBe('dungeon');
+    expect(zone.name).toBe('Fungal Grotto I');
+    expect(zone.zoneId).toBe(ZONE_DUNGEON);
+  });
+});
+
+describe('groupFightsIntoRuns', () => {
+  it('groups one trial into a single run', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 22,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].zone.name).toBe('Sunspire');
+    expect(runs[0].fights).toHaveLength(2);
+  });
+
+  it('separates a log that mixes two different trials', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' } }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        gameZone: { id: ZONE_CLOUDREST, name: 'Cloudrest' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(2);
+    expect(runs.map((r) => r.zone.name)).toEqual(['Sunspire', 'Cloudrest']);
+  });
+
+  it('separates a trial followed by a dungeon', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' } }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 500,
+        gameZone: { id: ZONE_DUNGEON, name: 'Fungal Grotto I' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(2);
+    expect(runs[1].zone.type).toBe('dungeon');
+  });
+
+  it('starts a new run when a killed boss is re-cleared in the same zone', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        kill: true,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 21,
+        kill: true,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(2);
+  });
+
+  it('keeps multiple wipe attempts on the same boss in one run', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, encounterID: 21, kill: false, bossPercentage: 30 }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 21,
+        kill: false,
+        bossPercentage: 10,
+      }),
+      makeFight({ startTime: 4000, endTime: 5000, encounterID: 21, kill: true, bossPercentage: 0 }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].fights).toHaveLength(3);
+  });
+
+  it('attaches inter-zone trash (no gameZone) to the current run without splitting', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+      makeFight({
+        startTime: 1500,
+        endTime: 1800,
+        encounterID: 0,
+        difficulty: null,
+        gameZone: null,
+        name: 'Trash',
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 22,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].fights).toHaveLength(3);
+  });
+});
+
+describe('buildRunEncounters', () => {
+  it('groups attempts of the same boss by encounterID and associates trash', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 0,
+        difficulty: null,
+        name: 'Pre Trash',
+      }),
+      makeFight({ startTime: 1000, endTime: 2000, encounterID: 21, kill: false, name: 'Boss A' }),
+      makeFight({ startTime: 2000, endTime: 3000, encounterID: 21, kill: true, name: 'Boss A' }),
+      makeFight({
+        startTime: 3000,
+        endTime: 3500,
+        encounterID: 0,
+        difficulty: null,
+        name: 'Mid Trash',
+      }),
+      makeFight({ startTime: 4000, endTime: 5000, encounterID: 22, kill: true, name: 'Boss B' }),
+    ];
+    const [run] = groupFightsIntoRuns(fights, reportData);
+    const encounters = buildRunEncounters(run);
+    expect(encounters).toHaveLength(2);
+    expect(encounters[0].bossFights).toHaveLength(2); // two attempts on Boss A
+    expect(encounters[0].preTrash).toHaveLength(1);
+    expect(uncategorizedTrash(run, encounters)).toHaveLength(0);
+  });
+});

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -20,6 +20,8 @@ import {
 const ZONE_SUNSPIRE = 1121;
 const ZONE_CLOUDREST = 1051;
 const ZONE_KYNES_AEGIS = 1196;
+const ZONE_HRC = 636;
+const ZONE_AA = 638;
 const ZONE_DUNGEON = 999999; // not a known trial → treated as dungeon
 
 let nextId = 1;
@@ -341,6 +343,116 @@ describe('summarizeEncounter', () => {
     const s = summarizeEncounter(encounter);
     expect(s.killed).toBe(false);
     expect(s.bestPercent).toBe(18);
+  });
+});
+
+describe('edge cases', () => {
+  it('separates three distinct trials in one log, in order', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, gameZone: { id: ZONE_AA, name: 'AA' } }),
+      makeFight({ startTime: 2000, endTime: 3000, gameZone: { id: ZONE_HRC, name: 'HRC' } }),
+      makeFight({ startTime: 4000, endTime: 5000, gameZone: { id: ZONE_SUNSPIRE, name: 'SS' } }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs.map((r) => r.zone.name)).toEqual([
+      'Aetherian Archive',
+      'Hel Ra Citadel',
+      'Sunspire',
+    ]);
+  });
+
+  it('treats returning to an earlier zone (A → B → A) as three separate runs', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, gameZone: { id: ZONE_SUNSPIRE, name: 'SS' } }),
+      makeFight({ startTime: 2000, endTime: 3000, gameZone: { id: ZONE_CLOUDREST, name: 'CR' } }),
+      makeFight({ startTime: 4000, endTime: 5000, gameZone: { id: ZONE_SUNSPIRE, name: 'SS' } }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs.map((r) => r.zone.name)).toEqual(['Sunspire', 'Cloudrest', 'Sunspire']);
+  });
+
+  it('is order-independent (sorts by start time)', () => {
+    const fights = [
+      makeFight({
+        startTime: 4000,
+        endTime: 5000,
+        encounterID: 22,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'SS' },
+      }),
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'SS' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].fights.map((f) => f.startTime)).toEqual([0, 4000]);
+  });
+
+  it('classifies known arenas as arenas, not dungeons', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: { id: 1234567, name: 'Maelstrom Arena' }, encounterID: 900 }),
+    );
+    expect(zone.type).toBe('arena');
+    expect(zone.name).toBe('Maelstrom Arena');
+  });
+
+  it('resolves a full no-gameZone (legacy) log via boss names', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        gameZone: null,
+        name: 'Yolnahkriin',
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 23,
+        gameZone: null,
+        name: 'Nahviintaas',
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, { zone: { name: 'Sunspire' } } as ReportFragment);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].zone.name).toBe('Sunspire');
+  });
+
+  it('returns a single bossless run for a trash-only log', () => {
+    const fights = [
+      makeFight({ startTime: 0, endTime: 1000, encounterID: 0, difficulty: null, name: 'Trash A' }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 0,
+        difficulty: null,
+        name: 'Trash B',
+      }),
+    ];
+    const [run] = groupFightsIntoRuns(fights, reportData);
+    const encounters = buildRunEncounters(run);
+    expect(encounters).toHaveLength(0);
+    expect(uncategorizedTrash(run, encounters)).toHaveLength(2);
+  });
+
+  it('returns [] for empty / null input', () => {
+    expect(groupFightsIntoRuns([], reportData)).toEqual([]);
+    expect(groupFightsIntoRuns(null, reportData)).toEqual([]);
+    expect(groupFightsIntoRuns(undefined, reportData)).toEqual([]);
+  });
+
+  it('drops zero-duration / invalid fights', () => {
+    const fights = [
+      makeFight({ startTime: 1000, endTime: 1000 }), // zero duration
+      makeFight({ startTime: 2000, endTime: 1500 }), // negative
+      makeFight({ startTime: 0, endTime: 1000, encounterID: 21 }), // valid
+    ];
+    const runs = groupFightsIntoRuns(fights, reportData);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].fights).toHaveLength(1);
   });
 });
 

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import type { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
 
 import {
@@ -5,7 +8,9 @@ import {
   effectiveEncounterId,
   groupFightsIntoRuns,
   isBossFight,
+  isResetPull,
   resolveFightZone,
+  summarizeEncounter,
   trialNameFromBossName,
   uncategorizedTrash,
   wasKill,
@@ -48,10 +53,12 @@ describe('boss vs trash classification', () => {
     expect(isBossFight(makeFight({ encounterID: 0, difficulty: null }))).toBe(false);
   });
 
-  it('treats a boss demoted to trash (originalEncounterID) as a boss', () => {
+  it('treats a fight ESO Logs demoted to trash (encounterID 0) as trash', () => {
+    // Demoted fights are post-kill / instant-reset noise, not phantom attempts.
     expect(
       isBossFight(makeFight({ encounterID: 0, originalEncounterID: 21, difficulty: null })),
-    ).toBe(true);
+    ).toBe(false);
+    // The original id is still recoverable for callers that need it.
     expect(effectiveEncounterId(makeFight({ encounterID: 0, originalEncounterID: 21 }))).toBe(21);
   });
 
@@ -161,7 +168,7 @@ describe('groupFightsIntoRuns', () => {
     expect(runs[1].zone.type).toBe('dungeon');
   });
 
-  it('starts a new run when a killed boss is re-cleared in the same zone', () => {
+  it('keeps same-zone re-clears in one run by default (farm/reset logs)', () => {
     const fights = [
       makeFight({
         startTime: 0,
@@ -178,8 +185,27 @@ describe('groupFightsIntoRuns', () => {
         gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
       }),
     ];
-    const runs = groupFightsIntoRuns(fights, reportData);
-    expect(runs).toHaveLength(2);
+    expect(groupFightsIntoRuns(fights, reportData)).toHaveLength(1);
+  });
+
+  it('splits re-clears into separate runs only when splitReclears is set', () => {
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 21,
+        kill: true,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 3000,
+        encounterID: 21,
+        kill: true,
+        gameZone: { id: ZONE_SUNSPIRE, name: 'Sunspire' },
+      }),
+    ];
+    expect(groupFightsIntoRuns(fights, reportData, { splitReclears: true })).toHaveLength(2);
   });
 
   it('keeps multiple wipe attempts on the same boss in one run', () => {
@@ -255,5 +281,116 @@ describe('buildRunEncounters', () => {
     expect(encounters[0].bossFights).toHaveLength(2); // two attempts on Boss A
     expect(encounters[0].preTrash).toHaveLength(1);
     expect(uncategorizedTrash(run, encounters)).toHaveLength(0);
+  });
+});
+
+describe('isResetPull', () => {
+  it('flags a short pull that barely dented the boss as a reset', () => {
+    expect(
+      isResetPull(makeFight({ startTime: 0, endTime: 8_000, kill: false, bossPercentage: 99 })),
+    ).toBe(true);
+  });
+
+  it('does not flag a long, deep wipe as a reset', () => {
+    expect(
+      isResetPull(makeFight({ startTime: 0, endTime: 120_000, kill: false, bossPercentage: 20 })),
+    ).toBe(false);
+  });
+
+  it('never flags a kill as a reset', () => {
+    expect(
+      isResetPull(makeFight({ startTime: 0, endTime: 5_000, kill: true, bossPercentage: 0 })),
+    ).toBe(false);
+  });
+});
+
+describe('summarizeEncounter', () => {
+  it('summarises attempts, kills, resets and best pull', () => {
+    const encounter = {
+      id: 'e',
+      name: 'Boss',
+      preTrash: [],
+      postTrash: [],
+      bossFights: [
+        makeFight({ startTime: 0, endTime: 6_000, kill: false, bossPercentage: 99 }), // reset
+        makeFight({ startTime: 0, endTime: 90_000, kill: false, bossPercentage: 40 }), // wipe
+        makeFight({ startTime: 0, endTime: 90_000, kill: false, bossPercentage: 12 }), // closer wipe
+        makeFight({ startTime: 0, endTime: 90_000, kill: true, bossPercentage: 0 }), // kill
+      ],
+    };
+    const s = summarizeEncounter(encounter);
+    expect(s.attempts).toBe(4);
+    expect(s.resets).toBe(1);
+    expect(s.realAttempts).toBe(3);
+    expect(s.kills).toBe(1);
+    expect(s.killed).toBe(true);
+    expect(s.bestPercent).toBe(0); // killed
+  });
+
+  it('reports best pull when the boss was never killed', () => {
+    const encounter = {
+      id: 'e',
+      name: 'Boss',
+      preTrash: [],
+      postTrash: [],
+      bossFights: [
+        makeFight({ startTime: 0, endTime: 90_000, kill: false, bossPercentage: 55 }),
+        makeFight({ startTime: 0, endTime: 90_000, kill: false, bossPercentage: 18 }),
+      ],
+    };
+    const s = summarizeEncounter(encounter);
+    expect(s.killed).toBe(false);
+    expect(s.bestPercent).toBe(18);
+  });
+});
+
+// ── End-to-end checks against real committed ESO Logs reports ──────────────
+function loadSampleReport(code: string): { report: ReportFragment; fights: FightFragment[] } {
+  const file = path.resolve(process.cwd(), 'public/sample-reports', code, 'report.json');
+  const raw = fs.readFileSync(file, 'utf8').replace(/^﻿/, '');
+  const json = JSON.parse(raw);
+  const report = (json?.reportData?.report ?? json?.data?.reportData?.report) as ReportFragment;
+  const fights = ((report as unknown as { fights?: FightFragment[] })?.fights ??
+    []) as FightFragment[];
+  return { report, fights };
+}
+
+describe('integration: real sample reports', () => {
+  it('DSR reset farm → one Dreadsail Reef run with grouped, multi-kill encounters', () => {
+    const { report, fights } = loadSampleReport('F4f2bMwWtgVKxjB9');
+    const runs = groupFightsIntoRuns(fights, report);
+
+    // 57 fights of the same group resetting the trial all stay in ONE run.
+    expect(runs).toHaveLength(1);
+    expect(runs[0].zone.name).toBe('Dreadsail Reef');
+    expect(runs[0].zone.type).toBe('trial');
+
+    const encounters = buildRunEncounters(runs[0]);
+    const lylanar = encounters.find((e) => e.name.includes('Lylanar'));
+    expect(lylanar).toBeDefined();
+    const s = summarizeEncounter(lylanar!);
+    expect(s.attempts).toBeGreaterThanOrEqual(5); // farmed many times
+    expect(s.kills).toBeGreaterThanOrEqual(2); // killed on multiple resets
+    expect(s.killed).toBe(true);
+
+    // Demoted (encounterID 0) post-kill fights must not appear as boss attempts.
+    expect(lylanar!.bossFights.every((f) => (f.encounterID ?? 0) !== 0)).toBe(true);
+  });
+
+  it('VSE progression → one run; 30+ Yaseyla attempts incl. resets, eventual kill', () => {
+    const { report, fights } = loadSampleReport('YArFDbq7BdhwL691');
+    const runs = groupFightsIntoRuns(fights, report);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].zone.name).toBe("Sanity's Edge");
+
+    const encounters = buildRunEncounters(runs[0]);
+    const yaseyla = encounters.find((e) => e.name.includes('Yaseyla'));
+    expect(yaseyla).toBeDefined();
+    const s = summarizeEncounter(yaseyla!);
+    expect(s.attempts).toBeGreaterThan(30); // long prog boss
+    expect(s.resets).toBeGreaterThan(0); // quick re-pulls detected
+    expect(s.realAttempts).toBeLessThan(s.attempts);
+    expect(s.killed).toBe(true);
   });
 });

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -141,6 +141,23 @@ describe('resolveFightZone', () => {
     expect(zone.type).toBe('trial');
     expect(zone.zoneId).toBe(ZONE_SUNSPIRE);
   });
+
+  it('enriches a recognised dungeon with its expected boss count from the curated rosters', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: { id: ZONE_DUNGEON, name: 'Bal Sunnar' }, encounterID: 500 }),
+    );
+    expect(zone.type).toBe('dungeon');
+    // Kovan Giryon, Roksa the Warped, Matriarch Lladi Telvanni
+    expect(zone.expectedBossCount).toBe(3);
+  });
+
+  it('leaves expectedBossCount undefined for an unrecognised dungeon name', () => {
+    const zone = resolveFightZone(
+      makeFight({ gameZone: { id: ZONE_DUNGEON, name: 'Some Future Dungeon' }, encounterID: 500 }),
+    );
+    expect(zone.type).toBe('dungeon');
+    expect(zone.expectedBossCount).toBeUndefined();
+  });
 });
 
 describe('groupFightsIntoRuns', () => {

--- a/src/features/report_details/fightGrouping.test.ts
+++ b/src/features/report_details/fightGrouping.test.ts
@@ -254,6 +254,103 @@ describe('groupFightsIntoRuns', () => {
     expect(runs).toHaveLength(1);
     expect(runs[0].fights).toHaveLength(3);
   });
+
+  it('keeps no-gameZone fights with an id-keyed dungeon run of the same name', () => {
+    // In a dungeon log the report-level zone name matches the dungeon, but the
+    // name-keyed fallback (`name:bal sunnar`) differs from the id key
+    // (`zone:1564`) — that mismatch must not split the run.
+    const dungeonReport = { zone: { name: 'Bal Sunnar' } } as ReportFragment;
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 60_000,
+        encounterID: 71,
+        gameZone: { id: 1564, name: 'Bal Sunnar' },
+      }),
+      makeFight({
+        startTime: 61_000,
+        endTime: 62_000,
+        encounterID: 0,
+        difficulty: null,
+        gameZone: null,
+        name: 'Trash',
+      }),
+      makeFight({
+        startTime: 63_000,
+        endTime: 120_000,
+        encounterID: 72,
+        gameZone: { id: 1564, name: 'Bal Sunnar' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, dungeonReport);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].fights).toHaveLength(3);
+    expect(runs[0].zone.zoneId).toBe(1564);
+  });
+
+  it('does not let the report-level zone fallback shatter another zone’s run (mixed log)', () => {
+    // Mixed log whose report-level zone is Dreadsail Reef. Mid-dungeon trash
+    // with no gameZone resolves to the report zone — that must NOT split the
+    // dungeon run (previously produced DSR → Bal Sunnar → DSR → Bal Sunnar).
+    const mixedReport = { zone: { name: 'Dreadsail Reef' } } as ReportFragment;
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 60_000,
+        encounterID: 31,
+        gameZone: { id: 1344, name: 'Dreadsail Reef' },
+      }),
+      makeFight({
+        startTime: 100_000,
+        endTime: 160_000,
+        encounterID: 71,
+        gameZone: { id: 1564, name: 'Bal Sunnar' },
+      }),
+      makeFight({
+        startTime: 161_000,
+        endTime: 162_000,
+        encounterID: 0,
+        difficulty: null,
+        gameZone: null,
+        name: 'Trash',
+      }),
+      makeFight({
+        startTime: 163_000,
+        endTime: 220_000,
+        encounterID: 72,
+        gameZone: { id: 1564, name: 'Bal Sunnar' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, mixedReport);
+    expect(runs).toHaveLength(2);
+    expect(runs[0].zone.name).toBe('Dreadsail Reef');
+    expect(runs[1].zone.name).toBe('Bal Sunnar');
+    expect(runs[1].fights).toHaveLength(3);
+  });
+
+  it('upgrades a run started from the name fallback once an id-keyed fight arrives', () => {
+    const dungeonReport = { zone: { name: 'Bal Sunnar' } } as ReportFragment;
+    const fights = [
+      makeFight({
+        startTime: 0,
+        endTime: 1000,
+        encounterID: 0,
+        difficulty: null,
+        gameZone: null,
+        name: 'Trash',
+      }),
+      makeFight({
+        startTime: 2000,
+        endTime: 60_000,
+        encounterID: 71,
+        gameZone: { id: 1564, name: 'Bal Sunnar' },
+      }),
+    ];
+    const runs = groupFightsIntoRuns(fights, dungeonReport);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].zone.zoneId).toBe(1564);
+    expect(runs[0].zone.key).toBe('zone:1564');
+  });
 });
 
 describe('buildRunEncounters', () => {

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -195,6 +195,13 @@ export interface ResolvedZone {
   type: ContentType;
   shortName?: string;
   expectedBossCount?: number;
+  /**
+   * True when the zone came from the report-level zone name rather than from
+   * the fight itself. The report zone is report-wide, so in a mixed log it is
+   * wrong for every fight outside the "main" zone — grouping must treat these
+   * as weak evidence (attach to the current run, never force a split).
+   */
+  fromReportFallback?: boolean;
 }
 
 const UNKNOWN_ZONE: ResolvedZone = {
@@ -280,7 +287,8 @@ export function resolveFightZone(
     };
   }
 
-  // 4. Report-level zone name.
+  // 4. Report-level zone name (weak: report-wide, so wrong for every fight
+  //    outside the main zone of a mixed log — see `fromReportFallback`).
   const reportZoneName = reportData?.zone?.name;
   if (reportZoneName) {
     const byName = ZONE_BY_NAME.get(reportZoneName.toLowerCase());
@@ -292,6 +300,7 @@ export function resolveFightZone(
         type: byName.type,
         shortName: byName.shortName,
         expectedBossCount: byName.expectedBossCount,
+        fromReportFallback: true,
       };
     }
     return {
@@ -299,6 +308,7 @@ export function resolveFightZone(
       zoneId: null,
       name: reportZoneName,
       type: 'unknown',
+      fromReportFallback: true,
     };
   }
 
@@ -356,12 +366,30 @@ export function groupFightsIntoRuns(
     const boss = isBossFight(fight);
     const encId = effectiveEncounterId(fight);
 
-    const zoneKnown = zone.zoneId != null || zone.key.startsWith('name:');
+    // Report-fallback zones are weak evidence (report-wide, wrong for every
+    // fight outside a mixed log's main zone): they can seed/label a run but
+    // never force a split away from one.
+    const zoneKnown =
+      !zone.fromReportFallback && (zone.zoneId != null || zone.key.startsWith('name:'));
     const currentKnown =
-      current != null && (current.zone.zoneId != null || current.zone.key.startsWith('name:'));
+      current != null &&
+      !current.zone.fromReportFallback &&
+      (current.zone.zoneId != null || current.zone.key.startsWith('name:'));
+
+    // A name-keyed fallback zone (e.g. a `gameZone` with a name but no id) must
+    // not split away from an id-keyed run of the same content — compare by
+    // display name when either side is name-keyed.
+    const sameContentByName =
+      current != null &&
+      zone.name.toLowerCase() === current.zone.name.toLowerCase() &&
+      (zone.key.startsWith('name:') || current.zone.key.startsWith('name:'));
 
     const zoneChanged =
-      current != null && zoneKnown && currentKnown && zone.key !== current.zone.key;
+      current != null &&
+      zoneKnown &&
+      currentKnown &&
+      zone.key !== current.zone.key &&
+      !sameContentByName;
     // Only treat a *kill* of an already-killed boss as a re-clear, and only when
     // the caller opts in.
     const reclear =
@@ -378,8 +406,12 @@ export function groupFightsIntoRuns(
       };
       runs.push(current);
       killedBossEncounters = new Set();
-    } else if (!currentKnown && zoneKnown) {
-      // Upgrade a run that started before its zone was identifiable.
+    } else if (
+      zoneKnown &&
+      (!currentKnown || (sameContentByName && current.zone.zoneId == null && zone.zoneId != null))
+    ) {
+      // Upgrade a run whose zone was not yet known, or that started from the
+      // name-keyed fallback, once an id-keyed fight identifies it precisely.
       current.zone = zone;
       current.id = `${zone.key}#${runSeq}`;
     }

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -204,6 +204,20 @@ const UNKNOWN_ZONE: ResolvedZone = {
   type: 'unknown',
 };
 
+/** Lowercased name fragments for the solo/group arenas (not trials or dungeons). */
+const ARENA_NAME_TOKENS: readonly string[] = [
+  'maelstrom arena',
+  'vateshran hollows',
+  'dragonstar arena',
+  'blackrose prison',
+];
+
+/** Classify an unrecognised (non-trial) zone as an arena or a dungeon by name. */
+function classifyUnknownZone(name: string | null | undefined): ContentType {
+  const n = (name ?? '').toLowerCase();
+  return ARENA_NAME_TOKENS.some((token) => n.includes(token)) ? 'arena' : 'dungeon';
+}
+
 /**
  * Resolve which trial/dungeon a fight belongs to, in priority order:
  *   1. `gameZone.id` matched against the canonical content table (most reliable).
@@ -247,17 +261,23 @@ export function resolveFightZone(
     }
   }
 
-  // 3. Raw gameZone — an unrecognised zone (typically a dungeon). Group by its id.
+  // 3. Raw gameZone — an unrecognised zone (a dungeon, or a solo/group arena).
+  //    Group by its id; classify arenas by name so they aren't called dungeons.
   if (gz?.id) {
     return {
       key: `zone:${gz.id}`,
       zoneId: gz.id,
       name: gz.name || reportData?.zone?.name || 'Unknown Zone',
-      type: 'dungeon',
+      type: classifyUnknownZone(gz.name),
     };
   }
   if (gz?.name) {
-    return { key: `name:${gz.name.toLowerCase()}`, zoneId: null, name: gz.name, type: 'dungeon' };
+    return {
+      key: `name:${gz.name.toLowerCase()}`,
+      zoneId: null,
+      name: gz.name,
+      type: classifyUnknownZone(gz.name),
+    };
   }
 
   // 4. Report-level zone name.

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -228,9 +228,11 @@ function classifyUnknownZone(name: string | null | undefined): ContentType {
 /**
  * Resolve which trial/dungeon a fight belongs to, in priority order:
  *   1. `gameZone.id` matched against the canonical content table (most reliable).
- *   2. Boss-name → trial fallback (legacy logs without `gameZone`).
- *   3. The raw `gameZone` (id/name) as a dungeon/unknown zone — no static table
- *      needed, so dungeons still group and label correctly.
+ *   2. The raw `gameZone` (id/name) as a dungeon/unknown zone — the per-fight
+ *      API signal always outranks name heuristics, so a dungeon boss whose name
+ *      happens to contain a trial token ("the mage", "serpent", …) is never
+ *      mislabeled as a trial.
+ *   3. Boss-name → trial fallback (legacy logs with no `gameZone` at all).
  *   4. The report-level zone name.
  */
 export function resolveFightZone(
@@ -252,7 +254,39 @@ export function resolveFightZone(
     };
   }
 
-  // 2. Boss-name fallback (only for recognised trial bosses).
+  // 2. Raw gameZone — an unrecognised zone (a dungeon, or a solo/group arena).
+  //    Group by its id; classify arenas by name so they aren't called dungeons.
+  if (gz?.id) {
+    return {
+      key: `zone:${gz.id}`,
+      zoneId: gz.id,
+      name: gz.name || reportData?.zone?.name || 'Unknown Zone',
+      type: classifyUnknownZone(gz.name),
+    };
+  }
+  if (gz?.name) {
+    // A name-only gameZone can still match a canonical trial by name.
+    const byName = ZONE_BY_NAME.get(gz.name.toLowerCase());
+    if (byName) {
+      return {
+        key: `zone:${byName.zoneId}`,
+        zoneId: byName.zoneId,
+        name: byName.name,
+        type: byName.type,
+        shortName: byName.shortName,
+        expectedBossCount: byName.expectedBossCount,
+      };
+    }
+    return {
+      key: `name:${gz.name.toLowerCase()}`,
+      zoneId: null,
+      name: gz.name,
+      type: classifyUnknownZone(gz.name),
+    };
+  }
+
+  // 3. Boss-name fallback — only for legacy logs with no `gameZone` at all,
+  //    and only for recognised trial bosses.
   if (isBossFight(fight)) {
     const trialName = trialNameFromBossName(fight.name);
     const byName = trialName ? ZONE_BY_NAME.get(trialName.toLowerCase()) : undefined;
@@ -266,25 +300,6 @@ export function resolveFightZone(
         expectedBossCount: byName.expectedBossCount,
       };
     }
-  }
-
-  // 3. Raw gameZone — an unrecognised zone (a dungeon, or a solo/group arena).
-  //    Group by its id; classify arenas by name so they aren't called dungeons.
-  if (gz?.id) {
-    return {
-      key: `zone:${gz.id}`,
-      zoneId: gz.id,
-      name: gz.name || reportData?.zone?.name || 'Unknown Zone',
-      type: classifyUnknownZone(gz.name),
-    };
-  }
-  if (gz?.name) {
-    return {
-      key: `name:${gz.name.toLowerCase()}`,
-      zoneId: null,
-      name: gz.name,
-      type: classifyUnknownZone(gz.name),
-    };
   }
 
   // 4. Report-level zone name (weak: report-wide, so wrong for every fight

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -14,7 +14,12 @@
  * All functions here are pure so they can be unit-tested without React.
  */
 
-import { CONTENT_ZONES, getContentZone, type ContentType } from '../../data/esoContentZones';
+import {
+  CONTENT_ZONES,
+  getContentZone,
+  getDungeonBossCount,
+  type ContentType,
+} from '../../data/esoContentZones';
 import type { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
 
 /** Index of canonical display name → content zone, for the name-based fallback. */
@@ -256,12 +261,15 @@ export function resolveFightZone(
 
   // 2. Raw gameZone — an unrecognised zone (a dungeon, or a solo/group arena).
   //    Group by its id; classify arenas by name so they aren't called dungeons.
+  //    Dungeons get an expected boss count from the curated dungeon rosters.
   if (gz?.id) {
+    const type = classifyUnknownZone(gz.name);
     return {
       key: `zone:${gz.id}`,
       zoneId: gz.id,
       name: gz.name || reportData?.zone?.name || 'Unknown Zone',
-      type: classifyUnknownZone(gz.name),
+      type,
+      expectedBossCount: type === 'dungeon' ? getDungeonBossCount(gz.name) : undefined,
     };
   }
   if (gz?.name) {
@@ -277,11 +285,13 @@ export function resolveFightZone(
         expectedBossCount: byName.expectedBossCount,
       };
     }
+    const type = classifyUnknownZone(gz.name);
     return {
       key: `name:${gz.name.toLowerCase()}`,
       zoneId: null,
       name: gz.name,
-      type: classifyUnknownZone(gz.name),
+      type,
+      expectedBossCount: type === 'dungeon' ? getDungeonBossCount(gz.name) : undefined,
     };
   }
 

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -35,13 +35,16 @@ export function effectiveEncounterId(fight: FightFragment): number {
 /**
  * Whether a fight is a boss encounter (vs. trash).
  *
- * Authoritative signal is `encounterID !== 0`. `difficulty != null` is kept as a
- * union fallback so we never *drop* a boss that older logs only tag via
- * difficulty. (The schema guarantees `difficulty` is null for trash, so the union
- * cannot promote real trash to a boss.)
+ * Follows the *live* `encounterID` (0 = trash), which is what ESO Logs intends:
+ * when it demotes a boss fight to trash it sets `encounterID` to 0 (preserving
+ * the real id in `originalEncounterID`). Real logs show these demoted fights are
+ * post-kill / instant-reset noise, so they belong with trash — not as phantom
+ * boss attempts. `difficulty != null` is kept as a union fallback so a boss that
+ * older logs only tag via difficulty is never dropped. (The schema guarantees
+ * `difficulty` is null for trash, so the union cannot promote real trash.)
  */
 export function isBossFight(fight: FightFragment): boolean {
-  return effectiveEncounterId(fight) !== 0 || fight.difficulty != null;
+  return (fight.encounterID ?? 0) !== 0 || fight.difficulty != null;
 }
 
 /**
@@ -295,10 +298,17 @@ export interface ContentRun {
 
 /**
  * Group a report's fights into runs, correctly separating logs that mix several
- * trials/dungeons. A new run starts when:
- *   - the resolved zone changes, or
- *   - a boss encounter that was already *killed* in the current run reappears
- *     (a re-clear / second lockout of the same content).
+ * trials/dungeons.
+ *
+ * A new run always starts when the resolved **zone changes** — this is the key
+ * fix for logs that mix multiple trials/dungeons.
+ *
+ * Same-zone re-clears (farm/reset nights that kill the same bosses repeatedly)
+ * are kept in a **single run by default**, because real reset logs interleave
+ * kills and wipes in a way that makes per-clear splitting noisy and unhelpful —
+ * attempt grouping (see {@link buildRunEncounters} / {@link summarizeEncounter})
+ * organises those far better. Pass `{ splitReclears: true }` to opt into starting
+ * a new run each time a previously-killed boss is killed again.
  *
  * Fights with an unknown zone (e.g. inter-zone trash with no `gameZone`) attach
  * to the current run rather than forcing a split, and can "upgrade" a run whose
@@ -307,8 +317,10 @@ export interface ContentRun {
 export function groupFightsIntoRuns(
   fights: readonly FightFragment[] | null | undefined,
   reportData?: ReportFragment | null,
+  options?: { splitReclears?: boolean },
 ): ContentRun[] {
   if (!fights?.length) return [];
+  const splitReclears = options?.splitReclears ?? false;
 
   const valid = fights
     .filter((f) => f.startTime != null && f.endTime != null && f.endTime > f.startTime)
@@ -330,7 +342,10 @@ export function groupFightsIntoRuns(
 
     const zoneChanged =
       current != null && zoneKnown && currentKnown && zone.key !== current.zone.key;
-    const reclear = boss && encId !== 0 && killedBossEncounters.has(encId);
+    // Only treat a *kill* of an already-killed boss as a re-clear, and only when
+    // the caller opts in.
+    const reclear =
+      splitReclears && boss && encId !== 0 && wasKill(fight) && killedBossEncounters.has(encId);
 
     if (current == null || zoneChanged || reclear) {
       runSeq += 1;
@@ -427,4 +442,67 @@ export function uncategorizedTrash(run: ContentRun, encounters: RunEncounter[]):
     encounters.flatMap((e) => [...e.preTrash, ...e.postTrash]).map((f) => f.id),
   );
   return run.fights.filter((f) => !isBossFight(f) && !categorized.has(f.id));
+}
+
+/** Fight duration in milliseconds. */
+export function fightDurationMs(fight: FightFragment): number {
+  return Math.max(0, (fight.endTime ?? 0) - (fight.startTime ?? 0));
+}
+
+/**
+ * Whether a wipe is really a quick "reset" / re-pull rather than a genuine
+ * progression attempt. On prog nights, groups frequently pull, see the opener,
+ * and immediately reset — producing a very short fight that ends with the boss at
+ * near-full health. Real logs (e.g. a 45-attempt boss) are roughly half resets,
+ * so distinguishing them is what makes the attempt list legible.
+ */
+export function isResetPull(fight: FightFragment): boolean {
+  if (!isBossFight(fight) || wasKill(fight)) return false;
+  const remaining = bossHealthRemaining(fight);
+  if (remaining == null) return false;
+  return fightDurationMs(fight) < 30_000 && remaining >= 90;
+}
+
+/** Aggregate stats for one boss encounter (all of its attempts). */
+export interface EncounterSummary {
+  /** Total boss attempts. */
+  attempts: number;
+  /** Attempts excluding quick resets. */
+  realAttempts: number;
+  /** Quick reset / re-pull count. */
+  resets: number;
+  /** Number of kills (>1 on farm logs). */
+  kills: number;
+  killed: boolean;
+  /**
+   * Best boss health % remaining among genuine (non-reset) wipes — lower is
+   * closer to a kill. `0` when the boss was killed, `null` when there are no
+   * genuine wipes to measure.
+   */
+  bestPercent: number | null;
+  /** Distinct difficulty codes seen across attempts (e.g. `[121, 122]`). */
+  difficulties: number[];
+}
+
+/** Summarise an encounter's attempts for the organised / collapsed view. */
+export function summarizeEncounter(encounter: RunEncounter): EncounterSummary {
+  const bosses = encounter.bossFights.filter(isBossFight);
+  const kills = bosses.filter(wasKill);
+  const resets = bosses.filter(isResetPull);
+  const genuineWipes = bosses.filter((f) => !wasKill(f) && !isResetPull(f));
+  const wipePercents = genuineWipes.map(bossHealthRemaining).filter((p): p is number => p != null);
+  const killed = kills.length > 0;
+  const difficulties = Array.from(
+    new Set(bosses.map((f) => f.difficulty).filter((d): d is number => d != null)),
+  ).sort((a, b) => a - b);
+
+  return {
+    attempts: bosses.length,
+    realAttempts: bosses.length - resets.length,
+    resets: resets.length,
+    kills: kills.length,
+    killed,
+    bestPercent: killed ? 0 : wipePercents.length ? Math.min(...wipePercents) : null,
+    difficulties,
+  };
 }

--- a/src/features/report_details/fightGrouping.ts
+++ b/src/features/report_details/fightGrouping.ts
@@ -1,0 +1,430 @@
+/**
+ * Authoritative fight / trial / dungeon detection for the Report Fights page.
+ *
+ * Design goals (the "best detection possible" audit, June 2026):
+ *   1. Boss vs. trash is decided by the API's `encounterID` (0 = trash), not by
+ *      the presence of a `difficulty` value.
+ *   2. Kill vs. wipe is decided by the API's authoritative `kill` flag, not by a
+ *      hand-tuned `bossPercentage` heuristic.
+ *   3. Which trial/dungeon a fight belongs to is decided by the per-fight
+ *      `gameZone.id` (an in-game zone ID), which lets us correctly separate logs
+ *      that mix multiple trials and/or dungeons. Boss-name matching survives only
+ *      as a fallback for older logs that lack `gameZone`.
+ *
+ * All functions here are pure so they can be unit-tested without React.
+ */
+
+import { CONTENT_ZONES, getContentZone, type ContentType } from '../../data/esoContentZones';
+import type { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
+
+/** Index of canonical display name → content zone, for the name-based fallback. */
+const ZONE_BY_NAME = new Map(
+  Object.values(CONTENT_ZONES).map((zone) => [zone.name.toLowerCase(), zone]),
+);
+
+/**
+ * The effective encounter ID for a fight. ESO Logs occasionally demotes a boss
+ * fight to trash (`encounterID === 0`) while preserving the real ID in
+ * `originalEncounterID`; we treat that as the boss encounter.
+ */
+export function effectiveEncounterId(fight: FightFragment): number {
+  if (fight.encounterID && fight.encounterID !== 0) return fight.encounterID;
+  return fight.originalEncounterID ?? 0;
+}
+
+/**
+ * Whether a fight is a boss encounter (vs. trash).
+ *
+ * Authoritative signal is `encounterID !== 0`. `difficulty != null` is kept as a
+ * union fallback so we never *drop* a boss that older logs only tag via
+ * difficulty. (The schema guarantees `difficulty` is null for trash, so the union
+ * cannot promote real trash to a boss.)
+ */
+export function isBossFight(fight: FightFragment): boolean {
+  return effectiveEncounterId(fight) !== 0 || fight.difficulty != null;
+}
+
+/**
+ * Whether the boss was killed (fight succeeded).
+ *
+ * Prefers the authoritative `kill` flag. Falls back to `bossPercentage` only when
+ * `kill` is null (some legacy logs), using the "<= 1% boss health remaining"
+ * convention. This replaces the previous `isFalsePositiveWipe` heuristic, which
+ * existed only because the UI ignored `kill` and inferred success from
+ * `bossPercentage`.
+ */
+export function wasKill(fight: FightFragment): boolean {
+  if (fight.kill === true) return true;
+  if (fight.kill === false) return false;
+  // kill == null → fall back to boss health remaining.
+  return fight.bossPercentage != null && fight.bossPercentage <= 1.0;
+}
+
+/** Boss health % remaining at end of fight (0–100), or null if unknown. */
+export function bossHealthRemaining(fight: FightFragment): number | null {
+  if (fight.bossPercentage == null) return null;
+  return Math.max(0, Math.min(100, fight.bossPercentage));
+}
+
+/**
+ * Boss-name → trial name fallback, used only when `gameZone` is unavailable.
+ * Returns a canonical trial name (matching `CONTENT_ZONES`) or null if the boss
+ * is not recognised. Matching is done with `includes` to tolerate instance
+ * suffixes (e.g. "Falgravn #2") and minor name variants.
+ */
+export function trialNameFromBossName(bossName: string | null | undefined): string | null {
+  const name = (bossName ?? '').toLowerCase();
+  if (!name) return null;
+
+  const tables: Array<{ trial: string; bosses: string[] }> = [
+    { trial: 'Opulent Ordeal', bosses: ['opulent trio', 'opulent'] },
+    {
+      trial: 'Ossein Cage',
+      bosses: [
+        'gedna relvel',
+        'hall of fleshcraft',
+        'shaper of flesh',
+        'shapers of flesh',
+        'tortured ranyu',
+        'tortured kathutet',
+        'tortured amkaos',
+        'tortured trio',
+        'jynorah',
+        'skorkhif',
+        'blood drinker thisa',
+        'overfiend kazpian',
+      ],
+    },
+    { trial: "Sanity's Edge", bosses: ['ansuul', 'spiral', 'twelvane', 'yaseyla', 'yasela'] },
+    { trial: "Kyne's Aegis", bosses: ['falgravn', 'vrol', 'yandir'] },
+    { trial: 'Sunspire', bosses: ['lokke', 'nahviintaas', 'yolnahkriin'] },
+    { trial: 'Cloudrest', bosses: ["z'maja", 'galenwe', 'relequen', 'siroria'] },
+    {
+      trial: 'Asylum Sanctorium',
+      bosses: ['lord felms', 'saint felms', 'saint llothis', 'saint olms'],
+    },
+    {
+      trial: 'Lucent Citadel',
+      bosses: [
+        'xoryn',
+        'count ryelaz',
+        'zilyesset',
+        'cavot agnan',
+        'orphic shattered shard',
+        'cavot',
+        'orphic',
+      ],
+    },
+    {
+      trial: 'Rockgrove',
+      bosses: [
+        'oaxiltso',
+        'flame-herald bahsei',
+        'xalvakka',
+        'ash titan',
+        'basks-in-snakes',
+        'basks',
+      ],
+    },
+    {
+      trial: 'Dreadsail Reef',
+      bosses: [
+        'lylanar and turlassil',
+        'lylanar',
+        'sail ripper',
+        'bow breaker',
+        'reef guardian',
+        'tideborn taleria',
+      ],
+    },
+    {
+      trial: 'Halls of Fabrication',
+      bosses: [
+        'hunter-killer fabricant',
+        'pinnacle factotum',
+        'archcustodian',
+        'assembly general',
+        'refabrication committee',
+      ],
+    },
+    {
+      trial: 'Maw of Lorkhaj',
+      bosses: ["zhaj'hassa the forgotten", 'vashai', 'rakkhat', 'twins', "zhaj'hassa"],
+    },
+    {
+      trial: 'Sanctum Ophidia',
+      bosses: [
+        'possessed manticora',
+        'possessed mantikora',
+        'stonebreaker',
+        'ozara',
+        'serpent',
+        'mantikora',
+        'manticora',
+      ],
+    },
+    { trial: 'Hel Ra Citadel', bosses: ['ra kotu', "yokeda rok'dun", 'yokedas', 'the warrior'] },
+    {
+      trial: 'Aetherian Archive',
+      bosses: [
+        'storm atronach',
+        'stone atronach',
+        'varlariel',
+        'the mage',
+        'foundation stone atronach',
+        'lightning storm atronach',
+      ],
+    },
+  ];
+
+  const match = tables.find((t) => t.bosses.some((b) => name.includes(b)));
+  return match?.trial ?? null;
+}
+
+/** Resolved zone identity for a single fight. */
+export interface ResolvedZone {
+  /** Stable grouping key. */
+  key: string;
+  /** In-game zone ID when known. */
+  zoneId: number | null;
+  /** Display name. */
+  name: string;
+  type: ContentType;
+  shortName?: string;
+  expectedBossCount?: number;
+}
+
+const UNKNOWN_ZONE: ResolvedZone = {
+  key: 'unknown',
+  zoneId: null,
+  name: 'Unknown',
+  type: 'unknown',
+};
+
+/**
+ * Resolve which trial/dungeon a fight belongs to, in priority order:
+ *   1. `gameZone.id` matched against the canonical content table (most reliable).
+ *   2. Boss-name → trial fallback (legacy logs without `gameZone`).
+ *   3. The raw `gameZone` (id/name) as a dungeon/unknown zone — no static table
+ *      needed, so dungeons still group and label correctly.
+ *   4. The report-level zone name.
+ */
+export function resolveFightZone(
+  fight: FightFragment,
+  reportData?: ReportFragment | null,
+): ResolvedZone {
+  const gz = fight.gameZone;
+
+  // 1. Known content zone by in-game zone id.
+  const known = getContentZone(gz?.id);
+  if (known) {
+    return {
+      key: `zone:${known.zoneId}`,
+      zoneId: known.zoneId,
+      name: known.name,
+      type: known.type,
+      shortName: known.shortName,
+      expectedBossCount: known.expectedBossCount,
+    };
+  }
+
+  // 2. Boss-name fallback (only for recognised trial bosses).
+  if (isBossFight(fight)) {
+    const trialName = trialNameFromBossName(fight.name);
+    const byName = trialName ? ZONE_BY_NAME.get(trialName.toLowerCase()) : undefined;
+    if (byName) {
+      return {
+        key: `zone:${byName.zoneId}`,
+        zoneId: byName.zoneId,
+        name: byName.name,
+        type: byName.type,
+        shortName: byName.shortName,
+        expectedBossCount: byName.expectedBossCount,
+      };
+    }
+  }
+
+  // 3. Raw gameZone — an unrecognised zone (typically a dungeon). Group by its id.
+  if (gz?.id) {
+    return {
+      key: `zone:${gz.id}`,
+      zoneId: gz.id,
+      name: gz.name || reportData?.zone?.name || 'Unknown Zone',
+      type: 'dungeon',
+    };
+  }
+  if (gz?.name) {
+    return { key: `name:${gz.name.toLowerCase()}`, zoneId: null, name: gz.name, type: 'dungeon' };
+  }
+
+  // 4. Report-level zone name.
+  const reportZoneName = reportData?.zone?.name;
+  if (reportZoneName) {
+    const byName = ZONE_BY_NAME.get(reportZoneName.toLowerCase());
+    if (byName) {
+      return {
+        key: `zone:${byName.zoneId}`,
+        zoneId: byName.zoneId,
+        name: byName.name,
+        type: byName.type,
+        shortName: byName.shortName,
+        expectedBossCount: byName.expectedBossCount,
+      };
+    }
+    return {
+      key: `name:${reportZoneName.toLowerCase()}`,
+      zoneId: null,
+      name: reportZoneName,
+      type: 'unknown',
+    };
+  }
+
+  return UNKNOWN_ZONE;
+}
+
+/** A single run of one trial/dungeon within a report. */
+export interface ContentRun {
+  /** Unique id for this run within the report. */
+  id: string;
+  zone: ResolvedZone;
+  /** All fights (boss + trash) in chronological order. */
+  fights: FightFragment[];
+  startTime: number;
+  endTime: number;
+}
+
+/**
+ * Group a report's fights into runs, correctly separating logs that mix several
+ * trials/dungeons. A new run starts when:
+ *   - the resolved zone changes, or
+ *   - a boss encounter that was already *killed* in the current run reappears
+ *     (a re-clear / second lockout of the same content).
+ *
+ * Fights with an unknown zone (e.g. inter-zone trash with no `gameZone`) attach
+ * to the current run rather than forcing a split, and can "upgrade" a run whose
+ * zone was not yet known.
+ */
+export function groupFightsIntoRuns(
+  fights: readonly FightFragment[] | null | undefined,
+  reportData?: ReportFragment | null,
+): ContentRun[] {
+  if (!fights?.length) return [];
+
+  const valid = fights
+    .filter((f) => f.startTime != null && f.endTime != null && f.endTime > f.startTime)
+    .sort((a, b) => a.startTime - b.startTime);
+
+  const runs: ContentRun[] = [];
+  let current: ContentRun | null = null;
+  let killedBossEncounters = new Set<number>();
+  let runSeq = 0;
+
+  for (const fight of valid) {
+    const zone = resolveFightZone(fight, reportData);
+    const boss = isBossFight(fight);
+    const encId = effectiveEncounterId(fight);
+
+    const zoneKnown = zone.zoneId != null || zone.key.startsWith('name:');
+    const currentKnown =
+      current != null && (current.zone.zoneId != null || current.zone.key.startsWith('name:'));
+
+    const zoneChanged =
+      current != null && zoneKnown && currentKnown && zone.key !== current.zone.key;
+    const reclear = boss && encId !== 0 && killedBossEncounters.has(encId);
+
+    if (current == null || zoneChanged || reclear) {
+      runSeq += 1;
+      current = {
+        id: `${zone.key}#${runSeq}`,
+        zone,
+        fights: [],
+        startTime: fight.startTime,
+        endTime: fight.endTime,
+      };
+      runs.push(current);
+      killedBossEncounters = new Set();
+    } else if (!currentKnown && zoneKnown) {
+      // Upgrade a run that started before its zone was identifiable.
+      current.zone = zone;
+      current.id = `${zone.key}#${runSeq}`;
+    }
+
+    current.fights.push(fight);
+    current.endTime = Math.max(current.endTime, fight.endTime);
+    if (boss && encId !== 0 && wasKill(fight)) {
+      killedBossEncounters.add(encId);
+    }
+  }
+
+  return runs;
+}
+
+/** A boss encounter within a run, with its surrounding trash. */
+export interface RunEncounter {
+  id: string;
+  name: string;
+  bossFights: FightFragment[];
+  preTrash: FightFragment[];
+  postTrash: FightFragment[];
+}
+
+/**
+ * Build the boss encounters for a run, grouping every attempt of the same boss
+ * together. Bosses are grouped by `encounterID` (stable across name variants and
+ * instance suffixes), and trash is associated with the encounter it precedes /
+ * follows by chronological position.
+ */
+export function buildRunEncounters(run: ContentRun): RunEncounter[] {
+  const bossFights = run.fights.filter(isBossFight).sort((a, b) => a.startTime - b.startTime);
+  const trashFights = run.fights
+    .filter((f) => !isBossFight(f))
+    .sort((a, b) => a.startTime - b.startTime);
+
+  const encounters: RunEncounter[] = [];
+  const byKey = new Map<string, RunEncounter>();
+
+  for (let i = 0; i < bossFights.length; i++) {
+    const boss = bossFights[i];
+    const encId = effectiveEncounterId(boss);
+    // Group by encounter id when present, else by normalised name.
+    const key = encId !== 0 ? `enc:${encId}` : `name:${(boss.name || 'boss').toLowerCase()}`;
+
+    let encounter = byKey.get(key);
+    if (!encounter) {
+      encounter = {
+        id: `${run.id}-${key}`,
+        name: boss.name || 'Unknown Boss',
+        bossFights: [],
+        preTrash: [],
+        postTrash: [],
+      };
+      byKey.set(key, encounter);
+      encounters.push(encounter);
+    }
+
+    const prevBossEnd = i > 0 ? bossFights[i - 1].endTime : 0;
+    const preTrash = trashFights.filter(
+      (t) => t.startTime >= prevBossEnd && t.startTime < boss.startTime,
+    );
+    encounter.bossFights.push(boss);
+    encounter.preTrash.push(...preTrash);
+
+    const nextBoss = bossFights[i + 1];
+    if (nextBoss) {
+      const postTrash = trashFights.filter(
+        (t) => t.startTime > boss.endTime && t.startTime < nextBoss.startTime,
+      );
+      encounter.postTrash.push(...postTrash);
+    }
+  }
+
+  return encounters;
+}
+
+/** Trash fights in a run not associated with any boss encounter. */
+export function uncategorizedTrash(run: ContentRun, encounters: RunEncounter[]): FightFragment[] {
+  const categorized = new Set(
+    encounters.flatMap((e) => [...e.preTrash, ...e.postTrash]).map((f) => f.id),
+  );
+  return run.fights.filter((f) => !isBossFight(f) && !categorized.has(f.id));
+}

--- a/src/features/report_details/runDifficulty.test.ts
+++ b/src/features/report_details/runDifficulty.test.ts
@@ -103,6 +103,20 @@ describe('determineRunDifficulty', () => {
     expect(determineRunDifficulty(encounters, 'Dreadsail Reef').label).toBeNull();
   });
 
+  it('returns a null label when no fight carries difficulty data (dungeons / legacy logs)', () => {
+    const perBoss = [enc('Some Dungeon Boss', [bossFight({ difficulty: null })])];
+    expect(determineRunDifficulty(perBoss, 'Bal Sunnar')).toEqual({ difficulty: 0, label: null });
+
+    const finalBossOnly = [enc('The Mage', [bossFight({ difficulty: null })])];
+    expect(determineRunDifficulty(finalBossOnly, 'Aetherian Archive')).toEqual({
+      difficulty: 0,
+      label: null,
+    });
+
+    const special = [enc("Z'Maja", [bossFight({ difficulty: null })])];
+    expect(determineRunDifficulty(special, 'Cloudrest')).toEqual({ difficulty: 0, label: null });
+  });
+
   it('labels a Normal-mode trial (code ≤ 120) as Normal, not Veteran', () => {
     const perBoss = [enc('Tideborn Taleria', [bossFight({ difficulty: 120, kill: true })])];
     expect(determineRunDifficulty(perBoss, 'Dreadsail Reef').label).toBe('Normal');

--- a/src/features/report_details/runDifficulty.test.ts
+++ b/src/features/report_details/runDifficulty.test.ts
@@ -102,6 +102,17 @@ describe('determineRunDifficulty', () => {
     const encounters = [enc('Trash', [])];
     expect(determineRunDifficulty(encounters, 'Dreadsail Reef').label).toBeNull();
   });
+
+  it('labels a Normal-mode trial (code ≤ 120) as Normal, not Veteran', () => {
+    const perBoss = [enc('Tideborn Taleria', [bossFight({ difficulty: 120, kill: true })])];
+    expect(determineRunDifficulty(perBoss, 'Dreadsail Reef').label).toBe('Normal');
+
+    const finalBossOnly = [enc('The Mage', [bossFight({ difficulty: 120, kill: true })])];
+    expect(determineRunDifficulty(finalBossOnly, 'Aetherian Archive').label).toBe('Normal');
+
+    const special = [enc("Z'Maja", [bossFight({ difficulty: 120, kill: true })])];
+    expect(determineRunDifficulty(special, 'Cloudrest').label).toBe('Normal');
+  });
 });
 
 // End-to-end: the two real reports should both read as Veteran HM (mains on HM,

--- a/src/features/report_details/runDifficulty.test.ts
+++ b/src/features/report_details/runDifficulty.test.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { FightFragment, ReportFragment } from '../../graphql/gql/graphql';
+
+import { buildRunEncounters, groupFightsIntoRuns, type RunEncounter } from './fightGrouping';
+import { determineRunDifficulty, getTrialHMType, isHmCapableBoss } from './runDifficulty';
+
+let nextId = 1;
+function bossFight(overrides: Partial<FightFragment> = {}): FightFragment {
+  return {
+    __typename: 'ReportFight',
+    id: overrides.id ?? nextId++,
+    name: 'Boss',
+    difficulty: 122,
+    startTime: 0,
+    endTime: 60_000,
+    kill: true,
+    encounterID: 100,
+    originalEncounterID: null,
+    bossPercentage: 0,
+    gameZone: null,
+    ...overrides,
+  } as FightFragment;
+}
+
+function enc(name: string, fights: FightFragment[]): RunEncounter {
+  return { id: name, name, bossFights: fights, preTrash: [], postTrash: [] };
+}
+
+describe('isHmCapableBoss', () => {
+  it('excludes mini-bosses that have no Hard Mode', () => {
+    expect(isHmCapableBoss('Spiral Descender')).toBe(false);
+    expect(isHmCapableBoss('Bow Breaker')).toBe(false);
+    expect(isHmCapableBoss('Sail Ripper')).toBe(false);
+    expect(isHmCapableBoss('Haj Mota')).toBe(false);
+    expect(isHmCapableBoss('Basks-In-Snakes')).toBe(false);
+  });
+
+  it('treats real bosses as HM-capable', () => {
+    expect(isHmCapableBoss('Tideborn Taleria')).toBe(true);
+    expect(isHmCapableBoss('Exarchanic Yaseyla')).toBe(true);
+    expect(isHmCapableBoss('Lord Falgravn')).toBe(true);
+  });
+});
+
+describe('getTrialHMType', () => {
+  it('classifies trials', () => {
+    expect(getTrialHMType('Dreadsail Reef')).toBe('per-boss');
+    expect(getTrialHMType('Cloudrest')).toBe('special');
+    expect(getTrialHMType('Asylum Sanctorium')).toBe('special');
+    expect(getTrialHMType('Aetherian Archive')).toBe('final-boss-only');
+  });
+});
+
+describe('determineRunDifficulty', () => {
+  it('labels Veteran HM when mains are HM and only minis are Veteran (DSR shape)', () => {
+    const encounters = [
+      enc('Lylanar and Turlassil', [bossFight({ difficulty: 122, kill: true })]),
+      enc('Bow Breaker', [bossFight({ difficulty: 121, kill: true })]), // mini, no HM
+      enc('Reef Guardian', [bossFight({ difficulty: 122, kill: true })]),
+      enc('Tideborn Taleria', [bossFight({ difficulty: 122, kill: true })]),
+    ];
+    // Minis must NOT downgrade this to "Partial Veteran HM".
+    expect(determineRunDifficulty(encounters, 'Dreadsail Reef')).toEqual({
+      difficulty: 122,
+      label: 'Veteran HM',
+    });
+  });
+
+  it('judges HM on the kill, ignoring lower-difficulty wipes', () => {
+    const encounters = [
+      enc('Exarchanic Yaseyla', [bossFight({ difficulty: 122, kill: true })]),
+      enc('Archwizard Twelvane and Chimera', [
+        bossFight({ difficulty: 121, kill: false, bossPercentage: 40 }), // vet wipe
+        bossFight({ difficulty: 122, kill: true }), // HM kill
+      ]),
+      enc('Ansuul the Tormentor', [bossFight({ difficulty: 122, kill: true })]),
+      enc('Spiral Descender', [bossFight({ difficulty: 121, kill: true })]), // mini
+    ];
+    expect(determineRunDifficulty(encounters, "Sanity's Edge").label).toBe('Veteran HM');
+  });
+
+  it('reports Partial Veteran HM when an HM-capable boss was only done on Veteran', () => {
+    const encounters = [
+      enc('Lylanar and Turlassil', [bossFight({ difficulty: 122, kill: true })]),
+      enc('Reef Guardian', [bossFight({ difficulty: 121, kill: true })]), // main on vet
+      enc('Tideborn Taleria', [bossFight({ difficulty: 122, kill: true })]),
+    ];
+    expect(determineRunDifficulty(encounters, 'Dreadsail Reef').label).toBe('Partial Veteran HM');
+  });
+
+  it('uses +N codes for Cloudrest/Asylum from the final-boss kill', () => {
+    const encounters = [enc("Z'Maja", [bossFight({ difficulty: 124, kill: true })])];
+    expect(determineRunDifficulty(encounters, 'Cloudrest')).toEqual({
+      difficulty: 124,
+      label: 'Veteran HM +2',
+    });
+  });
+
+  it('returns a null label for a bossless (trash-only) run', () => {
+    const encounters = [enc('Trash', [])];
+    expect(determineRunDifficulty(encounters, 'Dreadsail Reef').label).toBeNull();
+  });
+});
+
+// End-to-end: the two real reports should both read as Veteran HM (mains on HM,
+// minis on Veteran) — NOT "Partial Veteran HM".
+function loadSampleReport(code: string): { report: ReportFragment; fights: FightFragment[] } {
+  const file = path.resolve(process.cwd(), 'public/sample-reports', code, 'report.json');
+  const raw = fs.readFileSync(file, 'utf8').replace(/^﻿/, '');
+  const json = JSON.parse(raw);
+  const report = (json?.reportData?.report ?? json?.data?.reportData?.report) as ReportFragment;
+  const fights = ((report as unknown as { fights?: FightFragment[] })?.fights ??
+    []) as FightFragment[];
+  return { report, fights };
+}
+
+describe('integration: real-log difficulty', () => {
+  it('DSR farm reads as Veteran HM (mini Bow Breaker does not make it Partial)', () => {
+    const { report, fights } = loadSampleReport('F4f2bMwWtgVKxjB9');
+    const [run] = groupFightsIntoRuns(fights, report);
+    expect(determineRunDifficulty(buildRunEncounters(run), run.zone.name).label).toBe('Veteran HM');
+  });
+
+  it('VSE progression reads as Veteran HM (mini Spiral Descender excluded)', () => {
+    const { report, fights } = loadSampleReport('YArFDbq7BdhwL691');
+    const [run] = groupFightsIntoRuns(fights, report);
+    expect(determineRunDifficulty(buildRunEncounters(run), run.zone.name).label).toBe('Veteran HM');
+  });
+});

--- a/src/features/report_details/runDifficulty.ts
+++ b/src/features/report_details/runDifficulty.ts
@@ -94,7 +94,7 @@ export interface RunDifficulty {
  * among its kills, or — if it was never killed — the highest difficulty it was
  * attempted at (so an in-progress HM prog still reads as HM).
  */
-function encounterResultDifficulty(encounter: RunEncounter): number {
+export function encounterResultDifficulty(encounter: RunEncounter): number {
   const bosses = encounter.bossFights.filter(isBossFight);
   const kills = bosses.filter(wasKill);
   const pool = kills.length > 0 ? kills : bosses;
@@ -132,7 +132,9 @@ export function determineRunDifficulty(
     if (code >= 123) return { difficulty: 123, label: 'Veteran HM +1' };
     if (code >= VETERAN_HM) return { difficulty: VETERAN_HM, label: 'Veteran HM' };
     if (code >= VETERAN) return { difficulty: VETERAN, label: 'Veteran' };
-    return { difficulty: 0, label: 'Normal' };
+    if (code > 0) return { difficulty: 0, label: 'Normal' };
+    // No difficulty data at all (dungeons / legacy logs) — claim nothing.
+    return { difficulty: 0, label: null };
   }
 
   // Per-boss and final-boss-only: only HM-capable bosses count toward HM status.
@@ -150,7 +152,8 @@ export function determineRunDifficulty(
     if (hm > 0) return { difficulty: VETERAN_HM, label: 'Veteran HM' };
     if (vet > 0) return { difficulty: VETERAN, label: 'Veteran' };
     if (normal > 0) return { difficulty: 0, label: 'Normal' };
-    return { difficulty: VETERAN, label: 'Veteran' };
+    // No difficulty data at all (dungeons / legacy logs) — claim nothing.
+    return { difficulty: 0, label: null };
   }
 
   // per-boss
@@ -158,5 +161,6 @@ export function determineRunDifficulty(
   if (hm > 0 && vet > 0) return { difficulty: VETERAN_HM, label: 'Partial Veteran HM' };
   if (vet > 0) return { difficulty: VETERAN, label: 'Veteran' };
   if (normal > 0) return { difficulty: 0, label: 'Normal' };
-  return { difficulty: VETERAN, label: 'Veteran' };
+  // No difficulty data at all (dungeons / legacy logs) — claim nothing.
+  return { difficulty: 0, label: null };
 }

--- a/src/features/report_details/runDifficulty.ts
+++ b/src/features/report_details/runDifficulty.ts
@@ -19,9 +19,15 @@
 import type { RunEncounter } from './fightGrouping';
 import { isBossFight, wasKill } from './fightGrouping';
 
-// ESO Logs difficulty codes for trials.
+// ESO Logs difficulty codes for trials: Normal ≤ 120, Veteran 121,
+// Veteran Hard Mode 122 (Cloudrest/Asylum go 123/124/125 for +1/+2/+3).
 const VETERAN = 121;
 const VETERAN_HM = 122; // +0; Cloudrest/Asylum go 123/124/125 for +1/+2/+3.
+
+/** A positive difficulty code below Veteran (e.g. 120) is a Normal clear. */
+function isNormalCode(d: number): boolean {
+  return d > 0 && d < VETERAN;
+}
 
 /**
  * Lowercased name fragments for bosses that have **no Hard Mode option** —
@@ -136,7 +142,7 @@ export function determineRunDifficulty(
 
   const hm = results.filter((d) => d >= VETERAN_HM).length;
   const vet = results.filter((d) => d === VETERAN).length;
-  const normal = results.filter((d) => d > 0 && d < 10).length;
+  const normal = results.filter((d) => isNormalCode(d)).length;
 
   if (hmType === 'final-boss-only') {
     // Older trials: HM lives only on the final boss, so any HM-capable HM kill

--- a/src/features/report_details/runDifficulty.ts
+++ b/src/features/report_details/runDifficulty.ts
@@ -1,0 +1,156 @@
+/**
+ * Trial difficulty / Hard Mode determination for a run.
+ *
+ * ESO specifics that this encodes (and that the old per-fight heuristic got
+ * wrong):
+ *   - **Mini-bosses have no Hard Mode.** Spiral Descender, Bow Breaker, Sail
+ *     Ripper, Haj Mota, etc. are always Veteran, so they must NOT drag a full-HM
+ *     clear down to "Partial Veteran HM".
+ *   - HM is judged on the **kill** difficulty of the HM-capable bosses, not on
+ *     wipes. Wiping a boss on Veteran and later killing it on HM is an HM kill.
+ *   - Most trials are **linear** (per-boss HM, or final-boss-only HM). Cloudrest
+ *     and Asylum Sanctorium are **"skip to the end"** trials whose HM is encoded
+ *     as +0..+3 difficulty codes (122–125) on the final boss.
+ *
+ * Getting HM right is the foundation for trifecta reasoning (Veteran HM + speed
+ * + no-death), so this is intentionally explicit and unit-tested.
+ */
+
+import type { RunEncounter } from './fightGrouping';
+import { isBossFight, wasKill } from './fightGrouping';
+
+// ESO Logs difficulty codes for trials.
+const VETERAN = 121;
+const VETERAN_HM = 122; // +0; Cloudrest/Asylum go 123/124/125 for +1/+2/+3.
+
+/**
+ * Lowercased name fragments for bosses that have **no Hard Mode option** —
+ * mini-bosses and optional "trash bosses". They are always Veteran and are
+ * excluded from the trial's HM determination.
+ */
+const NON_HM_BOSS_TOKENS: readonly string[] = [
+  // Mini-bosses
+  'haj mota',
+  'bow breaker',
+  'sail ripper',
+  'spiral descender',
+  'the hollow one',
+  'gedna relvel',
+  'tortured trio',
+  'tortured amkaos',
+  'tortured kathutet',
+  'tortured ranyu',
+  'blood drinker thisa',
+  // Optional non-HM bosses
+  'basks-in-snakes',
+  'basks-in-snake',
+  'ash titan',
+];
+
+/** True when a boss can be done on Hard Mode (i.e. is not a mini / non-HM boss). */
+export function isHmCapableBoss(name: string | null | undefined): boolean {
+  const n = (name ?? '').toLowerCase();
+  if (!n) return true;
+  return !NON_HM_BOSS_TOKENS.some((token) => n.includes(token));
+}
+
+export type TrialHMType = 'per-boss' | 'final-boss-only' | 'special';
+
+/** How a trial exposes Hard Mode. */
+export function getTrialHMType(trialName: string): TrialHMType {
+  const specialTrials = ['Cloudrest', 'Asylum'];
+  if (specialTrials.some((t) => trialName.includes(t))) return 'special';
+
+  const perBossHMTrials = [
+    'Sunspire',
+    "Kyne's Aegis",
+    'Rockgrove',
+    'Dreadsail Reef',
+    "Sanity's Edge",
+    'Lucent Citadel',
+    'Ossein Cage',
+    'Opulent Ordeal',
+  ];
+  if (perBossHMTrials.some((t) => trialName.includes(t))) return 'per-boss';
+
+  return 'final-boss-only';
+}
+
+export interface RunDifficulty {
+  /** Representative difficulty code (e.g. 122). 0 when normal/unknown. */
+  difficulty: number;
+  /** Human label, or null for a bossless segment. */
+  label: string | null;
+}
+
+/**
+ * The difficulty a boss encounter was *completed* at: the highest difficulty
+ * among its kills, or — if it was never killed — the highest difficulty it was
+ * attempted at (so an in-progress HM prog still reads as HM).
+ */
+function encounterResultDifficulty(encounter: RunEncounter): number {
+  const bosses = encounter.bossFights.filter(isBossFight);
+  const kills = bosses.filter(wasKill);
+  const pool = kills.length > 0 ? kills : bosses;
+  return pool.reduce((max, f) => Math.max(max, f.difficulty ?? 0), 0);
+}
+
+/**
+ * Determine the overall difficulty/HM label for a run from its encounters.
+ *
+ * Returns `{ label: null }` for a run with no boss encounters (pure trash).
+ */
+export function determineRunDifficulty(
+  encounters: readonly RunEncounter[],
+  zoneName: string,
+): RunDifficulty {
+  const bossEncounters = encounters.filter((e) => e.bossFights.some(isBossFight));
+  if (bossEncounters.length === 0) return { difficulty: 0, label: null };
+
+  const hmType = getTrialHMType(zoneName);
+
+  if (hmType === 'special') {
+    // Cloudrest / Asylum: HM (and +1/+2/+3) is encoded on the final-boss kill.
+    const killed = bossEncounters
+      .map((e) => {
+        const kills = e.bossFights.filter((f) => isBossFight(f) && wasKill(f));
+        return kills.reduce((m, f) => Math.max(m, f.difficulty ?? 0), 0);
+      })
+      .filter((d) => d > 0);
+    const code = killed.length
+      ? Math.max(...killed)
+      : Math.max(0, ...bossEncounters.map(encounterResultDifficulty));
+
+    if (code >= 125) return { difficulty: 125, label: 'Veteran HM +3' };
+    if (code >= 124) return { difficulty: 124, label: 'Veteran HM +2' };
+    if (code >= 123) return { difficulty: 123, label: 'Veteran HM +1' };
+    if (code >= VETERAN_HM) return { difficulty: VETERAN_HM, label: 'Veteran HM' };
+    if (code >= VETERAN) return { difficulty: VETERAN, label: 'Veteran' };
+    return { difficulty: 0, label: 'Normal' };
+  }
+
+  // Per-boss and final-boss-only: only HM-capable bosses count toward HM status.
+  const hmCapable = bossEncounters.filter((e) => isHmCapableBoss(e.name));
+  const pool = hmCapable.length > 0 ? hmCapable : bossEncounters;
+  const results = pool.map(encounterResultDifficulty);
+
+  const hm = results.filter((d) => d >= VETERAN_HM).length;
+  const vet = results.filter((d) => d === VETERAN).length;
+  const normal = results.filter((d) => d > 0 && d < 10).length;
+
+  if (hmType === 'final-boss-only') {
+    // Older trials: HM lives only on the final boss, so any HM-capable HM kill
+    // makes the run HM.
+    if (hm > 0) return { difficulty: VETERAN_HM, label: 'Veteran HM' };
+    if (vet > 0) return { difficulty: VETERAN, label: 'Veteran' };
+    if (normal > 0) return { difficulty: 0, label: 'Normal' };
+    return { difficulty: VETERAN, label: 'Veteran' };
+  }
+
+  // per-boss
+  if (hm > 0 && vet === 0) return { difficulty: VETERAN_HM, label: 'Veteran HM' };
+  if (hm > 0 && vet > 0) return { difficulty: VETERAN_HM, label: 'Partial Veteran HM' };
+  if (vet > 0) return { difficulty: VETERAN, label: 'Veteran' };
+  if (normal > 0) return { difficulty: 0, label: 'Normal' };
+  return { difficulty: VETERAN, label: 'Veteran' };
+}

--- a/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
@@ -45,9 +45,21 @@ describe('calibrateFromEvents', () => {
 
   it('ignores non-ultimate resource changes', () => {
     const events = [
-      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.magicka }),
-      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.stamina }),
-      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate }),
+      ultEvent({
+        abilityGameID: 1,
+        resourceChange: 5,
+        resourceChangeType: RESOURCE_CHANGE_TYPE.magicka,
+      }),
+      ultEvent({
+        abilityGameID: 1,
+        resourceChange: 5,
+        resourceChangeType: RESOURCE_CHANGE_TYPE.stamina,
+      }),
+      ultEvent({
+        abilityGameID: 1,
+        resourceChange: 5,
+        resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate,
+      }),
     ];
     const result = calibrateFromEvents({ events, fightDurationSeconds: 1 });
     expect(result.totalNetUltimate).toBe(5);

--- a/src/features/ultimate-simulator/core/__tests__/simulate.test.ts
+++ b/src/features/ultimate-simulator/core/__tests__/simulate.test.ts
@@ -81,8 +81,7 @@ describe('Monte Carlo — reconciles the sheet', () => {
       },
       { runs: 20000, baseSeed: 1 },
     );
-    const meanDecisive =
-      result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0);
+    const meanDecisive = result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0);
     expect(meanDecisive).toBeCloseTo(SHEET_DECISIVE_HALF, -1); // within ~5 ult
   });
 

--- a/src/features/ultimate-simulator/core/monteCarlo.ts
+++ b/src/features/ultimate-simulator/core/monteCarlo.ts
@@ -35,7 +35,10 @@ export function runMonteCarlo(
   let maxTotal = -Infinity;
 
   // Accumulate per-source contributions to report a mean breakdown.
-  const baseBySource = new Map<string, { label: string; base: number; decisive: number; instances: number }>();
+  const baseBySource = new Map<
+    string,
+    { label: string; base: number; decisive: number; instances: number }
+  >();
 
   for (let i = 0; i < runs; i += 1) {
     const result = simulateFight({ ...config, seed: options.baseSeed + i });

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateSimulator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateSimulator.test.tsx
@@ -18,7 +18,9 @@ describe('UltimateSimulator (render smoke)', () => {
   it('renders headline, inputs, and a results table with all raid sources', () => {
     renderSimulator();
 
-    expect(screen.getByRole('heading', { name: /Arcanist Ultimate Simulator/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Arcanist Ultimate Simulator/i }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Fight duration/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Monte Carlo runs/i)).toBeInTheDocument();
 

--- a/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
@@ -102,9 +102,7 @@ export const UltimateSimulator: React.FC<UltimateSimulatorProps> = ({ className 
                         labelId="decisive-quality-label"
                         label="Weapon quality"
                         value={state.decisiveQuality}
-                        onChange={(e) =>
-                          sim.setDecisiveQuality(e.target.value as DecisiveQuality)
-                        }
+                        onChange={(e) => sim.setDecisiveQuality(e.target.value as DecisiveQuality)}
                       >
                         {QUALITY_OPTIONS.map((opt) => (
                           <MenuItem key={opt.value} value={opt.value}>
@@ -231,10 +229,17 @@ export const UltimateSimulator: React.FC<UltimateSimulatorProps> = ({ className 
                 <TableRow>
                   <TableCell sx={{ fontWeight: 'bold' }}>Total</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                    {fmt(result.meanTotal - result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0), 0)}
+                    {fmt(
+                      result.meanTotal -
+                        result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0),
+                      0,
+                    )}
                   </TableCell>
                   <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                    {fmt(result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0), 1)}
+                    {fmt(
+                      result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0),
+                      1,
+                    )}
                   </TableCell>
                   <TableCell align="right" sx={{ fontWeight: 'bold' }} data-testid="grand-total">
                     {fmt(result.meanTotal, 1)}

--- a/src/utils/trialClassification.ts
+++ b/src/utils/trialClassification.ts
@@ -204,10 +204,11 @@ export function getTrialNameFromBoss(
  *
  * Cloudrest and Asylum Sanctorium use the +1/+2/+3 hard-mode ladder (difficulty
  * codes 123-125); every other trial uses the standard Normal/Veteran/Veteran HM
- * mapping (codes <10 / 121 / 122).
+ * mapping (codes ≤120 / 121 / 122).
  */
 export function getDifficultyLabel(difficulty: number | null, trialName: string): string | null {
-  if (!difficulty || difficulty < 10) {
+  // Difficulty codes: Normal ≤ 120, Veteran 121, Veteran HM 122 (+1/+2/+3 = 123/124/125).
+  if (!difficulty || difficulty < 121) {
     return 'Normal';
   }
 


### PR DESCRIPTION
## Summary

Full audit of **#1197** (authoritative trial/dungeon/fight detection) and **#1193** (all 58 ESO group dungeons in the loadout-manager), verified end-to-end in Chrome. This branch **contains both PRs' commits**, resolves #1197's merge conflict with `main` (#1188's color swap), fixes the issues the audit surfaced, and completes the dungeon-metadata integration that #1197 had deferred — so it can be merged in place of both.

Findings are documented as items **12–16** in [`FIGHT-DETECTION-AUDIT-2026-06-08.md`](FIGHT-DETECTION-AUDIT-2026-06-08.md).

## Conflict resolution

#1197 branched before #1188 (green = kill, red→periwinkle→indigo wipe palette) landed on `main`, leaving the PR `dirty` and silently skipping all `pull_request` workflows. Resolved by keeping **all of #1188's color scheme** on top of #1197's refactored `ReportFightsView`. #1193 has no file overlap and merged cleanly.

## Audit fixes (all unit-tested)

1. **Report-level zone fallback shattered mixed-log runs (High)** — fights with no `gameZone` resolved to the *report-wide* zone name. In a mixed log that zone is wrong for every fight outside the main zone: a no-`gameZone` trash pull inside a Bal Sunnar segment of a DSR-rooted report split the dungeon run in half (`DSR → Bal Sunnar → DSR → Bal Sunnar`, observed live in the browser). Report-fallback zones are now weak evidence: they can seed/label a run but never force a split.
2. **Per-fight `gameZone` outranks the boss-name trial fallback (Codex P2)** — a dungeon boss whose name contains a generic trial token ("the mage", "serpent", "twins") was mislabeled as a trial. The raw `gameZone` branch now runs first; the boss-name fallback is reserved for legacy logs with no `gameZone` at all.
3. **Runs with no difficulty data were asserted "Veteran" (Medium)** — mislabeled dungeons (commonly `difficulty: null`) and legacy logs. Now returns no badge when there is no difficulty signal.
4. **Per-encounter difficulty badge used the first attempt, not the kill (Medium)** — a Veteran wipe followed by an HM kill displayed "(Veteran)". Now uses the kill's difficulty, consistent with the run-level HM logic.
5. **Chaotic-log headers were indistinguishable (UX)** — run headers now show a wall-clock **time range**, a **"Run N" badge** when the same zone appears as multiple runs, and a **Dungeon/Arena tag** for non-trial content.

Also removed dead `isFalsePositive` plumbing and keyed the kill-card background off `isBossFight` instead of `difficulty != null`.

## #1193 integration (finding 16)

`resolveFightZone` now enriches dungeon zones (matched by `gameZone` name) with an `expectedBossCount` from #1193's curated, achievement-verified rosters via `getDungeonBossCount`. The completion ring shows real dungeon progress — e.g. **2/3 yellow** for a partial Bal Sunnar clear instead of a misleading green. Unmatched names degrade gracefully (no count, as before). Ring thresholds generalised to *all-killed = green, ≥half = yellow* (identical behaviour for the previous 3/4/5-boss trial special cases).

## Verification

- `npm run validate` — clean; 506 tests across `report_details` + `loadout-manager` (493 passed, 13 pre-existing skips), incl. new regressions for every fix above.
- **Chrome (CDP) end-to-end** against the dev server:
  - `F4f2bMwWtgVKxjB9` (DSR reset farm): one "Veteran HM" run, grouped multi-kill encounters, "Show all 7 attempts", 31% wipe in the #1188 blue palette.
  - `YArFDbq7BdhwL691` (FAST VSE HM): 44 Yaseyla attempts collapsed to best pull (1%) + kill, "14 resets" chip, minis correctly Veteran.
  - Synthetic **chaos log** (DSR → Bal Sunnar → Sanity's Edge → DSR re-entry, with no-`gameZone` trash): four correctly separated runs with time ranges — `Dreadsail Reef · Veteran HM · Run 1`, `Bal Sunnar · Dungeon` (2/3 expected bosses, yellow ring, no bogus difficulty badge), `Sanity's Edge · Veteran HM` (Best 17% / 7 resets), `Dreadsail Reef · Veteran HM · Run 2`; dark and light mode.
  - **Loadout-manager selector** (#1193): sectioned General/Trials/Dungeons/Arenas/Substitutes headers, all 58 dungeons alphabetised, "Dungeon" captions correct.

Supersedes #1197 and #1193 (same commits + fixes); closing those after this merges avoids the conflict-blocked CI on #1197.

https://claude.ai/code/session_01Mz5jmKZzrdKyM4KtNnMmeu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mz5jmKZzrdKyM4KtNnMmeu)_