### PR TITLE
fix(tooltips): resolve scribed grimoire morphs to their skill line

### DIFF
--- a/src/data/skill-lines/ability-ids.ts
+++ b/src/data/skill-lines/ability-ids.ts
@@ -266,7 +266,9 @@ export enum AbilityId {
 
   // Assault
   WAR_HORN = 38563,
-  TRAMPLE = 46947,
+  // Scribing grimoire base (46947 is an unrelated NPC "Trample"; the Assault
+  // grimoire base is 217667, matching src/types/abilities.ts).
+  TRAMPLE = 217667,
   RAPID_MANEUVER = 38566,
   VIGOR = 61503,
   CALTROPS = 38549,

--- a/src/utils/scribingSkillLineResolver.test.ts
+++ b/src/utils/scribingSkillLineResolver.test.ts
@@ -1,0 +1,103 @@
+import { resolveGrimoireIcon, resolveScribingSkillLine } from './scribingSkillLineResolver';
+import { ALL_SKILL_LINES } from './skillLinesRegistry';
+
+describe('scribingSkillLineResolver', () => {
+  describe('resolveGrimoireIcon', () => {
+    it('resolves a scribed ability id to its grimoire icon via the generated table', () => {
+      // 220542 = "Magical Trample" (a Trample grimoire morph)
+      expect(resolveGrimoireIcon(220542)).toBe('ability_grimoire_assault');
+    });
+
+    it('uses the fallback icon when the id is not in the table', () => {
+      expect(resolveGrimoireIcon(999999, 'ability_grimoire_bow')).toBe('ability_grimoire_bow');
+    });
+
+    it('prefers the generated table over the fallback icon', () => {
+      // The live master-data icon for a sub-effect may not be the grimoire icon;
+      // the generated table is authoritative.
+      expect(resolveGrimoireIcon(220542, 'ability_mage_065')).toBe('ability_grimoire_assault');
+    });
+
+    it('returns undefined for non-grimoire icons', () => {
+      expect(resolveGrimoireIcon(undefined, 'ability_mage_065')).toBeUndefined();
+      expect(resolveGrimoireIcon(999999)).toBeUndefined();
+      expect(resolveGrimoireIcon()).toBeUndefined();
+    });
+  });
+
+  describe('resolveScribingSkillLine', () => {
+    it('resolves Trample grimoire morphs to the Assault skill line', () => {
+      // 220541-220545 are Sundering/Magical/Dazing/Dispelling Trample morphs.
+      for (const id of [220541, 220542, 220543, 220544, 220545]) {
+        expect(resolveScribingSkillLine(id)).toEqual({
+          className: 'alliance-war',
+          skillLineName: 'Assault',
+        });
+      }
+    });
+
+    it('resolves Banner Bearer morphs to the Support skill line', () => {
+      // 217699 = Banner Bearer grimoire base.
+      expect(resolveScribingSkillLine(217699)).toEqual({
+        className: 'alliance-war',
+        skillLineName: 'Support',
+      });
+    });
+
+    it('resolves weapon grimoires from their icon', () => {
+      expect(resolveScribingSkillLine(undefined, 'ability_grimoire_bow')).toEqual({
+        className: 'Weapon',
+        skillLineName: 'Bow',
+      });
+      expect(resolveScribingSkillLine(undefined, 'ability_grimoire_staffresto')).toEqual({
+        className: 'Weapon',
+        skillLineName: 'Restoration Staff',
+      });
+    });
+
+    it('maps both Soul Magic grimoires to the Soul Magic line', () => {
+      expect(resolveScribingSkillLine(undefined, 'ability_grimoire_soulmagic1')).toEqual({
+        className: 'world',
+        skillLineName: 'Soul Magic',
+      });
+      expect(resolveScribingSkillLine(undefined, 'ability_grimoire_soulmagic2')).toEqual({
+        className: 'world',
+        skillLineName: 'Soul Magic',
+      });
+    });
+
+    it('returns null for non-scribed abilities', () => {
+      expect(resolveScribingSkillLine(46947, 'ability_mage_065')).toBeNull();
+      expect(resolveScribingSkillLine(undefined, undefined)).toBeNull();
+    });
+  });
+
+  // Drift guard: every skill line the resolver claims must exist in the registry
+  // with a matching class/weapon label, so a future skill-line rename can't
+  // silently desync the grimoire mapping.
+  it('every mapped grimoire line matches a real skill line in the registry', () => {
+    const grimoireIcons = [
+      'ability_grimoire_1handed',
+      'ability_grimoire_2handed',
+      'ability_grimoire_bow',
+      'ability_grimoire_dualwield',
+      'ability_grimoire_staffdestro',
+      'ability_grimoire_staffresto',
+      'ability_grimoire_fightersguild',
+      'ability_grimoire_magesguild',
+      'ability_grimoire_soulmagic1',
+      'ability_grimoire_soulmagic2',
+      'ability_grimoire_assault',
+      'ability_grimoire_support',
+    ];
+
+    for (const icon of grimoireIcons) {
+      const label = resolveScribingSkillLine(undefined, icon);
+      expect(label).not.toBeNull();
+      const line = ALL_SKILL_LINES.find((sl) => sl.name === label!.skillLineName);
+      expect(line).toBeDefined();
+      const labelSource = line as unknown as { class?: string; weapon?: string };
+      expect(labelSource.class ?? labelSource.weapon).toBe(label!.className);
+    }
+  });
+});

--- a/src/utils/scribingSkillLineResolver.ts
+++ b/src/utils/scribingSkillLineResolver.ts
@@ -1,0 +1,70 @@
+import { SCRIBING_ICON_OVERRIDES } from '../data/skill-lines/generated/scribingIconOverrides';
+
+/**
+ * Resolve a scribed ability to the skill line that owns its grimoire.
+ *
+ * Scribing morphs (e.g. "Dazing Trample", "Magical Banner", "Sundering Smash")
+ * are generated per focus/signature script. They never appear in the static
+ * skill-line registry — not by id (each script combination mints a fresh id) and
+ * not by name (the morphed name differs from the base grimoire). So the normal
+ * id/name lookup misses them and the tooltip falls through to "Unknown Skill
+ * Line", even though the ability clearly belongs to a known line.
+ *
+ * The one signal that survives every morph is the grimoire icon
+ * (`ability_grimoire_<line>`). Every grimoire is owned by exactly one skill line,
+ * so the icon deterministically identifies the line. We read the icon from the
+ * generated id -> icon table (authoritative, works before master data loads) and
+ * fall back to the live master-data icon when an id is not in the table.
+ */
+
+export interface ScribingSkillLineLabel {
+  /** Class/weapon label, matching what the skill-line registry renders for the line. */
+  className: string;
+  /** Skill line display name, matching the owning line in the registry. */
+  skillLineName: string;
+}
+
+// Grimoire icon -> owning skill line. className/skillLineName mirror the values
+// the skill-line registry produces for the owning line, so a scribed morph reads
+// identically to its base skill in the line. Two Soul Magic grimoires (Wield Soul
+// and Soul Burst) share the same line.
+const GRIMOIRE_ICON_TO_SKILL_LINE: Record<string, ScribingSkillLineLabel> = {
+  ability_grimoire_1handed: { className: 'Weapon', skillLineName: 'One Hand and Shield' },
+  ability_grimoire_2handed: { className: 'Weapon', skillLineName: 'Two Handed' },
+  ability_grimoire_bow: { className: 'Weapon', skillLineName: 'Bow' },
+  ability_grimoire_dualwield: { className: 'Weapon', skillLineName: 'Dual Wield' },
+  ability_grimoire_staffdestro: { className: 'Weapon', skillLineName: 'Destruction Staff' },
+  ability_grimoire_staffresto: { className: 'Weapon', skillLineName: 'Restoration Staff' },
+  ability_grimoire_fightersguild: { className: 'guild', skillLineName: 'Fighters Guild' },
+  ability_grimoire_magesguild: { className: 'guild', skillLineName: 'Mages Guild' },
+  ability_grimoire_soulmagic1: { className: 'world', skillLineName: 'Soul Magic' },
+  ability_grimoire_soulmagic2: { className: 'world', skillLineName: 'Soul Magic' },
+  ability_grimoire_assault: { className: 'alliance-war', skillLineName: 'Assault' },
+  ability_grimoire_support: { className: 'alliance-war', skillLineName: 'Support' },
+};
+
+const ICON_OVERRIDES = SCRIBING_ICON_OVERRIDES as Record<number, string>;
+
+/**
+ * Resolve the grimoire icon for an ability, preferring the generated id -> icon
+ * table and falling back to a live master-data icon. Returns undefined unless the
+ * resolved icon is an `ability_grimoire_*` icon (the only ones that identify a line).
+ */
+export function resolveGrimoireIcon(abilityId?: number, fallbackIcon?: string): string | undefined {
+  const fromOverride = typeof abilityId === 'number' ? ICON_OVERRIDES[abilityId] : undefined;
+  const icon = fromOverride ?? fallbackIcon;
+  return typeof icon === 'string' && icon.startsWith('ability_grimoire_') ? icon : undefined;
+}
+
+/**
+ * Resolve the skill line that owns a scribed ability's grimoire, or null when the
+ * ability is not a recognizable scribed grimoire ability.
+ */
+export function resolveScribingSkillLine(
+  abilityId?: number,
+  fallbackIcon?: string,
+): ScribingSkillLineLabel | null {
+  const icon = resolveGrimoireIcon(abilityId, fallbackIcon);
+  if (!icon) return null;
+  return GRIMOIRE_ICON_TO_SKILL_LINE[icon] ?? null;
+}

--- a/src/utils/skillTooltipMapper.test.ts
+++ b/src/utils/skillTooltipMapper.test.ts
@@ -431,6 +431,27 @@ describe('skillTooltipMapper', () => {
       });
     });
 
+    it('should resolve scribed grimoire morphs to their skill line instead of "Unknown Skill Line"', () => {
+      // 220543 = "Dazing Trample", a Trample grimoire morph that is absent from the
+      // registry by both id and (morphed) name. Before the grimoire-icon fallback it
+      // rendered as "Unknown Skill Line".
+      const abilityData = {
+        gameID: 220543,
+        name: 'Dazing Trample',
+        icon: 'ability_grimoire_assault',
+      };
+
+      mockAbilityIdMapper.getAbilityById.mockReturnValue(abilityData);
+      mockAbilityIdMapper.getIconUrl.mockReturnValue('https://example.com/trample.png');
+      mockFindSkillByName.mockReturnValue(null);
+
+      const result = buildTooltipPropsFromAbilityId(220543);
+
+      expect(result?.name).toBe('Dazing Trample');
+      expect(result?.lineText).toBe('alliance-war — Assault');
+      expect(result?.abilityId).toBe(220543);
+    });
+
     it('should handle weapon skill lines', () => {
       const abilityData = {
         gameID: 126,
@@ -546,6 +567,21 @@ describe('skillTooltipMapper', () => {
           { label: 'Radius', value: '18 meters' },
         ],
       });
+    });
+
+    it('should resolve scribed grimoire morphs by name via the grimoire icon', () => {
+      mockFindSkillByName.mockReturnValue(null);
+      // 217705 = "Magical Banner", a Banner Bearer (Support) grimoire morph.
+      mockAbilityIdMapper.getAbilityByName.mockReturnValue({
+        gameID: 217705,
+        name: 'Magical Banner',
+        icon: 'ability_grimoire_support',
+      });
+
+      const result = buildTooltipPropsFromClassAndName('', 'Magical Banner');
+
+      expect(result?.name).toBe('Magical Banner');
+      expect(result?.lineText).toBe('alliance-war — Support');
     });
 
     it('should return null for unknown abilities', () => {

--- a/src/utils/skillTooltipMapper.ts
+++ b/src/utils/skillTooltipMapper.ts
@@ -51,6 +51,7 @@ import {
 import { PlayerTalent } from '../types/playerDetails';
 
 import { abilityIdMapper } from './abilityIdMapper';
+import { resolveScribingSkillLine } from './scribingSkillLineResolver';
 import { findSkillByName, findSkillById, SkillNode, getClassKey } from './skillLinesRegistry';
 
 // SkillNode type is now imported from skillLinesRegistry
@@ -305,6 +306,21 @@ export function buildTooltipPropsFromAbilityId(
     });
   }
 
+  // Scribed grimoire morphs (e.g. "Dazing Trample") never match the registry by
+  // id or by their morphed name, so resolve their owning skill line from the
+  // grimoire icon instead of falling through to "Unknown Skill Line".
+  const grimoireLine = resolveScribingSkillLine(abilityId, abilityData?.icon);
+  if (grimoireLine && abilityData?.name) {
+    return mapSkillToTooltipProps({
+      className: grimoireLine.className,
+      skillLineName: grimoireLine.skillLineName,
+      node: { name: abilityData.name },
+      abilityId,
+      iconUrl: abilityIdMapper.getIconUrl(abilityId) || undefined,
+      scribedSkillData: finalScribedSkillData,
+    });
+  }
+
   // Fallback to basic tooltip with just ability data (only if mapper has loaded)
   if (abilityData) {
     return {
@@ -392,6 +408,22 @@ export function buildTooltipPropsFromClassAndName(
     return {
       ...weaponFallback,
     };
+  }
+
+  // Scribed grimoire morphs resolve to their owning skill line via the grimoire
+  // icon even though the morphed name is absent from the registry.
+  const grimoireLine = resolveScribingSkillLine(abilityData?.gameID, abilityData?.icon);
+  if (grimoireLine) {
+    return mapSkillToTooltipProps({
+      className: grimoireLine.className,
+      skillLineName: grimoireLine.skillLineName,
+      node: { name: abilityName },
+      abilityId: abilityData?.gameID,
+      iconUrl: abilityData?.gameID
+        ? abilityIdMapper.getIconUrl(abilityData.gameID) || undefined
+        : undefined,
+      scribedSkillData: finalScribedSkillData,
+    });
   }
 
   // If this is a scribed skill but not found in skill lines, create a basic scribed skill tooltip


### PR DESCRIPTION
## Problem

Hovering a scribed ability such as **Trample** (and many other scribing morphs) showed **"Unknown Skill Line"** in its tooltip.

### Root cause

Scribing morphs (e.g. `Sundering Trample`, `Magical Trample`, `Dazing Trample`, `Dispelling Trample`, `Magical Banner`, `Sundering Smash`, …) are minted **per focus/signature-script combination**. As a result they:

- are **absent from the static skill-line registry by id** — every script combination mints a fresh ability id, and
- **don't match by name** — the morphed name (`Dazing Trample`) differs from the base grimoire (`Trample`).

So both `findSkillById` and `findSkillByName` miss them, and `buildTooltipPropsFromAbilityId` fell through to `lineText: 'Unknown Skill Line'`. The only scribing fallback was a 4-entry hardcoded stub map, so every other morph across all 12 grimoires was unresolved. This is the "there's probably a lot more" the report mentions.

## Fix

Resolve the owning skill line from the **grimoire icon** (`ability_grimoire_<line>`) — the one signal that survives every morph. Every grimoire belongs to exactly one skill line, so the icon deterministically identifies the line.

- New `scribingSkillLineResolver` reads the id → icon mapping from the **committed, generated `SCRIBING_ICON_OVERRIDES` table** (authoritative, works before master data loads), falling back to the live master-data icon, then maps the grimoire icon → owning skill line.
- Wired into both fallback paths in `skillTooltipMapper` (`buildTooltipPropsFromAbilityId` and `buildTooltipPropsFromClassAndName`), just before the "Unknown Skill Line" / null fallbacks.
- `className` / `skillLineName` mirror the registry's values, so a scribed morph reads identically to its base skill (e.g. `alliance-war — Assault`).

This covers **all 12 grimoires and every morph**, sourced entirely from existing authoritative data — no IDs or descriptions are fabricated.

### Data correction

`AbilityId.TRAMPLE` was `46947`, an unrelated NPC "Trample". Corrected to `217667`, the Assault grimoire base, matching `src/types/abilities.ts`.

## Tests

- `scribingSkillLineResolver.test.ts` — icon/id resolution, weapon/guild/world/alliance lines, both Soul Magic grimoires, and a **drift guard** that ties every grimoire-icon mapping to a real skill line in the registry (so a future skill-line rename can't silently desync the map).
- `skillTooltipMapper.test.ts` — new coverage for the id- and name-based grimoire fallbacks (verifies `Dazing Trample` → `alliance-war — Assault` instead of "Unknown Skill Line").

### Validation

- `tsc --noEmit` clean
- 207 tests across 16 related suites pass
- Tooltip provenance gate: PASS (100% coverage, unchanged)
- Skill-line icon gate: PASS

https://claude.ai/code/session_01VBm7TWUCThDBrc9dhUTvDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBm7TWUCThDBrc9dhUTvDt)_