### PR TITLE
fix(dev-server): proxy roster-hub API same-origin so any dev port works

### DIFF
--- a/src/EsoLogsClientContext.tsx
+++ b/src/EsoLogsClientContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useMemo, ReactNode, useState, useCall
 import { useLogger } from './contexts/LoggerContext';
 import { EsoLogsClient } from './esologsClient';
 import { LOCAL_STORAGE_ACCESS_TOKEN_KEY } from './features/auth/auth';
-import { getEnvVar } from './utils/envUtils';
+import { getRosterHubBaseUrl } from './utils/envUtils';
 import { addBreadcrumb } from './utils/errorTracking';
 
 interface EsoLogsClientContextType {
@@ -25,9 +25,8 @@ const initialToken = localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY) || '';
 
 // Proxy URL for public /api/v2/client queries — routes through the Cloudflare
 // Worker so the server-side OAuth secret is never exposed to the browser.
-const workerBaseUrl =
-  getEnvVar('VITE_ROSTER_HUB_API_URL') ?? 'https://roster-hub-api.eso-toolkit.workers.dev';
-const CLIENT_API_PROXY_URL = `${workerBaseUrl}/graphql`;
+// (Same-origin in dev via the Vite proxy; see getRosterHubBaseUrl.)
+const CLIENT_API_PROXY_URL = `${getRosterHubBaseUrl()}/graphql`;
 
 export const EsoLogsClientProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(!!initialToken);

--- a/src/features/build-editor/api/image-upload-api.ts
+++ b/src/features/build-editor/api/image-upload-api.ts
@@ -3,10 +3,9 @@
  * Uploads images via the roster-hub-api Worker proxy (keeps ImgBB key server-side).
  */
 
-const BASE_URL = (import.meta.env.VITE_ROSTER_HUB_API_URL ?? 'http://localhost:8787').replace(
-  /\/$/,
-  '',
-);
+import { getRosterHubBaseUrl } from '../../../utils/envUtils';
+
+const BASE_URL = getRosterHubBaseUrl();
 
 export interface ImageUploadResult {
   id: string;

--- a/src/features/build-editor/api/temp-build-api.ts
+++ b/src/features/build-editor/api/temp-build-api.ts
@@ -4,10 +4,9 @@
  * No auth required — rate limited by IP on the server.
  */
 
-const BASE_URL = (import.meta.env.VITE_ROSTER_HUB_API_URL ?? 'http://localhost:8787').replace(
-  /\/$/,
-  '',
-);
+import { getRosterHubBaseUrl } from '../../../utils/envUtils';
+
+const BASE_URL = getRosterHubBaseUrl();
 
 export const tempBuildApi = {
   async create(buildData: string): Promise<{ id: string; expires_at: string }> {

--- a/src/features/build-hub/api/build-hub-api.ts
+++ b/src/features/build-hub/api/build-hub-api.ts
@@ -3,6 +3,7 @@
  * Mirrors the roster-hub-api pattern: thin fetch wrappers, auth via Bearer token.
  */
 
+import { getRosterHubBaseUrl } from '../../../utils/envUtils';
 import type {
   HubBuild,
   HubBuildComment,
@@ -10,10 +11,7 @@ import type {
   PublishBuildPayload,
 } from '../types/build-hub.types';
 
-const BASE_URL = (import.meta.env.VITE_ROSTER_HUB_API_URL ?? 'http://localhost:8787').replace(
-  /\/$/,
-  '',
-);
+const BASE_URL = getRosterHubBaseUrl();
 
 async function apiFetch<T>(path: string, options: RequestInit = {}, token?: string): Promise<T> {
   const headers: Record<string, string> = {

--- a/src/features/pack-hub/api/pack-hub-api.ts
+++ b/src/features/pack-hub/api/pack-hub-api.ts
@@ -7,6 +7,7 @@
  */
 
 import { decodeHtmlEntities } from '../../../utils/decodeHtmlEntities';
+import { getRosterHubBaseUrl } from '../../../utils/envUtils';
 import type {
   HubPack,
   ListPacksResponse,
@@ -17,8 +18,7 @@ import type {
   VoteResponse,
 } from '../types/pack-hub.types';
 
-const BASE_URL =
-  (import.meta.env.VITE_ROSTER_HUB_API_URL as string | undefined) ?? 'http://localhost:8787';
+const BASE_URL = getRosterHubBaseUrl();
 
 const REQUEST_TIMEOUT_MS = 15_000;
 

--- a/src/features/roster-hub/api/roster-hub-api.ts
+++ b/src/features/roster-hub/api/roster-hub-api.ts
@@ -4,7 +4,7 @@
  * during development so the Worker dev server Just Works.
  */
 
-import { getBaseUrl, getEnvVar } from '../../../utils/envUtils';
+import { getBaseUrl, getRosterHubBaseUrl } from '../../../utils/envUtils';
 import type {
   HubRoster,
   ListCommentsResponse,
@@ -38,8 +38,7 @@ function hydrateRoster(roster: HubRoster): HubRoster {
   };
 }
 
-const BASE_URL =
-  getEnvVar('VITE_ROSTER_HUB_API_URL') ?? 'https://roster-hub-api.eso-toolkit.workers.dev';
+const BASE_URL = getRosterHubBaseUrl();
 
 const REQUEST_TIMEOUT_MS = 15_000;
 

--- a/src/utils/__mocks__/envUtils.ts
+++ b/src/utils/__mocks__/envUtils.ts
@@ -42,3 +42,13 @@ export const getEnvVar = jest.fn((key: string): string | undefined => {
   if (key === 'VITE_BASE_URL') return '/';
   return undefined;
 });
+
+/**
+ * Base URL of the roster-hub-api Worker.
+ * Mocked to the production Worker URL — the resolution tests saw before the
+ * same-origin dev proxy existed (isDevelopment() is mocked false here, so the
+ * real helper would resolve the same way).
+ */
+export const getRosterHubBaseUrl = jest.fn((): string => {
+  return 'https://roster-hub-api.eso-toolkit.workers.dev';
+});

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -60,3 +60,26 @@ export const isProduction = (): boolean => {
 export const getEnvVar = (key: string): string | undefined => {
   return import.meta.env[key];
 };
+
+/**
+ * Base URL of the roster-hub-api Worker (reports, roster hub, pack hub, build hub,
+ * the ESO Logs client-credential proxy) — the single resolution every API client uses.
+ *
+ * Resolution order:
+ *  1. `VITE_ROSTER_HUB_API_URL` when set — prod builds pin the Worker URL here, and
+ *     Worker developers point it at `http://localhost:8787` (wrangler dev).
+ *  2. Dev fallback: `/roster-hub-api`, a SAME-ORIGIN path the Vite dev server proxies
+ *     to the deployed Worker (see `server.proxy` in vite.config.mjs). Same-origin means
+ *     no CORS preflight, so dev works on ANY localhost port — the Worker's CORS
+ *     allowlist only covers localhost:3000–3003/5173, and worktree dev servers on other
+ *     ports (e.g. :3007) had every report query silently blocked.
+ *  3. Prod fallback: the deployed Worker URL.
+ *
+ * Trailing slash is stripped so callers can append `/graphql`, `/packs`, … verbatim.
+ */
+export const getRosterHubBaseUrl = (): string => {
+  const explicit = getEnvVar('VITE_ROSTER_HUB_API_URL');
+  if (explicit) return explicit.replace(/\/$/, '');
+  if (isDevelopment()) return '/roster-hub-api';
+  return 'https://roster-hub-api.eso-toolkit.workers.dev';
+};

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -246,6 +246,25 @@ ${downloadBtn}
       headers: {
         'Access-Control-Allow-Origin': '*',
       },
+      proxy: {
+        // Same-origin route to the roster-hub-api Worker (reports, roster/pack/build hubs,
+        // the ESO Logs client proxy). The Worker's CORS allowlist only admits localhost
+        // ports 3000–3003/5173, so dev servers on any other port (worktrees each get their
+        // own PORT) had every API call killed in preflight — pages rendered empty. Browser
+        // requests go to /roster-hub-api/* on THIS origin (no CORS at all) and Vite forwards
+        // them server-side. API clients resolve this path via getRosterHubBaseUrl()
+        // (src/utils/envUtils.ts); an explicit VITE_ROSTER_HUB_API_URL still bypasses it.
+        '/roster-hub-api': {
+          target: 'https://roster-hub-api.eso-toolkit.workers.dev',
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/roster-hub-api/, ''),
+          configure: (proxy) => {
+            // Strip the browser Origin so the Worker's allowlist never rejects the
+            // forwarded request (it sees a plain server-to-server call).
+            proxy.on('proxyReq', (proxyReq) => proxyReq.removeHeader('origin'));
+          },
+        },
+      },
     },
 
     // Preview server configuration (for production preview)


### PR DESCRIPTION
## What & why

**Symptom:** on local dev servers, the reports pages load nothing — Latest Reports shows an empty table, report details never populate, and the console fills with `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`.

**Root cause:** the roster-hub-api Worker's CORS allowlist only admits `localhost:3000–3003` and `:5173`. Every worktree dev server runs on its own `PORT`, so any server outside that tiny range (e.g. `:3007`) has **every** Worker request killed at preflight — reports, roster hub, pack hub, build hub, the ESO Logs client proxy. Production is unaffected (`esotk.com` is allowlisted).

## The fix

Make dev traffic same-origin so the port stops mattering:

- **`vite.config.mjs`** — new `server.proxy` route: `/roster-hub-api/*` on the dev server's own origin forwards server-side to `https://roster-hub-api.eso-toolkit.workers.dev`, stripping the browser `Origin` header. Same-origin requests never trigger a CORS preflight.
- **`getRosterHubBaseUrl()`** (new, in `envUtils.ts`) — single resolution used by all six API clients:
  1. explicit `VITE_ROSTER_HUB_API_URL` always wins (prod builds pin the Worker URL; Worker devs point it at wrangler's `localhost:8787`);
  2. dev fallback → `/roster-hub-api` (the Vite proxy);
  3. prod fallback → the deployed Worker URL.
- Side benefit: the pack-hub / build-hub / build-editor clients previously fell back to `http://localhost:8787` in dev — a wrangler instance that usually isn't running — so those hubs were broken on most dev servers too. They now ride the same proxy.

## Validation

- Verified live on `localhost:3210` (a port the Worker **blocks**): Latest Reports renders the full table and report details load, with requests going to `localhost:3210/roster-hub-api/graphql` (200) and zero env configuration.
- Production resolution unchanged (env var pinned at build time; prod fallback identical).
- `tsc` clean, `eslint --max-warnings 0` clean, prettier clean on changed files, targeted jest suites pass (57 tests).
