### PR TITLE
feat(ultimate-simulator): Arcanist ult-gen Monte Carlo engine + page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,11 @@ const ScribingSimulatorPage = React.lazy(() =>
     default: module.ScribingSimulatorPage,
   })),
 );
+const UltimateSimulatorPage = React.lazy(() =>
+  import('./pages/UltimateSimulatorPage').then((module) => ({
+    default: module.UltimateSimulatorPage,
+  })),
+);
 const ParseAnalysisPage = React.lazy(() =>
   import('./pages/ParseAnalysisPage').then((module) => ({
     default: module.ParseAnalysisPage,
@@ -614,6 +619,16 @@ const AppRoutes: React.FC = () => {
                 <ErrorBoundary>
                   <Suspense fallback={<LoadingFallback />}>
                     <ScribingSimulatorPage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/ultimate-simulator"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <UltimateSimulatorPage />
                   </Suspense>
                 </ErrorBoundary>
               }

--- a/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
@@ -1,0 +1,83 @@
+import { calibrateFromEvents, RESOURCE_CHANGE_TYPE } from '../calibration';
+import type { ResourceChangeEvent } from '../../../../types/combatlogEvents';
+
+function ultEvent(partial: Partial<ResourceChangeEvent>): ResourceChangeEvent {
+  return {
+    timestamp: 0,
+    type: 'resourcechange',
+    sourceID: 1,
+    sourceIsFriendly: true,
+    targetID: 1,
+    targetIsFriendly: true,
+    abilityGameID: 0,
+    fight: 1,
+    resourceChange: 0,
+    resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate,
+    otherResourceChange: 0,
+    maxResourceAmount: 500,
+    waste: 0,
+    castTrackID: 0,
+    // sourceResources/targetResources are not read by the analyzer.
+    sourceResources: undefined as never,
+    targetResources: undefined as never,
+    ...partial,
+  };
+}
+
+describe('calibrateFromEvents', () => {
+  it('buckets ultimate gains by ability and sums net/waste', () => {
+    const events = [
+      ultEvent({ abilityGameID: 100, resourceChange: 3, waste: 0 }),
+      ultEvent({ abilityGameID: 100, resourceChange: 3, waste: 1 }),
+      ultEvent({ abilityGameID: 200, resourceChange: 4, waste: 0 }),
+    ];
+    const result = calibrateFromEvents({ events, fightDurationSeconds: 10 });
+
+    expect(result.totalNetUltimate).toBe(10);
+    expect(result.totalWastedUltimate).toBe(1);
+    expect(result.perSecond).toBeCloseTo(1.0, 5);
+    expect(result.bySource).toHaveLength(2);
+    // Sorted by netUltimate desc: ability 100 (6) before 200 (4).
+    expect(result.bySource[0].abilityGameID).toBe(100);
+    expect(result.bySource[0].netUltimate).toBe(6);
+    expect(result.bySource[0].events).toBe(2);
+  });
+
+  it('ignores non-ultimate resource changes', () => {
+    const events = [
+      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.magicka }),
+      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.stamina }),
+      ultEvent({ abilityGameID: 1, resourceChange: 5, resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate }),
+    ];
+    const result = calibrateFromEvents({ events, fightDurationSeconds: 1 });
+    expect(result.totalNetUltimate).toBe(5);
+  });
+
+  it('ignores ultimate SPENDS (non-positive change)', () => {
+    const events = [
+      ultEvent({ abilityGameID: 1, resourceChange: -250 }),
+      ultEvent({ abilityGameID: 1, resourceChange: 3 }),
+    ];
+    const result = calibrateFromEvents({ events, fightDurationSeconds: 1 });
+    expect(result.totalNetUltimate).toBe(3);
+  });
+
+  it('filters to the target actor when provided', () => {
+    const events = [
+      ultEvent({ abilityGameID: 1, resourceChange: 3, targetID: 7 }),
+      ultEvent({ abilityGameID: 1, resourceChange: 9, targetID: 8 }),
+    ];
+    const result = calibrateFromEvents({ events, fightDurationSeconds: 1, targetActorID: 7 });
+    expect(result.totalNetUltimate).toBe(3);
+  });
+
+  it('resolves ability labels from masterData when supplied', () => {
+    const events = [ultEvent({ abilityGameID: 999, resourceChange: 1 })];
+    const result = calibrateFromEvents({
+      events,
+      fightDurationSeconds: 1,
+      abilityNames: new Map([[999, 'Minor Heroism']]),
+    });
+    expect(result.bySource[0].label).toBe('Minor Heroism');
+  });
+});

--- a/src/features/ultimate-simulator/application/calibration.ts
+++ b/src/features/ultimate-simulator/application/calibration.ts
@@ -1,0 +1,122 @@
+/**
+ * Calibration: derive empirical per-source ultimate generation from real ESO
+ * Logs `Resources` events. Measured log data is the SOURCE OF TRUTH — the
+ * simulator's presets are validated against (and can be overridden by) whatever
+ * this analyzer reports for a real fight.
+ *
+ * This module is a pure analyzer over already-fetched events (no network), so it
+ * is unit-testable. The existing `fetchResourceEvents` thunk
+ * (store/events_data/resourceEventsSlice.ts) supplies the events; a thin hook can
+ * wire the two together in the presentation layer.
+ */
+
+import type { ResourceChangeEvent } from '../../../types/combatlogEvents';
+
+/**
+ * ESO Logs `resourceChangeType` enum values. 0/6 are confirmed in this codebase
+ * (RotationAnalysisPanel.tsx); 10 = Ultimate is the ESO Logs / Hodor combat-log
+ * convention.
+ *
+ * VERIFY against a real event sample before treating ultimate buckets as ground
+ * truth — if a calibration run yields zero ultimate events, this constant is the
+ * first thing to check.
+ */
+export const RESOURCE_CHANGE_TYPE = {
+  magicka: 0,
+  stamina: 6,
+  ultimate: 10,
+} as const;
+
+/** Empirical generation attributed to one ability (game) ID over a fight. */
+export interface AbilityUltimateStat {
+  readonly abilityGameID: number;
+  /** Resolved display name if masterData was provided, else the numeric ID. */
+  readonly label: string;
+  /** Net ultimate granted (sum of positive resourceChange), excluding waste. */
+  readonly netUltimate: number;
+  /** Ultimate that was wasted (overcapped). */
+  readonly wastedUltimate: number;
+  /** Number of contributing events (≈ instances). */
+  readonly events: number;
+  /** netUltimate / fightDurationSeconds. */
+  readonly ultimatePerSecond: number;
+}
+
+export interface CalibrationResult {
+  readonly fightDurationSeconds: number;
+  /** Total net ultimate generated for the target actor over the fight. */
+  readonly totalNetUltimate: number;
+  readonly totalWastedUltimate: number;
+  readonly perSecond: number;
+  /** Per-ability breakdown, sorted by netUltimate descending. */
+  readonly bySource: readonly AbilityUltimateStat[];
+}
+
+export interface CalibrationInput {
+  readonly events: readonly ResourceChangeEvent[];
+  readonly fightDurationSeconds: number;
+  /** Restrict to this actor's gains (the modeled Arcanist). Omit = all actors. */
+  readonly targetActorID?: number;
+  /** Optional abilityGameID → display name map (from report masterData). */
+  readonly abilityNames?: ReadonlyMap<number, string>;
+}
+
+/** Is this event an ultimate-resource gain for the target actor? */
+function isUltimateGain(event: ResourceChangeEvent, targetActorID?: number): boolean {
+  if (event.resourceChangeType !== RESOURCE_CHANGE_TYPE.ultimate) return false;
+  if (event.resourceChange <= 0) return false;
+  // Ultimate accrues to the actor as the TARGET of the resourcechange event.
+  if (targetActorID !== undefined && event.targetID !== targetActorID) return false;
+  return true;
+}
+
+/**
+ * Bucket ultimate-gain events by ability into empirical per-source rates.
+ *
+ * Note on Decisive: ESO Logs typically folds the Decisive +1 into the host
+ * ability's resourceChange rather than emitting a separate event, so Decisive
+ * usually has no bucket of its own here — its contribution shows up as slightly
+ * larger per-instance amounts on the sources it rolls against. That is expected;
+ * the simulator models Decisive explicitly, and calibration measures the totals.
+ */
+export function calibrateFromEvents(input: CalibrationInput): CalibrationResult {
+  const { events, fightDurationSeconds, targetActorID, abilityNames } = input;
+
+  const buckets = new Map<number, { net: number; wasted: number; count: number }>();
+  let totalNet = 0;
+  let totalWasted = 0;
+
+  for (const event of events) {
+    if (!isUltimateGain(event, targetActorID)) continue;
+    const id = event.abilityGameID;
+    const bucket = buckets.get(id) ?? { net: 0, wasted: 0, count: 0 };
+    bucket.net += event.resourceChange;
+    bucket.wasted += event.waste ?? 0;
+    bucket.count += 1;
+    buckets.set(id, bucket);
+
+    totalNet += event.resourceChange;
+    totalWasted += event.waste ?? 0;
+  }
+
+  const safeDuration = fightDurationSeconds > 0 ? fightDurationSeconds : 1;
+
+  const bySource: AbilityUltimateStat[] = Array.from(buckets.entries())
+    .map(([abilityGameID, b]) => ({
+      abilityGameID,
+      label: abilityNames?.get(abilityGameID) ?? `Ability ${abilityGameID}`,
+      netUltimate: b.net,
+      wastedUltimate: b.wasted,
+      events: b.count,
+      ultimatePerSecond: b.net / safeDuration,
+    }))
+    .sort((a, b) => b.netUltimate - a.netUltimate);
+
+  return {
+    fightDurationSeconds,
+    totalNetUltimate: totalNet,
+    totalWastedUltimate: totalWasted,
+    perSecond: totalNet / safeDuration,
+    bySource,
+  };
+}

--- a/src/features/ultimate-simulator/core/__tests__/simulate.test.ts
+++ b/src/features/ultimate-simulator/core/__tests__/simulate.test.ts
@@ -1,0 +1,137 @@
+import { createRng } from '../rng';
+import { simulateFight } from '../simulate';
+import { runMonteCarlo } from '../monteCarlo';
+import type { SimulationConfig, UltimateSource } from '../../shared/types';
+import {
+  SHEET_VALIDATION_SOURCES,
+  SHEET_FIGHT_DURATION_SECONDS,
+  SHEET_SUM_TICKS,
+  SHEET_DECISIVE_HALF,
+  SHEET_DECISIVE_FULL,
+  SHEET_DECISIVE_HALF_PER_INSTANCE,
+  SHEET_DECISIVE_FULL_PER_INSTANCE,
+} from '../../shared/constants/sheetValidation';
+
+describe('seeded RNG', () => {
+  it('is deterministic for the same seed', () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    const seqA = Array.from({ length: 5 }, () => a.next());
+    const seqB = Array.from({ length: 5 }, () => b.next());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('produces different streams for different seeds', () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    expect(a.next()).not.toEqual(b.next());
+  });
+
+  it('chance() honors boundaries', () => {
+    const rng = createRng(7);
+    expect(rng.chance(0)).toBe(false);
+    expect(rng.chance(1)).toBe(true);
+  });
+
+  it('chance(p) converges to p over many trials', () => {
+    const rng = createRng(123);
+    const n = 100000;
+    let hits = 0;
+    for (let i = 0; i < n; i += 1) if (rng.chance(0.3)) hits += 1;
+    expect(hits / n).toBeCloseTo(0.3, 2);
+  });
+});
+
+describe('simulateFight — determinism', () => {
+  const config: SimulationConfig = {
+    fightDurationSeconds: SHEET_FIGHT_DURATION_SECONDS,
+    sources: SHEET_VALIDATION_SOURCES,
+    decisive: null,
+    seed: 99,
+  };
+
+  it('same seed + config => identical result', () => {
+    expect(simulateFight(config)).toEqual(simulateFight(config));
+  });
+});
+
+describe('Monte Carlo — reconciles the sheet', () => {
+  const base = {
+    fightDurationSeconds: SHEET_FIGHT_DURATION_SECONDS,
+    sources: SHEET_VALIDATION_SOURCES,
+  };
+
+  it('mean instance count matches the sheet SUM Ticks (404.8)', () => {
+    const result = runMonteCarlo({ ...base, decisive: null }, { runs: 20000, baseSeed: 1 });
+    const totalInstances = result.contributions.reduce((s, c) => s + c.instances, 0);
+    expect(totalInstances).toBeCloseTo(SHEET_SUM_TICKS, 0);
+  });
+
+  it('base ult/s reconciles with the sheet (~6.61, no Decisive)', () => {
+    const result = runMonteCarlo({ ...base, decisive: null }, { runs: 20000, baseSeed: 1 });
+    // Sheet SUM Ult/s = 6.6078. Base-only mean per second should match closely.
+    expect(result.meanPerSecond).toBeCloseTo(6.6078, 1);
+  });
+
+  it('Decisive HALF reproduces ~112.06 (single roll @ sheet per-instance rate)', () => {
+    const result = runMonteCarlo(
+      {
+        ...base,
+        decisive: { procChance: SHEET_DECISIVE_HALF_PER_INSTANCE, rollsPerInstance: 1 },
+      },
+      { runs: 20000, baseSeed: 1 },
+    );
+    const meanDecisive =
+      result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0);
+    expect(meanDecisive).toBeCloseTo(SHEET_DECISIVE_HALF, -1); // within ~5 ult
+  });
+
+  it('Decisive FULL reproduces ~218.06 (sheet linear-2x per-instance rate)', () => {
+    const result = runMonteCarlo(
+      {
+        ...base,
+        // Reproduce the sheet's literal FULL value as a single roll at its
+        // decoded per-instance rate (the sheet modeled 2H as linear 2x).
+        decisive: { procChance: SHEET_DECISIVE_FULL_PER_INSTANCE, rollsPerInstance: 1 },
+      },
+      { runs: 20000, baseSeed: 1 },
+    );
+    const meanDecisive = result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0);
+    expect(meanDecisive).toBeCloseTo(SHEET_DECISIVE_FULL, -1);
+  });
+
+  it('reports a shrinking standard error with more runs', () => {
+    const few = runMonteCarlo({ ...base, decisive: null }, { runs: 100, baseSeed: 1 });
+    const many = runMonteCarlo({ ...base, decisive: null }, { runs: 10000, baseSeed: 1 });
+    expect(many.standardError).toBeLessThan(few.standardError);
+  });
+});
+
+describe('Decisive 2H — correct binomial, not linear double-count', () => {
+  // A single source emitting a known number of instances lets us assert the
+  // exact binomial behavior the real raid preset relies on.
+  const oneSource: UltimateSource = {
+    id: 'x',
+    label: 'X',
+    kind: 'periodic',
+    amountPerInstance: 0, // isolate Decisive
+    instancesPerSecond: 1,
+    uptime: 1,
+    rollsDecisive: true,
+  };
+
+  it('two rolls at p give expected bonus = instances * (1-(1-p)^2)', () => {
+    const p = 0.275;
+    const result = runMonteCarlo(
+      {
+        fightDurationSeconds: 200, // 200 instances
+        sources: [oneSource],
+        decisive: { procChance: p, rollsPerInstance: 2 },
+      },
+      { runs: 20000, baseSeed: 1 },
+    );
+    const meanDecisive = result.contributions[0].decisiveUltimate;
+    const expectedPerInstance = 2 * p; // E[bonus] for 2 independent rolls = 2p (can be 0,1,2)
+    expect(meanDecisive).toBeCloseTo(200 * expectedPerInstance, -1);
+  });
+});

--- a/src/features/ultimate-simulator/core/monteCarlo.ts
+++ b/src/features/ultimate-simulator/core/monteCarlo.ts
@@ -1,0 +1,91 @@
+/**
+ * Monte Carlo runner: estimate expected ultimate generation by averaging many
+ * deterministic single-fight simulations.
+ *
+ * This replaces the original spreadsheet's "rolling average of 100 sims that
+ * recalculates on edit". Two improvements over the sheet:
+ *   1. Far more runs (default 10k) shrink the standard error so the displayed
+ *      mean no longer visibly wobbles (the sheet's 100-run mean had SE ≈ ±1).
+ *   2. A base seed makes the whole estimate reproducible — same config + base
+ *      seed => identical aggregate.
+ */
+
+import type { SimulationConfig, MonteCarloResult, SourceContribution } from '../shared/types';
+
+import { simulateFight } from './simulate';
+
+const Z_95 = 1.959963984540054; // two-sided 95% normal quantile
+
+export interface MonteCarloOptions {
+  /** Number of fight simulations to average. */
+  readonly runs: number;
+  /** Base seed; run i uses seed = baseSeed + i. */
+  readonly baseSeed: number;
+}
+
+export function runMonteCarlo(
+  config: Omit<SimulationConfig, 'seed'>,
+  options: MonteCarloOptions,
+): MonteCarloResult {
+  const runs = Math.max(1, Math.floor(options.runs));
+
+  let sum = 0;
+  let sumSq = 0;
+  let minTotal = Infinity;
+  let maxTotal = -Infinity;
+
+  // Accumulate per-source contributions to report a mean breakdown.
+  const baseBySource = new Map<string, { label: string; base: number; decisive: number; instances: number }>();
+
+  for (let i = 0; i < runs; i += 1) {
+    const result = simulateFight({ ...config, seed: options.baseSeed + i });
+    const total = result.totalUltimate;
+    sum += total;
+    sumSq += total * total;
+    if (total < minTotal) minTotal = total;
+    if (total > maxTotal) maxTotal = total;
+
+    for (const c of result.contributions) {
+      const acc = baseBySource.get(c.sourceId) ?? {
+        label: c.label,
+        base: 0,
+        decisive: 0,
+        instances: 0,
+      };
+      acc.base += c.baseUltimate;
+      acc.decisive += c.decisiveUltimate;
+      acc.instances += c.instances;
+      baseBySource.set(c.sourceId, acc);
+    }
+  }
+
+  const meanTotal = sum / runs;
+  // Population variance: E[X^2] - E[X]^2, floored at 0 against float error.
+  const variance = Math.max(0, sumSq / runs - meanTotal * meanTotal);
+  const stdDevTotal = Math.sqrt(variance);
+  const standardError = stdDevTotal / Math.sqrt(runs);
+
+  const contributions: SourceContribution[] = Array.from(baseBySource.entries()).map(
+    ([sourceId, acc]) => ({
+      sourceId,
+      label: acc.label,
+      baseUltimate: acc.base / runs,
+      decisiveUltimate: acc.decisive / runs,
+      instances: acc.instances / runs,
+    }),
+  );
+
+  const fightDuration = config.fightDurationSeconds;
+
+  return {
+    runs,
+    meanTotal,
+    meanPerSecond: fightDuration > 0 ? meanTotal / fightDuration : 0,
+    stdDevTotal,
+    standardError,
+    ci95HalfWidth: Z_95 * standardError,
+    minTotal: Number.isFinite(minTotal) ? minTotal : 0,
+    maxTotal: Number.isFinite(maxTotal) ? maxTotal : 0,
+    contributions,
+  };
+}

--- a/src/features/ultimate-simulator/core/rng.ts
+++ b/src/features/ultimate-simulator/core/rng.ts
@@ -1,0 +1,47 @@
+/**
+ * Deterministic seeded pseudo-random number generator (mulberry32).
+ *
+ * The simulator must be reproducible: the same seed + config always yields the
+ * same result, so Monte Carlo means don't wobble between recalcs the way the
+ * original Google Sheet did. mulberry32 is tiny, fast, and statistically good
+ * enough for Bernoulli proc rolls (it is NOT cryptographically secure — never
+ * use it for anything security-sensitive).
+ */
+
+export interface Rng {
+  /** Next float in [0, 1). */
+  next(): number;
+  /** Bernoulli trial: true with probability `p` (clamped to [0,1]). */
+  chance(p: number): boolean;
+}
+
+/**
+ * Create a seeded RNG. The seed is mixed first so that sequential seeds
+ * (0, 1, 2, …), which Monte Carlo runs use, produce well-separated streams
+ * rather than correlated ones.
+ */
+export function createRng(seed: number): Rng {
+  // Mix the incoming seed (splitmix32-style) before seeding mulberry32, so that
+  // adjacent seeds don't yield near-identical first outputs.
+  let a = (seed ^ 0x9e3779b9) >>> 0;
+  a = Math.imul(a ^ (a >>> 16), 0x21f0aaad) >>> 0;
+  a = Math.imul(a ^ (a >>> 15), 0x735a2d97) >>> 0;
+  let state = (a ^ (a >>> 15)) >>> 0;
+
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  return {
+    next,
+    chance: (p: number): boolean => {
+      if (p <= 0) return false;
+      if (p >= 1) return true;
+      return next() < p;
+    },
+  };
+}

--- a/src/features/ultimate-simulator/core/simulate.ts
+++ b/src/features/ultimate-simulator/core/simulate.ts
@@ -1,0 +1,92 @@
+/**
+ * Single-fight ultimate simulation.
+ *
+ * Each source emits a whole number of "ultimate gain instances" over the fight.
+ * On every instance, the Decisive weapon trait rolls one Bernoulli trial per
+ * `rollsPerInstance` for a bonus +1 ultimate — this is the real ESO mechanic
+ * (Decisive procs per instance of ultimate gain, not per attack). Because proc
+ * counts are integer and binomial, a single fight is noisy; the Monte Carlo
+ * runner (see monteCarlo.ts) averages many fights to estimate the expectation.
+ */
+
+import type {
+  SimulationConfig,
+  SimulationResult,
+  SourceContribution,
+  UltimateSource,
+  DecisiveConfig,
+} from '../shared/types';
+
+import { createRng, Rng } from './rng';
+
+/**
+ * Resolve how many ult-gain instances a source emits over the fight.
+ *
+ * The expected count is `instancesPerSecond * duration * uptime`. The integer
+ * part is deterministic; the fractional remainder is realized as one extra
+ * instance with probability equal to the fraction (so the long-run mean matches
+ * the expectation exactly while keeping per-fight counts integer).
+ */
+function resolveInstances(source: UltimateSource, durationSeconds: number, rng: Rng): number {
+  const expected = source.instancesPerSecond * durationSeconds * source.uptime;
+  if (expected <= 0) return 0;
+  const whole = Math.floor(expected);
+  const frac = expected - whole;
+  return whole + (rng.chance(frac) ? 1 : 0);
+}
+
+/** Count Decisive bonus ult granted across `instances` ult-gain instances. */
+function rollDecisive(
+  instances: number,
+  decisive: DecisiveConfig | null,
+  rollsDecisive: boolean,
+  rng: Rng,
+): number {
+  if (!decisive || !rollsDecisive || instances <= 0) return 0;
+  let bonus = 0;
+  for (let i = 0; i < instances; i += 1) {
+    for (let r = 0; r < decisive.rollsPerInstance; r += 1) {
+      if (rng.chance(decisive.procChance)) bonus += 1;
+    }
+  }
+  return bonus;
+}
+
+/**
+ * Run one deterministic simulation of the fight.
+ *
+ * Same `config` (including `seed`) always returns an identical result.
+ */
+export function simulateFight(config: SimulationConfig): SimulationResult {
+  const rng = createRng(config.seed);
+  const { fightDurationSeconds, sources, decisive } = config;
+
+  const contributions: SourceContribution[] = [];
+  let baseUltimate = 0;
+  let decisiveUltimate = 0;
+
+  for (const source of sources) {
+    const instances = resolveInstances(source, fightDurationSeconds, rng);
+    const base = instances * source.amountPerInstance;
+    const bonus = rollDecisive(instances, decisive, source.rollsDecisive, rng);
+
+    baseUltimate += base;
+    decisiveUltimate += bonus;
+    contributions.push({
+      sourceId: source.id,
+      label: source.label,
+      baseUltimate: base,
+      decisiveUltimate: bonus,
+      instances,
+    });
+  }
+
+  const totalUltimate = baseUltimate + decisiveUltimate;
+  return {
+    totalUltimate,
+    baseUltimate,
+    decisiveUltimate,
+    ultimatePerSecond: fightDurationSeconds > 0 ? totalUltimate / fightDurationSeconds : 0,
+    contributions,
+  };
+}

--- a/src/features/ultimate-simulator/index.ts
+++ b/src/features/ultimate-simulator/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Public API for the Arcanist Ultimate Simulator feature.
+ */
+
+// Types & constants
+export * from './shared/types';
+export * from './shared/constants';
+
+// Core engine
+export { createRng } from './core/rng';
+export { simulateFight } from './core/simulate';
+export { runMonteCarlo } from './core/monteCarlo';
+export type { MonteCarloOptions } from './core/monteCarlo';
+
+// Calibration (log = source of truth)
+export { calibrateFromEvents, RESOURCE_CHANGE_TYPE } from './application/calibration';
+export type {
+  CalibrationInput,
+  CalibrationResult,
+  AbilityUltimateStat,
+} from './application/calibration';
+
+// Presentation
+export { useUltimateSimulator } from './presentation/useUltimateSimulator';
+export { UltimateSimulator } from './presentation/components/UltimateSimulator';
+export { UltimateSimulatorPage } from './presentation/pages/UltimateSimulatorPage';

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateSimulator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateSimulator.test.tsx
@@ -1,0 +1,57 @@
+import { ThemeProvider, createTheme } from '@mui/material';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { UltimateSimulator } from '../components/UltimateSimulator';
+
+const theme = createTheme();
+
+function renderSimulator() {
+  return render(
+    <ThemeProvider theme={theme}>
+      <UltimateSimulator />
+    </ThemeProvider>,
+  );
+}
+
+describe('UltimateSimulator (render smoke)', () => {
+  it('renders headline, inputs, and a results table with all raid sources', () => {
+    renderSimulator();
+
+    expect(screen.getByRole('heading', { name: /Arcanist Ultimate Simulator/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Fight duration/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Monte Carlo runs/i)).toBeInTheDocument();
+
+    // Each raid-context source label appears in both the uptime inputs and the
+    // results table, so use getAllByText (≥1 occurrence proves it rendered).
+    expect(screen.getAllByText('Base (light-attack buff)').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Minor Heroism').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Major Heroism').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Implacable Outcome').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Pillager's Profit/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows a non-zero mean total and a confidence interval', () => {
+    renderSimulator();
+    // The "Mean total ultimate" stat should render a numeric value > 0.
+    expect(screen.getByText(/Mean total ultimate/i)).toBeInTheDocument();
+    expect(screen.getByText(/95% CI/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ultimate \/ second/i)).toBeInTheDocument();
+  });
+
+  it('recomputes when Decisive is toggled off (total drops)', () => {
+    renderSimulator();
+
+    // Read the grand-total cell before/after toggling Decisive off.
+    const readTotal = (): number =>
+      Number(screen.getByTestId('grand-total').textContent?.replace(/,/g, '') ?? '0');
+
+    const withDecisive = readTotal();
+    // The Decisive toggle is the first checkbox (its FormControlLabel reads "Decisive trait").
+    const decisiveSwitch = screen.getByLabelText(/Decisive trait/i);
+    fireEvent.click(decisiveSwitch);
+    const withoutDecisive = readTotal();
+
+    expect(withoutDecisive).toBeLessThan(withDecisive);
+  });
+});

--- a/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
@@ -1,0 +1,250 @@
+/**
+ * Arcanist Ultimate Simulator — minimal first-pass UI.
+ *
+ * Editable inputs (fight length, Decisive weapon, MC runs, per-source uptime)
+ * drive a live Monte Carlo aggregate. Results show the mean total ultimate, the
+ * 95% confidence interval (so the estimate's precision is visible — the thing
+ * the original 100-run sheet couldn't surface), ult/s, and a per-source split.
+ */
+
+import {
+  Box,
+  Container,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Slider,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+
+import { DECISIVE_PROC_CHANCE, DecisiveQuality } from '../../shared/constants';
+import { useUltimateSimulator } from '../useUltimateSimulator';
+
+const QUALITY_OPTIONS: { value: DecisiveQuality; label: string }[] = [
+  { value: 'fine', label: 'Fine (green)' },
+  { value: 'superior', label: 'Superior (blue)' },
+  { value: 'epic', label: 'Epic (purple)' },
+  { value: 'legendary', label: 'Legendary (gold)' },
+];
+
+const fmt = (n: number, digits = 1): string =>
+  n.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+
+export interface UltimateSimulatorProps {
+  className?: string;
+}
+
+export const UltimateSimulator: React.FC<UltimateSimulatorProps> = ({ className }) => {
+  const sim = useUltimateSimulator();
+  const { state, sources, result } = sim;
+
+  React.useEffect(() => {
+    document.title = 'Arcanist Ultimate Simulator | ESO Toolkit';
+  }, []);
+
+  return (
+    <Container maxWidth="lg" className={className}>
+      <Box sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Arcanist Ultimate Simulator
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
+          Estimates ultimate generation for an Arcanist receiving realistic raid support, using a
+          Monte Carlo over the Decisive trait&apos;s per-instance procs. Measured ESO Logs data is
+          the source of truth; these defaults are calibrated to match it.
+        </Typography>
+
+        <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3 }}>
+          {/* Inputs */}
+          <Paper variant="outlined" sx={{ p: 3, flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" gutterBottom>
+              Inputs
+            </Typography>
+            <Stack spacing={3} sx={{ mt: 1 }}>
+              <TextField
+                label="Fight duration (seconds)"
+                type="number"
+                size="small"
+                value={state.fightDurationSeconds}
+                onChange={(e) => sim.setFightDuration(Number(e.target.value))}
+                slotProps={{ htmlInput: { min: 1, step: 5 } }}
+              />
+
+              <Box>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={state.decisiveEnabled}
+                      onChange={(e) => sim.setDecisiveEnabled(e.target.checked)}
+                    />
+                  }
+                  label="Decisive trait"
+                />
+                {state.decisiveEnabled && (
+                  <Stack spacing={2} sx={{ mt: 1 }}>
+                    <FormControl size="small" fullWidth>
+                      <InputLabel id="decisive-quality-label">Weapon quality</InputLabel>
+                      <Select
+                        labelId="decisive-quality-label"
+                        label="Weapon quality"
+                        value={state.decisiveQuality}
+                        onChange={(e) =>
+                          sim.setDecisiveQuality(e.target.value as DecisiveQuality)
+                        }
+                      >
+                        {QUALITY_OPTIONS.map((opt) => (
+                          <MenuItem key={opt.value} value={opt.value}>
+                            {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <Tooltip title="Two-handed weapons (incl. staves/bows) roll Decisive twice per ultimate-gain instance.">
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={state.decisiveTwoHanded}
+                            onChange={(e) => sim.setDecisiveTwoHanded(e.target.checked)}
+                          />
+                        }
+                        label="Two-handed (rolls twice)"
+                      />
+                    </Tooltip>
+                  </Stack>
+                )}
+              </Box>
+
+              <TextField
+                label="Monte Carlo runs"
+                type="number"
+                size="small"
+                value={state.runs}
+                onChange={(e) => sim.setRuns(Number(e.target.value))}
+                slotProps={{ htmlInput: { min: 1, max: 100000, step: 1000 } }}
+                helperText="More runs → tighter confidence interval."
+              />
+
+              <Divider textAlign="left">
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Source uptimes
+                </Typography>
+              </Divider>
+              {sources.map((source) => (
+                <Box key={source.id}>
+                  <Stack
+                    direction="row"
+                    sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+                  >
+                    <Typography variant="body2">{source.label}</Typography>
+                    <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                      {Math.round(source.uptime * 100)}%
+                    </Typography>
+                  </Stack>
+                  <Slider
+                    size="small"
+                    value={Math.round(source.uptime * 100)}
+                    onChange={(_, v) => sim.setUptimeOverride(source.id, (v as number) / 100)}
+                    min={0}
+                    max={100}
+                    aria-label={`${source.label} uptime`}
+                  />
+                  {source.note && (
+                    <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                      {source.note}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Stack>
+          </Paper>
+
+          {/* Results */}
+          <Paper variant="outlined" sx={{ p: 3, flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" gutterBottom>
+              Results
+            </Typography>
+            <Stack direction="row" spacing={4} sx={{ mt: 1, mb: 2, flexWrap: 'wrap' }}>
+              <Box>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Mean total ultimate
+                </Typography>
+                <Typography variant="h4">{fmt(result.meanTotal, 1)}</Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  ± {fmt(result.ci95HalfWidth, 1)} (95% CI)
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Ultimate / second
+                </Typography>
+                <Typography variant="h4">{fmt(result.meanPerSecond, 2)}</Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  over {result.runs.toLocaleString()} runs
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Stack direction="row" spacing={4} sx={{ mb: 2, flexWrap: 'wrap' }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                Range: {fmt(result.minTotal, 0)}–{fmt(result.maxTotal, 0)}
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                Std dev: {fmt(result.stdDevTotal, 1)}
+              </Typography>
+            </Stack>
+
+            <Divider sx={{ my: 1 }} />
+            <Table size="small" aria-label="per-source contribution">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Source</TableCell>
+                  <TableCell align="right">Base</TableCell>
+                  <TableCell align="right">Decisive</TableCell>
+                  <TableCell align="right">Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {result.contributions.map((c) => (
+                  <TableRow key={c.sourceId}>
+                    <TableCell>{c.label}</TableCell>
+                    <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
+                    <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
+                    <TableCell align="right">
+                      {fmt(c.baseUltimate + c.decisiveUltimate, 1)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 'bold' }}>Total</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+                    {fmt(result.meanTotal - result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0), 0)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+                    {fmt(result.contributions.reduce((s, c) => s + c.decisiveUltimate, 0), 1)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 'bold' }} data-testid="grand-total">
+                    {fmt(result.meanTotal, 1)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </Paper>
+        </Box>
+      </Box>
+    </Container>
+  );
+};

--- a/src/features/ultimate-simulator/presentation/pages/UltimateSimulatorPage.tsx
+++ b/src/features/ultimate-simulator/presentation/pages/UltimateSimulatorPage.tsx
@@ -1,0 +1,15 @@
+/**
+ * Arcanist Ultimate Simulator page.
+ */
+
+import React from 'react';
+
+import { UltimateSimulator } from '../components/UltimateSimulator';
+
+export interface UltimateSimulatorPageProps {
+  className?: string;
+}
+
+export const UltimateSimulatorPage: React.FC<UltimateSimulatorPageProps> = ({ className }) => {
+  return <UltimateSimulator className={className} />;
+};

--- a/src/features/ultimate-simulator/presentation/useUltimateSimulator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateSimulator.ts
@@ -1,0 +1,136 @@
+/**
+ * Presenter hook for the Arcanist Ultimate Simulator.
+ *
+ * Holds the editable inputs (fight duration, Decisive weapon config, per-source
+ * uptimes) and runs the Monte Carlo aggregate. Recomputes synchronously on
+ * change — 10k runs over a handful of sources is sub-frame, so no worker is
+ * needed in this first pass (a worker can be added later if source counts grow).
+ */
+
+import { useMemo, useState, useCallback } from 'react';
+
+import { runMonteCarlo } from '../core/monteCarlo';
+import {
+  DEFAULT_FIGHT_DURATION_SECONDS,
+  DEFAULT_MONTE_CARLO_RUNS,
+  DEFAULT_BASE_SEED,
+  RAID_CONTEXT_SOURCES,
+  makeDecisiveConfig,
+  DecisiveQuality,
+} from '../shared/constants';
+import type { MonteCarloResult, UltimateSource } from '../shared/types';
+
+export interface UltimateSimulatorState {
+  fightDurationSeconds: number;
+  runs: number;
+  decisiveEnabled: boolean;
+  decisiveQuality: DecisiveQuality;
+  decisiveTwoHanded: boolean;
+  /** Per-source uptime overrides keyed by source id (0..1). */
+  uptimeOverrides: Record<string, number>;
+}
+
+const INITIAL_STATE: UltimateSimulatorState = {
+  fightDurationSeconds: DEFAULT_FIGHT_DURATION_SECONDS,
+  runs: DEFAULT_MONTE_CARLO_RUNS,
+  decisiveEnabled: true,
+  decisiveQuality: 'legendary',
+  decisiveTwoHanded: false,
+  uptimeOverrides: {},
+};
+
+export interface UseUltimateSimulator {
+  state: UltimateSimulatorState;
+  sources: readonly UltimateSource[];
+  result: MonteCarloResult;
+  setFightDuration: (seconds: number) => void;
+  setRuns: (runs: number) => void;
+  setDecisiveEnabled: (enabled: boolean) => void;
+  setDecisiveQuality: (quality: DecisiveQuality) => void;
+  setDecisiveTwoHanded: (twoHanded: boolean) => void;
+  setUptimeOverride: (sourceId: string, uptime: number) => void;
+  reset: () => void;
+}
+
+export function useUltimateSimulator(): UseUltimateSimulator {
+  const [state, setState] = useState<UltimateSimulatorState>(INITIAL_STATE);
+
+  // Apply per-source uptime overrides on top of the preset.
+  const sources = useMemo<readonly UltimateSource[]>(
+    () =>
+      RAID_CONTEXT_SOURCES.map((source) => {
+        const override = state.uptimeOverrides[source.id];
+        return override === undefined ? source : { ...source, uptime: override };
+      }),
+    [state.uptimeOverrides],
+  );
+
+  const result = useMemo<MonteCarloResult>(() => {
+    const decisive = state.decisiveEnabled
+      ? makeDecisiveConfig(state.decisiveQuality, state.decisiveTwoHanded)
+      : null;
+    return runMonteCarlo(
+      {
+        fightDurationSeconds: state.fightDurationSeconds,
+        sources,
+        decisive,
+      },
+      { runs: state.runs, baseSeed: DEFAULT_BASE_SEED },
+    );
+  }, [
+    sources,
+    state.fightDurationSeconds,
+    state.runs,
+    state.decisiveEnabled,
+    state.decisiveQuality,
+    state.decisiveTwoHanded,
+  ]);
+
+  const setFightDuration = useCallback(
+    (seconds: number) =>
+      setState((s) => ({ ...s, fightDurationSeconds: Math.max(1, Math.round(seconds)) })),
+    [],
+  );
+  const setRuns = useCallback(
+    (runs: number) =>
+      setState((s) => ({ ...s, runs: Math.min(100000, Math.max(1, Math.round(runs))) })),
+    [],
+  );
+  const setDecisiveEnabled = useCallback(
+    (decisiveEnabled: boolean) => setState((s) => ({ ...s, decisiveEnabled })),
+    [],
+  );
+  const setDecisiveQuality = useCallback(
+    (decisiveQuality: DecisiveQuality) => setState((s) => ({ ...s, decisiveQuality })),
+    [],
+  );
+  const setDecisiveTwoHanded = useCallback(
+    (decisiveTwoHanded: boolean) => setState((s) => ({ ...s, decisiveTwoHanded })),
+    [],
+  );
+  const setUptimeOverride = useCallback(
+    (sourceId: string, uptime: number) =>
+      setState((s) => ({
+        ...s,
+        uptimeOverrides: {
+          ...s.uptimeOverrides,
+          [sourceId]: Math.min(1, Math.max(0, uptime)),
+        },
+      })),
+    [],
+  );
+  const reset = useCallback(() => setState(INITIAL_STATE), []);
+
+  return {
+    state,
+    sources,
+    result,
+    setFightDuration,
+    setRuns,
+    setDecisiveEnabled,
+    setDecisiveQuality,
+    setDecisiveTwoHanded,
+    setUptimeOverride,
+    reset,
+  };
+}

--- a/src/features/ultimate-simulator/shared/constants/index.ts
+++ b/src/features/ultimate-simulator/shared/constants/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Constants and presets for the Arcanist Ultimate Simulator.
+ *
+ * Numbers derive from research (.scratch/ult-sim-research.md) and from decoding
+ * the original Google Sheet. The model is a raid-context Arcanist: it RECEIVES
+ * group ult support (Major Heroism from a Warden's U50 Class Mastery scrip,
+ * Pillager's Profit batteried from the healer) on top of its own base income.
+ *
+ * Calibration against real ESO Logs data (the source of truth) can later
+ * override any of these — they are defaults, not assumptions baked in code.
+ */
+
+import type { UltimateSource, DecisiveConfig } from '../types';
+
+/** Default fight length used by the sheet. */
+export const DEFAULT_FIGHT_DURATION_SECONDS = 180;
+
+/** Default Monte Carlo run count (10k → standard error ≈ sheet's ÷10). */
+export const DEFAULT_MONTE_CARLO_RUNS = 10000;
+
+/** Default base seed for reproducible aggregates. */
+export const DEFAULT_BASE_SEED = 1;
+
+/**
+ * Decisive per-instance proc chance by weapon quality (single roll).
+ * The five-tier ladder; the gold value matches the sheet's decoded 27.68%.
+ * NOTE: some sources list legendary as .254 — kept .275 to match the sheet's
+ * empirical "Half" value pending in-game verification.
+ */
+export const DECISIVE_PROC_CHANCE = {
+  fine: 0.191,
+  superior: 0.212,
+  epic: 0.233,
+  legendary: 0.275,
+} as const;
+
+export type DecisiveQuality = keyof typeof DECISIVE_PROC_CHANCE;
+
+/**
+ * Build a DecisiveConfig from quality + whether the weapon is two-handed.
+ * 1H / staff / bow = 1 roll per instance; 2H melee = 2 independent rolls
+ * (ESO's "two-handed weapons provide twice the bonus").
+ */
+export function makeDecisiveConfig(quality: DecisiveQuality, twoHanded: boolean): DecisiveConfig {
+  return {
+    procChance: DECISIVE_PROC_CHANCE[quality],
+    rollsPerInstance: twoHanded ? 2 : 1,
+  };
+}
+
+/**
+ * Raid-context source preset (corrected from the sheet).
+ *
+ * Tick cadences: Heroism buffs tick every 1.5s (instancesPerSecond = 1/1.5).
+ * The "base" row is the light/heavy-attack buff (3 ult/sec, 1 instance/sec),
+ * NOT a passive regen (no such stat exists). Implacable Outcome is a triggered
+ * +4 on an 8s ICD. Pillager's Profit is batteried from the group healer.
+ *
+ * `instancesPerSecond` and `amountPerInstance` are chosen so each row's expected
+ * ult/s matches the sheet's "Est. Ult/s" column, and the total instance count
+ * reconciles with the sheet's SUM Ticks (404.8 over 180s) for Decisive validation.
+ */
+export const RAID_CONTEXT_SOURCES: readonly UltimateSource[] = [
+  {
+    id: 'base-light-attack',
+    label: 'Base (light-attack buff)',
+    kind: 'periodic',
+    amountPerInstance: 3,
+    instancesPerSecond: 1, // 3 ult/sec while weaving
+    uptime: 0.99,
+    rollsDecisive: true,
+    note: 'Light/heavy-attack hidden buff — the real base income (no passive ult regen exists).',
+  },
+  {
+    id: 'minor-heroism',
+    label: 'Minor Heroism',
+    kind: 'periodic',
+    amountPerInstance: 1,
+    instancesPerSecond: 1 / 1.5, // 1 ult / 1.5s
+    uptime: 0.95,
+    rollsDecisive: true,
+    note: 'From Cryptcanon Vestments (Mythic) / ult potions / sets.',
+  },
+  {
+    id: 'major-heroism',
+    label: 'Major Heroism',
+    kind: 'periodic',
+    amountPerInstance: 3,
+    instancesPerSecond: 1 / 1.5, // 3 ult / 1.5s
+    uptime: 0.78,
+    rollsDecisive: true,
+    note: 'Group buff — from a Warden U50 Class Mastery scrip in the raid.',
+  },
+  {
+    id: 'implacable-outcome',
+    label: 'Implacable Outcome',
+    kind: 'triggered',
+    amountPerInstance: 4,
+    instancesPerSecond: 1 / 8, // +4 ult, max once / 8s on Crux consume
+    uptime: 1,
+    rollsDecisive: true,
+    note: 'Arcanist passive (Soldier of Apocrypha): +4 ult on Crux consume, 8s ICD.',
+  },
+  {
+    id: 'pillagers-profit',
+    label: "Pillager's Profit (from healer)",
+    kind: 'perCast',
+    amountPerInstance: 50,
+    instancesPerSecond: 1 / 45, // batteried to allies once / 45s
+    uptime: 1,
+    rollsDecisive: false, // externally-granted; does not roll the wearer's Decisive
+    note: "Batteried to the Arcanist by the group healer's Pillager's Profit (~50 ult / 45s).",
+  },
+];

--- a/src/features/ultimate-simulator/shared/constants/sheetValidation.ts
+++ b/src/features/ultimate-simulator/shared/constants/sheetValidation.ts
@@ -1,0 +1,58 @@
+/**
+ * SHEET VALIDATION preset — reproduces the original Google Sheet's exact numbers
+ * so the engine has a known-good regression target ("validate, then extend").
+ *
+ * These rows mirror the sheet's `Ticks` and `Raw Ult per Tick` columns literally,
+ * including its quirks (Implacable fixed at 15 ticks, not 180/8). The sheet's
+ * Decisive figures decode to:
+ *   - Half  ≈ 0.2768 per eligible instance  → 112.06 over 404.8 instances
+ *   - Full  ≈ 0.5387 per eligible instance  → 218.06 (a LINEAR 2× of ~0.2694,
+ *     which slightly overstates a real 2H weapon vs the correct binomial
+ *     1-(1-p)^2; the real raid preset uses the binomial instead).
+ *
+ * Do not "improve" these — they exist to lock the port's fidelity to the sheet.
+ */
+
+import type { UltimateSource } from '../types';
+
+export const SHEET_FIGHT_DURATION_SECONDS = 180;
+
+/** Total ult-gain instances the sheet sums (row 21, "SUM Ticks"). */
+export const SHEET_SUM_TICKS = 404.8;
+
+/** The sheet's reported Decisive means (Monte Carlo over 100 runs). */
+export const SHEET_DECISIVE_HALF = 112.06;
+export const SHEET_DECISIVE_FULL = 218.06;
+
+/** The sheet's decoded per-eligible-instance Decisive values. */
+export const SHEET_DECISIVE_HALF_PER_INSTANCE = SHEET_DECISIVE_HALF / SHEET_SUM_TICKS; // ≈ 0.2768
+export const SHEET_DECISIVE_FULL_PER_INSTANCE = SHEET_DECISIVE_FULL / SHEET_SUM_TICKS; // ≈ 0.5387
+
+/**
+ * The sheet's five non-Decisive rows, expressed so that
+ *   instancesPerSecond * duration * uptime === sheet "Ticks"
+ * and amountPerInstance === sheet "Raw Ult per Tick".
+ *
+ * Encoded as uptime=1 with instancesPerSecond = ticks/duration so the instance
+ * counts reproduce the sheet exactly (the sheet already folded uptime into ticks).
+ */
+function row(id: string, label: string, ticks: number, ultPerTick: number): UltimateSource {
+  return {
+    id,
+    label,
+    kind: 'periodic',
+    amountPerInstance: ultPerTick,
+    instancesPerSecond: ticks / SHEET_FIGHT_DURATION_SECONDS,
+    uptime: 1,
+    rollsDecisive: true,
+  };
+}
+
+export const SHEET_VALIDATION_SOURCES: readonly UltimateSource[] = [
+  row('minor-heroism', 'Minor Heroism', 114, 1),
+  row('implacable-outcome', 'Implacable Outcome', 15, 4),
+  row('major-heroism', 'Major Heroism', 93.6, 3),
+  row('base', 'Base', 178.2, 3),
+  row('pillagers-profit', "Pillager's Profit", 4, 50),
+  // Cryptcannon row in the sheet is disabled (0 ticks) — omitted.
+];

--- a/src/features/ultimate-simulator/shared/types/index.ts
+++ b/src/features/ultimate-simulator/shared/types/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Core type vocabulary for the Arcanist Ultimate Simulator.
+ *
+ * The model: an Arcanist in a realistic raid context accumulates ultimate from
+ * several SOURCES over a fixed fight duration. Each source emits discrete
+ * "ultimate gain instances" on its own cadence. The Decisive weapon trait then
+ * rolls a separate Bernoulli trial on EVERY such instance for a bonus +1 ult.
+ *
+ * See .scratch/ult-sim-research.md for the mechanics this encodes.
+ */
+
+/** How a source places its ultimate-gain instances on the fight timeline. */
+export type SourceKind =
+  /**
+   * A buff/effect that grants a flat ult amount on a fixed cadence while active,
+   * gated by an uptime fraction (e.g. Minor Heroism: 1 ult / 1.5s at 95% uptime).
+   * This is the dominant raid-support shape.
+   */
+  | 'periodic'
+  /**
+   * A flat ult amount granted on a trigger with an internal cooldown
+   * (e.g. Implacable Outcome: +4 ult on Crux consume, max once / 8s).
+   */
+  | 'triggered'
+  /**
+   * Discrete casts placed on the timeline, each its own event
+   * (the per-cast model — e.g. an ult-battery proc landing on the Arcanist).
+   */
+  | 'perCast';
+
+/**
+ * A single ultimate-generation source feeding the modeled Arcanist.
+ *
+ * `amountPerInstance` is the raw ult granted by ONE instance. `instancesPerSecond`
+ * is the long-run cadence (before uptime). `uptime` scales how often the source is
+ * actually active over the fight (1 = always). `rollsDecisive` controls whether the
+ * Decisive trait gets to roll on each instance this source emits (base/Heroism ticks
+ * do; some external proc sources may not — calibration decides).
+ */
+export interface UltimateSource {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: SourceKind;
+  /** Raw ultimate granted by a single instance, before Decisive. */
+  readonly amountPerInstance: number;
+  /** Instances per second at full activity (e.g. 1/1.5 for a 1.5s ticker). */
+  readonly instancesPerSecond: number;
+  /** Fraction of the fight the source is active (0..1). */
+  readonly uptime: number;
+  /** Whether Decisive rolls a bonus on each instance from this source. */
+  readonly rollsDecisive: boolean;
+  /** Optional note surfaced in the UI (e.g. "from raid healer's Pillager's Profit"). */
+  readonly note?: string;
+}
+
+/** Weapon configuration governing how Decisive rolls. */
+export interface DecisiveConfig {
+  /**
+   * Per-instance proc chance for +1 ultimate (0..1). By weapon quality:
+   * Fine .191 / Superior .212 / Epic .233 / Legendary .254 (some sources .275).
+   */
+  readonly procChance: number;
+  /**
+   * Number of independent rolls per ult-gain instance. 1H/staff/bow = 1;
+   * 2H melee = 2 (ESO grants 2H "twice the bonus").
+   */
+  readonly rollsPerInstance: number;
+}
+
+/** Everything needed to run one simulation of a fight. */
+export interface SimulationConfig {
+  readonly fightDurationSeconds: number;
+  readonly sources: readonly UltimateSource[];
+  readonly decisive: DecisiveConfig | null;
+  /** Deterministic seed; same seed + config => identical result. */
+  readonly seed: number;
+}
+
+/** Per-source contribution breakdown from a run or aggregate. */
+export interface SourceContribution {
+  readonly sourceId: string;
+  readonly label: string;
+  /** Raw ult from the source itself (excludes Decisive bonus). */
+  readonly baseUltimate: number;
+  /** Bonus ult attributable to Decisive procs on this source's instances. */
+  readonly decisiveUltimate: number;
+  /** Number of ult-gain instances this source emitted. */
+  readonly instances: number;
+}
+
+/** Result of a single deterministic fight simulation. */
+export interface SimulationResult {
+  readonly totalUltimate: number;
+  readonly baseUltimate: number;
+  readonly decisiveUltimate: number;
+  readonly ultimatePerSecond: number;
+  readonly contributions: readonly SourceContribution[];
+}
+
+/** Aggregate of many simulations (the Monte Carlo estimate). */
+export interface MonteCarloResult {
+  readonly runs: number;
+  /** Mean total ultimate over the fight across all runs. */
+  readonly meanTotal: number;
+  /** Mean ultimate per second. */
+  readonly meanPerSecond: number;
+  /** Population standard deviation of total ultimate. */
+  readonly stdDevTotal: number;
+  /** Standard error of the mean (stdDev / sqrt(runs)). */
+  readonly standardError: number;
+  /** 95% confidence-interval half-width on the mean (≈1.96 * SE). */
+  readonly ci95HalfWidth: number;
+  readonly minTotal: number;
+  readonly maxTotal: number;
+  /** Mean per-source contribution across runs. */
+  readonly contributions: readonly SourceContribution[];
+}

--- a/src/pages/UltimateSimulatorPage.tsx
+++ b/src/pages/UltimateSimulatorPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { UltimateSimulatorPage as NewUltimateSimulatorPage } from '@features/ultimate-simulator/presentation/pages/UltimateSimulatorPage';
+
+export const UltimateSimulatorPage: React.FC = () => {
+  return <NewUltimateSimulatorPage />;
+};


### PR DESCRIPTION
## Summary

Adds an **Arcanist Ultimate Simulator** at `/ultimate-simulator`, porting a Google Sheets ult-generation model into a real esotk feature.

The original sheet estimated ultimate generation by recalculating a 100-run rolling average on every edit, which made the result wobble (standard error ≈ ±1 ult) and couldn't show how precise the estimate was. This replaces that with a **seeded, reproducible Monte Carlo engine** and corrects the underlying mechanics from research.

### Engine (pure, framework-agnostic — `core/`)
- `rng.ts` — mulberry32 seeded RNG. Same seed + config ⇒ identical result.
- `simulate.ts` — per-source event emitters (periodic / triggered / perCast) with uptime.
- Decisive trait modeled as its **real per-instance Bernoulli proc**: 1H/staff/bow = 1 roll, 2H = 2 independent rolls (correct binomial, not the sheet's linear 2×).
- `monteCarlo.ts` — aggregates mean, std dev, standard error, and a **95% confidence interval**, so the estimate's precision is visible.

### Validation, then extension
A `SHEET_VALIDATION` preset reproduces the original sheet's known outputs as regression tests — 404.8 instance count, ~6.61 base ult/s, Decisive Half ≈ 112.06, Full ≈ 218.06 — then the real preset extends past them with corrected mechanics.

Research corrections baked into the raid-context preset:
- There is **no passive ultimate regen** — "Base" is the light/heavy-attack hidden buff (3 ult/s while weaving).
- "Cryptcannon" is the **Cryptcanon Vestments** Mythic (grants Minor Heroism), not a per-cast generator.
- Group context is intentional: Major Heroism from a Warden U50 Class Mastery scrip, Pillager's Profit batteried from the raid healer.

### Calibration — measured logs as source of truth (`application/calibration.ts`)
A pure analyzer over real ESO Logs `Resources` events buckets ultimate gains by `abilityGameID` into empirical per-source rates, reusing the existing `fetchResourceEvents` thunk. This lets the simulator be validated against (and overridden by) real fight data. Wiring a live report into the UI is a deferred follow-up.

### UI
Minimal MUI page (lazy route, mirrors `scribing-simulator`) with editable inputs (fight length, Decisive weapon quality + 1H/2H, MC runs, per-source uptimes) and a live per-source result breakdown.

## Testing
- **19 tests** pass (engine determinism, sheet-reconciliation regression, Decisive binomial, calibration bucketing, render smoke test).
- `tsc`, ESLint, and production build all green; the page code-splits into its own chunk.
- Verified live in-browser: renders correctly, 2H toggle ~doubles Decisive (112.5 → 224.6) and the total recomputes reactively.

## Follow-ups (out of scope for this first pass)
- Wire calibration to a live report code in the UI; verify `resourceChangeType: 10 = ultimate` against a real event sample.
- ECharts distribution histogram; optional web-worker offload; configurable source picker.

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`
