### PR TITLE
fix(build-editor): plain placeholder for build short description

### DIFF
--- a/src/features/build-editor/components/BuildCompletionHeader.tsx
+++ b/src/features/build-editor/components/BuildCompletionHeader.tsx
@@ -524,7 +524,7 @@ export const BuildCompletionHeader: React.FC = () => {
             }}
           />
           <input
-            placeholder="Short description (e.g. Runic Sunder + Fatecarver rotation)"
+            placeholder="Short description (one line summarizing this build)"
             value={build.shortDescription}
             onChange={(e) => dispatch(setBuildDescription(e.target.value))}
             maxLength={140}


### PR DESCRIPTION
## What

Replaces the build short-description placeholder in the build editor with a plain, universal hint.

**Before:** `Short description (e.g. Runic Sunder + Fatecarver rotation)`
**After:** `Short description (one line summarizing this build)`

## Why

The old example was niche ESO jargon (and the "X + Y rotation" pairing read oddly), which isn't helpful as generic placeholder guidance. The new text simply tells users what the field is for.

## Scope

One-line change to the placeholder string in `BuildCompletionHeader.tsx`. No behavior or logic changes.