### PR TITLE
fix(fight-replay): UX audit of #1199 — flat marker icon picker, mobile redo, touch-target fixes

### DIFF
--- a/src/features/fight_replay/FightReplay.tsx
+++ b/src/features/fight_replay/FightReplay.tsx
@@ -446,6 +446,8 @@ export const FightReplay: React.FC = () => {
         onEditMarker={setEditingMarkerId}
         canUndoMarkers={canUndo}
         onUndoMarkers={undo}
+        canRedoMarkers={canRedo}
+        onRedoMarkers={redo}
         showPlayerPaths={true}
         initialSelectedPlayerIds={[]} // Empty initially, user can select via HUD
       />

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -1,6 +1,5 @@
 import { Fullscreen, FullscreenExit, LockOpen, Videocam } from '@mui/icons-material';
 import Bolt from '@mui/icons-material/Bolt';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import HelpOutline from '@mui/icons-material/HelpOutlineOutlined';
 import Insights from '@mui/icons-material/Insights';
 import Label from '@mui/icons-material/Label';
@@ -10,7 +9,6 @@ import {
   Box,
   Button,
   Chip,
-  ClickAwayListener,
   IconButton,
   Tooltip,
   Typography,
@@ -32,7 +30,6 @@ import { MapTimeline } from '../../../utils/mapTimelineUtils';
 import { getActorPositionAtClosestTimestamp } from '../../../workers/calculations/CalculateActorPositions';
 import { ARENA_HEIGHT } from '../constants/replayDesign';
 import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
-import { COMMON_MARKER_GROUPS, MarkerGroup, MarkerGroupKey } from '../utils/mapMarkerConverters';
 import { DEFAULT_ACTOR_SCALE, computeActorScaleFromMapData } from '../utils/mapScaling';
 import { getVisiblePlayerIds } from '../utils/pathUtils';
 import { decidePreviewMode } from '../utils/previewMode';
@@ -41,7 +38,7 @@ import { ADD_MARKER_AT_CENTER_EVENT, Arena3DScene, GroundContextMenuPayload } fr
 import { BossHealthPanel } from './BossHealthPanel';
 import { LockedPlayerStatsPanel } from './LockedPlayerStatsPanel';
 import { MarkerContextMenuPayload } from './Marker3D';
-import { MarkerSpritePreview } from './MarkerSpritePreview';
+import { MarkerIconPicker } from './MarkerIconPicker';
 import { MobileReplayControls } from './MobileReplayControls';
 import { PerformanceMonitorExternal } from './PerformanceMonitor/PerformanceMonitorExternal';
 import { PlayerListPanel } from './PlayerListPanel';
@@ -115,9 +112,11 @@ interface Arena3DProps {
   onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
   /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
   onEditMarker?: (markerId: string) => void;
-  /** Marker undo (mobile tools sheet — Ctrl+Z has no touch equivalent). */
+  /** Marker undo/redo (mobile tools sheet — Ctrl+Z/Ctrl+Shift+Z have no touch equivalent). */
   canUndoMarkers?: boolean;
   onUndoMarkers?: () => void;
+  canRedoMarkers?: boolean;
+  onRedoMarkers?: () => void;
   /** Fight data for zone/map information (required for map markers coordinate transformation) */
   fight: FightFragment;
   /** Selected player IDs for path visualization */
@@ -173,6 +172,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   onEditMarker,
   canUndoMarkers = false,
   onUndoMarkers,
+  canRedoMarkers = false,
+  onRedoMarkers,
   fight,
   selectedPlayerIds,
   onPlayerSelectionChange,
@@ -262,10 +263,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   // Player IDs for the DOM player-list overlay (derived from the same lookup the scene uses).
   const availablePlayerIds = useMemo(() => (lookup ? getVisiblePlayerIds(lookup) : []), [lookup]);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [submenuState, setSubmenuState] = useState<{
-    key: MarkerGroupKey;
-    anchorEl: HTMLElement | null;
-  } | null>(null);
 
   const markerLookup = useMemo(() => {
     if (!markersState) {
@@ -283,7 +280,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         return;
       }
 
-      setSubmenuState(null);
       setContextMenu({
         type: 'ground',
         anchor: payload.screenPosition,
@@ -299,7 +295,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         return;
       }
 
-      setSubmenuState(null);
       setContextMenu({
         type: 'marker',
         anchor: payload.screenPosition,
@@ -311,7 +306,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
 
   const handleCloseContextMenu = useCallback(() => {
     setContextMenu(null);
-    setSubmenuState(null);
   }, []);
 
   const handleAddMarkerOption = useCallback(
@@ -322,44 +316,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
 
       onAddMarker(iconKey, contextMenu.arenaPoint);
       setContextMenu(null);
-      setSubmenuState(null);
     },
     [contextMenu, onAddMarker],
   );
-
-  const handleOpenSubmenu = useCallback(
-    (event: React.MouseEvent<HTMLElement>, groupKey: MarkerGroupKey) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      setSubmenuState({ key: groupKey, anchorEl: event.currentTarget });
-    },
-    [],
-  );
-
-  const handleGroupMouseLeave = useCallback(() => {
-    // Don't close submenu on mouse leave - let it stay open
-    // It will close when clicking outside or when another group is hovered
-  }, []);
-
-  const handleGroupKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLElement>, groupKey: MarkerGroupKey) => {
-      if (event.key !== 'ArrowRight' && event.key !== 'Enter' && event.key !== ' ') {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      const target = event.currentTarget as HTMLElement;
-      setSubmenuState({ key: groupKey, anchorEl: target });
-    },
-    [],
-  );
-
-  const handleCloseSubmenu = useCallback(() => {
-    setSubmenuState(null);
-  }, []);
 
   const handleRemoveMarkerClick = useCallback(() => {
     if (!contextMenu || contextMenu.type !== 'marker' || !onRemoveMarker) {
@@ -386,15 +345,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       ? `Remove "${markerForMenu.text.trim()}"`
       : 'Remove marker';
 
-  const activeSubmenuGroup: MarkerGroup | null = useMemo(() => {
-    if (!submenuState) {
-      return null;
-    }
-
-    const group = COMMON_MARKER_GROUPS.find((candidate) => candidate.key === submenuState.key);
-    return group && group.options.length > 0 ? group : null;
-  }, [submenuState]);
-
   const handleCanvasContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -413,12 +363,6 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
     return () => {
       document.removeEventListener('contextmenu', suppressNativeContextMenu);
     };
-  }, [contextMenu]);
-
-  useEffect(() => {
-    if (!contextMenu) {
-      setSubmenuState(null);
-    }
   }, [contextMenu]);
 
   // Show keyboard help on initial mount for 5 seconds
@@ -955,132 +899,61 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
         {/* Player-list + boss-health HUDs are DOM overlays (above) rendered as siblings of
             the <Canvas>, not in-canvas textured planes — crisp text, real scroll, native
             MUI styling. */}
-        {contextMenu && (
-          <ClickAwayListener onClickAway={handleCloseContextMenu}>
-            <div>
-              <Menu
-                open={Boolean(contextMenu)}
-                onClose={handleCloseContextMenu}
-                anchorReference="anchorPosition"
-                anchorPosition={
-                  contextMenu
-                    ? { top: contextMenu.anchor.top, left: contextMenu.anchor.left }
-                    : undefined
-                }
-                disableScrollLock
-                slotProps={{
-                  list: {
-                    dense: true,
-                    onContextMenu: (event: React.MouseEvent) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                    },
-                  },
-                  // Portaled past the replay container, so it needs its own selection
-                  // suppression: iOS otherwise text-selects the menu items the long-press
-                  // gesture lands on and covers them with the Copy/Look Up callout.
-                  paper: {
-                    sx: { userSelect: 'none', WebkitTouchCallout: 'none' },
-                  },
-                }}
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-              >
-                {contextMenu?.type === 'ground' &&
-                  COMMON_MARKER_GROUPS.filter((group) => group.options.length > 0).map((group) => (
-                    <MenuItem
-                      key={group.key}
-                      onMouseEnter={(event: React.MouseEvent<HTMLLIElement>) =>
-                        handleOpenSubmenu(event, group.key)
-                      }
-                      onMouseLeave={handleGroupMouseLeave}
-                      onClick={(event: React.MouseEvent<HTMLLIElement>) =>
-                        handleOpenSubmenu(event, group.key)
-                      }
-                      onContextMenu={(event: React.MouseEvent<HTMLLIElement>) =>
-                        handleOpenSubmenu(event, group.key)
-                      }
-                      onKeyDown={(event: React.KeyboardEvent<HTMLLIElement>) =>
-                        handleGroupKeyDown(event, group.key)
-                      }
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        gap: 1,
-                      }}
-                    >
-                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        {group.label}
-                      </Typography>
-                      <ChevronRightIcon fontSize="small" />
-                    </MenuItem>
-                  ))}
-                {contextMenu?.type === 'marker' && onEditMarker && (
-                  <MenuItem onClick={handleEditMarkerClick}>Edit marker…</MenuItem>
-                )}
-                {contextMenu?.type === 'marker' && (
-                  <MenuItem onClick={handleRemoveMarkerClick} disabled={!onRemoveMarker}>
-                    {markerRemoveLabel}
-                  </MenuItem>
-                )}
-              </Menu>
-              <Menu
-                open={Boolean(activeSubmenuGroup && submenuState?.anchorEl)}
-                anchorEl={submenuState?.anchorEl ?? null}
-                onClose={handleCloseSubmenu}
-                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                disableScrollLock
-                disableAutoFocus
-                disableEnforceFocus
-                disableRestoreFocus
-                onContextMenu={(event: React.MouseEvent) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                slotProps={{
-                  list: {
-                    dense: true,
-                    onContextMenu: (event: React.MouseEvent) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                    },
-                    onMouseLeave: handleGroupMouseLeave,
-                    sx: { pointerEvents: 'auto' },
-                  },
-                  paper: {
-                    onMouseLeave: handleGroupMouseLeave,
-                    sx: { pointerEvents: 'auto', userSelect: 'none', WebkitTouchCallout: 'none' },
-                  },
-                  root: {
-                    sx: { pointerEvents: 'none' },
-                  },
-                }}
-              >
-                {activeSubmenuGroup?.options.map((option) => (
-                  <MenuItem
-                    key={option.iconKey}
-                    onClick={(event: React.MouseEvent<HTMLLIElement>) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      handleAddMarkerOption(option.iconKey);
-                    }}
-                    disabled={!onAddMarker}
-                    sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}
-                  >
-                    <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
-                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                      {option.label}
-                    </Typography>
-                  </MenuItem>
-                ))}
-              </Menu>
-            </div>
-          </ClickAwayListener>
-        )}
+
+        {/* Add-marker picker: one flat surface with every icon (bottom sheet on touch,
+            popover at the click point on desktop). Kept mounted so close transitions run. */}
+        <MarkerIconPicker
+          open={contextMenu?.type === 'ground'}
+          anchorPosition={contextMenu?.type === 'ground' ? contextMenu.anchor : null}
+          mobile={isMobile}
+          onSelect={handleAddMarkerOption}
+          onClose={handleCloseContextMenu}
+        />
+
+        {/* Marker context menu: edit/remove for an existing marker. */}
+        <Menu
+          open={contextMenu?.type === 'marker'}
+          onClose={handleCloseContextMenu}
+          anchorReference="anchorPosition"
+          anchorPosition={
+            contextMenu?.type === 'marker'
+              ? { top: contextMenu.anchor.top, left: contextMenu.anchor.left }
+              : undefined
+          }
+          disableScrollLock
+          slotProps={{
+            list: {
+              dense: !isMobile,
+              onContextMenu: (event: React.MouseEvent) => {
+                event.preventDefault();
+                event.stopPropagation();
+              },
+            },
+            // Portaled past the replay container, so it needs its own selection
+            // suppression: iOS otherwise text-selects the menu items the long-press
+            // gesture lands on and covers them with the Copy/Look Up callout.
+            paper: {
+              sx: { userSelect: 'none', WebkitTouchCallout: 'none' },
+            },
+          }}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          {onEditMarker && (
+            <MenuItem onClick={handleEditMarkerClick} sx={isMobile ? { minHeight: 48 } : undefined}>
+              Edit marker…
+            </MenuItem>
+          )}
+          <MenuItem
+            onClick={handleRemoveMarkerClick}
+            disabled={!onRemoveMarker}
+            sx={isMobile ? { minHeight: 48 } : undefined}
+          >
+            {markerRemoveLabel}
+          </MenuItem>
+        </Menu>
       </ReplayErrorBoundary>
 
       {/* Performance Monitor Overlay - rendered outside Canvas for proper screen-space positioning */}
@@ -1401,6 +1274,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           }
           canUndoMarkers={canUndoMarkers}
           onUndoMarkers={onUndoMarkers}
+          canRedoMarkers={canRedoMarkers}
+          onRedoMarkers={onRedoMarkers}
         />
       )}
 

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -40,9 +40,11 @@ interface FightReplay3DProps {
   onMarkerMove?: (markerId: string, arenaPoint: { x: number; z: number }) => void;
   /** Opens the marker edit dialog (owned by FightReplay) for the given marker. */
   onEditMarker?: (markerId: string) => void;
-  /** Marker undo for the mobile tools sheet (Ctrl+Z has no touch equivalent). */
+  /** Marker undo/redo for the mobile tools sheet (Ctrl+Z/Ctrl+Shift+Z have no touch equivalent). */
   canUndoMarkers?: boolean;
   onUndoMarkers?: () => void;
+  canRedoMarkers?: boolean;
+  onRedoMarkers?: () => void;
   /** Whether to show player paths toolkit */
   showPlayerPaths?: boolean;
   /** Initial selected player IDs for path visualization */
@@ -62,6 +64,8 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   onEditMarker,
   canUndoMarkers = false,
   onUndoMarkers,
+  canRedoMarkers = false,
+  onRedoMarkers,
   showPlayerPaths = false,
   initialSelectedPlayerIds = [],
 }) => {
@@ -720,6 +724,8 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           onEditMarker={onEditMarker}
           canUndoMarkers={canUndoMarkers}
           onUndoMarkers={onUndoMarkers}
+          canRedoMarkers={canRedoMarkers}
+          onRedoMarkers={onRedoMarkers}
           fight={selectedFight}
           selectedPlayerIds={selectedPlayerIds}
           onPlayerSelectionChange={setSelectedPlayerIds}

--- a/src/features/fight_replay/components/MarkerEditDialog.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.tsx
@@ -2,6 +2,7 @@
  * Dialog for editing a single map marker: icon (Elms template), label, colour, and size.
  * Submits one atomic MarkerEdit so the change is a single undo step.
  */
+import CloseIcon from '@mui/icons-material/Close';
 import {
   Box,
   Button,
@@ -9,6 +10,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
   Slider,
   TextField,
   Tooltip,
@@ -22,9 +24,9 @@ import { MorMarker } from '@/types/mapMarkers';
 import { ELMS_ICON_MAP } from '@/utils/elmsMarkersDecoder';
 
 import { ReplayMarker } from '../types/mapMarkers';
-import { COMMON_MARKER_GROUPS, MarkerEdit } from '../utils/mapMarkerConverters';
+import { MarkerEdit } from '../utils/mapMarkerConverters';
 
-import { MarkerSpritePreview } from './MarkerSpritePreview';
+import { MarkerIconGrid } from './MarkerIconGrid';
 
 const MIN_SIZE_METERS = 0.5;
 const MAX_SIZE_METERS = 5;
@@ -139,49 +141,23 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
       fullWidth
       fullScreen={fullScreen}
     >
-      <DialogTitle>Edit Marker</DialogTitle>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', pr: 1.5 }}>
+        <Box component="span" sx={{ flexGrow: 1 }}>
+          Edit Marker
+        </Box>
+        {/* Full-screen on phones, so the dialog needs an exit at the top — reaching the
+            bottom Cancel one-handed is a stretch. */}
+        <IconButton aria-label="Close" onClick={onClose} edge="end">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1 }}>
         {/* Icon picker */}
         <Box>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             Icon
           </Typography>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {COMMON_MARKER_GROUPS.map((group) => (
-              <Box key={group.key} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ width: 110, flexShrink: 0 }}
-                >
-                  {group.label}
-                </Typography>
-                <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-                  {group.options.map((option) => (
-                    <Box
-                      key={option.iconKey}
-                      component="button"
-                      type="button"
-                      onClick={() => handlePickIcon(option.iconKey)}
-                      aria-label={`Use icon ${option.label}`}
-                      aria-pressed={iconKey === option.iconKey}
-                      sx={{
-                        p: 0.25,
-                        background: 'none',
-                        border: '2px solid',
-                        borderColor: iconKey === option.iconKey ? 'primary.main' : 'transparent',
-                        borderRadius: 1,
-                        cursor: 'pointer',
-                        display: 'inline-flex',
-                      }}
-                    >
-                      <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
-                    </Box>
-                  ))}
-                </Box>
-              </Box>
-            ))}
-          </Box>
+          <MarkerIconGrid selectedIconKey={iconKey} onPick={handlePickIcon} touch={fullScreen} />
         </Box>
 
         {/* Label */}

--- a/src/features/fight_replay/components/MarkerIconGrid.tsx
+++ b/src/features/fight_replay/components/MarkerIconGrid.tsx
@@ -1,0 +1,78 @@
+/**
+ * Grouped grid of the common Elms marker icons (Numbers / Arrows / Squares / Hexagons),
+ * shared by the add-marker picker and the marker edit dialog. Every option is visible at
+ * once — no nested menus — and each cell is a real button, so the grid works the same for
+ * touch, mouse, and keyboard.
+ */
+import { Box, Tooltip, Typography } from '@mui/material';
+import React from 'react';
+
+import { COMMON_MARKER_GROUPS } from '../utils/mapMarkerConverters';
+
+import { MarkerSpritePreview } from './MarkerSpritePreview';
+
+interface MarkerIconGridProps {
+  /** Highlights the matching cell (edit dialog); omit for one-shot pickers. */
+  selectedIconKey?: number;
+  onPick: (iconKey: number) => void;
+  /** Finger-sized cells (≥48px) for touch surfaces; compact cells for pointer use. */
+  touch?: boolean;
+}
+
+export const MarkerIconGrid: React.FC<MarkerIconGridProps> = ({
+  selectedIconKey,
+  onPick,
+  touch = false,
+}) => {
+  const cellSize = touch ? 48 : 38;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: touch ? 1.5 : 1 }}>
+      {COMMON_MARKER_GROUPS.filter((group) => group.options.length > 0).map((group) => (
+        <Box key={group.key}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mb: 0.5, fontWeight: 600 }}
+          >
+            {group.label}
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: touch ? 1 : 0.5 }}>
+            {group.options.map((option) => {
+              const selected = selectedIconKey === option.iconKey;
+              return (
+                <Tooltip key={option.iconKey} title={option.label}>
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={() => onPick(option.iconKey)}
+                    aria-label={`Use icon ${option.label}`}
+                    aria-pressed={selectedIconKey !== undefined ? selected : undefined}
+                    sx={{
+                      width: cellSize,
+                      height: cellSize,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      background: 'none',
+                      border: '2px solid',
+                      borderColor: selected ? 'primary.main' : 'transparent',
+                      borderRadius: 1.5,
+                      cursor: 'pointer',
+                      p: 0,
+                      WebkitTapHighlightColor: 'transparent',
+                      '&:hover': { backgroundColor: 'action.hover' },
+                      '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main' },
+                    }}
+                  >
+                    <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
+                  </Box>
+                </Tooltip>
+              );
+            })}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/features/fight_replay/components/MarkerIconGrid.tsx
+++ b/src/features/fight_replay/components/MarkerIconGrid.tsx
@@ -3,13 +3,24 @@
  * shared by the add-marker picker and the marker edit dialog. Every option is visible at
  * once — no nested menus — and each cell is a real button, so the grid works the same for
  * touch, mouse, and keyboard.
+ *
+ * Touch activation is pointer-based, NOT click-based: iOS Safari's synthesized click is
+ * unreliable inside the replay's immersive overlay (field-reported as "can't tap anything
+ * in the sheet" — the same WebKit behavior that forced the canvas gestures onto pointer
+ * events). A touch/pen tap commits on `pointerup` (slop-gated so a scroll over the grid
+ * never picks), and the trailing synthetic click — if the browser does emit one — is
+ * suppressed so the pick can't double-fire or click through to whatever is underneath.
+ * Mouse and keyboard still use the plain click path.
  */
 import { Box, Tooltip, Typography } from '@mui/material';
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { COMMON_MARKER_GROUPS } from '../utils/mapMarkerConverters';
 
 import { MarkerSpritePreview } from './MarkerSpritePreview';
+
+/** Max pointer travel (px) between down and up for the touch to count as a tap. */
+const TAP_SLOP_PX = 12;
 
 interface MarkerIconGridProps {
   /** Highlights the matching cell (edit dialog); omit for one-shot pickers. */
@@ -26,6 +37,59 @@ export const MarkerIconGrid: React.FC<MarkerIconGridProps> = ({
 }) => {
   const cellSize = touch ? 48 : 38;
 
+  // One finger at a time is the case that matters; a shared ref keeps the handlers simple.
+  const touchPressRef = useRef<{ pointerId: number; x: number; y: number; iconKey: number } | null>(
+    null,
+  );
+  const suppressClickRef = useRef(false);
+
+  const handlePointerDown = (event: React.PointerEvent, iconKey: number): void => {
+    suppressClickRef.current = false;
+    if (event.pointerType === 'mouse') {
+      touchPressRef.current = null;
+      return;
+    }
+    touchPressRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      iconKey,
+    };
+  };
+
+  const handlePointerUp = (event: React.PointerEvent, iconKey: number): void => {
+    const press = touchPressRef.current;
+    if (!press || event.pointerId !== press.pointerId || press.iconKey !== iconKey) {
+      return;
+    }
+    touchPressRef.current = null;
+
+    const dx = event.clientX - press.x;
+    const dy = event.clientY - press.y;
+    if (dx * dx + dy * dy > TAP_SLOP_PX * TAP_SLOP_PX) {
+      return; // The finger travelled — that was a scroll over the grid, not a pick.
+    }
+
+    suppressClickRef.current = true;
+    onPick(iconKey);
+  };
+
+  const handleTouchEnd = (event: React.TouchEvent): void => {
+    // The pick already committed on pointerup; cancel the synthetic click so it can't
+    // double-fire here or land on whatever replaces the sheet once it closes.
+    if (suppressClickRef.current) {
+      event.preventDefault();
+    }
+  };
+
+  const handleClick = (iconKey: number): void => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    onPick(iconKey);
+  };
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: touch ? 1.5 : 1 }}>
       {COMMON_MARKER_GROUPS.filter((group) => group.options.length > 0).map((group) => (
@@ -40,33 +104,52 @@ export const MarkerIconGrid: React.FC<MarkerIconGridProps> = ({
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: touch ? 1 : 0.5 }}>
             {group.options.map((option) => {
               const selected = selectedIconKey === option.iconKey;
-              return (
+              const cell = (
+                <Box
+                  key={option.iconKey}
+                  component="button"
+                  type="button"
+                  onPointerDown={(event: React.PointerEvent) =>
+                    handlePointerDown(event, option.iconKey)
+                  }
+                  onPointerUp={(event: React.PointerEvent) =>
+                    handlePointerUp(event, option.iconKey)
+                  }
+                  onTouchEnd={handleTouchEnd}
+                  onClick={() => handleClick(option.iconKey)}
+                  aria-label={`Use icon ${option.label}`}
+                  aria-pressed={selectedIconKey !== undefined ? selected : undefined}
+                  sx={{
+                    width: cellSize,
+                    height: cellSize,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: 'none',
+                    border: '2px solid',
+                    borderColor: selected ? 'primary.main' : 'transparent',
+                    borderRadius: 1.5,
+                    cursor: 'pointer',
+                    p: 0,
+                    // Kill iOS double-tap-zoom heuristics on the cells; taps act immediately.
+                    touchAction: 'manipulation',
+                    WebkitTapHighlightColor: 'transparent',
+                    '&:hover': { backgroundColor: 'action.hover' },
+                    '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main' },
+                  }}
+                >
+                  <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
+                </Box>
+              );
+
+              // Tooltips are hover affordances; on touch they only add competing touch
+              // listeners (and iOS press-and-hold behaviors), so the label rides on
+              // aria-label alone there.
+              return touch ? (
+                cell
+              ) : (
                 <Tooltip key={option.iconKey} title={option.label}>
-                  <Box
-                    component="button"
-                    type="button"
-                    onClick={() => onPick(option.iconKey)}
-                    aria-label={`Use icon ${option.label}`}
-                    aria-pressed={selectedIconKey !== undefined ? selected : undefined}
-                    sx={{
-                      width: cellSize,
-                      height: cellSize,
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      background: 'none',
-                      border: '2px solid',
-                      borderColor: selected ? 'primary.main' : 'transparent',
-                      borderRadius: 1.5,
-                      cursor: 'pointer',
-                      p: 0,
-                      WebkitTapHighlightColor: 'transparent',
-                      '&:hover': { backgroundColor: 'action.hover' },
-                      '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main' },
-                    }}
-                  >
-                    <MarkerSpritePreview iconKey={option.iconKey} label={option.label} />
-                  </Box>
+                  {cell}
                 </Tooltip>
               );
             })}

--- a/src/features/fight_replay/components/MarkerIconPicker.stories.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.stories.tsx
@@ -1,0 +1,55 @@
+import { Box, Typography } from '@mui/material';
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { MarkerIconPicker } from './MarkerIconPicker';
+
+const meta: Meta<typeof MarkerIconPicker> = {
+  title: 'FightReplay/MarkerIconPicker',
+  component: MarkerIconPicker,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MarkerIconPicker>;
+
+const Backdrop: React.FC = () => (
+  <Box sx={{ height: '100vh', bgcolor: '#1a1a1a', p: 2 }}>
+    <Typography sx={{ color: 'rgba(255,255,255,0.6)' }}>
+      3D replay stand-in — the picker overlays this.
+    </Typography>
+  </Box>
+);
+
+/** Desktop: popover anchored at the right-click point, all groups on one surface. */
+export const DesktopPopover: Story = {
+  render: () => (
+    <>
+      <Backdrop />
+      <MarkerIconPicker
+        open
+        anchorPosition={{ left: 220, top: 160 }}
+        onSelect={() => undefined}
+        onClose={() => undefined}
+      />
+    </>
+  ),
+};
+
+/** Touch: bottom sheet with finger-sized cells, a title, and an explicit close button. */
+export const MobileBottomSheet: Story = {
+  render: () => (
+    <>
+      <Backdrop />
+      <MarkerIconPicker
+        open
+        mobile
+        anchorPosition={{ left: 180, top: 320 }}
+        onSelect={() => undefined}
+        onClose={() => undefined}
+      />
+    </>
+  ),
+};

--- a/src/features/fight_replay/components/MarkerIconPicker.stories.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.stories.tsx
@@ -15,41 +15,57 @@ const meta: Meta<typeof MarkerIconPicker> = {
 export default meta;
 type Story = StoryObj<typeof MarkerIconPicker>;
 
-const Backdrop: React.FC = () => (
-  <Box sx={{ height: '100vh', bgcolor: '#1a1a1a', p: 2 }}>
-    <Typography sx={{ color: 'rgba(255,255,255,0.6)' }}>
-      3D replay stand-in — the picker overlays this.
-    </Typography>
-  </Box>
-);
+/** Stand-in for the 3D canvas, reporting the picker's last action for hands-on testing. */
+const Harness: React.FC<{ mobile?: boolean }> = ({ mobile }) => {
+  const [open, setOpen] = React.useState(true);
+  const [lastEvent, setLastEvent] = React.useState('none yet');
+  const eventCount = React.useRef(0);
+
+  return (
+    <>
+      <Box sx={{ height: '100vh', bgcolor: '#1a1a1a', p: 2 }}>
+        <Typography sx={{ color: 'rgba(255,255,255,0.6)' }}>
+          3D replay stand-in — the picker overlays this.
+        </Typography>
+        <Typography data-testid="picker-event" sx={{ color: '#7dd3fc', mt: 1 }}>
+          Last picker event: {lastEvent}
+        </Typography>
+        {!open && (
+          <Typography
+            component="button"
+            type="button"
+            onClick={() => setOpen(true)}
+            sx={{ mt: 2, display: 'block' }}
+          >
+            Reopen picker
+          </Typography>
+        )}
+      </Box>
+      <MarkerIconPicker
+        open={open}
+        mobile={mobile}
+        anchorPosition={{ left: 220, top: 160 }}
+        onSelect={(iconKey) => {
+          eventCount.current += 1;
+          setLastEvent(`selected icon ${iconKey} (event #${eventCount.current})`);
+          setOpen(false);
+        }}
+        onClose={() => {
+          eventCount.current += 1;
+          setLastEvent(`closed (event #${eventCount.current})`);
+          setOpen(false);
+        }}
+      />
+    </>
+  );
+};
 
 /** Desktop: popover anchored at the right-click point, all groups on one surface. */
 export const DesktopPopover: Story = {
-  render: () => (
-    <>
-      <Backdrop />
-      <MarkerIconPicker
-        open
-        anchorPosition={{ left: 220, top: 160 }}
-        onSelect={() => undefined}
-        onClose={() => undefined}
-      />
-    </>
-  ),
+  render: () => <Harness />,
 };
 
 /** Touch: bottom sheet with finger-sized cells, a title, and an explicit close button. */
 export const MobileBottomSheet: Story = {
-  render: () => (
-    <>
-      <Backdrop />
-      <MarkerIconPicker
-        open
-        mobile
-        anchorPosition={{ left: 180, top: 320 }}
-        onSelect={() => undefined}
-        onClose={() => undefined}
-      />
-    </>
-  ),
+  render: () => <Harness mobile />,
 };

--- a/src/features/fight_replay/components/MarkerIconPicker.test.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.test.tsx
@@ -6,6 +6,17 @@ import { MarkerIconPicker } from './MarkerIconPicker';
 const anchor = { left: 120, top: 80 };
 const noop = (): void => undefined;
 
+/** jsdom lacks a full PointerEvent, so build a plain event carrying the pointer fields. */
+function firePointer(
+  element: Element,
+  type: 'pointerdown' | 'pointerup',
+  init: { pointerId: number; pointerType: string; clientX: number; clientY: number },
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, init);
+  fireEvent(element, event);
+}
+
 describe('MarkerIconPicker', () => {
   it('renders nothing while closed', () => {
     render(<MarkerIconPicker open={false} anchorPosition={null} onSelect={noop} onClose={noop} />);
@@ -33,6 +44,56 @@ describe('MarkerIconPicker', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Use icon MT Hex' }));
     expect(onSelect).toHaveBeenCalledWith(21);
+  });
+
+  it('commits a touch tap on pointerup and swallows the trailing synthetic click', () => {
+    const onSelect = jest.fn();
+    render(
+      <MarkerIconPicker open mobile anchorPosition={anchor} onSelect={onSelect} onClose={noop} />,
+    );
+
+    const cell = screen.getByRole('button', { name: 'Use icon MT Hex' });
+    // iOS-style sequence: pointer events, then the (sometimes-missing) synthetic click.
+    firePointer(cell, 'pointerdown', {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 50,
+      clientY: 50,
+    });
+    firePointer(cell, 'pointerup', {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 52,
+      clientY: 51,
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(21);
+
+    // A browser that does emit the trailing click must not double-fire the pick.
+    fireEvent.click(cell);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('a touch that travels (scroll over the grid) does not pick', () => {
+    const onSelect = jest.fn();
+    render(
+      <MarkerIconPicker open mobile anchorPosition={anchor} onSelect={onSelect} onClose={noop} />,
+    );
+
+    const cell = screen.getByRole('button', { name: 'Use icon Number 1' });
+    firePointer(cell, 'pointerdown', {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 50,
+      clientY: 50,
+    });
+    firePointer(cell, 'pointerup', {
+      pointerId: 1,
+      pointerType: 'touch',
+      clientX: 50,
+      clientY: 90,
+    });
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it('mobile bottom sheet has a title and an explicit close affordance', () => {

--- a/src/features/fight_replay/components/MarkerIconPicker.test.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MarkerIconPicker } from './MarkerIconPicker';
+
+const anchor = { left: 120, top: 80 };
+const noop = (): void => undefined;
+
+describe('MarkerIconPicker', () => {
+  it('renders nothing while closed', () => {
+    render(<MarkerIconPicker open={false} anchorPosition={null} onSelect={noop} onClose={noop} />);
+    expect(screen.queryByText('Add marker')).not.toBeInTheDocument();
+  });
+
+  it('shows every group and option on one surface (desktop popover)', () => {
+    render(<MarkerIconPicker open anchorPosition={anchor} onSelect={noop} onClose={noop} />);
+
+    // All four groups visible at once — no nested submenu to drill into.
+    expect(screen.getByText('Numbers')).toBeInTheDocument();
+    expect(screen.getByText('Arrows & Chevron')).toBeInTheDocument();
+    expect(screen.getByText('Squares')).toBeInTheDocument();
+    expect(screen.getByText('Hexagons')).toBeInTheDocument();
+
+    // Both hexagon variants are individually pickable (no auto-selected first option).
+    expect(screen.getByRole('button', { name: 'Use icon OT Hex' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use icon MT Hex' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use icon Number 10' })).toBeInTheDocument();
+  });
+
+  it('selecting an icon reports its key', () => {
+    const onSelect = jest.fn();
+    render(<MarkerIconPicker open anchorPosition={anchor} onSelect={onSelect} onClose={noop} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use icon MT Hex' }));
+    expect(onSelect).toHaveBeenCalledWith(21);
+  });
+
+  it('mobile bottom sheet has a title and an explicit close affordance', () => {
+    const onClose = jest.fn();
+    const onSelect = jest.fn();
+    render(
+      <MarkerIconPicker
+        open
+        mobile
+        anchorPosition={anchor}
+        onSelect={onSelect}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Add marker')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use icon Number 3' }));
+    expect(onSelect).toHaveBeenCalledWith(3);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close marker picker' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/fight_replay/components/MarkerIconPicker.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.tsx
@@ -1,0 +1,115 @@
+/**
+ * The add-marker icon picker: one flat surface showing every common marker at once.
+ *
+ * Presentation adapts to the input:
+ *  - Touch (mobile): a bottom sheet with finger-sized cells, a visible title, and an
+ *    explicit close button — dismissible by the backdrop, swipe, or the X. Replaces the
+ *    desktop-style nested submenu, which on a phone opened under the finger (the tap's
+ *    trailing click instantly placed the first option) and offered no way back to the
+ *    other groups without dismissing everything.
+ *  - Pointer (desktop): a popover anchored at the click point with the same grid, so one
+ *    click places a marker and Escape/click-away backs out.
+ */
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, Drawer, IconButton, Popover, Typography } from '@mui/material';
+import React, { useRef } from 'react';
+
+import { MarkerIconGrid } from './MarkerIconGrid';
+
+interface MarkerIconPickerProps {
+  open: boolean;
+  /** Screen point the picker was invoked at — anchors the desktop popover. */
+  anchorPosition: { left: number; top: number } | null;
+  /** Bottom-sheet presentation (touch); false = popover at the pointer (desktop). */
+  mobile?: boolean;
+  onSelect: (iconKey: number) => void;
+  onClose: () => void;
+}
+
+/** Both surfaces were opened by a right-click/long-press; don't let a second native
+ *  context menu fire on top of them. */
+const suppressContextMenu = (event: React.MouseEvent): void => {
+  event.preventDefault();
+};
+
+export const MarkerIconPicker: React.FC<MarkerIconPickerProps> = ({
+  open,
+  anchorPosition,
+  mobile = false,
+  onSelect,
+  onClose,
+}) => {
+  // Keep the last real anchor through the close transition — the owner nulls the anchor
+  // the moment a pick/dismiss happens, and the popover would otherwise jump to (0,0)
+  // while fading out.
+  const lastAnchorRef = useRef(anchorPosition);
+  if (anchorPosition) {
+    lastAnchorRef.current = anchorPosition;
+  }
+
+  if (mobile) {
+    return (
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={onClose}
+        // The mobile replay overlay sits at zIndex.modal; the sheet must stack above it.
+        sx={(theme) => ({ zIndex: theme.zIndex.modal + 1 })}
+        slotProps={{
+          paper: {
+            onContextMenu: suppressContextMenu,
+            sx: {
+              borderTopLeftRadius: 16,
+              borderTopRightRadius: 16,
+              maxHeight: '70dvh',
+              pb: 'calc(env(safe-area-inset-bottom) + 12px)',
+              // iOS: a long-press that bleeds into the sheet must not text-select it.
+              userSelect: 'none',
+              WebkitTouchCallout: 'none',
+            },
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'center', pt: 1 }}>
+          <Box sx={{ width: 36, height: 4, borderRadius: 2, backgroundColor: 'action.disabled' }} />
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', pl: 2, pr: 1, pt: 0.5, pb: 0.5 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700, flexGrow: 1 }}>
+            Add marker
+          </Typography>
+          <IconButton aria-label="Close marker picker" onClick={onClose} sx={{ p: 1.25 }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <Box sx={{ px: 2, pt: 0.5, overflowY: 'auto' }}>
+          <MarkerIconGrid touch onPick={onSelect} />
+        </Box>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Popover
+      open={open}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={lastAnchorRef.current ?? undefined}
+      sx={(theme) => ({ zIndex: theme.zIndex.modal + 1 })}
+      slotProps={{
+        paper: {
+          onContextMenu: suppressContextMenu,
+          sx: { p: 1.5, maxWidth: 320 },
+        },
+      }}
+    >
+      <Typography
+        variant="overline"
+        color="text.secondary"
+        sx={{ display: 'block', lineHeight: 1.6, mb: 0.5 }}
+      >
+        Add marker
+      </Typography>
+      <MarkerIconGrid onPick={onSelect} />
+    </Popover>
+  );
+};

--- a/src/features/fight_replay/components/MarkerIconPicker.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.tsx
@@ -12,7 +12,7 @@
  */
 import CloseIcon from '@mui/icons-material/Close';
 import { Box, Drawer, IconButton, Popover, Typography } from '@mui/material';
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 import { MarkerIconGrid } from './MarkerIconGrid';
 
@@ -47,6 +47,33 @@ export const MarkerIconPicker: React.FC<MarkerIconPickerProps> = ({
     lastAnchorRef.current = anchorPosition;
   }
 
+  // Close commits on pointerup for touch/pen (same iOS synthesized-click unreliability the
+  // grid guards against — see MarkerIconGrid); the click path stays for mouse/keyboard,
+  // with a flag so a browser that does emit the trailing click can't double-close.
+  const closeHandledRef = useRef(false);
+  const handleClosePointerUp = useCallback(
+    (event: React.PointerEvent) => {
+      if (event.pointerType === 'mouse') {
+        return;
+      }
+      closeHandledRef.current = true;
+      onClose();
+    },
+    [onClose],
+  );
+  const handleCloseTouchEnd = useCallback((event: React.TouchEvent) => {
+    if (closeHandledRef.current) {
+      event.preventDefault();
+    }
+  }, []);
+  const handleCloseClick = useCallback(() => {
+    if (closeHandledRef.current) {
+      closeHandledRef.current = false;
+      return;
+    }
+    onClose();
+  }, [onClose]);
+
   if (mobile) {
     return (
       <Drawer
@@ -63,9 +90,11 @@ export const MarkerIconPicker: React.FC<MarkerIconPickerProps> = ({
               borderTopRightRadius: 16,
               maxHeight: '70dvh',
               pb: 'calc(env(safe-area-inset-bottom) + 12px)',
-              // iOS: a long-press that bleeds into the sheet must not text-select it.
+              // iOS: a long-press that bleeds into the sheet must not text-select it, and
+              // taps must act immediately (no double-tap-zoom heuristics).
               userSelect: 'none',
               WebkitTouchCallout: 'none',
+              touchAction: 'manipulation',
             },
           },
         }}
@@ -77,7 +106,13 @@ export const MarkerIconPicker: React.FC<MarkerIconPickerProps> = ({
           <Typography variant="subtitle1" sx={{ fontWeight: 700, flexGrow: 1 }}>
             Add marker
           </Typography>
-          <IconButton aria-label="Close marker picker" onClick={onClose} sx={{ p: 1.25 }}>
+          <IconButton
+            aria-label="Close marker picker"
+            onPointerUp={handleClosePointerUp}
+            onTouchEnd={handleCloseTouchEnd}
+            onClick={handleCloseClick}
+            sx={{ p: 1.25, touchAction: 'manipulation' }}
+          >
             <CloseIcon />
           </IconButton>
         </Box>

--- a/src/features/fight_replay/components/MarkersPanel.tsx
+++ b/src/features/fight_replay/components/MarkersPanel.tsx
@@ -154,10 +154,12 @@ export const MarkersPanel: React.FC<MarkersPanelProps> = ({
               secondaryAction={
                 <Box sx={{ display: 'flex', gap: 0.25 }}>
                   <Tooltip title="Edit marker">
+                    {/* p:1 → ~36px targets; the small default (~30px) is fiddly on touch. */}
                     <IconButton
                       size="small"
                       onClick={() => onEditMarker(marker.id)}
                       aria-label={`Edit ${describeMarker(marker)}`}
+                      sx={{ p: 1 }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>
@@ -167,13 +169,14 @@ export const MarkersPanel: React.FC<MarkersPanelProps> = ({
                       size="small"
                       onClick={() => onRemoveMarker(marker.id)}
                       aria-label={`Delete ${describeMarker(marker)}`}
+                      sx={{ p: 1 }}
                     >
                       <DeleteOutlineIcon fontSize="small" />
                     </IconButton>
                   </Tooltip>
                 </Box>
               }
-              sx={{ pr: 9 }}
+              sx={{ pr: 10 }}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, minWidth: 0 }}>
                 <MarkerGlyph marker={marker} />

--- a/src/features/fight_replay/components/MobileReplayControls.tsx
+++ b/src/features/fight_replay/components/MobileReplayControls.tsx
@@ -7,6 +7,7 @@ import Insights from '@mui/icons-material/Insights';
 import Label from '@mui/icons-material/Label';
 import LabelOff from '@mui/icons-material/LabelOff';
 import People from '@mui/icons-material/People';
+import Redo from '@mui/icons-material/Redo';
 import RestartAlt from '@mui/icons-material/RestartAlt';
 import Route from '@mui/icons-material/Route';
 import Tune from '@mui/icons-material/Tune';
@@ -58,9 +59,11 @@ export interface MobileReplayControlsProps {
   onToggleMarkersEditMode?: () => void;
   /** Gesture-free marker placement: opens the add-marker menu at the screen center. */
   onAddMarkerAtCenter?: () => void;
-  /** Undo the last marker change — only shown while edit mode is on. */
+  /** Undo/redo the last marker change — only shown while edit mode is on. */
   canUndoMarkers?: boolean;
   onUndoMarkers?: () => void;
+  canRedoMarkers?: boolean;
+  onRedoMarkers?: () => void;
 }
 
 /** A row in the tools sheet. `closesOnTap` items open another on-screen panel, so the sheet dismisses
@@ -93,6 +96,8 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
   onAddMarkerAtCenter,
   canUndoMarkers = false,
   onUndoMarkers,
+  canRedoMarkers = false,
+  onRedoMarkers,
 }) => {
   // The tools sheet anchor — null = closed.
   const [toolsAnchor, setToolsAnchor] = useState<HTMLElement | null>(null);
@@ -161,6 +166,18 @@ export const MobileReplayControls: React.FC<MobileReplayControlsProps> = ({
             active: false,
             onTap: onUndoMarkers,
             disabled: !canUndoMarkers,
+          } as ToolItem,
+        ]
+      : []),
+    ...(markersEditMode && onRedoMarkers
+      ? [
+          {
+            key: 'redoMarkers',
+            label: 'Redo marker change',
+            icon: <Redo fontSize="small" />,
+            active: false,
+            onTap: onRedoMarkers,
+            disabled: !canRedoMarkers,
           } as ToolItem,
         ]
       : []),


### PR DESCRIPTION
# UX audit of #1199 (custom map markers)

Targets the #1199 branch so these fixes land inside that PR. Driven by iPhone Safari field reports; both reported bugs trace to one root cause.

## Root cause: the add-marker menu was a desktop hover-submenu used on touch

The icon list was two stacked MUI `Menu`s (groups → child submenu). On a phone:

- **No way back from a group.** The submenu's backdrop was `pointer-events: none`, so the only tappable surface outside it was the *parent* menu's backdrop — which dismissed the whole thing. Reported as "when I click on numbers, there's no way to back out".
- **"Hexagons" instantly placed an OT Hex.** Group rows had `onMouseEnter` (iOS fires it on tap), so the submenu opened directly under the finger and the tap's trailing click landed on the first child item before the user saw anything.

## Fix: one flat picker surface (`MarkerIconPicker`)

All four groups (Numbers / Arrows & Chevron / Squares / Hexagons) are visible at once — nothing to drill into, nothing to back out of:

- **Touch:** a bottom sheet with 48px icon cells, an "Add marker" title, an explicit close button, swipe/backdrop dismissal, safe-area padding, and iOS selection suppression. Explicitly stacked above the immersive overlay — the overlay sits at `zIndex.modal`, so a default `Drawer` (zIndex.drawer) would have rendered *behind* it.
- **Desktop:** a popover anchored at the right-click point with the same grouped grid. One click places; Escape/click-away backs out. (Also an upgrade over the old hover submenu: every icon is tabbable, no `ArrowRight` knowledge required.)

All entry points route through it: right-click, long-press, and the tools sheet's "Add marker here".

## Follow-up: iOS Safari taps inside the sheet (second commit)

Real-iPhone testing of the first commit found the sheet opened but nothing inside was tappable. Reproduction in Chromium with full touch emulation showed the sheet working there — the failure is **WebKit's touch→click synthesis inside the immersive overlay** (the same iOS behavior that forced this PR's canvas gestures onto pointer events). The grid and the sheet's close button now commit taps on **`pointerup`** (slop-gated 12px so scrolling the grid never picks), suppress the trailing synthetic click (no double-fire, no click-through after the sheet closes), drop Tooltip wrappers on touch, and set `touch-action: manipulation`. Mouse/keyboard keep the plain click path.

## Other findings fixed in the same pass

- **Redo was impossible on touch.** The tools sheet had Undo but no Redo (`Ctrl+Shift+Z` has no touch equivalent). Added a "Redo marker change" row, threading `canRedoMarkers`/`onRedoMarkers` through `FightReplay → FightReplay3D → Arena3D → MobileReplayControls`.
- **`MarkerEditDialog` is fullscreen on phones with no exit at the top** — only the bottom Cancel. Added a top-right Close button.
- **Icon grid deduplicated:** extracted `MarkerIconGrid`, shared by the picker and the edit dialog (which gains touch-sized cells when fullscreen and keeps the same `Use icon <label>` accessible names, so existing tests pass unchanged).
- **Touch targets:** marker edit/remove context-menu rows get 48px min-height on mobile; `MarkersPanel` per-row edit/delete buttons bumped from ~30px to ~36px.
- Dead code removed: submenu state machine, hover handlers, `ClickAwayListener` wrapper.

## Verification

- `npm run validate` ✅ · full jest suite ✅ (including new `MarkerIconPicker` tests: both presentations, per-option selection, close affordance, pointerup-commit, click-suppression, scroll-slop)
- **Live touch verification in a real Chromium** (bundled binary, emulated iPhone viewport, synthesized touch input driving the Storybook harness): one tap = exactly one selection; close works; trailing click correctly swallowed
- Storybook story (`FightReplay/MarkerIconPicker`) doubles as a hands-on QA harness — it reports each picker event with a counter
- Real-WebKit confirmation pending on-device: please re-test the sheet on iPhone via the dev preview

https://claude.ai/code/session_01TeBk58LvEXE2FaWg3S9gTj