### PR TITLE
fix(fight-replay): restore mobile marker editing + persistent close/restore in immersive (PR #1207 fixes)

### DIFF
--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -1,4 +1,5 @@
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
 import { Box, IconButton, Paper, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { visuallyHidden } from '@mui/utils';
@@ -34,6 +35,7 @@ import { lockDocumentSelection } from '../utils/documentSelectionLock';
 import { clampReplayTime } from '../utils/replayTime';
 
 import { Arena3D } from './Arena3D';
+import { ADD_MARKER_AT_CENTER_EVENT } from './Arena3DScene';
 import { MobileReplayDock } from './mobile/MobileReplayDock';
 import { PlaybackControls, PLAYBACK_SPEEDS, type TransportTrial } from './PlaybackControls';
 import { ReplayTransitionOverlay } from './ReplayTransitionOverlay';
@@ -730,6 +732,13 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // they don't break Arena3D's React.memo on every render.
   const togglePlayerPathsHUD = useCallback(() => setShowPlayerPathsHUD((prev) => !prev), []);
   const toggleTrails = useCallback(() => setShowPlayerTrails((prev) => !prev), []);
+
+  // Gesture-free marker placement for the mobile Settings sheet: the in-canvas bridge raycasts the
+  // screen center onto the arena floor and opens the icon picker there. Stable so it doesn't break
+  // the dock's React.memo on every playback tick.
+  const handleAddMarkerAtCenter = useCallback(() => {
+    window.dispatchEvent(new CustomEvent(ADD_MARKER_AT_CENTER_EVENT));
+  }, []);
 
   // A mobile bottom sheet is open (Chapters / Settings) — chrome must never auto-hide
   // out from under an open sheet.
@@ -1472,15 +1481,61 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           Replaces the desktop transport + the floating trial chip + the tools button entirely.
           Fades with the tap-to-toggle chrome (opacity only — NO transform, the sheets inside are
           position:fixed and a transformed ancestor would become their containing block). */}
+      {/* Chrome hidden (auto-hide while playing): two persistent affordances so the user is never
+          stranded — the cinema-tap-anywhere reveal isn't discoverable on its own (field-reported as
+          "no way to bring the controls back"). A bottom restore handle (carries the progress
+          hairline) reveals the dock, and a top-right Close always offers a way out of the overlay. */}
       {mobileImmersive && !barVisible && (
-        <Box
-          aria-hidden
-          sx={(t) => ({
-            ...transportHairline(t, duration > 0 ? (currentTime / duration) * 100 : 0),
-            position: 'absolute',
-            zIndex: 6,
-          })}
-        />
+        <>
+          <Box
+            component="button"
+            type="button"
+            aria-label="Show playback controls"
+            onClick={toggleBar}
+            sx={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              zIndex: 7,
+              appearance: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              p: 0,
+              m: 0,
+              height: 'calc(28px + env(safe-area-inset-bottom))',
+              display: 'flex',
+              alignItems: 'flex-start',
+              justifyContent: 'center',
+              pt: '4px',
+              background: 'linear-gradient(0deg, rgba(0,0,0,0.5) 0%, rgba(0,0,0,0) 100%)',
+            }}
+          >
+            <KeyboardArrowUpRoundedIcon sx={{ fontSize: 20, color: 'rgba(255,255,255,0.82)' }} />
+            <Box
+              aria-hidden
+              sx={(t) => transportHairline(t, duration > 0 ? (currentTime / duration) * 100 : 0)}
+            />
+          </Box>
+          <IconButton
+            aria-label="Close replay"
+            onClick={toggleFullscreen}
+            sx={{
+              position: 'absolute',
+              top: 'calc(env(safe-area-inset-top) + 8px)',
+              right: 12,
+              zIndex: 7,
+              color: '#fff',
+              width: 44,
+              height: 44,
+              backgroundColor: 'rgba(8,11,20,0.86)',
+              border: '1px solid rgba(255,255,255,0.14)',
+              '&:hover': { backgroundColor: 'rgba(8,11,20,0.95)' },
+            }}
+          >
+            <CloseRoundedIcon />
+          </IconButton>
+        </>
       )}
       {mobileImmersive && (
         <Box
@@ -1531,6 +1586,13 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
             onToggleStats={toggleStats}
             following={followingActorId != null}
             onSheetOpenChange={setMobileSheetOpen}
+            markersEditMode={markersEditMode}
+            onToggleMarkersEditMode={onToggleMarkersEditMode}
+            onAddMarkerAtCenter={onAddMarker ? handleAddMarkerAtCenter : undefined}
+            canUndoMarkers={canUndoMarkers}
+            onUndoMarkers={onUndoMarkers}
+            canRedoMarkers={canRedoMarkers}
+            onRedoMarkers={onRedoMarkers}
           />
         </Box>
       )}

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.test.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { MobileReplayDock } from './MobileReplayDock';
+
+// The dock pulls in redux selectors and several heavy leaf components; stub them so the test
+// focuses on the dock's own wiring (here: the Settings-sheet Markers section added so marker
+// editing is reachable inside the mobile immersive overlay).
+jest.mock('../../../../hooks/useOptimizedTimelineScrubbing', () => ({
+  useOptimizedTimelineScrubbing: (): {
+    displayTime: number;
+    isDragging: boolean;
+    isScrubbingMode: boolean;
+    handleSliderChange: () => void;
+    handleSliderChangeStart: () => void;
+    handleSliderChangeEnd: () => void;
+    optimizedStep: number;
+  } => ({
+    displayTime: 0,
+    isDragging: false,
+    isScrubbingMode: false,
+    handleSliderChange: (): void => undefined,
+    handleSliderChangeStart: (): void => undefined,
+    handleSliderChangeEnd: (): void => undefined,
+    optimizedStep: 1,
+  }),
+}));
+jest.mock('../../../../hooks/useTimelineMarkers', () => ({
+  useTimelineMarkers: (): { markers: [] } => ({ markers: [] }),
+}));
+jest.mock('../TimelineSlider', () => ({ TimelineSlider: (): React.ReactNode => null }));
+jest.mock('../PlaybackButtons', () => ({ PlaybackButtons: (): React.ReactNode => null }));
+jest.mock('../ShareButton', () => ({ ShareButton: (): React.ReactNode => null }));
+jest.mock('../ChapterList', () => ({ ChapterList: (): React.ReactNode => null }));
+jest.mock('../TrialTimeline', () => ({ TrialTimeline: (): React.ReactNode => null }));
+jest.mock('./MobileSheet', () => ({
+  MobileSheet: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }): React.ReactNode => (open ? <div role="dialog">{children}</div> : null),
+}));
+
+const noop = (): void => undefined;
+
+type DockProps = React.ComponentProps<typeof MobileReplayDock>;
+
+function renderDock(overrides: Partial<DockProps> = {}): void {
+  const props: DockProps = {
+    currentTime: 0,
+    duration: 10000,
+    isPlaying: false,
+    playbackSpeed: 1,
+    onTimeChange: noop,
+    onPlayPause: noop,
+    onSpeedChange: noop,
+    onSkipToStart: noop,
+    onSkipToEnd: noop,
+    onSkipBackward10: noop,
+    onSkipForward10: noop,
+    playersOpen: false,
+    onTogglePlayers: noop,
+    showTrails: false,
+    onToggleTrails: noop,
+    namesEnabled: false,
+    onToggleNames: noop,
+    performanceMode: false,
+    onTogglePerformance: noop,
+    statsPanelEnabled: false,
+    onToggleStats: noop,
+    following: false,
+    ...overrides,
+  };
+  render(<MobileReplayDock {...props} />);
+}
+
+function openSettings(): void {
+  fireEvent.click(screen.getByLabelText('Settings'));
+}
+
+describe('MobileReplayDock — Markers section', () => {
+  it('hides the Markers section when no marker toggle is wired', () => {
+    renderDock();
+    openSettings();
+    expect(screen.queryByLabelText('Edit markers')).not.toBeInTheDocument();
+  });
+
+  it('surfaces an Edit markers toggle that calls the handler', () => {
+    const onToggleMarkersEditMode = jest.fn();
+    renderDock({ onToggleMarkersEditMode });
+    openSettings();
+
+    fireEvent.click(screen.getByLabelText('Edit markers'));
+    expect(onToggleMarkersEditMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the marker actions until edit mode is on', () => {
+    renderDock({ onToggleMarkersEditMode: noop, markersEditMode: false });
+    openSettings();
+    expect(screen.queryByLabelText('Add here')).not.toBeInTheDocument();
+  });
+
+  it('shows Add / Undo / Redo while editing and routes each to its handler', () => {
+    const onAddMarkerAtCenter = jest.fn();
+    const onUndoMarkers = jest.fn();
+    const onRedoMarkers = jest.fn();
+    renderDock({
+      onToggleMarkersEditMode: noop,
+      markersEditMode: true,
+      onAddMarkerAtCenter,
+      onUndoMarkers,
+      onRedoMarkers,
+      canUndoMarkers: true,
+      canRedoMarkers: true,
+    });
+    openSettings();
+
+    // Undo/Redo keep the sheet open for repeated tweaks; "Add here" closes it (the icon picker
+    // opens over the arena), so click it last or it would unmount the others mid-test.
+    fireEvent.click(screen.getByLabelText('Undo'));
+    fireEvent.click(screen.getByLabelText('Redo'));
+    fireEvent.click(screen.getByLabelText('Add here'));
+
+    expect(onUndoMarkers).toHaveBeenCalledTimes(1);
+    expect(onRedoMarkers).toHaveBeenCalledTimes(1);
+    expect(onAddMarkerAtCenter).toHaveBeenCalledTimes(1);
+
+    // "Add here" dismisses the Settings sheet so the placement picker isn't hidden behind it.
+    expect(screen.queryByLabelText('Add here')).not.toBeInTheDocument();
+  });
+
+  it('disables Undo / Redo when there is no history to traverse', () => {
+    renderDock({
+      onToggleMarkersEditMode: noop,
+      markersEditMode: true,
+      onAddMarkerAtCenter: noop,
+      onUndoMarkers: noop,
+      onRedoMarkers: noop,
+      canUndoMarkers: false,
+      canRedoMarkers: false,
+    });
+    openSettings();
+
+    expect(screen.getByLabelText('Undo')).toBeDisabled();
+    expect(screen.getByLabelText('Redo')).toBeDisabled();
+  });
+});

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
@@ -12,15 +12,19 @@
  * @module features/fight_replay/components/mobile/MobileReplayDock
  */
 
+import AddLocationAltRoundedIcon from '@mui/icons-material/AddLocationAltRounded';
 import BoltRoundedIcon from '@mui/icons-material/BoltRounded';
 import DeleteSweepRoundedIcon from '@mui/icons-material/DeleteSweepRounded';
+import EditLocationAltRoundedIcon from '@mui/icons-material/EditLocationAltRounded';
 import GroupRoundedIcon from '@mui/icons-material/GroupRounded';
 import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
 import LabelRoundedIcon from '@mui/icons-material/LabelRounded';
 import PlaylistPlayRoundedIcon from '@mui/icons-material/PlaylistPlayRounded';
+import RedoRoundedIcon from '@mui/icons-material/RedoRounded';
 import RouteRoundedIcon from '@mui/icons-material/RouteRounded';
 import TimelineRoundedIcon from '@mui/icons-material/TimelineRounded';
 import TuneRoundedIcon from '@mui/icons-material/TuneRounded';
+import UndoRoundedIcon from '@mui/icons-material/UndoRounded';
 import { Box, Switch, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -91,6 +95,19 @@ interface MobileReplayDockProps {
   following: boolean;
   /** Reports whether a sheet is open (the host pauses chrome auto-hide while one is). */
   onSheetOpenChange?: (open: boolean) => void;
+  // Map markers — the touch home for the desktop "Edit Markers" tools, surfaced in the Settings
+  // sheet (the page-toolbar marker controls sit behind the immersive overlay, unreachable on a
+  // phone). Omit onToggleMarkersEditMode to hide the whole Markers section.
+  /** Marker edit mode: long-press to place/edit, drag to move. */
+  markersEditMode?: boolean;
+  onToggleMarkersEditMode?: () => void;
+  /** Gesture-free marker placement: drops a marker at the screen center (opens the icon picker). */
+  onAddMarkerAtCenter?: () => void;
+  /** Undo/redo the last marker change — shown while edit mode is on (no touch Ctrl+Z). */
+  canUndoMarkers?: boolean;
+  onUndoMarkers?: () => void;
+  canRedoMarkers?: boolean;
+  onRedoMarkers?: () => void;
 }
 
 type SheetId = 'chapters' | 'settings' | null;
@@ -214,6 +231,47 @@ const DockButton: React.FC<{
   </Box>
 );
 
+/**
+ * A marker-action button (icon over a tiny label) for the Settings-sheet Markers row — Add / Undo /
+ * Redo. Module-scope for a stable component identity across the dock's per-tick re-renders.
+ */
+const MarkerActionButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}> = ({ icon, label, onClick, disabled }) => (
+  <Box
+    component="button"
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    aria-label={label}
+    sx={(theme) => ({
+      appearance: 'none',
+      cursor: disabled ? 'default' : 'pointer',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 0.25,
+      minHeight: 56,
+      borderRadius: 2.5,
+      border: '1px solid',
+      borderColor: 'divider',
+      backgroundColor:
+        theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+      color: disabled ? 'text.disabled' : 'text.primary',
+      opacity: disabled ? 0.5 : 1,
+      transition: 'background-color 120ms ease',
+      '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main' },
+    })}
+  >
+    {icon}
+    <Typography sx={{ fontSize: '0.72rem', fontWeight: 600, lineHeight: 1 }}>{label}</Typography>
+  </Box>
+);
+
 const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
   currentTime,
   duration,
@@ -250,6 +308,13 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
   onToggleStats,
   following,
   onSheetOpenChange,
+  markersEditMode = false,
+  onToggleMarkersEditMode,
+  onAddMarkerAtCenter,
+  canUndoMarkers = false,
+  onUndoMarkers,
+  canRedoMarkers = false,
+  onRedoMarkers,
 }) => {
   const [sheet, setSheet] = useState<SheetId>(null);
 
@@ -288,6 +353,20 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
     },
     [onTrialSeek, onChapterSelect, trialNav?.currentFightId],
   );
+
+  // Entering edit mode closes the Settings sheet so the map is reachable for long-press placement
+  // (the sheet covers the arena). Leaving it keeps the sheet so the user can flip other settings.
+  const handleToggleEditMarkers = useCallback(() => {
+    onToggleMarkersEditMode?.();
+    if (!markersEditMode) setSheet(null);
+  }, [onToggleMarkersEditMode, markersEditMode]);
+
+  // "Add here" drops a marker at the screen center; close the sheet first so the icon picker that
+  // opens there isn't hidden behind it.
+  const handleAddMarkerAtCenter = useCallback(() => {
+    setSheet(null);
+    onAddMarkerAtCenter?.();
+  }, [onAddMarkerAtCenter]);
 
   const {
     displayTime,
@@ -642,6 +721,68 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
                 }
               />
             </Box>
+
+            {/* Markers — the touch home for the desktop "Edit Markers" tools. The page-toolbar
+                marker controls sit behind the immersive overlay, so on a phone this sheet is the
+                only place to manage markers. Hidden entirely when the host wires no marker toggle. */}
+            {onToggleMarkersEditMode && (
+              <>
+                <Typography
+                  variant="overline"
+                  sx={{ color: 'text.secondary', fontWeight: 700, letterSpacing: '0.08em' }}
+                >
+                  Markers
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mt: 1, mb: 2.5 }}>
+                  <SettingRow
+                    icon={<EditLocationAltRoundedIcon fontSize="small" />}
+                    label="Edit markers"
+                    description="Place, move, and remove map markers"
+                    active={markersEditMode}
+                    control={
+                      <Switch
+                        checked={markersEditMode}
+                        onChange={handleToggleEditMarkers}
+                        slotProps={{ input: { 'aria-label': 'Edit markers' } }}
+                      />
+                    }
+                  />
+                  {markersEditMode && (
+                    <>
+                      <Typography
+                        variant="caption"
+                        sx={{ color: 'text.secondary', px: 0.5, lineHeight: 1.4 }}
+                      >
+                        Press and hold the map to place a marker · drag a marker to move it · press
+                        and hold a marker to edit or remove it
+                      </Typography>
+                      <Box
+                        sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 0.75 }}
+                      >
+                        <MarkerActionButton
+                          icon={<AddLocationAltRoundedIcon fontSize="small" />}
+                          label="Add here"
+                          onClick={handleAddMarkerAtCenter}
+                          disabled={!onAddMarkerAtCenter}
+                        />
+                        <MarkerActionButton
+                          icon={<UndoRoundedIcon fontSize="small" />}
+                          label="Undo"
+                          onClick={() => onUndoMarkers?.()}
+                          disabled={!onUndoMarkers || !canUndoMarkers}
+                        />
+                        <MarkerActionButton
+                          icon={<RedoRoundedIcon fontSize="small" />}
+                          label="Redo"
+                          onClick={() => onRedoMarkers?.()}
+                          disabled={!onRedoMarkers || !canRedoMarkers}
+                        />
+                      </Box>
+                    </>
+                  )}
+                </Box>
+              </>
+            )}
 
             <Typography
               variant="overline"


### PR DESCRIPTION
## What & why

Fixes three mobile (iPhone/Safari) regressions reported against **#1207** (the #1194 + #1199 + #1206 consolidation). On a phone the **pseudo-fullscreen overlay is the only interactive replay mode**, but the consolidation swapped the old in-canvas control cluster (`MobileReplayControls`) for the new bottom dock + top-bar shell and lost behavior that only lived in the old cluster.

Stacked on top of `claude/map-markers-ui-consolidation-dw0z52` so the diff is just the fixes — merging this folds them into #1207.

### 1. Marker editing was unreachable on mobile 🔧
The whole point of #1199/#1206. The marker props were threaded to `FightReplay3D` → `Arena3D`, but Arena3D's mobile cluster is suppressed in immersive (`hideMobileControls`), and the replacement `MobileReplayDock` was **never given the marker props**. The page-toolbar marker tools sit *behind* the fixed overlay, so there was no way in.

- Threaded the marker props (edit toggle, add-at-center, undo/redo) into `MobileReplayDock`.
- Added a **Markers** section to the Settings sheet: an *Edit markers* toggle, plus *Add here / Undo / Redo* while editing, with the long-press gesture hint.
- Entering edit mode closes the sheet so the map is reachable for long-press placement; *Add here* closes it so the icon picker isn't hidden behind it.

### 2. Auto-hidden playback bar had no way back ▶️
In immersive mode the dock auto-hides while playing; the only restore was an undocumented "tap the empty canvas." Added a **bottom restore handle** (carrying the progress hairline) that reveals the dock on tap — discoverable and reliable.

### 3. No way to close fullscreen ✕
The Close button lived inside the top bar, which fades out with the chrome — so once auto-hidden, both the bar *and* the exit were gone. Now a **persistent top-right Close** renders whenever the chrome is hidden, so there's always a way out.

## Note on the reported "Tap to explore" lag
The fourth report (a delay entering immersive) is most likely the heavier `MobileReplayDock` mount + overlay reflow that replaced the lightweight cluster, rather than a single bug. It needs on-device profiling to fix safely, so it's **not** addressed here — the changes above don't add to the enter cost (the new affordances only render once the chrome is hidden, never on enter).

## Validation
- `npm run validate` ✅ (typecheck + lint + format, zero warnings)
- `npx jest src/features/fight_replay` ✅ — **40 suites / 355 tests** (added `MobileReplayDock.test.tsx`, 5 tests covering the Markers section wiring)

https://claude.ai/code/session_01AJCXz3vr8s6yYYQ2BQbeP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJCXz3vr8s6yYYQ2BQbeP5)_