### PR TITLE
fix(report): correct broken Magma Fist (and similar) ability icons

### DIFF
--- a/src/components/AbilityIcon.tsx
+++ b/src/components/AbilityIcon.tsx
@@ -2,6 +2,7 @@ import { Avatar } from '@mui/material';
 import React from 'react';
 
 import { useReportMasterData } from '../hooks';
+import { abilityIconUrl } from '../utils/abilityIconCorrections';
 
 export interface AbilityIconProps {
   abilityId: string | number;
@@ -14,16 +15,18 @@ export function AbilityIcon(props: AbilityIconProps): React.ReactElement | null 
 
   const ability = reportMasterData?.abilitiesById[props.abilityId];
 
-  // Determine icon filename: prefer master data, fall back to explicit prop if provided
-  const iconFile = ability?.icon || props.fallbackIcon;
+  // Determine icon filename: prefer master data, fall back to explicit prop if
+  // provided. Correct known-broken filenames (e.g. Magma Fist) via the ability
+  // id, which applies even when master data has no entry for this ability.
+  const src = abilityIconUrl(ability?.icon || props.fallbackIcon, props.abilityId);
 
-  if (!iconFile) {
+  if (!src) {
     return null;
   }
 
   return (
     <Avatar
-      src={`https://assets.rpglogs.com/img/eso/abilities/${iconFile}.png`}
+      src={src}
       alt={ability?.name || `Ability ${props.abilityId}`}
       sx={{ width: 32, height: 32, borderRadius: 1, boxShadow: 1 }}
       variant="rounded"

--- a/src/contexts/AbilityIdMapperContext.tsx
+++ b/src/contexts/AbilityIdMapperContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useReportMasterData } from '../hooks/useReportMasterData';
+import { abilityIconUrl } from '../utils/abilityIconCorrections';
 
 import { useLogger } from './LoggerContext';
 
@@ -145,7 +146,7 @@ export const AbilityIdMapperProvider: React.FC<{ children: React.ReactNode }> = 
       getIconUrl: (id: number): string | null => {
         const ability = idToDataMap.get(id);
         if (ability?.icon && ability.icon !== 'icon_missing') {
-          return `https://assets.rpglogs.com/img/eso/abilities/${ability.icon}.png`;
+          return abilityIconUrl(ability.icon, ability.gameID) ?? null;
         }
         return null;
       },
@@ -154,7 +155,7 @@ export const AbilityIdMapperProvider: React.FC<{ children: React.ReactNode }> = 
         const normalized = normalizeAbilityName(name);
         const ability = nameToDataMap.get(normalized);
         if (ability?.icon && ability.icon !== 'icon_missing') {
-          return `https://assets.rpglogs.com/img/eso/abilities/${ability.icon}.png`;
+          return abilityIconUrl(ability.icon, ability.gameID) ?? null;
         }
         return null;
       },

--- a/src/features/report_details/insights/BuffUptimeProgressBar.tsx
+++ b/src/features/report_details/insights/BuffUptimeProgressBar.tsx
@@ -12,6 +12,8 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { abilityIconUrl } from '../../../utils/abilityIconCorrections';
+
 export interface BuffUptime {
   abilityGameID: string;
   abilityName: string;
@@ -314,7 +316,7 @@ export const BuffUptimeProgressBar: React.FC<BuffUptimeProgressBarProps> = ({
         {/* Icon — decorative; the parent button's aria-label conveys the ability name */}
         {buff.icon ? (
           <Avatar
-            src={`https://assets.rpglogs.com/img/eso/abilities/${buff.icon}.png`}
+            src={abilityIconUrl(buff.icon, buff.abilityGameID)}
             alt=""
             aria-hidden="true"
             sx={{

--- a/src/features/report_details/insights/BuffsOverviewPanelView.tsx
+++ b/src/features/report_details/insights/BuffsOverviewPanelView.tsx
@@ -3,6 +3,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import React from 'react';
 
 import { DataGrid } from '../../../components/LazyDataGrid';
+import { abilityIconUrl } from '../../../utils/abilityIconCorrections';
 
 import { BuffOverviewData } from './BuffsOverviewPanel';
 
@@ -25,12 +26,12 @@ export const BuffsOverviewPanelView: React.FC<BuffsOverviewPanelViewProps> = ({
         header: 'Buff Name',
         size: 300,
         cell: ({ row }) => {
-          const { buffName, icon } = row.original;
+          const { buffName, icon, buffId } = row.original;
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
               {icon && (
                 <Avatar
-                  src={`https://assets.rpglogs.com/img/eso/abilities/${icon}.png`}
+                  src={abilityIconUrl(icon, buffId)}
                   alt={buffName}
                   sx={{
                     width: 24,

--- a/src/features/report_details/insights/DebuffsOverviewPanelView.tsx
+++ b/src/features/report_details/insights/DebuffsOverviewPanelView.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 
 import { DataGrid } from '../../../components/LazyDataGrid';
 import { useReportMasterData } from '../../../hooks';
+import { abilityIconUrl } from '../../../utils/abilityIconCorrections';
 
 import { DebuffOverviewData } from './DebuffsOverviewPanel';
 
@@ -75,12 +76,12 @@ export const DebuffsOverviewPanelView: React.FC<DebuffsOverviewPanelViewProps> =
         header: 'Debuff Name',
         size: 300,
         cell: ({ row }) => {
-          const { debuffName, icon } = row.original;
+          const { debuffName, icon, debuffId } = row.original;
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
               {icon && (
                 <Avatar
-                  src={`https://assets.rpglogs.com/img/eso/abilities/${icon}.png`}
+                  src={abilityIconUrl(icon, debuffId)}
                   alt={debuffName}
                   sx={{
                     width: 24,

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -21,6 +21,7 @@ import type { Theme } from '@mui/material/styles';
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { abilityIconUrl } from '@/utils/abilityIconCorrections';
 import { getArmorWeightCounts } from '@/utils/armorUtils';
 import { encodeBuildToURL } from '@/utils/buildEncoding';
 import { toClassKey } from '@/utils/classNameUtils';
@@ -1292,7 +1293,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                       }
                                       iconUrl={
                                         rich?.iconUrl ||
-                                        `https://assets.rpglogs.com/img/eso/abilities/${talent.abilityIcon}.png`
+                                        abilityIconUrl(talent.abilityIcon, talent.guid)
                                       }
                                       abilityId={talent.guid}
                                       scribedSkillData={
@@ -1350,7 +1351,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                 }}
                               >
                                 <Avatar
-                                  src={`https://assets.rpglogs.com/img/eso/abilities/${talent.abilityIcon}.png`}
+                                  src={abilityIconUrl(talent.abilityIcon, talent.guid)}
                                   alt={talent.name}
                                   variant="rounded"
                                   sx={{
@@ -1413,7 +1414,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                         }
                                         iconUrl={
                                           rich?.iconUrl ||
-                                          `https://assets.rpglogs.com/img/eso/abilities/${talent.abilityIcon}.png`
+                                          abilityIconUrl(talent.abilityIcon, talent.guid)
                                         }
                                         abilityId={talent.guid}
                                         fightId={fightId || undefined}
@@ -1467,7 +1468,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                   }}
                                 >
                                   <Avatar
-                                    src={`https://assets.rpglogs.com/img/eso/abilities/${talent.abilityIcon}.png`}
+                                    src={abilityIconUrl(talent.abilityIcon, talent.guid)}
                                     alt={talent.name}
                                     variant="rounded"
                                     sx={{

--- a/src/features/report_details/synergy/SynergyPanelView.tsx
+++ b/src/features/report_details/synergy/SynergyPanelView.tsx
@@ -18,6 +18,7 @@ import React, { useMemo, useState } from 'react';
 
 import { MetricPill } from '@/components/MetricPill';
 import { SynergyPanelSkeleton } from '@/components/SynergyPanelSkeleton';
+import { abilityIconUrl } from '@/utils/abilityIconCorrections';
 
 import type { FightFragment, ReportActorFragment } from '../../../graphql/gql/graphql';
 
@@ -673,7 +674,7 @@ const PlayerSynergyCard: React.FC<{
             >
               {info.abilityIcon && (
                 <Avatar
-                  src={`https://assets.rpglogs.com/img/eso/abilities/${info.abilityIcon}.png`}
+                  src={abilityIconUrl(info.abilityIcon, abilityId)}
                   alt=""
                   sx={{
                     width: 20,
@@ -784,7 +785,7 @@ const AbilityCard: React.FC<{
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1.25 }}>
         {ability.abilityIcon ? (
           <Avatar
-            src={`https://assets.rpglogs.com/img/eso/abilities/${ability.abilityIcon}.png`}
+            src={abilityIconUrl(ability.abilityIcon, ability.abilityGameID)}
             alt=""
             variant="rounded"
             sx={{
@@ -1084,7 +1085,7 @@ const ActivationTimeline: React.FC<{
               {activation.abilityIcon && (
                 <Tooltip title={activation.abilityName ?? ''} arrow placement="top">
                   <Avatar
-                    src={`https://assets.rpglogs.com/img/eso/abilities/${activation.abilityIcon}.png`}
+                    src={abilityIconUrl(activation.abilityIcon, activation.abilityGameID)}
                     alt=""
                     variant="rounded"
                     sx={{

--- a/src/features/report_details/talents/TalentsGridPanel.tsx
+++ b/src/features/report_details/talents/TalentsGridPanel.tsx
@@ -7,6 +7,7 @@ import { useLogger } from '../../../contexts/LoggerContext';
 import { FightFragment } from '../../../graphql/gql/graphql';
 import { usePlayerData } from '../../../hooks';
 import { PlayerTalent } from '../../../types/playerDetails';
+import { abilityIconUrl } from '../../../utils/abilityIconCorrections';
 import { resolveActorName } from '../../../utils/resolveActorName';
 
 interface TalentsGridPanelProps {
@@ -107,7 +108,7 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
         header: 'Icon',
         cell: (info) => (
           <Avatar
-            src={info.row.original.abilityIcon}
+            src={abilityIconUrl(info.row.original.abilityIcon, info.row.original.guid)}
             alt={info.row.original.name}
             sx={{ width: 32, height: 32 }}
             variant="rounded"

--- a/src/utils/abilityIconCorrections.test.ts
+++ b/src/utils/abilityIconCorrections.test.ts
@@ -1,0 +1,90 @@
+import {
+  ABILITY_ICON_BASE_URL,
+  ABILITY_ICON_FILE_OVERRIDES,
+  ABILITY_ICON_ID_OVERRIDES,
+  abilityIconUrl,
+  correctAbilityIcon,
+} from './abilityIconCorrections';
+
+// The broken filename ESO Logs serves for Magma Fist / "Stone Giant".
+const BROKEN = 'ability_dragonknight_013_stonefist_b';
+const CORRECT = 'ability_dragonknight_013_a';
+
+describe('abilityIconCorrections', () => {
+  describe('override tables', () => {
+    it('seeds the known Magma Fist ability ids to the correct icon', () => {
+      // Guard so the entries cannot be silently dropped — these are the live fix.
+      expect(ABILITY_ICON_ID_OVERRIDES[31816]).toBe(CORRECT);
+      expect(ABILITY_ICON_ID_OVERRIDES[133027]).toBe(CORRECT);
+      expect(ABILITY_ICON_ID_OVERRIDES[258293]).toBe(CORRECT);
+    });
+
+    it('seeds the broken filename to the correct icon', () => {
+      expect(ABILITY_ICON_FILE_OVERRIDES[BROKEN]).toBe(CORRECT);
+    });
+  });
+
+  describe('correctAbilityIcon', () => {
+    it('corrects via ability id even when the raw filename is the broken one', () => {
+      expect(correctAbilityIcon(BROKEN, 31816)).toBe(CORRECT);
+    });
+
+    it('corrects via ability id when the raw filename is missing', () => {
+      // A U50 id absent from our dataset still resolves through the id table.
+      expect(correctAbilityIcon(undefined, 258293)).toBe(CORRECT);
+      expect(correctAbilityIcon('', 31816)).toBe(CORRECT);
+    });
+
+    it('corrects via the broken filename when the id is unknown/absent', () => {
+      // No id in scope, but the report served the known-broken file.
+      expect(correctAbilityIcon(BROKEN)).toBe(CORRECT);
+      expect(correctAbilityIcon(BROKEN, 999999)).toBe(CORRECT);
+    });
+
+    it('accepts string ability ids', () => {
+      expect(correctAbilityIcon(BROKEN, '31816')).toBe(CORRECT);
+    });
+
+    it('passes a normal icon through unchanged', () => {
+      expect(correctAbilityIcon('ability_arcanist_005_a', 185842)).toBe('ability_arcanist_005_a');
+      expect(correctAbilityIcon('ability_arcanist_005_a')).toBe('ability_arcanist_005_a');
+    });
+
+    it('returns nullish/empty input as-is when no correction applies', () => {
+      expect(correctAbilityIcon(undefined)).toBeUndefined();
+      expect(correctAbilityIcon(null)).toBeNull();
+      expect(correctAbilityIcon('')).toBe('');
+    });
+
+    it('ignores non-finite ability ids', () => {
+      expect(correctAbilityIcon('ability_arcanist_005_a', Number.NaN)).toBe(
+        'ability_arcanist_005_a',
+      );
+      expect(correctAbilityIcon('ability_arcanist_005_a', 'not-a-number')).toBe(
+        'ability_arcanist_005_a',
+      );
+    });
+  });
+
+  describe('abilityIconUrl', () => {
+    it('builds a corrected CDN url from the broken filename', () => {
+      expect(abilityIconUrl(BROKEN, 31816)).toBe(`${ABILITY_ICON_BASE_URL}${CORRECT}.png`);
+    });
+
+    it('builds a normal CDN url for an uncorrected filename', () => {
+      expect(abilityIconUrl('ability_arcanist_005_a')).toBe(
+        `${ABILITY_ICON_BASE_URL}ability_arcanist_005_a.png`,
+      );
+    });
+
+    it('returns undefined for nullish/empty input with no id correction', () => {
+      expect(abilityIconUrl(undefined)).toBeUndefined();
+      expect(abilityIconUrl(null)).toBeUndefined();
+      expect(abilityIconUrl('')).toBeUndefined();
+    });
+
+    it('builds a url from the id correction even when the filename is empty', () => {
+      expect(abilityIconUrl('', 31816)).toBe(`${ABILITY_ICON_BASE_URL}${CORRECT}.png`);
+    });
+  });
+});

--- a/src/utils/abilityIconCorrections.ts
+++ b/src/utils/abilityIconCorrections.ts
@@ -1,0 +1,88 @@
+/**
+ * Ability-icon corrections for broken icon filenames served by ESO Logs.
+ *
+ * ESO Logs occasionally ships an icon filename in a report (in both
+ * `combatantInfo.talents[].abilityIcon` and `masterData.abilities[].icon`) that
+ * 403/404s on the rpglogs CDN, leaving the skill rendered with no icon.
+ *
+ * The canonical case (U49/U50): Stone Giant → Magma Fist (DK Earthen Heart).
+ * ESO Logs serves `ability_dragonknight_013_stonefist_b` for several game ids
+ * (31816, 258293, …), but that file 403s on https://assets.rpglogs.com. The real
+ * icon is `ability_dragonknight_013_a` (verified HTTP 200, and the value the
+ * build-time oracles data/abilities.json + data/abilityIcons.json map for
+ * 31816 / 133027 / 134340).
+ *
+ * Two complementary, perf-safe lookups — both are tiny hand-curated tables, NOT
+ * a copy of the ~5 MB `abilityIcons.json` oracle (which is dev/build-time only
+ * and must never be imported into the runtime bundle):
+ *
+ *   1. ID-keyed (primary). Matches the repo's established override idiom
+ *      (`SKILL_ICON_OVERRIDE_MAP: Record<number,string>` in
+ *      loadout-manager/data/skillLineSkills.ts) and corrects every render path
+ *      that has an ability id in scope (all of them do).
+ *   2. FILENAME-keyed (fallback). Catches ids that map to a known-broken file
+ *      but are absent from our id table — e.g. 258293, a U50 id ESO Logs serves
+ *      with the same broken `stonefist_b` art. One filename entry covers them.
+ *
+ * Maintenance: entries are added ONLY after confirming the replacement returns
+ * HTTP 200 on the rpglogs CDN. There is no auto-generator — no repo oracle flags
+ * which CDN filenames 403.
+ */
+
+/**
+ * Correct icon filename (no extension) keyed by ESO Logs ability id, for ids
+ * whose report-served `abilityIcon` 403s on the CDN.
+ */
+export const ABILITY_ICON_ID_OVERRIDES: Readonly<Record<number, string>> = {
+  31816: 'ability_dragonknight_013_a', // Magma Fist / report "Stone Giant" (base id)
+  133027: 'ability_dragonknight_013_a', // Magma Fist (U49 damage id)
+  258293: 'ability_dragonknight_013_a', // Magma Fist (U50 id)
+};
+
+/**
+ * Correct icon filename (no extension) keyed by the broken filename ESO Logs
+ * serves. Catches any ability id mapped to this file that is not in the id
+ * table above.
+ */
+export const ABILITY_ICON_FILE_OVERRIDES: Readonly<Record<string, string>> = {
+  ability_dragonknight_013_stonefist_b: 'ability_dragonknight_013_a',
+};
+
+/** Base URL for ESO Logs ability icons on the rpglogs CDN. */
+export const ABILITY_ICON_BASE_URL = 'https://assets.rpglogs.com/img/eso/abilities/';
+
+/**
+ * Resolves the correct ability-icon filename from a report-supplied filename and
+ * (optionally) the ability id. The id override wins, then the filename override,
+ * then the raw value unchanged. Nullish/empty input is returned as-is so callers
+ * can keep their existing falsy guards.
+ *
+ * Pure and synchronous — safe on the lazy-tooltip hot path.
+ */
+export function correctAbilityIcon<T extends string | null | undefined>(
+  icon: T,
+  abilityId?: number | string | null,
+): T {
+  if (abilityId != null) {
+    const id = typeof abilityId === 'number' ? abilityId : Number(abilityId);
+    if (Number.isFinite(id) && ABILITY_ICON_ID_OVERRIDES[id]) {
+      return ABILITY_ICON_ID_OVERRIDES[id] as T;
+    }
+  }
+  if (!icon) return icon;
+  return (ABILITY_ICON_FILE_OVERRIDES[icon] ?? icon) as T;
+}
+
+/**
+ * Builds a full rpglogs CDN URL for a report-supplied ability icon filename,
+ * applying any known correction first. Returns `undefined` for nullish/empty
+ * input so callers can conditionally render. Pass the ability id when available
+ * so an id-keyed correction can apply even if the raw filename is unrecognised.
+ */
+export function abilityIconUrl(
+  icon: string | null | undefined,
+  abilityId?: number | string | null,
+): string | undefined {
+  const corrected = correctAbilityIcon(icon, abilityId);
+  return corrected ? `${ABILITY_ICON_BASE_URL}${corrected}.png` : undefined;
+}

--- a/src/utils/abilityIdMapper.ts
+++ b/src/utils/abilityIdMapper.ts
@@ -2,6 +2,7 @@ import { ReportAbilityFragment } from '../graphql/gql/graphql';
 import { selectAbilitiesById } from '../store/master_data/masterDataSelectors';
 import store, { RootState } from '../store/storeWithHistory';
 
+import { abilityIconUrl } from './abilityIconCorrections';
 import { Logger, LogLevel } from './logger';
 import { DataLoadError, NestedError, ValidationError } from './NestedError';
 
@@ -217,7 +218,7 @@ class AbilityIdMapper {
   getIconUrl(id: number): string | null {
     const ability = this.getAbilityById(id);
     if (ability?.icon && ability.icon !== 'icon_missing') {
-      return `https://assets.rpglogs.com/img/eso/abilities/${ability.icon}.png`;
+      return abilityIconUrl(ability.icon, ability.gameID) ?? null;
     }
     return null;
   }
@@ -228,7 +229,7 @@ class AbilityIdMapper {
   getIconUrlByName(name: string): string | null {
     const ability = this.getAbilityByName(name);
     if (ability?.icon && ability.icon !== 'icon_missing') {
-      return `https://assets.rpglogs.com/img/eso/abilities/${ability.icon}.png`;
+      return abilityIconUrl(ability.icon, ability.gameID) ?? null;
     }
     return null;
   }
@@ -339,7 +340,7 @@ class AbilityIdMapper {
     try {
       const ability = await this.getAbilityByIdAsync(id);
       if (ability?.icon && ability.icon !== 'icon_missing') {
-        return `https://assets.rpglogs.com/img/eso/abilities/${ability.icon}.png`;
+        return abilityIconUrl(ability.icon, ability.gameID) ?? null;
       }
       return null;
     } catch (error) {


### PR DESCRIPTION
## Problem

Magma Fist rendered with **no icon** on the players panel (and anywhere its ability icon appears). Reproduced on https://esotk.com/report/3q6hFmcMzBN1TpVA/fight/34/players.

**Root cause:** ESO Logs serves the icon filename `ability_dragonknight_013_stonefist_b` for the Magma Fist / "Stone Giant" ability (game ids `31816`, `258293`, `133027`) in both `combatantInfo.talents[].abilityIcon` and report `masterData`. That file returns **HTTP 403** on the rpglogs CDN, so the `<Avatar>` shows blank. The correct icon is `ability_dragonknight_013_a` (HTTP 200 — the value `data/abilities.json` and `data/abilityIcons.json` map for those ids).

The render sites built the CDN URL straight from the report-supplied filename with no correction, so the broken name went through verbatim.

## Fix

New `src/utils/abilityIconCorrections.ts` — a small, central correction layer:

- `correctAbilityIcon(icon, abilityId)` / `abilityIconUrl(icon, abilityId)`.
- Two tiny curated tables: an **ability-id override** (primary; matches the repo's existing `SKILL_ICON_OVERRIDE_MAP` idiom) and a **broken-filename override** (fallback).
- The filename fallback makes it future-proof: it catches ids absent from our dataset (e.g. the U50 id `258293`) and any future ability ESO Logs serves the same broken art for.

Every report-data ability-icon render site now routes through the helper: `PlayerCard` (the reported bug), `AbilityIcon`, the central `abilityIdMapper` / `AbilityIdMapperContext` (which feed the skill tooltip icon), `SynergyPanelView`, the Buffs/Debuffs overview panels, and `BuffUptimeProgressBar`. `TalentsGridPanel` is also fixed for a separate latent bug where its `<Avatar src>` was a bare filename with no CDN prefix.

**Perf:** kept as a few-hundred-byte curated table. The ~5 MB `abilityIcons.json` oracle stays build-time only and is never imported into the runtime bundle, preserving the players-panel performance work.

## Verification

- Replayed the live report's fight 34 data through the actual helper and probed the resulting CDN URLs: **1 of 77 talent icons broken before → 0 after.** Magma Fist now resolves `ability_dragonknight_013_stonefist_b` → `ability_dragonknight_013_a` (HTTP 200).
- `tsc --noEmit` clean, eslint clean.
- 80 tests pass (13 new unit tests for the helper + `abilityIdMapper`/`AbilityIcon`/`SkillTooltip`/`report_details` suites green).

Note: live in-browser screenshot not captured — this worktree has no `node_modules` to run its own dev server; verification is at the data layer against the exact reported report/fight.