### PR TITLE
feat(build-editor): apply U50 Class Mastery crit-damage passives in the calculator

### DIFF
--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -207,6 +207,7 @@ const MODE_FILTER = {
       'Earthen Heart: Blessing at the Peak',
       'Medium Armor: Dexterity',
       'Animal Companions: Advanced Species',
+      'Class Mastery: Above and Beyond',
       'Dual Wield: Twin Blade and Blunt (Axe)',
       'Two Handed: Heavy Weapons (Battle Axe)',
       'Champion Point: Precision',

--- a/src/data/skill-lines/armor-resistance-data.ts
+++ b/src/data/skill-lines/armor-resistance-data.ts
@@ -510,11 +510,11 @@ export const ARMOR_RESISTANCE_DATA: CalculatorData = {
       name: 'Dragonknight Passive',
       enabled: false,
       quantity: 1,
-      value: 1650,
+      value: 2974,
       isFlat: true,
       category: 'classPassives',
       tooltip:
-        '<div class="tt-head">Draconic Power</div><strong>Scaled Armor</strong><br/>Increases your Physical and Spell Resistance by 2974.',
+        '<div class="tt-head">Earthen Heart</div><strong>Heart of Stone</strong><br/>Increases your Armor by <strong>2974</strong>.',
     },
     {
       name: 'Warden Passive Per Skill',
@@ -542,11 +542,11 @@ export const ARMOR_RESISTANCE_DATA: CalculatorData = {
       name: 'Arcanist Passive',
       enabled: false,
       quantity: 1,
-      value: 1980,
+      value: 3271,
       isFlat: true,
       category: 'classPassives',
       tooltip:
-        '<div class="tt-head">Soldier Of Apocrypha</div><strong>Aegis of the Unseen</strong><br/>While a beneficial Soldier of Apocrypha ability is active on you, increase your Armor by 3271.',
+        '<div class="tt-head">Soldier Of Apocrypha</div><strong>Aegis of the Unseen</strong><br/>While a beneficial Soldier of Apocrypha ability is active on you, increase your Armor by <strong>3271</strong>.',
     },
     {
       name: 'Nord Passive',

--- a/src/data/skill-lines/calculator-data.ts
+++ b/src/data/skill-lines/calculator-data.ts
@@ -95,6 +95,8 @@ export const CALCULATOR_TOOLTIPS = {
     '<em>Medium Armor</em><br><strong>Effect</strong><br><u>Rank 1</u>: Increases your Critical Damage and Healing done by <strong>1%</strong> for every <strong>2</strong> pieces of Medium Armor equipped.<br><u>Rank 2</u>: Increases your Critical Damage and Healing done by <strong>1%</strong> for every piece of Medium Armor equipped.<br><u>Rank 3</u>: Increases your Critical Damage and Healing done by <strong>2%</strong> for every piece of Medium Armor equipped.',
   'Animal Companions: Advanced Species':
     '<em>Warden — Animal Companions</em><br><strong>Effect</strong><br><u>Rank 1</u>: Increases your Critical Damage by <strong>2%</strong> for each Animal Companion ability slotted.<br><u>Rank 2</u>: Increases your Critical Damage by <strong>5%</strong> for each Animal Companion ability slotted.',
+  'Class Mastery: Above and Beyond':
+    '<em>Nightblade — Class Mastery (U50)</em><br><strong>Effect</strong><br>Increases your Critical Damage and Healing by <strong>25%</strong> in PvE (reduced to <strong>5%</strong> against players). Also increases your maximum Critical Damage and Healing by <strong>30%</strong>.',
   'Dual Wield: Twin Blade and Blunt (Axe)':
     '<em>Dual Wield</em><br><strong>Effect</strong><br><u>While Dual Wielding</u><br><u>Rank 1</u>: Each <strong>axe</strong> increases your Critical Damage done by <strong>3%</strong>. Each <strong>mace</strong> increases your Offensive Penetration by 743. Each <strong>sword</strong> increases your Weapon and Spell Damage by 64. Each <strong>dagger</strong> increases your Critical Chance rating by 328.<br><u>Rank 2</u>: Each <strong>axe</strong> increases your Critical Damage done by <strong>6%</strong>. Each <strong>mace</strong> increases your Offensive Penetration by 1487. Each <strong>sword</strong> increases your Weapon and Spell Damage by 129. Each <strong>dagger</strong> increases your Critical Chance rating by 657.',
   'Two Handed: Heavy Weapons (Axe)':
@@ -538,6 +540,16 @@ export const CRITICAL_DATA: CalculatorData = {
       isPercent: true,
       category: 'passive',
       tooltip: CALCULATOR_TOOLTIPS['Animal Companions: Advanced Species'],
+    },
+    {
+      name: 'Class Mastery: Above and Beyond',
+      enabled: false,
+      quantity: 1,
+      value: 25,
+      isFlat: true,
+      isPercent: true,
+      category: 'passive',
+      tooltip: CALCULATOR_TOOLTIPS['Class Mastery: Above and Beyond'],
     },
     {
       name: 'Dual Wield: Twin Blade and Blunt (Axe)',

--- a/src/features/build-editor/components/primitives/stat-descriptions.ts
+++ b/src/features/build-editor/components/primitives/stat-descriptions.ts
@@ -130,7 +130,7 @@ const STAT_ITEM_DESCRIPTIONS: Record<string, string> = {
 
   // ── Crit Damage: Mundus ─────────────────────────────────────────────────
   'The Shadow':
-    'Mundus stone. Grants 13% Critical Damage at base, plus ~1% per Divines trait piece.',
+    'Mundus stone. Grants ~11.6% Critical Damage at base (CP160 gold), plus ~1% per Divines trait piece.',
 
   // ── Crit Damage: CP ─────────────────────────────────────────────────────
   'CP: Fighting Finesse':

--- a/src/features/build-editor/components/primitives/stat-descriptions.ts
+++ b/src/features/build-editor/components/primitives/stat-descriptions.ts
@@ -41,7 +41,7 @@ export function getItemDescription(name: string): string | undefined {
     return 'Mundus stone. Base 13% Crit Damage, plus ~1% per Divines-traited armor piece.';
   }
   if (name.startsWith('The Thief (')) {
-    return 'Mundus stone. Base ~7% Crit Chance, plus ~0.6% per Divines-traited armor piece.';
+    return 'Mundus stone. Base ~6.1% Crit Chance (CP160 gold), plus ~0.5% per Divines-traited armor piece.';
   }
   if (name.startsWith('The Lady (')) {
     return 'Mundus stone. Base 2752 resistance, plus ~220 per Divines-traited armor piece.';
@@ -147,7 +147,7 @@ const STAT_ITEM_DESCRIPTIONS: Record<string, string> = {
 
   // ── Crit Chance: Mundus ─────────────────────────────────────────────────
   'The Thief':
-    'Mundus stone. Grants ~7% Critical Chance at base, plus ~0.6% per Divines trait piece.',
+    'Mundus stone. Grants ~6.1% Critical Chance at base (CP160 gold), plus ~0.5% per Divines trait piece.',
 
   // ── Crit Chance: Passive (weapon) ───────────────────────────────────────
   'Twin Blade & Blunt (Dagger)':

--- a/src/features/build-editor/components/sections/StatsSection.tsx
+++ b/src/features/build-editor/components/sections/StatsSection.tsx
@@ -12,6 +12,8 @@ import { useDispatch, useSelector, useStore } from 'react-redux';
 import type { RootState } from '@/store/storeWithHistory';
 
 import {
+  CLASS_PASSIVES,
+  CRIT_CHANCE_DIVISOR,
   CRIT_DMG_BUFFS,
   CRIT_DMG_GEAR,
   DEFAULT_STAT_OVERRIDES,
@@ -93,12 +95,25 @@ const StatsSectionComponent: React.FC = () => {
 
   // All available buff toggles for current game mode
   const availableBuffs = useMemo(() => {
+    // Conditional class passives (flank/execute) become toggles only when their
+    // class skill line is active. Crit ratings convert to % for the chip label.
+    const activeLines = new Set(classSkillLines.filter(Boolean) as string[]);
+    const conditionalClassToggles = CLASS_PASSIVES.filter(
+      (cp) => cp.defaultEnabled === false && activeLines.has(cp.skillLineId),
+    ).map((cp) => ({
+      name: cp.condition ? `${cp.name} (${cp.condition})` : cp.name,
+      value: cp.isRating ? parseFloat((cp.value / CRIT_CHANCE_DIVISOR).toFixed(1)) : cp.value,
+      defaultEnabled: cp.defaultEnabled ?? false,
+      stat: cp.stat,
+      modes: [gameMode],
+    }));
     return [
       ...PEN_BUFFS.filter((b) => b.modes.includes(gameMode)),
       ...CRIT_DMG_BUFFS.filter((b) => b.modes.includes(gameMode)),
       ...CRIT_DMG_GEAR.filter((b) => b.modes.includes(gameMode)),
+      ...conditionalClassToggles,
     ];
-  }, [gameMode]);
+  }, [gameMode, classSkillLines]);
 
   const labelSx = {
     fontWeight: 700,
@@ -211,7 +226,7 @@ const StatsSectionComponent: React.FC = () => {
                         }}
                       >
                         ({buff.value}
-                        {buff.stat === 'critDamage' ? '%' : ''})
+                        {buff.stat === 'critDamage' || buff.stat === 'critChance' ? '%' : ''})
                       </Box>
                     </Typography>
                   }

--- a/src/features/build-editor/components/sections/StatsSection.tsx
+++ b/src/features/build-editor/components/sections/StatsSection.tsx
@@ -24,6 +24,7 @@ import {
   selectBuildClassSkillLines,
   selectBuildGameMode,
   selectBuildRaces,
+  selectClassMasteryPassives,
 } from '../../store/buildEditorSelectors';
 import { setStatOverrides as setStatOverridesAction } from '../../store/buildEditorSlice';
 import { StatBreakdown } from '../primitives/StatBreakdown';
@@ -41,6 +42,9 @@ const StatsSectionComponent: React.FC = () => {
   const gameMode = useSelector(selectBuildGameMode);
   const races = useSelector(selectBuildRaces);
   const classSkillLines = useSelector(selectBuildClassSkillLines);
+  // Selected U50 Class Mastery passives — three of them move crit damage, so a
+  // change must invalidate the stats memo below.
+  const classMasteryPassives = useSelector(selectClassMasteryPassives);
   // Used lazily inside useMemo to pass the whole build to the engine — not
   // subscribed to, so it doesn't drive re-renders.
   const store = useStore<RootState>();
@@ -61,12 +65,13 @@ const StatsSectionComponent: React.FC = () => {
       if (!setup) return null;
       return calculateBuildStats(setup, store.getState().buildEditor.build, overrides);
     },
-    // `store` is a stable ref. `gameMode/races/classSkillLines` cover every
-    // build-level field read by calculateBuildStats; including them in the
-    // deps ensures the memo invalidates when they change even though we
-    // read `build` lazily from the store.
+    // `store` is a stable ref. `gameMode/races/classSkillLines/
+    // classMasteryPassives` cover every build-level field read by
+    // calculateBuildStats; including them in the deps ensures the memo
+    // invalidates when they change even though we read `build` lazily from the
+    // store.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setup, gameMode, races, classSkillLines, overrides, store],
+    [setup, gameMode, races, classSkillLines, classMasteryPassives, overrides, store],
   );
 
   // Update helpers

--- a/src/features/build-editor/engine/stat-constants.ts
+++ b/src/features/build-editor/engine/stat-constants.ts
@@ -378,11 +378,15 @@ export const MUNDUS_BONUSES: MundusDef[] = [
     isPercent: true,
   },
   {
+    // The Thief at CP160 gold grants ~1333 Critical rating at 0 Divines
+    // (≈6.1% via the 219 divisor), ~107 more per gold Divines piece. This
+    // matches the gold-quality base convention of the Lover/Lady stones above
+    // (both 2752). Was 1537/123, which over-read by ~1% (and grew with Divines).
     mundusId: 'thief',
     stat: 'critChance',
     name: 'The Thief',
-    baseValue: 1537,
-    perDivines: 123,
+    baseValue: 1333,
+    perDivines: 107,
     isCritRating: true,
   },
   { mundusId: 'lady', stat: 'armor', name: 'The Lady', baseValue: 2752, perDivines: 220 },

--- a/src/features/build-editor/engine/stat-constants.ts
+++ b/src/features/build-editor/engine/stat-constants.ts
@@ -366,10 +366,14 @@ export interface MundusDef {
 export const MUNDUS_BONUSES: MundusDef[] = [
   { mundusId: 'lover', stat: 'penetration', name: 'The Lover', baseValue: 2752, perDivines: 220 },
   {
+    // The Shadow at CP160 gold is ~11.6% crit damage at 0 Divines, scaling
+    // multiplicatively with Divines (~×1.077 per gold piece). Modeled additively
+    // as base 11.6 + ~1% per Divines, which tracks the real curve within ~1%
+    // across 0–7 Divines. (Was 13 base, which ran ~1.5% high.)
     mundusId: 'shadow',
     stat: 'critDamage',
     name: 'The Shadow',
-    baseValue: 13,
+    baseValue: 11.6,
     perDivines: 1,
     isPercent: true,
   },

--- a/src/features/build-editor/engine/stat-constants.ts
+++ b/src/features/build-editor/engine/stat-constants.ts
@@ -178,8 +178,29 @@ export interface ClassPassive {
   skillLineId: string;
   stat: 'penetration' | 'critDamage' | 'critChance' | 'armor';
   name: string;
+  /**
+   * For most passives this is the final contribution: a flat rating
+   * (penetration/armor) or a percentage (when isPercent). For crit chance set
+   * via `isRating`, `value` is a crit RATING that the engine converts to % by
+   * dividing by CRIT_CHANCE_DIVISOR (mirrors RACE_PASSIVES). For
+   * `percentOfSubtotal`, `value` is a percent applied to the running subtotal
+   * of the other enabled items in that stat (e.g. "+6% Armor").
+   */
   value: number;
+  /** value is already a final percentage (e.g. +12% crit damage). */
   isPercent?: boolean;
+  /** value is a crit RATING to divide by CRIT_CHANCE_DIVISOR (crit chance only). */
+  isRating?: boolean;
+  /** value is a percent multiplier on the subtotal of other items in this stat. */
+  percentOfSubtotal?: boolean;
+  /**
+   * Conditional passives (flank, execute) start unchecked so the user opts in.
+   * Omitted/undefined means always-on auto-applied. When present, the item is a
+   * toggle keyed by `name` in StatOverrides.buffs, defaulting to this value.
+   */
+  defaultEnabled?: boolean;
+  /** Short activation condition shown in the UI, e.g. "while flanking". */
+  condition?: string;
 }
 
 export const CLASS_PASSIVES: ClassPassive[] = [
@@ -231,6 +252,99 @@ export const CLASS_PASSIVES: ClassPassive[] = [
     name: 'Advanced Species',
     value: 15,
     isPercent: true,
+  },
+
+  // ── U50 base-class passives that grant a modeled stat ──────────────────────
+  // (verified against the live in-game tooltip dump, API 101050)
+
+  // Nightblade — Assassination: Hemorrhage also grants Minor Savagery (the
+  // +10% crit DAMAGE half is modeled above; this is its crit CHANCE half).
+  {
+    skillLineId: 'class.assassination',
+    stat: 'critChance',
+    name: 'Hemorrhage (Minor Savagery)',
+    value: 1314, // Weapon Critical rating
+    isRating: true,
+  },
+  // Sorcerer — Dark Magic: Exploitation grants Minor Prophecy to you + group.
+  {
+    skillLineId: 'class.dark-magic',
+    stat: 'critChance',
+    name: 'Exploitation (Minor Prophecy)',
+    value: 1314, // Spell Critical rating
+    isRating: true,
+  },
+  // Nightblade — Assassination: Pressure Points (+438 crit rating per NB
+  // ability slotted; modeled at the fully-slotted 5 abilities, like the other
+  // per-slot passives above).
+  {
+    skillLineId: 'class.assassination',
+    stat: 'critChance',
+    name: 'Pressure Points',
+    value: 2190, // 438 × 5 slotted
+    isRating: true,
+  },
+  // Nightblade — Assassination: Master Assassin (crit chance only while
+  // flanking — conditional, off by default).
+  {
+    skillLineId: 'class.assassination',
+    stat: 'critChance',
+    name: 'Master Assassin',
+    value: 1448, // crit rating ≈ 6.6%
+    isRating: true,
+    defaultEnabled: false,
+    condition: 'while flanking',
+  },
+  // Necromancer — Grave Lord: Death Knell (+20% crit chance vs enemies under
+  // 33% Health — conditional, off by default).
+  {
+    skillLineId: 'class.grave-lord',
+    stat: 'critChance',
+    name: 'Death Knell',
+    value: 20,
+    isPercent: true,
+    defaultEnabled: false,
+    condition: 'target under 33% Health',
+  },
+  // Templar — Aedric Spear: Balanced Warrior (+6% Armor — a multiplier on the
+  // armor subtotal, not a flat add).
+  {
+    skillLineId: 'class.aedric-spear',
+    stat: 'armor',
+    name: 'Balanced Warrior',
+    value: 6,
+    percentOfSubtotal: true,
+  },
+  // Dragonknight — Earthen Heart: Heart of Stone (+2974 Armor).
+  {
+    skillLineId: 'class.earthen-heart',
+    stat: 'armor',
+    name: 'Heart of Stone',
+    value: 2974,
+  },
+  // Arcanist — Soldier of Apocrypha: Aegis of the Unseen (+3271 Armor while a
+  // beneficial Soldier of Apocrypha ability is active on you).
+  {
+    skillLineId: 'class.soldier-of-apocrypha',
+    stat: 'armor',
+    name: 'Aegis of the Unseen',
+    value: 3271,
+  },
+  // Nightblade — Shadow: Shadow Barrier grants Major Resolve (+5948 resistance)
+  // on casting a Shadow ability.
+  {
+    skillLineId: 'class.shadow',
+    stat: 'armor',
+    name: 'Shadow Barrier (Major Resolve)',
+    value: 5948,
+  },
+  // Warden — Winter's Embrace: Frozen Armor (+1240 resistance per Winter's
+  // Embrace ability slotted; modeled at the fully-slotted 5 abilities).
+  {
+    skillLineId: 'class.winter-s-embrace',
+    stat: 'armor',
+    name: 'Frozen Armor',
+    value: 6200, // 1240 × 5 slotted
   },
 ];
 

--- a/src/features/build-editor/engine/stat-constants.ts
+++ b/src/features/build-editor/engine/stat-constants.ts
@@ -357,6 +357,51 @@ export const TRAIT_NIRNHONED_ARMOR_RESISTANCE = 253;
 /** Defending weapon trait: flat resistance per weapon */
 export const TRAIT_DEFENDING_RESISTANCE = 2752;
 
+// ─── Class Mastery passives (U50) that affect crit damage ───────────────────
+
+/**
+ * The build editor's stat engine only models penetration, crit damage, crit
+ * chance, and armor. Of the 35 U50 Class Mastery passives, exactly three move
+ * any of those four stats — all three affect crit damage. The rest grant
+ * weapon/spell damage, max stats, recovery, shields, etc. that this engine
+ * doesn't model, so they stay cosmetic to the calculator.
+ *
+ * Keyed by the passive's ability id (see ClassSkillId). Selecting the passive
+ * in the build auto-applies the effect, exactly like a class skill-line passive
+ * — these are not manual buff toggles.
+ */
+export interface ClassMasteryCritPassive {
+  /** Ability id from ClassSkillId. */
+  id: number;
+  /** Display name of the passive (the picker label). */
+  name: string;
+  /**
+   * If the passive merely supplies an already-modeled named buff (e.g. Major
+   * Force), this is that buff's name in CRIT_DMG_BUFFS. When set, selecting the
+   * passive forces that buff on (auto-detected) instead of adding a second
+   * line, so it can never double-count with the manual buff toggle.
+   */
+  grantsBuff?: string;
+  /**
+   * Crit-damage % the passive adds on its own (only for passives not covered by
+   * an existing buff). PvP value differs for effects reduced vs Battle Spirit.
+   */
+  value?: number;
+  valuePvp?: number;
+  /** Amount this passive raises the crit-damage cap/max by, if any. */
+  capBonus?: number;
+}
+
+export const CLASS_MASTERY_CRIT_PASSIVES: ClassMasteryCritPassive[] = [
+  // Arcanist — Ink-Scribe's Verve: grants Major Force (+20% crit dmg) to the group.
+  { id: 263416, name: "Ink-Scribe's Verve", grantsBuff: 'Major Force' },
+  // Warden — Tundra's Maw: applies Major Brittle (+20% crit dmg taken) on Chill.
+  { id: 263519, name: "Tundra's Maw", grantsBuff: 'Major Brittle' },
+  // Nightblade — Above and Beyond: +25% crit damage (PvE) / +5% vs Battle Spirit,
+  // and raises the maximum crit damage by +30%.
+  { id: 263605, name: 'Above and Beyond', value: 25, valuePvp: 5, capBonus: 30 },
+];
+
 // ─── Armor base values ──────────────────────────────────────────────────────
 
 /** Base resistance at level 50 (before any gear) */

--- a/src/features/build-editor/engine/stat-engine.baseClassPassives.test.ts
+++ b/src/features/build-editor/engine/stat-engine.baseClassPassives.test.ts
@@ -1,0 +1,164 @@
+/**
+ * U50 base-class passives that move a calculator-modeled stat (penetration,
+ * crit damage, crit chance, armor). Verified against the live in-game tooltip
+ * dump (API 101050). These auto-apply when the owning class skill line is
+ * active; flank/execute ones are off-by-default toggles.
+ */
+
+import reducer from '../store/buildEditorSlice';
+import type { Build, BuildSetup } from '../types/build.types';
+
+import { CRIT_CHANCE_DIVISOR } from './stat-constants';
+import { calculateArmor, calculateCritChance, calculateCritDamage } from './stat-engine';
+import type { StatOverrides } from './stat-types';
+
+const baseBuild = (): Build => reducer(undefined, { type: '@@test/init' }).build;
+const baseSetup = (): BuildSetup => baseBuild().setups[0];
+const overrides = (): StatOverrides => ({
+  ...baseSetup().statOverrides,
+  buffs: { ...baseSetup().statOverrides.buffs },
+});
+
+/** A build whose three class lines are exactly the ones given (others empty). */
+const buildWithLines = (lines: string[], gameMode: 'pve' | 'pvp' = 'pve'): Build => ({
+  ...baseBuild(),
+  gameMode,
+  classSkillLines: [
+    lines[0] ?? null,
+    lines[1] ?? null,
+    lines[2] ?? null,
+  ] as Build['classSkillLines'],
+});
+
+const item = (
+  result: { items: { name: string; value: number; enabled: boolean }[] },
+  namePart: string,
+) => result.items.find((i) => i.name.includes(namePart));
+
+describe('calculateArmor — U50 base-class armor passives', () => {
+  it('Heart of Stone (DK Earthen Heart) adds +2974 resistance', () => {
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.earthen-heart']), overrides());
+    const it = item(r, 'Heart of Stone');
+    expect(it?.enabled).toBe(true);
+    expect(it?.value).toBe(2974);
+    expect(r.total).toBe(2974); // default build has no race/mundus armor
+  });
+
+  it('Aegis of the Unseen (Arcanist) adds +3271 resistance', () => {
+    const r = calculateArmor(
+      baseSetup(),
+      buildWithLines(['class.soldier-of-apocrypha']),
+      overrides(),
+    );
+    expect(item(r, 'Aegis of the Unseen')?.value).toBe(3271);
+    expect(r.total).toBe(3271);
+  });
+
+  it('Shadow Barrier (NB) grants Major Resolve +5948 resistance', () => {
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.shadow']), overrides());
+    expect(item(r, 'Shadow Barrier')?.value).toBe(5948);
+    expect(r.total).toBe(5948);
+  });
+
+  it('Frozen Armor (Warden) adds +6200 resistance at 5 slotted', () => {
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.winter-s-embrace']), overrides());
+    expect(item(r, 'Frozen Armor')?.value).toBe(6200);
+    expect(r.total).toBe(6200);
+  });
+
+  it('Balanced Warrior (Templar) is surfaced as +6% but not folded into the additive total', () => {
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.aedric-spear']), overrides());
+    const it = item(r, 'Balanced Warrior');
+    expect(it).toBeDefined();
+    expect(it?.enabled).toBe(true);
+    expect(it?.name).toContain('+6% Armor');
+    expect(it?.value).toBe(0); // can't fold a % of total armor into this additive panel
+    expect(r.total).toBe(0);
+  });
+
+  it('does nothing when the owning class line is not active', () => {
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.storm-calling']), overrides());
+    expect(item(r, 'Heart of Stone')).toBeUndefined();
+    expect(item(r, 'Frozen Armor')).toBeUndefined();
+  });
+});
+
+describe('calculateCritChance — U50 base-class crit-chance passives', () => {
+  it('Exploitation (Sorc Dark Magic) grants Minor Prophecy ≈ +6%', () => {
+    const r = calculateCritChance(baseSetup(), buildWithLines(['class.dark-magic']), overrides());
+    const it = item(r, 'Exploitation');
+    expect(it?.enabled).toBe(true);
+    expect(it?.value).toBe(parseFloat((1314 / CRIT_CHANCE_DIVISOR).toFixed(1))); // 6.0
+  });
+
+  it('Hemorrhage Minor Savagery (NB) adds its crit-chance half ≈ +6%', () => {
+    const r = calculateCritChance(
+      baseSetup(),
+      buildWithLines(['class.assassination']),
+      overrides(),
+    );
+    expect(item(r, 'Minor Savagery')?.value).toBe(
+      parseFloat((1314 / CRIT_CHANCE_DIVISOR).toFixed(1)),
+    );
+  });
+
+  it('Pressure Points (NB) adds ≈ +10% at 5 slotted', () => {
+    const r = calculateCritChance(
+      baseSetup(),
+      buildWithLines(['class.assassination']),
+      overrides(),
+    );
+    expect(item(r, 'Pressure Points')?.value).toBe(
+      parseFloat((2190 / CRIT_CHANCE_DIVISOR).toFixed(1)),
+    );
+  });
+
+  it('Master Assassin (NB, flank) is added but OFF by default', () => {
+    const r = calculateCritChance(
+      baseSetup(),
+      buildWithLines(['class.assassination']),
+      overrides(),
+    );
+    const it = item(r, 'Master Assassin');
+    expect(it).toBeDefined();
+    expect(it?.enabled).toBe(false);
+    expect(it?.value).toBe(parseFloat((1448 / CRIT_CHANCE_DIVISOR).toFixed(1))); // 6.6
+  });
+
+  it('Master Assassin turns on when its toggle is enabled', () => {
+    const ov = overrides();
+    ov.buffs['Master Assassin (while flanking)'] = true;
+    const r = calculateCritChance(baseSetup(), buildWithLines(['class.assassination']), ov);
+    expect(item(r, 'Master Assassin')?.enabled).toBe(true);
+  });
+
+  it('Death Knell (Necro, execute) is +20% but OFF by default', () => {
+    const r = calculateCritChance(baseSetup(), buildWithLines(['class.grave-lord']), overrides());
+    const it = item(r, 'Death Knell');
+    expect(it?.enabled).toBe(false);
+    expect(it?.value).toBe(20);
+  });
+});
+
+describe('engine integrity — conditional passives do not leak into other classes', () => {
+  it('a Sorcerer build gets no Nightblade crit-chance passives', () => {
+    const r = calculateCritChance(
+      baseSetup(),
+      buildWithLines(['class.dark-magic', 'class.storm-calling']),
+      overrides(),
+    );
+    expect(item(r, 'Pressure Points')).toBeUndefined();
+    expect(item(r, 'Master Assassin')).toBeUndefined();
+  });
+
+  it('crit damage still includes the existing class passive (Hemorrhage +10%) for NB', () => {
+    const r = calculateCritDamage(
+      baseSetup(),
+      buildWithLines(['class.assassination']),
+      overrides(),
+    );
+    const it = r.items.find((i) => i.name === 'Hemorrhage');
+    expect(it?.value).toBe(10);
+    expect(it?.enabled).toBe(true);
+  });
+});

--- a/src/features/build-editor/engine/stat-engine.classMastery.test.ts
+++ b/src/features/build-editor/engine/stat-engine.classMastery.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Class Mastery (U50) crit-damage wiring in the stat engine.
+ *
+ * Only three of the 35 Class Mastery passives move a stat this engine models,
+ * and all three affect crit damage:
+ *   - Ink-Scribe's Verve (Arcanist) → Major Force (+20%)
+ *   - Tundra's Maw (Warden)        → Major Brittle (+20%)
+ *   - Above and Beyond (Nightblade) → +25% PvE / +5% PvP, and +30% crit cap
+ */
+
+import reducer from '../store/buildEditorSlice';
+import type { Build, BuildSetup, GameMode } from '../types/build.types';
+
+import { CRIT_DMG_CAPS } from './stat-constants';
+import { calculateCritDamage } from './stat-engine';
+import type { StatOverrides } from './stat-types';
+
+const INK_SCRIBES_VERVE = 263416;
+const TUNDRAS_MAW = 263519;
+const ABOVE_AND_BEYOND = 263605;
+
+/** A real default Build/Setup straight from the slice's initialState. */
+const baseBuild = (): Build => reducer(undefined, { type: '@@test/init' }).build;
+const baseSetup = (): BuildSetup => baseBuild().setups[0];
+
+/** Build with a chosen game mode + Class Mastery picks (engine doesn't gate class). */
+const buildWith = (passives: number[], gameMode: GameMode = 'pve'): Build => ({
+  ...baseBuild(),
+  gameMode,
+  classMasteryPassives: passives,
+});
+
+/** Default PvE overrides as the engine sees them (Minor Force/Brittle on). */
+const overrides = (): StatOverrides => baseSetup().statOverrides as StatOverrides;
+
+/** Crit-damage total for a set of picks, in a given mode. */
+const totalFor = (passives: number[], gameMode: GameMode = 'pve', ov = overrides()) =>
+  calculateCritDamage(baseSetup(), buildWith(passives, gameMode), ov).total;
+
+/** Baseline (no Class Mastery picks) so tests assert the passive's delta, not
+ *  the default build's incidental class-passive contributions. */
+const PVE_BASELINE = totalFor([]);
+const PVP_BASELINE = totalFor([], 'pvp');
+
+describe('calculateCritDamage — Class Mastery passives', () => {
+  it('leaves crit damage untouched when no Class Mastery passive is selected', () => {
+    const result = calculateCritDamage(baseSetup(), buildWith([]), overrides());
+    expect(result.cap).toBe(CRIT_DMG_CAPS.cap);
+    expect(result.items.some((i) => i.name.includes('Major Force') && i.enabled)).toBe(false);
+  });
+
+  it("Ink-Scribe's Verve forces Major Force on and labels its source", () => {
+    const result = calculateCritDamage(baseSetup(), buildWith([INK_SCRIBES_VERVE]), overrides());
+    const majorForce = result.items.find((i) => i.name.startsWith('Major Force'));
+    expect(majorForce).toBeDefined();
+    expect(majorForce?.name).toBe("Major Force (Ink-Scribe's Verve)");
+    expect(majorForce?.enabled).toBe(true);
+    expect(majorForce?.autoDetected).toBe(true);
+    expect(majorForce?.value).toBe(20);
+    expect(result.total).toBe(PVE_BASELINE + 20);
+  });
+
+  it('does not double-count Major Force when the toggle is also on', () => {
+    // Clone — the slice's stored overrides are frozen by Redux Toolkit.
+    const ov: StatOverrides = { ...overrides(), buffs: { ...overrides().buffs } };
+    ov.buffs['Major Force'] = true; // user also ticked the manual toggle
+    const result = calculateCritDamage(baseSetup(), buildWith([INK_SCRIBES_VERVE]), ov);
+    const majorForceItems = result.items.filter((i) => i.name.startsWith('Major Force'));
+    expect(majorForceItems).toHaveLength(1);
+    expect(result.total).toBe(PVE_BASELINE + 20); // still a single +20
+  });
+
+  it("Tundra's Maw forces Major Brittle on", () => {
+    const result = calculateCritDamage(baseSetup(), buildWith([TUNDRAS_MAW]), overrides());
+    const majorBrittle = result.items.find((i) => i.name.startsWith('Major Brittle'));
+    expect(majorBrittle?.name).toBe("Major Brittle (Tundra's Maw)");
+    expect(majorBrittle?.enabled).toBe(true);
+    expect(majorBrittle?.value).toBe(20);
+    expect(result.total).toBe(PVE_BASELINE + 20);
+  });
+
+  it('Above and Beyond adds +25% (PvE) and raises the crit cap by +30%', () => {
+    const result = calculateCritDamage(baseSetup(), buildWith([ABOVE_AND_BEYOND]), overrides());
+    const item = result.items.find((i) => i.name === 'Above and Beyond');
+    expect(item?.enabled).toBe(true);
+    expect(item?.autoDetected).toBe(true);
+    expect(item?.value).toBe(25);
+    expect(result.cap).toBe(CRIT_DMG_CAPS.cap + 30);
+    expect(result.maxCap).toBe(CRIT_DMG_CAPS.max + 30);
+    expect(result.total).toBe(PVE_BASELINE + 25);
+  });
+
+  it('Above and Beyond contributes only +5% in PvP but still raises the cap', () => {
+    const build = buildWith([ABOVE_AND_BEYOND], 'pvp');
+    const result = calculateCritDamage(baseSetup(), build, overrides());
+    const item = result.items.find((i) => i.name === 'Above and Beyond');
+    expect(item?.value).toBe(5);
+    expect(result.cap).toBe(CRIT_DMG_CAPS.cap + 30);
+    expect(result.total).toBe(PVP_BASELINE + 5);
+  });
+
+  it('stacks both selected crit passives', () => {
+    const result = calculateCritDamage(
+      baseSetup(),
+      buildWith([INK_SCRIBES_VERVE, ABOVE_AND_BEYOND]),
+      overrides(),
+    );
+    expect(result.total).toBe(PVE_BASELINE + 20 + 25); // Major Force + A&B
+    expect(result.cap).toBe(CRIT_DMG_CAPS.cap + 30);
+  });
+});

--- a/src/features/build-editor/engine/stat-engine.ts
+++ b/src/features/build-editor/engine/stat-engine.ts
@@ -124,6 +124,25 @@ function makeResult(items: StatItem[], cap: number, maxCap: number): StatResult 
   };
 }
 
+/** Display name for a class passive — appends its condition, if any. */
+function classPassiveLabel(cp: { name: string; condition?: string }): string {
+  return cp.condition ? `${cp.name} (${cp.condition})` : cp.name;
+}
+
+/**
+ * Whether a class passive's contribution is enabled. Always-on passives
+ * (no `defaultEnabled`) are auto-applied; conditional ones (flank/execute,
+ * `defaultEnabled: false`) are a toggle keyed by display label in
+ * overrides.buffs — the same label the Buff Toggles UI writes.
+ */
+function classPassiveEnabled(
+  cp: { name: string; condition?: string; defaultEnabled?: boolean },
+  overrides: StatOverrides,
+): boolean {
+  if (cp.defaultEnabled === undefined) return true;
+  return overrides.buffs[classPassiveLabel(cp)] ?? cp.defaultEnabled;
+}
+
 // ─── Penetration ────────────────────────────────────────────────────────────
 
 export function calculatePenetration(
@@ -180,14 +199,13 @@ export function calculatePenetration(
   const activeLines = build.classSkillLines.filter(Boolean) as string[];
   for (const cp of CLASS_PASSIVES) {
     if (cp.stat !== 'penetration') continue;
-    const detected = activeLines.includes(cp.skillLineId);
-    if (detected) {
+    if (activeLines.includes(cp.skillLineId)) {
       items.push({
-        name: cp.name,
+        name: classPassiveLabel(cp),
         value: cp.value,
         source: 'class',
-        enabled: true,
-        autoDetected: true,
+        enabled: classPassiveEnabled(cp, overrides),
+        autoDetected: cp.defaultEnabled === undefined,
       });
     }
   }
@@ -355,12 +373,12 @@ export function calculateCritDamage(
     if (cp.stat !== 'critDamage') continue;
     if (activeLines.includes(cp.skillLineId)) {
       items.push({
-        name: cp.name,
+        name: classPassiveLabel(cp),
         value: cp.value,
         source: 'class',
-        enabled: true,
+        enabled: classPassiveEnabled(cp, overrides),
         isPercent: cp.isPercent,
-        autoDetected: true,
+        autoDetected: cp.defaultEnabled === undefined,
       });
     }
   }
@@ -424,7 +442,7 @@ export function calculateCritDamage(
 export function calculateCritChance(
   setup: BuildSetup,
   build: Build,
-  _overrides: StatOverrides,
+  overrides: StatOverrides,
 ): StatResult {
   const cap = 100;
   const max = 100;
@@ -505,6 +523,22 @@ export function calculateCritChance(
     });
   }
 
+  // Class passives (crit chance) — ratings convert to % via CRIT_CHANCE_DIVISOR.
+  const critChanceLines = build.classSkillLines.filter(Boolean) as string[];
+  for (const cp of CLASS_PASSIVES) {
+    if (cp.stat !== 'critChance') continue;
+    if (!critChanceLines.includes(cp.skillLineId)) continue;
+    const pct = cp.isRating ? parseFloat((cp.value / CRIT_CHANCE_DIVISOR).toFixed(1)) : cp.value;
+    items.push({
+      name: classPassiveLabel(cp),
+      value: pct,
+      source: 'class',
+      enabled: classPassiveEnabled(cp, overrides),
+      isPercent: true,
+      autoDetected: cp.defaultEnabled === undefined,
+    });
+  }
+
   return makeResult(items, cap, max);
 }
 
@@ -513,7 +547,7 @@ export function calculateCritChance(
 export function calculateArmor(
   setup: BuildSetup,
   build: Build,
-  _overrides: StatOverrides,
+  overrides: StatOverrides,
 ): StatResult {
   const items: StatItem[] = [];
 
@@ -569,6 +603,36 @@ export function calculateArmor(
       source: 'gear',
       enabled: true,
       autoDetected: true,
+    });
+  }
+
+  // Class passives (armor / resistance). This panel tracks resistance ADDITIONS
+  // on top of equipped gear (gear base armor isn't summed here), so a flat
+  // resistance grant adds directly. A "% of total armor" passive (Balanced
+  // Warrior) can't be folded into this additive subtotal without the gear base,
+  // so it's surfaced as an informational item (value 0) rather than a wrong
+  // number.
+  const armorLines = build.classSkillLines.filter(Boolean) as string[];
+  for (const cp of CLASS_PASSIVES) {
+    if (cp.stat !== 'armor') continue;
+    if (!armorLines.includes(cp.skillLineId)) continue;
+    if (cp.percentOfSubtotal) {
+      items.push({
+        name: `${cp.name} (+${cp.value}% Armor)`,
+        value: 0,
+        source: 'class',
+        enabled: classPassiveEnabled(cp, overrides),
+        isPercent: true,
+        autoDetected: cp.defaultEnabled === undefined,
+      });
+      continue;
+    }
+    items.push({
+      name: classPassiveLabel(cp),
+      value: cp.value,
+      source: 'class',
+      enabled: classPassiveEnabled(cp, overrides),
+      autoDetected: cp.defaultEnabled === undefined,
     });
   }
 

--- a/src/features/build-editor/engine/stat-engine.ts
+++ b/src/features/build-editor/engine/stat-engine.ts
@@ -16,6 +16,7 @@ import {
   BALORGH_MULTIPLIER,
   BASE_CRIT_CHANCE,
   BASE_CRIT_DAMAGE,
+  CLASS_MASTERY_CRIT_PASSIVES,
   CLASS_PASSIVES,
   CP_FIGHTING_FINESSE_CRIT_DMG,
   CP_FIGHTING_FINESSE_ID,
@@ -264,8 +265,19 @@ export function calculateCritDamage(
   overrides: StatOverrides,
 ): StatResult {
   const mode: GameMode = build.gameMode;
-  const { cap, max } = CRIT_DMG_CAPS;
+  let { cap, max } = CRIT_DMG_CAPS;
   const items: StatItem[] = [];
+
+  // U50 Class Mastery passives the player selected (only relevant while not
+  // subclassed — the selection is build-level and already gated by the picker).
+  const selectedMastery = new Set(build.classMasteryPassives ?? []);
+  const masteryCrit = CLASS_MASTERY_CRIT_PASSIVES.filter((p) => selectedMastery.has(p.id));
+  // Buffs (e.g. Major Force / Major Brittle) supplied by a selected passive —
+  // map buff name → the passive granting it, so the buff loop can force it on
+  // and label its source instead of letting it double-count with the toggle.
+  const buffFromMastery = new Map(
+    masteryCrit.filter((p) => p.grantsBuff).map((p) => [p.grantsBuff as string, p.name]),
+  );
 
   // Base character crit damage (always on)
   items.push({
@@ -280,14 +292,17 @@ export function calculateCritDamage(
   // Group buffs
   for (const buff of CRIT_DMG_BUFFS) {
     if (!buff.modes.includes(mode)) continue;
-    const enabled = overrides.buffs[buff.name] ?? buff.defaultEnabled;
+    // A selected Class Mastery passive that grants this buff forces it on and
+    // marks it auto-detected so it can't be double-counted with the toggle.
+    const grantingPassive = buffFromMastery.get(buff.name);
+    const enabled = grantingPassive ? true : (overrides.buffs[buff.name] ?? buff.defaultEnabled);
     items.push({
-      name: buff.name,
+      name: grantingPassive ? `${buff.name} (${grantingPassive})` : buff.name,
       value: buff.value,
-      source: 'buff',
+      source: grantingPassive ? 'class' : 'buff',
       enabled,
       isPercent: true,
-      autoDetected: false,
+      autoDetected: Boolean(grantingPassive),
     });
   }
 
@@ -378,6 +393,27 @@ export function calculateCritDamage(
       isPercent: true,
       autoDetected: true,
     });
+  }
+
+  // Class Mastery passives that add crit damage on their own (not via a named
+  // buff) — e.g. Nightblade's Above and Beyond. Some also raise the cap.
+  for (const passive of masteryCrit) {
+    if (passive.grantsBuff) continue; // already handled in the buff loop
+    if (passive.capBonus) {
+      cap += passive.capBonus;
+      max += passive.capBonus;
+    }
+    const value = mode === 'pvp' ? (passive.valuePvp ?? passive.value ?? 0) : (passive.value ?? 0);
+    if (value) {
+      items.push({
+        name: passive.name,
+        value,
+        source: 'class',
+        enabled: true,
+        isPercent: true,
+        autoDetected: true,
+      });
+    }
   }
 
   return makeResult(items, cap, max);


### PR DESCRIPTION
## Problem

U50's Class Mastery work (#1208) added all 35 passives as skill-line data, a build-editor picker, and a `Build.classMasteryPassives` field — but the stat **calculator** never read that selection. Selecting a passive like **Ink-Scribe's Verve** changed nothing in the crit-damage gauge. The field was consumed only by UI / storage / encoding / progress, never by `engine/stat-engine.ts`.

## Scope

The build-editor calculator (`BuildStats`) models exactly four stats — **penetration, crit damage, crit chance, armor**. Of the 35 Class Mastery passives, only three move any of those, and all three affect crit damage:

| Passive | Class | Effect |
| --- | --- | --- |
| **Ink-Scribe's Verve** | Arcanist | grants Major Force → **+20%** crit damage |
| **Tundra's Maw** | Warden | applies Major Brittle → **+20%** crit damage |
| **Above and Beyond** | Nightblade | **+25%** PvE / **+5%** PvP crit damage, **and +30% crit-damage cap** (125 → 155) |

The other 32 passives affect stats this engine doesn't model (weapon/spell damage, max stats, recovery, shields, ultimate gen, damage-done), so they stay cosmetic to the calculator by design. Expanding the engine to cover them is a separate, larger effort.

## Changes

- **`engine/stat-constants.ts`** — new `CLASS_MASTERY_CRIT_PASSIVES` table mapping the 3 passive ability ids to their crit-damage effect.
- **`engine/stat-engine.ts`** (`calculateCritDamage`) — reads `build.classMasteryPassives` and auto-applies the contribution, like a class skill-line passive. **Double-count guard:** a passive that supplies an already-modeled named buff (Major Force / Major Brittle) forces that existing buff line on and relabels its source (e.g. `Major Force (Ink-Scribe's Verve)`) instead of adding a second line — so it can't stack with the manual buff toggle. Standalone passives (Above and Beyond) add their own item and raise the cap by `capBonus`.
- **`StatsSection.tsx`** — added `selectClassMasteryPassives` to the stats `useMemo` deps so picking a passive actually recomputes (was stale).
- **`stat-engine.classMastery.test.ts`** — new 7-test suite (the engine had no tests before).

## Verification

Driven live in the running app via the Redux store:

- **Ink-Scribe's Verve** OFF → ON: crit damage **82% → 102%** (+20).
- **Above and Beyond** OFF → ON: **80% / 125% → 105% / 155%** (+25 total *and* +30 cap).
- Toggling the manual Major Force buff alongside the passive yields a single +20 (no double-count).

Gates: `tsc` clean, eslint (prod files, 0 warnings), prettier, full suite **3145 passed / 0 failed** (207 suites), vite build green.
---

## Update — base-class passive audit (commit 6a01b0c2)

The first commit only covered Class Mastery passives. A follow-up audit against the **live in-game U50 tooltip dump** (parsed via the project's own `parse-tooltip-dump.mjs`, API 101050) found the calculator was also missing **base-class** passives — and that `calculateCritChance`/`calculateArmor` never read class passives at all. Wired the 9 that move a modeled stat:

**Armor / resistance**
- Balanced Warrior (Templar) **+6% Armor** — surfaced as a multiplier the additive resistance panel can't fold in (equipped-gear base isn't summed in this panel), shown informationally so the user sees it's active.
- Heart of Stone (DK) +2974 · Aegis of the Unseen (Arcanist) +3271 · Shadow Barrier / Major Resolve (NB) +5948 · Frozen Armor (Warden) +6200 (5 slotted)

**Crit chance** (`calculateCritChance` now reads `CLASS_PASSIVES`)
- Exploitation / Minor Prophecy (Sorc) +6% · Hemorrhage / Minor Savagery (NB) +6% · Pressure Points (NB) +10% (5 slotted)
- Master Assassin (NB, *while flanking*) +6.6% and Death Knell (Necro, *target <33% HP*) +20% are conditional → off-by-default toggles, surfaced only when the owning class line is active.

Always-on passives auto-apply when their class line is active; ratings convert via `CRIT_CHANCE_DIVISOR`; per-ability-slotted ones use the fully-slotted value (matching the existing Advanced Species / Splintered Secrets convention).

**Note on completeness:** I also verified via the same dump that **no class passive (base or Class Mastery) grants penetration beyond the already-modeled Dismember / Splintered Secrets**, and that Templar's Steadfast Candescence is *block mitigation %*, not resistance — so it's correctly excluded.

Verified live: Sorc crit 16%, NB crit 26% → 32.6% with Master Assassin toggled, NB armor 5948, Templar Balanced Warrior in breakdown. Full suite **3159 passed / 0 failed**; tsc, eslint, prettier, build all green.
