### PR TITLE
fix(fight-replay): stop fight-name bar overlapping marker hint on mobile

### DIFF
--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -1330,12 +1330,18 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       )}
 
       {/* Marker edit-mode hint — touch gestures are invisible, so name them while the mode is on.
-          Top-center, clear of the Close (top-right) and the boss HUD; non-interactive. */}
+          Anchored bottom-center, just above the transport dock: the top band is taken by the
+          full-width fight-name bar (which would paint over a top-center chip) and the boss HUD
+          (top-right), so the clear horizontal strip is here, above the controls and below the
+          arena. Non-interactive. */}
       {mobileImmersive && markersEditMode && (
         <Box
           sx={{
             position: 'absolute',
-            top: 12,
+            // Plain px (no env()) — the immersive overlay container already pads the safe area,
+            // matching the Tools button (bottom: 96) in MobileReplayControls. 150 clears the
+            // transport dock + that button's band.
+            bottom: 150,
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 2,
@@ -1345,7 +1351,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             borderRadius: '999px',
             backgroundColor: 'rgba(13,20,48,0.85)',
             border: '1px solid rgba(148,210,255,0.35)',
-            maxWidth: 'calc(100% - 140px)',
+            maxWidth: 'calc(100% - 32px)',
           }}
         >
           <Typography


### PR DESCRIPTION
## What & why

On mobile (PR #1207), the **fight name covers the marker info chip** when marker edit mode is on.

The marker edit-mode hint chip (`Hold map: add · drag marker: move · hold marker: edit`) was anchored **top-center** (`top: 12`). But in the immersive mobile shell that top band is already taken:

- the **full-width fight-name bar** (title + difficulty badge, `zIndex: 6`) paints over a top-center chip — which is exactly what the screenshot shows (`Dreadsail Reef` + `HM` sitting on top of the hint), and
- the **boss HUD** occupies the top-right (`top: 64` on mobile, deliberately pushed down to clear that same bar).

The hint text is long and non-wrapping, so on a narrow screen there's no clear top-center slot.

## Fix

Move the hint to **bottom-center**, just above the transport dock (`bottom: 150`), where the horizontal strip is clear of the title bar, the Close button, the boss HUD, the bottom-right Tools button, and the bottom-left stats panel. Widened `maxWidth` to `calc(100% - 32px)` now that it no longer needs to dodge the top-right controls.

Single-file, style-only change in `Arena3D.tsx`.

## Validation

- `tsc --noEmit` ✅ (no new errors)
- `prettier --check` ✅
- No tests assert the hint's position.

> Targets the #1207 branch so it lands together with the marker work it fixes.

https://claude.ai/code/session_01VPP4KQmwGi8MrSLCkixzLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPP4KQmwGi8MrSLCkixzLR)_