### PR TITLE
fix(tests): stop nightly WebKit "minimal content" flake + live-log false click

### DIFF
--- a/tests/nightly-regression-interactive.spec.ts
+++ b/tests/nightly-regression-interactive.spec.ts
@@ -498,45 +498,20 @@ test.describe('Nightly Regression - Interactive Features', () => {
 
       await page.waitForTimeout(5000);
 
-      // Look for live logging interface elements
-      const hasLiveCssElements = await page
-        .locator('.live-log, .live-logging, .real-time, [data-testid*="live"]')
-        .isVisible()
-        .catch(() => false);
-      const hasLiveText = await page
-        .getByText(/live/i)
-        .isVisible()
-        .catch(() => false);
-
-      const hasLiveInterface = hasLiveCssElements || hasLiveText;
-
-      // Take screenshot with error handling
+      // LiveLog is a passive polling wrapper around ReportFightDetails — it has
+      // no Start/Stop/Connect controls. Earlier heuristics here matched
+      // unrelated UI (e.g. the "Enlivening Overflow" CP name, footer "Connect
+      // with our team" CTA), causing a speculative click that retried until a
+      // 30s timeout on chromium. The test now just takes a smoke-test
+      // screenshot, matching the pattern used by sibling tests in this file.
       try {
         await page.screenshot({
           path: `test-results/nightly-regression-live-logging-${reportId}.png`,
           fullPage: true,
-          timeout: 15000, // Increased timeout
+          timeout: 15000,
         });
       } catch (screenshotError) {
         console.log('Screenshot failed but continuing test:', (screenshotError as Error).message);
-      }
-
-      if (hasLiveInterface) {
-        // Test live logging controls if available
-        const controls = page.locator(
-          'button:has-text("Start"), button:has-text("Stop"), button:has-text("Connect")',
-        );
-
-        if (await controls.first().isVisible({ timeout: 3000 })) {
-          await controls.first().click();
-          await page.waitForTimeout(2000);
-
-          await page.screenshot({
-            path: `test-results/nightly-regression-live-active-${reportId}.png`,
-            fullPage: true,
-            timeout: TEST_TIMEOUTS.screenshot,
-          });
-        }
       }
     });
   });

--- a/tests/nightly-regression.spec.ts
+++ b/tests/nightly-regression.spec.ts
@@ -346,10 +346,17 @@ test.describe('Nightly Regression Tests - Real Data', () => {
 
       await page.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.dataLoad });
 
+      // Ensure the SPA has actually mounted before inspecting body content.
+      // On WebKit/mobile-safari, `networkidle` can resolve before React has
+      // rendered, leaving an effectively empty body (~61 chars) and producing a
+      // false "minimal content" failure. This mirrors the WebKit guard already
+      // used by the Report Landing Pages test above.
+      await waitForAppMount(page);
+
       // Check if the page loaded successfully - don't assume fight list exists
       const bodyContent = await page.locator('body').textContent();
       const contentLength = bodyContent?.length || 0;
-      
+
       if (contentLength < 100) {
         throw new Error(`Report ${reportId} appears to have minimal content (${contentLength} characters)`);
       }
@@ -737,8 +744,12 @@ test.describe('Nightly Regression Tests - Real Data', () => {
         await page.waitForLoadState('networkidle', { timeout: TEST_TIMEOUTS.networkIdle });
       } catch (error) {
         console.log('⚠️ NetworkIdle timeout for visual regression test, checking for content instead...');
-        await waitForAppMount(page);
       }
+
+      // Wait for the SPA to mount regardless of whether networkidle resolved or
+      // timed out. On WebKit, networkidle frequently fires before React renders,
+      // which previously made this test flaky with a "minimal content" error.
+      await waitForAppMount(page);
 
       // Check if the page loaded successfully
       const bodyContent = await page.locator('body').textContent();


### PR DESCRIPTION
## Why nightly is failing

The scheduled **Nightly Regression Tests** failed on runs [305](https://github.com/ESO-Toolkit/eso-toolkit/actions/runs/27416927016) and [304](https://github.com/ESO-Toolkit/eso-toolkit/actions/runs/27352220073) (and intermittently before that). In both runs, shard 3 reported the same single failure:

```
[mobile-safari] › tests/nightly-regression.spec.ts:337:9 › Experimental Tabs ›
  should load experimental tabs for report with fights
  Error: Report prV8jWb1NqFJc97Z appears to have minimal content (61 characters)
```

### Root cause

The **Experimental Tabs** and **Visual Regression** tests read `body.textContent()` *immediately after* `page.waitForLoadState('networkidle')` and fail if the body is under 100 chars. On **WebKit / mobile-safari**, `networkidle` frequently resolves *before* React has mounted, so the body is just the empty ~61-char app shell → false `"minimal content"` failure. The same report loads fine on chromium and tablet-ipad (4,600+ chars).

The **Report Landing Pages** test already solved this exact problem with a WebKit-specific `waitForAppMount(page)` guard before its content check — the two failing tests simply never got the same treatment. (The Visual Regression test only waited for mount in the `networkidle` *timeout* branch, so when networkidle resolved early it hit the same race — that's why it shows as `flaky` rather than `failed`.)

## What this changes

1. **`nightly-regression.spec.ts`**
   - Experimental Tabs: add `await waitForAppMount(page)` before the content-length check.
   - Visual Regression: wait for app mount whether `networkidle` resolves *or* times out (previously only the timeout path waited).

2. **`nightly-regression-interactive.spec.ts`** — folds in the fix from #1114 (the "PR we should've merged"). The `should load live logging interface` test used a `/live/i` text heuristic that false-positives on the "Enlivening Overflow" CP name, then clicked a button matched via the footer "Connect with our team" CTA, retrying until a 30s timeout on chromium. `LiveLog` is a passive polling wrapper with no Start/Stop/Connect controls, so the heuristic + speculative click are removed, keeping the smoke-test screenshot.

> Note: this supersedes #1114 — once this merges, #1114 can be closed.

## Validation

- `npm run validate` (typecheck + lint + format:check) — passes.
- These are Playwright nightly specs that run against production (`esotk.com`), so they aren't exercised by `npm test`; the changes are additive waits + a heuristic removal, no behavioral test coverage lost.

https://claude.ai/code/session_01Hpz3Gu1PxV9uRfZrPY3mMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpz3Gu1PxV9uRfZrPY3mMa)_