### PR TITLE
fix(player-card): hide redundant Class Mastery chip from skill-line row

### DIFF
--- a/src/data/skill-lines/class/classMastery.ts
+++ b/src/data/skill-lines/class/classMastery.ts
@@ -11,9 +11,17 @@
 import { SkillLineData } from '@/data/types/skill-line-types';
 import { ClassSkillId } from '@/features/loadout-manager/data/classSkillIds';
 
+/**
+ * Shared display name for every Class Mastery line (all seven classes use it).
+ * Exported so display layers can recognise the line by name — the report-side
+ * class detection (classDetectionUtils) keys skill lines by NAME and carries no
+ * line id, so name matching is the only discriminator available there.
+ */
+export const CLASS_MASTERY_LINE_NAME = 'Class Mastery';
+
 export const classMasteryDragonknight: SkillLineData = {
   id: 'class.class-mastery-dragonknight',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Dragonknight',
   category: 'class',
   icon: 'ability_weapon_005',
@@ -68,7 +76,7 @@ export const classMasteryDragonknight: SkillLineData = {
 
 export const classMasteryArcanist: SkillLineData = {
   id: 'class.class-mastery-arcanist',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Arcanist',
   category: 'class',
   icon: 'passive_arcanist_09',
@@ -123,7 +131,7 @@ export const classMasteryArcanist: SkillLineData = {
 
 export const classMasteryNecromancer: SkillLineData = {
   id: 'class.class-mastery-necromancer',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Necromancer',
   category: 'class',
   icon: 'passive_necromancer_011',
@@ -178,7 +186,7 @@ export const classMasteryNecromancer: SkillLineData = {
 
 export const classMasteryWarden: SkillLineData = {
   id: 'class.class-mastery-warden',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Warden',
   category: 'class',
   icon: 'passive_warden_001',
@@ -233,7 +241,7 @@ export const classMasteryWarden: SkillLineData = {
 
 export const classMasteryTemplar: SkillLineData = {
   id: 'class.class-mastery-templar',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Templar',
   category: 'class',
   icon: 'ability_templar_025',
@@ -288,7 +296,7 @@ export const classMasteryTemplar: SkillLineData = {
 
 export const classMasteryNightblade: SkillLineData = {
   id: 'class.class-mastery-nightblade',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Nightblade',
   category: 'class',
   icon: 'passive_sorcerer_017',
@@ -343,7 +351,7 @@ export const classMasteryNightblade: SkillLineData = {
 
 export const classMasterySorcerer: SkillLineData = {
   id: 'class.class-mastery-sorcerer',
-  name: 'Class Mastery',
+  name: CLASS_MASTERY_LINE_NAME,
   class: 'Sorcerer',
   category: 'class',
   icon: 'ability_sorcerer_044',

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -45,6 +45,7 @@ import { LazySkillTooltip as SkillTooltip } from '../../../components/LazySkillT
 import { OneLineAutoFit } from '../../../components/OneLineAutoFit';
 import { PlayerIcon } from '../../../components/PlayerIcon';
 import { GrimoireData } from '../../../components/ScribingSkillsDisplay';
+import { CLASS_MASTERY_LINE_NAME } from '../../../data/skill-lines/class/classMastery';
 import type { PlayerRoleResult } from '../../../features/role_detection';
 import { getRoleEmoji, ROLE_LABELS, toBroadRole } from '../../../hooks/useRoleDetection';
 import { selectPlayersByIdForContext } from '../../../store/player_data/playerDataSelectors';
@@ -297,8 +298,13 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
     );
     const allPlayers = React.useMemo(() => Object.values(playersById), [playersById]);
 
-    // Get dynamic skill lines from class analysis
-    const detectedSkillLines = classAnalysis?.skillLines || [];
+    // Get dynamic skill lines from class analysis. Class Mastery (a U50 passive
+    // line only non-subclassed characters can use) is dropped from this chip row:
+    // it's redundant noise here — three matching class skill lines already make
+    // the class obvious, and Class Mastery is a passive line, not a build choice.
+    const detectedSkillLines = (classAnalysis?.skillLines || []).filter(
+      (sl) => sl.skillLine !== CLASS_MASTERY_LINE_NAME,
+    );
 
     const foodAura = detectFoodFromAuras(auras);
     const distanceDisplay = React.useMemo(() => {


### PR DESCRIPTION
## Summary

On a report's **Players** panel, every non-subclassed character showed a redundant **"CM"** chip in the skill-line row (e.g. `STORM · DARK · DAEDRIC · CM`). It comes from the U50 *Class Mastery* passive line: the report-side class detection surfaces it as a skill line named "Class Mastery", which `abbreviateSkillLine` renders as "CM". It's pure noise here — three matching class lines already make the class obvious, and Class Mastery is a passive line, not a build choice.

This filters the "Class Mastery" entry out of the skill-line chip row in `PlayerCard` (display layer only).

## Changes

- **`PlayerCard.tsx`** — filter the `"Class Mastery"` entry out of `detectedSkillLines` *before* the render loop (so the `idx > 0` "•" separator stays correct — no leading/doubled bullet).
- **`classMastery.ts`** — add a `CLASS_MASTERY_LINE_NAME` constant and wire it into the 7 line entries' `name` fields, so the data and the filter stay in lockstep (no magic string).

## Why the display layer (not the detection source)

`classAnalysis.skillLines` is left untouched, so **Extract Build** still flows Class Mastery passives into the build editor unchanged. The detection result keys lines by name and carries no line id, so name-matching is the only discriminator available here. Subclassed characters (mixed-class lines) never had a CM chip and are unaffected.

## Verification

- **Live (report `3q6hFmcMzBN1TpVA` fight 34, all 12 players):** baseline showed **11 CM chips** → **0** after the fix, with every card's 3 real skill lines intact, correct bullet separators (no leading/doubled), and tooltips still resolving (e.g. STORM → "Storm Calling"). No console/React errors.
- **Static gates:** `tsc`, `eslint`, `vite build`, and the `classDetectionUtils` (31/31) + Class Mastery jest suites all green.
- **Audit:** a multi-agent adversarial audit across data edge-cases, separator/render logic, consumer blast-radius, constant coupling, and test regressions surfaced **0 confirmed in-scope issues** (build-extraction path byte-identical; empty-row case not concretely reachable).

## Risk

Low — a one-line display-layer `.filter()` plus a behavior-preserving constant extraction. No change to detection, build extraction, or roster paths.