### PR TITLE
refactor(fight-replay): declutter the replay UI + a11y/polish pass

### DIFF
--- a/src/features/fight_replay/FightReplay.tsx
+++ b/src/features/fight_replay/FightReplay.tsx
@@ -97,17 +97,15 @@ export const FightReplay: React.FC = () => {
   const toggleMarkersEditMode = useCallback(() => setMarkersEditMode((prev) => !prev), []);
 
   // Markers tools live behind a collapsed toggle so the deck no longer permanently shoulders the
-  // arena down the page (most viewers never place a marker). Default collapsed; auto-open whenever
-  // there's something to act on — edit mode is active or markers are loaded — so the tools and the
-  // edit-mode gesture hints are never hidden when they're actually needed.
-  const [markersDeckOpen, setMarkersDeckOpen] = useState(false);
-  const toggleMarkersDeck = useCallback(() => setMarkersDeckOpen((prev) => !prev), []);
+  // arena down the page (most viewers never place a marker). Default collapsed, but FORCED open
+  // whenever there's something to act on — edit mode is active or markers are loaded. Deriving the
+  // open state (rather than syncing it via an effect) means the toggle can never collapse the deck
+  // out from under an active edit session and strand the "Done Editing" button.
   const hasMarkers = !!markersState && markersState.markers.length > 0;
-  React.useEffect(() => {
-    if (markersEditMode || hasMarkers) {
-      setMarkersDeckOpen(true);
-    }
-  }, [markersEditMode, hasMarkers]);
+  const deckForcedOpen = markersEditMode || hasMarkers;
+  const [markersDeckUserOpen, setMarkersDeckUserOpen] = useState(false);
+  const markersDeckOpen = deckForcedOpen || markersDeckUserOpen;
+  const toggleMarkersDeck = useCallback(() => setMarkersDeckUserOpen((prev) => !prev), []);
 
   // The marker currently open in the edit dialog (from the context menu or the panel list).
   const [editingMarkerId, setEditingMarkerId] = useState<string | null>(null);
@@ -615,21 +613,26 @@ export const FightReplay: React.FC = () => {
         <Box sx={{ mb: 2 }}>
           {/* Collapsed by default: one quiet toggle keeps the markers tools (a power feature most
               viewers never touch) from permanently pushing the arena down the page. It expands the
-              full deck on demand, and auto-opens while editing / when markers are loaded. */}
+              full deck on demand. While the deck is FORCED open (editing / markers loaded) the
+              toggle is disabled so it can't hide the tools the user is actively working with — and
+              the chevron is dropped, since there's nothing to collapse to. */}
           <Button
             variant="text"
             color="inherit"
             onClick={toggleMarkersDeck}
+            disabled={deckForcedOpen}
             type="button"
             aria-expanded={markersDeckOpen}
             startIcon={<PlaceIcon fontSize="small" sx={{ color: 'secondary.main' }} />}
             endIcon={
-              <KeyboardArrowDownRoundedIcon
-                sx={{
-                  transition: 'transform 0.2s ease',
-                  transform: markersDeckOpen ? 'rotate(180deg)' : 'none',
-                }}
-              />
+              deckForcedOpen ? undefined : (
+                <KeyboardArrowDownRoundedIcon
+                  sx={{
+                    transition: 'transform 0.2s ease',
+                    transform: markersDeckOpen ? 'rotate(180deg)' : 'none',
+                  }}
+                />
+              )
             }
             sx={{
               ml: -1,
@@ -637,6 +640,8 @@ export const FightReplay: React.FC = () => {
               fontWeight: 700,
               letterSpacing: 0.2,
               textTransform: 'none',
+              // Keep the label legible even while disabled (MUI dims disabled text heavily).
+              '&.Mui-disabled': { color: 'text.primary', opacity: 0.85 },
             }}
           >
             Map Markers

--- a/src/features/fight_replay/FightReplay.tsx
+++ b/src/features/fight_replay/FightReplay.tsx
@@ -1,8 +1,9 @@
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EditLocationAltIcon from '@mui/icons-material/EditLocationAlt';
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
 import PlaceIcon from '@mui/icons-material/Place';
-import { Alert, Box, Button, Chip, Snackbar, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, Collapse, Snackbar, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -94,6 +95,19 @@ export const FightReplay: React.FC = () => {
   // On touch the same mode maps to long-press gestures instead of right-clicks.
   const [markersEditMode, setMarkersEditMode] = useState(false);
   const toggleMarkersEditMode = useCallback(() => setMarkersEditMode((prev) => !prev), []);
+
+  // Markers tools live behind a collapsed toggle so the deck no longer permanently shoulders the
+  // arena down the page (most viewers never place a marker). Default collapsed; auto-open whenever
+  // there's something to act on — edit mode is active or markers are loaded — so the tools and the
+  // edit-mode gesture hints are never hidden when they're actually needed.
+  const [markersDeckOpen, setMarkersDeckOpen] = useState(false);
+  const toggleMarkersDeck = useCallback(() => setMarkersDeckOpen((prev) => !prev), []);
+  const hasMarkers = !!markersState && markersState.markers.length > 0;
+  React.useEffect(() => {
+    if (markersEditMode || hasMarkers) {
+      setMarkersDeckOpen(true);
+    }
+  }, [markersEditMode, hasMarkers]);
 
   // The marker currently open in the edit dialog (from the context menu or the panel list).
   const [editingMarkerId, setEditingMarkerId] = useState<string | null>(null);
@@ -599,139 +613,172 @@ export const FightReplay: React.FC = () => {
           active state. */}
       {fight && (
         <Box sx={{ mb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              ...markerDeckSurface(theme),
-              p: { xs: 1.5, sm: 2 },
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1.5,
-            })}
+          {/* Collapsed by default: one quiet toggle keeps the markers tools (a power feature most
+              viewers never touch) from permanently pushing the arena down the page. It expands the
+              full deck on demand, and auto-opens while editing / when markers are loaded. */}
+          <Button
+            variant="text"
+            color="inherit"
+            onClick={toggleMarkersDeck}
+            type="button"
+            aria-expanded={markersDeckOpen}
+            startIcon={<PlaceIcon fontSize="small" sx={{ color: 'secondary.main' }} />}
+            endIcon={
+              <KeyboardArrowDownRoundedIcon
+                sx={{
+                  transition: 'transform 0.2s ease',
+                  transform: markersDeckOpen ? 'rotate(180deg)' : 'none',
+                }}
+              />
+            }
+            sx={{
+              ml: -1,
+              color: 'text.primary',
+              fontWeight: 700,
+              letterSpacing: 0.2,
+              textTransform: 'none',
+            }}
           >
-            {/* Deck header: an identity label for the cluster + the live marker-stat chips,
-                pushed to the trailing edge so they read as a status readout for this surface. */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-              <PlaceIcon fontSize="small" sx={{ color: 'secondary.main' }} />
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: 700, letterSpacing: 0.2, color: 'text.primary' }}
+            Map Markers
+            {hasMarkers && (
+              <Chip
+                label={markersState?.markers.length}
+                size="small"
+                color="success"
+                variant="outlined"
+                sx={{ ml: 1, height: 20, '& .MuiChip-label': { px: 0.75 } }}
+              />
+            )}
+          </Button>
+
+          <Collapse in={markersDeckOpen} unmountOnExit>
+            <Box sx={{ mt: 1 }}>
+              <Box
+                sx={(theme) => ({
+                  ...markerDeckSurface(theme),
+                  p: { xs: 1.5, sm: 2 },
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 1.5,
+                })}
               >
-                Map Markers
-              </Typography>
-              <Box sx={{ flexGrow: 1 }} />
-              {markersState && markerStats.success && (
-                <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'center', flexWrap: 'wrap' }}>
-                  <Chip
-                    label={`${markerStats.filtered} / ${markerStats.totalDecoded} markers`}
-                    color="success"
-                    size="small"
-                    variant="outlined"
-                  />
-                  {markerStats.is3D && (
-                    <Chip label="3D Filtering" color="info" size="small" variant="outlined" />
-                  )}
-                  {markerStats.removed > 0 && (
+                {/* Live marker-stat chips — a status readout for this surface. The cluster's identity
+                ("Map Markers") now lives on the toggle above, so the header is just the stats
+                (and renders nothing until markers are loaded). */}
+                {markersState && markerStats.success && (
+                  <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'center', flexWrap: 'wrap' }}>
                     <Chip
-                      label={`${markerStats.removed} filtered out`}
-                      color="warning"
+                      label={`${markerStats.filtered} / ${markerStats.totalDecoded} markers`}
+                      color="success"
                       size="small"
                       variant="outlined"
                     />
-                  )}
-                </Box>
-              )}
-            </Box>
+                    {markerStats.is3D && (
+                      <Chip label="3D Filtering" color="info" size="small" variant="outlined" />
+                    )}
+                    {markerStats.removed > 0 && (
+                      <Chip
+                        label={`${markerStats.removed} filtered out`}
+                        color="warning"
+                        size="small"
+                        variant="outlined"
+                      />
+                    )}
+                  </Box>
+                )}
 
-            {/* Actions. A clear hierarchy instead of three lookalike buttons: the primary entry
+                {/* Actions. A clear hierarchy instead of three lookalike buttons: the primary entry
                 point (Manage) is filled, Edit is a quiet outlined toggle, and Export is its own
                 grouped split control on the row below. The manage/edit pair share one row with
                 equal flex + `stretch` so they are always the same width AND the same height (no
                 ragged single-vs-double-line wrap); on phones they stack full width. */}
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  gap: 1,
-                  alignItems: 'stretch',
-                  flexDirection: { xs: 'column', sm: 'row' },
-                }}
-              >
-                <Button
-                  variant="contained"
-                  color="primary"
-                  startIcon={<PlaceIcon />}
-                  onClick={() => setMarkersModalOpen(true)}
-                  type="button"
-                  sx={{ flex: 1, whiteSpace: 'nowrap' }}
-                >
-                  {markersState ? 'Manage Map Markers' : 'Import Map Markers'}
-                </Button>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      gap: 1,
+                      alignItems: 'stretch',
+                      flexDirection: { xs: 'column', sm: 'row' },
+                    }}
+                  >
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      startIcon={<PlaceIcon />}
+                      onClick={() => setMarkersModalOpen(true)}
+                      type="button"
+                      sx={{ flex: 1, whiteSpace: 'nowrap' }}
+                    >
+                      {markersState ? 'Manage Map Markers' : 'Import Map Markers'}
+                    </Button>
 
-                <Button
-                  variant={markersEditMode ? 'contained' : 'outlined'}
-                  color="secondary"
-                  startIcon={<EditLocationAltIcon />}
-                  onClick={toggleMarkersEditMode}
-                  type="button"
-                  aria-pressed={markersEditMode}
-                  sx={{ flex: 1, whiteSpace: 'nowrap' }}
-                >
-                  {markersEditMode ? 'Done Editing' : 'Edit Markers'}
-                </Button>
-              </Box>
+                    <Button
+                      variant={markersEditMode ? 'contained' : 'outlined'}
+                      color="secondary"
+                      startIcon={<EditLocationAltIcon />}
+                      onClick={toggleMarkersEditMode}
+                      type="button"
+                      aria-pressed={markersEditMode}
+                      sx={{ flex: 1, whiteSpace: 'nowrap' }}
+                    >
+                      {markersEditMode ? 'Done Editing' : 'Edit Markers'}
+                    </Button>
+                  </Box>
 
-              {markersState && markersState.markers.length > 0 && (
-                <MarkerExportButton onExport={handleExportMarkers} sx={{ width: '100%' }} />
-              )}
-            </Box>
+                  {markersState && markersState.markers.length > 0 && (
+                    <MarkerExportButton onExport={handleExportMarkers} sx={{ width: '100%' }} />
+                  )}
+                </Box>
 
-            {/* Edit-mode hint: surfaces the gestures, which are otherwise invisible. Touch and
+                {/* Edit-mode hint: surfaces the gestures, which are otherwise invisible. Touch and
                 mouse get their own wording — right-click and Ctrl+Z don't exist on a phone. It
                 sits in a tinted well so it reads as inline guidance, not body copy. */}
-            {markersEditMode && (
-              <Box
-                sx={(theme) => ({
-                  borderRadius: 1.5,
-                  px: 1.5,
-                  py: 1,
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.secondary.main, 0.08)
-                      : alpha(theme.palette.primary.main, 0.05),
-                  border: '1px solid',
-                  borderColor:
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.secondary.main, 0.22)
-                      : 'divider',
-                })}
-              >
-                <Typography variant="caption" color="text.secondary">
-                  {isMobileReplay
-                    ? 'Press and hold the map to place a marker · drag a marker to move it · press and hold a marker to edit or remove it'
-                    : 'Right-click the map to place a marker · drag a marker to move it · right-click a marker to edit or remove it · Ctrl+Z to undo'}
-                </Typography>
+                {markersEditMode && (
+                  <Box
+                    sx={(theme) => ({
+                      borderRadius: 1.5,
+                      px: 1.5,
+                      py: 1,
+                      bgcolor:
+                        theme.palette.mode === 'dark'
+                          ? alpha(theme.palette.secondary.main, 0.08)
+                          : alpha(theme.palette.primary.main, 0.05),
+                      border: '1px solid',
+                      borderColor:
+                        theme.palette.mode === 'dark'
+                          ? alpha(theme.palette.secondary.main, 0.22)
+                          : 'divider',
+                    })}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {isMobileReplay
+                        ? 'Press and hold the map to place a marker · drag a marker to move it · press and hold a marker to edit or remove it'
+                        : 'Right-click the map to place a marker · drag a marker to move it · right-click a marker to edit or remove it · Ctrl+Z to undo'}
+                    </Typography>
+                  </Box>
+                )}
               </Box>
-            )}
-          </Box>
 
-          {/* Marker management list: edit/delete each marker, undo/redo, clear all. Kept just
+              {/* Marker management list: edit/delete each marker, undo/redo, clear all. Kept just
               below the deck (its own accordion surface) so the deck stays a compact command strip
               and the per-marker detail expands separately. */}
-          {(markersEditMode || (markersState && markersState.markers.length > 0)) && (
-            <Box sx={{ mt: 1.5 }}>
-              <MarkersPanel
-                markersState={markersState}
-                editMode={markersEditMode}
-                canUndo={canUndo}
-                canRedo={canRedo}
-                onUndo={undo}
-                onRedo={redo}
-                onEditMarker={setEditingMarkerId}
-                onRemoveMarker={removeMarker}
-                onClearMarkers={clearMarkers}
-              />
+              {(markersEditMode || (markersState && markersState.markers.length > 0)) && (
+                <Box sx={{ mt: 1.5 }}>
+                  <MarkersPanel
+                    markersState={markersState}
+                    editMode={markersEditMode}
+                    canUndo={canUndo}
+                    canRedo={canRedo}
+                    onUndo={undo}
+                    onRedo={redo}
+                    onEditMarker={setEditingMarkerId}
+                    onRemoveMarker={removeMarker}
+                    onClearMarkers={clearMarkers}
+                  />
+                </Box>
+              )}
             </Box>
-          )}
+          </Collapse>
         </Box>
       )}
 
@@ -744,8 +791,6 @@ export const FightReplay: React.FC = () => {
           markersState={markersState}
           onLoadMarkers={handleLoadMarkers}
           onClearMarkers={clearMarkers}
-          onExportElms={() => handleExportMarkers('elms')}
-          onExportMor={() => handleExportMarkers('mor')}
         />
       )}
 

--- a/src/features/fight_replay/components/ChaptersPopoverButton.tsx
+++ b/src/features/fight_replay/components/ChaptersPopoverButton.tsx
@@ -83,7 +83,9 @@ const ChaptersPopoverButtonComponent: React.FC<ChaptersPopoverButtonProps> = ({
       <Tooltip title="Chapters — jump to any boss ( [ and ] skip )">
         <IconButton
           aria-label="Chapters"
-          aria-haspopup="dialog"
+          // It opens a non-modal Popover (no role=dialog / focus trap), so announce it as a
+          // menu, not a dialog — "dialog" would mislead assistive tech into expecting modality.
+          aria-haspopup="menu"
           aria-expanded={open}
           size="small"
           onClick={(e) => setAnchor(e.currentTarget)}

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -252,6 +252,11 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // Playback state - initialize with URL parameter if available (clamped to range)
   const [currentTime, setCurrentTime] = useState(clampedInitialTime);
   const [isPlaying, setIsPlaying] = useState(false);
+  // Mirror into a ref so the keyboard play/pause handler can read the current value without
+  // depending on `isPlaying` (which would re-create the handler — and re-bind the window keydown
+  // listener — on every play/pause).
+  const isPlayingRef = useRef(isPlaying);
+  isPlayingRef.current = isPlaying;
   const [playbackSpeed, setPlaybackSpeed] = useState(initialPrefs.playbackSpeed);
   const [isScrubbingMode, setIsScrubbingMode] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -274,6 +279,13 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // normalizes lo/hi. Both set + a sane span → playback wraps within [A,B] until the chip clears.
   const [loopStart, setLoopStart] = useState<number | null>(null);
   const [loopEnd, setLoopEnd] = useState<number | null>(null);
+  // Mirror the loop bounds into refs so the keyboard play/pause handler can read them without
+  // taking them as deps — otherwise that handler (and the window keydown listener it lives in)
+  // would re-create every time a loop point is set, churning the listener on a frequent action.
+  const loopStartRef = useRef(loopStart);
+  loopStartRef.current = loopStart;
+  const loopEndRef = useRef(loopEnd);
+  loopEndRef.current = loopEnd;
 
   // Transport bar visibility (cinema model). Master state for the compact bar:
   //  - windowed: stays visible unless the user manually collapses it (C / chevron).
@@ -369,25 +381,22 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   // have just cancelled. With a sane A–B loop armed the restart is SKIPPED: the playback hook's
   // wrap branch never calls onEnd and resumes at the loop in-point — restarting to 0:00 would
   // dump a user looping the final burn back into the whole pre-loop section.
+  // Stable across play/pause + loop changes: reads the playing state and loop bounds from refs, so
+  // it never re-creates on those frequent interactions (and the window keydown listener that
+  // depends on it stops re-binding each time).
   const handlePlayPause = useCallback(() => {
-    if (!isPlaying) {
+    const wasPlaying = isPlayingRef.current;
+    if (!wasPlaying) {
       const dur = selectedFight.endTime - selectedFight.startTime;
-      const loopArmed =
-        loopStart != null && loopEnd != null && Math.abs(loopEnd - loopStart) >= 100;
+      const ls = loopStartRef.current;
+      const le = loopEndRef.current;
+      const loopArmed = ls != null && le != null && Math.abs(le - ls) >= 100;
       if (!loopArmed && animationTimeRef.timeRef.current >= dur - 250) {
         seekTo(0);
       }
     }
-    setIsPlaying(!isPlaying);
-  }, [
-    isPlaying,
-    selectedFight.endTime,
-    selectedFight.startTime,
-    animationTimeRef.timeRef,
-    loopStart,
-    loopEnd,
-    seekTo,
-  ]);
+    setIsPlaying(!wasPlaying);
+  }, [selectedFight.endTime, selectedFight.startTime, animationTimeRef.timeRef, seekTo]);
 
   const handlePlayingChange = useCallback((playing: boolean) => {
     setIsPlaying(playing);
@@ -546,17 +555,18 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     [animationTimeRef.timeRef, duration, seekTo],
   );
 
-  // +/- step through the same discrete speed ladder the on-screen SpeedSelector uses.
-  const stepSpeed = useCallback(
-    (direction: 1 | -1) => {
-      const idx = PLAYBACK_SPEEDS.indexOf(playbackSpeed);
+  // +/- step through the same discrete speed ladder the on-screen SpeedSelector uses. Uses the
+  // functional updater so it has no `playbackSpeed` dep — keeping it (and the keydown listener
+  // that depends on it) stable when the user steps the speed.
+  const stepSpeed = useCallback((direction: 1 | -1) => {
+    setPlaybackSpeed((current) => {
+      const idx = PLAYBACK_SPEEDS.indexOf(current);
       // If the current speed isn't on the ladder (shouldn't happen), fall back to 1x's slot.
       const currentIdx = idx === -1 ? PLAYBACK_SPEEDS.indexOf(1) : idx;
       const nextIdx = Math.max(0, Math.min(PLAYBACK_SPEEDS.length - 1, currentIdx + direction));
-      setPlaybackSpeed(PLAYBACK_SPEEDS[nextIdx]);
-    },
-    [playbackSpeed],
-  );
+      return PLAYBACK_SPEEDS[nextIdx];
+    });
+  }, []);
 
   // Frame-step (,/.): pause if playing, then nudge by FRAME_STEP_MS so the figures advance one
   // small visible step. Stepping is only meaningful on a still frame, so we always pause first.

--- a/src/features/fight_replay/components/MapMarkersModal.tsx
+++ b/src/features/fight_replay/components/MapMarkersModal.tsx
@@ -46,10 +46,6 @@ interface MapMarkersModalProps {
   onLoadMarkers: (markersString: string) => void;
   /** Callback when markers are cleared */
   onClearMarkers: () => void;
-  /** Optional: copy currently-loaded markers as an Elms string */
-  onExportElms?: () => void;
-  /** Optional: copy currently-loaded markers as an M0R string */
-  onExportMor?: () => void;
 }
 
 /**
@@ -62,8 +58,6 @@ export const MapMarkersModal: React.FC<MapMarkersModalProps> = ({
   markersState,
   onLoadMarkers,
   onClearMarkers,
-  onExportElms,
-  onExportMor,
 }) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
@@ -369,28 +363,8 @@ export const MapMarkersModal: React.FC<MapMarkersModalProps> = ({
         >
           Close
         </Button>
-        {hasCommittedMarkers && onExportElms && (
-          <Button
-            onClick={onExportElms}
-            color="secondary"
-            variant="outlined"
-            type="button"
-            startIcon={<ContentCopyIcon />}
-          >
-            Copy Elms
-          </Button>
-        )}
-        {hasCommittedMarkers && onExportMor && (
-          <Button
-            onClick={onExportMor}
-            color="secondary"
-            variant="outlined"
-            type="button"
-            startIcon={<ContentCopyIcon />}
-          >
-            Copy M0R
-          </Button>
-        )}
+        {/* Export (Copy Elms / Copy M0R) lives solely in the toolbar's MarkerExportButton now —
+            the duplicate modal buttons were removed to keep one export entry point. */}
         {hasCommittedMarkers && (
           <Button onClick={handleClearMarkers} color="secondary" variant="outlined" type="button">
             Clear Markers

--- a/src/features/fight_replay/components/MarkerEditDialog.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.tsx
@@ -134,6 +134,15 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
     onClose();
   }, [marker, onClose, onDelete]);
 
+  // Imported M0R markers can legitimately sit outside the slider range; the slider track clamps
+  // its display but the value is preserved. Flag that so the clamped track doesn't silently
+  // contradict the true size shown in the label.
+  const sizeOutOfRange = size < MIN_SIZE_METERS || size > MAX_SIZE_METERS;
+  // The colour editor only exposes RGB; the marker's alpha is preserved verbatim through Save
+  // (handleApply re-attaches marker.colour[3]). Surface it so a translucent marker isn't a
+  // silent surprise. Defaults to 1 (fully opaque) when unset.
+  const markerAlpha = marker?.colour[3] ?? 1;
+
   return (
     <Dialog
       open={Boolean(marker)}
@@ -228,12 +237,28 @@ export const MarkerEditDialog: React.FC<MarkerEditDialogProps> = ({
               }}
             />
           </Box>
+          {markerAlpha < 1 && (
+            <Typography
+              variant="caption"
+              sx={{ display: 'block', mt: 0.75, color: 'text.secondary' }}
+            >
+              Opacity ({Math.round(markerAlpha * 100)}%) is preserved from the original marker.
+            </Typography>
+          )}
         </Box>
 
         {/* Size */}
         <Box>
-          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+          <Typography
+            variant="subtitle2"
+            sx={{ mb: 0.5, color: sizeOutOfRange ? 'warning.main' : undefined }}
+          >
             Size: {size.toFixed(2)}m
+            {sizeOutOfRange && (
+              <Typography component="span" variant="caption" sx={{ ml: 1, color: 'warning.main' }}>
+                (outside the slider range — preserved as imported)
+              </Typography>
+            )}
           </Typography>
           <Slider
             // Display clamps an out-of-range size to the track edge; `size` itself stays

--- a/src/features/fight_replay/components/PlaybackButtons.tsx
+++ b/src/features/fight_replay/components/PlaybackButtons.tsx
@@ -10,6 +10,7 @@ import { PlayArrow, Pause, SkipPrevious, SkipNext, Forward10, Replay10 } from '@
 import { Box, IconButton, Tooltip } from '@mui/material';
 import React from 'react';
 
+import { usePrefersReducedMotion } from '../../../hooks/usePrefersReducedMotion';
 import { TRANSPORT_MOTION } from '../constants/replayDesign';
 
 interface PlaybackButtonsProps {
@@ -51,13 +52,22 @@ const PlaybackButtonsComponent: React.FC<PlaybackButtonsProps> = ({
   // Compact overlay shrinks the play orb (58→38) and its ring/icon so the bar reads as a thin
   // YouTube-style transport instead of a tall deck dominated by the orb.
   const orbSize = compact ? 38 : 58;
+  // Gate non-essential motion per replayDesign's motion contract (the play-orb hover lift/scale
+  // and the ghost-button hover tints). The global !important rule is a fallback.
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const ghostTransition = prefersReducedMotion
+    ? 'none'
+    : `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`;
+  const orbTransition = prefersReducedMotion
+    ? 'none'
+    : `transform ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, box-shadow ${TRANSPORT_MOTION.settle} ${TRANSPORT_MOTION.ease}, filter ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`;
   // Ghost skip buttons — flat by default, a soft accent tint on hover. Quiet next to the
   // play orb so the focal hierarchy reads instantly: one bright control, four supporting.
   const ghostSx = {
     color: 'text.secondary',
     borderRadius: 2,
     ...(compact ? { padding: 0.5 } : null),
-    transition: `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`,
+    transition: ghostTransition,
     '&:hover': { color: 'text.primary', backgroundColor: 'action.hover' },
     '& .MuiSvgIcon-root': { fontSize: compact ? '1.15rem' : '1.4rem' },
   } as const;
@@ -130,7 +140,7 @@ const PlaybackButtonsComponent: React.FC<PlaybackButtonsProps> = ({
             theme.palette.mode === 'dark'
               ? `inset 0 0 0 1px rgba(255,255,255,0.3), 0 0 0 1px ${theme.palette.primary.main}40, 0 0 28px ${theme.palette.primary.main}99, 0 8px 26px ${theme.palette.primary.main}80`
               : `inset 0 0 0 1px rgba(255,255,255,0.4), 0 0 22px ${theme.palette.primary.main}66, 0 8px 24px ${theme.palette.primary.main}59`,
-          transition: `transform ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, box-shadow ${TRANSPORT_MOTION.settle} ${TRANSPORT_MOTION.ease}, filter ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`,
+          transition: orbTransition,
           // Detached orbiting ring just outside the orb (the proto's bright halo gap).
           '&::after': {
             content: '""',
@@ -149,7 +159,7 @@ const PlaybackButtonsComponent: React.FC<PlaybackButtonsProps> = ({
                 ? `inset 0 0 0 1px rgba(255,255,255,0.3), 0 10px 32px ${theme.palette.primary.main}99`
                 : `inset 0 0 0 1px rgba(255,255,255,0.5), 0 10px 30px ${theme.palette.primary.main}73`,
           },
-          '&:active': { transform: 'scale(0.96)' },
+          '&:active': prefersReducedMotion ? undefined : { transform: 'scale(0.96)' },
           '& .MuiSvgIcon-root': { fontSize: compact ? '1.3rem' : '1.9rem' },
         })}
       >

--- a/src/features/fight_replay/components/PlaybackControls.tsx
+++ b/src/features/fight_replay/components/PlaybackControls.tsx
@@ -198,6 +198,18 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
   // grows the transport (which would overlap the player panel / boss-health / control cluster).
   const [moreAnchor, setMoreAnchor] = React.useState<HTMLElement | null>(null);
   const moreOpen = Boolean(moreAnchor);
+  // Move focus INTO the "more" popover on open so keyboard/screen-reader users land on the first
+  // speed option (a bare MUI Popover, unlike a Menu, doesn't auto-focus its content). MUI restores
+  // focus to the trigger (moreAnchor) on close by default, so we only manage the open direction.
+  const firstSpeedRef = React.useRef<HTMLButtonElement | null>(null);
+  React.useEffect(() => {
+    if (moreOpen) {
+      // Defer one frame so the Popover paper has mounted before we focus into it.
+      const id = requestAnimationFrame(() => firstSpeedRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+    return undefined;
+  }, [moreOpen]);
 
   // Use optimized timeline scrubbing for better performance
   const {
@@ -521,8 +533,13 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
               </Tooltip>
             )}
 
-            {/* Chapters — the fullscreen-reachable boss list. */}
-            {showTrial && trial && (
+            {/* Chapters — the fullscreen-reachable boss list. Gated to fullscreen ONLY: in
+                windowed (and mobile-preview) views the page-shell ChapterRail is already on
+                screen, so showing the popover too is pure duplication of both chapter-nav AND
+                the include-trash toggle. isFullscreen here is fed `isImmersive`
+                (= native fullscreen OR mobile pseudo-fullscreen), so the immersive surfaces —
+                where the rail is NOT reachable — still get the button. */}
+            {showTrial && isFullscreen && trial && (
               <ChaptersPopoverButton
                 chapters={chapterList}
                 currentFightId={trial.currentFightId}
@@ -594,11 +611,12 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
             Speed
           </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.25 }}>
-            {PLAYBACK_SPEEDS.map((speed) => {
+            {PLAYBACK_SPEEDS.map((speed, index) => {
               const active = speed === playbackSpeed;
               return (
                 <Box
                   key={speed}
+                  ref={index === 0 ? firstSpeedRef : undefined}
                   component="button"
                   type="button"
                   onClick={() => onSpeedChange(speed)}

--- a/src/features/fight_replay/components/PlayerListPanel.tsx
+++ b/src/features/fight_replay/components/PlayerListPanel.tsx
@@ -463,7 +463,12 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
                       onClick={() => onPlayerVisibilityChange(player.id, !isVisible)}
                       sx={{
                         p: 0.25,
-                        color: isVisible ? theme.palette.primary.main : theme.palette.text.disabled,
+                        // Hidden state uses text.secondary (not text.disabled): on the dark glass
+                        // panel, disabled (~0.38 alpha ≈ 2:1) fails WCAG 1.4.11 non-text contrast;
+                        // secondary keeps the muted look while passing.
+                        color: isVisible
+                          ? theme.palette.primary.main
+                          : theme.palette.text.secondary,
                       }}
                     >
                       {isVisible ? (
@@ -521,7 +526,7 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
         }}
       >
         {colorPicker && (
-          <Box sx={{ width: 132 }}>
+          <Box sx={{ width: 156 }}>
             <Box
               sx={{
                 display: 'grid',
@@ -542,8 +547,10 @@ export const PlayerListPanel: React.FC<PlayerListPanelProps> = ({
                       setColorPicker(null);
                     }}
                     sx={{
-                      width: 20,
-                      height: 20,
+                      // ~28px so the swatch clears a comfortable touch target (the old 20px was
+                      // below the floor); the 5-col grid + 156px popover width fit them exactly.
+                      width: 28,
+                      height: 28,
                       p: 0,
                       borderRadius: '4px',
                       cursor: 'pointer',

--- a/src/features/fight_replay/components/ShareButton.tsx
+++ b/src/features/fight_replay/components/ShareButton.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useState } from 'react';
 
 import { getBaseUrl } from '@/utils/envUtils';
 
-import { TRANSPORT_MOTION } from '../constants/replayDesign';
+import { TRANSPORT_MOTION, TRANSPORT_PILL_RADIUS } from '../constants/replayDesign';
 
 interface ShareButtonProps {
   /** Report ID for URL generation */
@@ -157,7 +157,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
             // the ghost transport buttons + collapse chevron. There, drop the border/fill/min-width so
             // Share becomes a quiet ghost icon like the rest of the row.
             height: 34,
-            borderRadius: '11px',
+            borderRadius: `${TRANSPORT_PILL_RADIUS}px`,
             fontSize: '13px',
             fontWeight: 600,
             textTransform: 'none',

--- a/src/features/fight_replay/components/SpeedSelector.tsx
+++ b/src/features/fight_replay/components/SpeedSelector.tsx
@@ -23,7 +23,8 @@ import {
 import type { Theme } from '@mui/material/styles';
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { TRANSPORT_MOTION } from '../constants/replayDesign';
+import { usePrefersReducedMotion } from '../../../hooks/usePrefersReducedMotion';
+import { TRANSPORT_MOTION, TRANSPORT_PILL_RADIUS } from '../constants/replayDesign';
 
 interface SpeedSelectorProps {
   /** Current playback speed multiplier */
@@ -57,6 +58,15 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
   // On narrow screens the segmented chips don't fit alongside the transport cluster, so the
   // whole control collapses to just the overflow trigger (which always shows current speed).
   const compact = useMediaQuery(theme.breakpoints.down('sm'));
+  // Gate the chip hover/select transitions per replayDesign's motion contract (the global
+  // !important rule is a fallback; component-level gating is the documented primary).
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const segmentTransition = prefersReducedMotion
+    ? 'none'
+    : `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`;
+  const triggerTransition = prefersReducedMotion
+    ? 'none'
+    : `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`;
 
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const menuOpen = Boolean(menuAnchor);
@@ -87,7 +97,7 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
   const segmentSx = {
     border: '1px solid',
     borderColor: 'divider',
-    borderRadius: '11px',
+    borderRadius: `${TRANSPORT_PILL_RADIUS}px`,
     overflow: 'hidden',
     bgcolor: 'action.hover',
     height: 34,
@@ -106,7 +116,7 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
       borderRight: '1px solid',
       borderRightColor: 'divider',
       '&:last-of-type': { borderRight: 0 },
-      transition: `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}, color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`,
+      transition: segmentTransition,
       '&:hover': { bgcolor: 'action.selected', color: 'text.primary' },
       '&.Mui-selected': {
         backgroundImage: (t: Theme) =>
@@ -155,10 +165,11 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
           onClick={(e) => setMenuAnchor(e.currentTarget)}
           aria-label="Choose playback speed"
           aria-haspopup="true"
+          aria-expanded={menuOpen}
           sx={{
             border: '1px solid',
             borderColor: 'divider',
-            borderRadius: '11px',
+            borderRadius: `${TRANSPORT_PILL_RADIUS}px`,
             height: 34,
             px: triggerLabel ? '11px' : '8px',
             py: 0,
@@ -169,7 +180,7 @@ export const SpeedSelector: React.FC<SpeedSelectorProps> = ({
             fontVariantNumeric: 'tabular-nums',
             lineHeight: 1,
             bgcolor: 'action.hover',
-            transition: `background-color ${TRANSPORT_MOTION.tap} ${TRANSPORT_MOTION.ease}`,
+            transition: triggerTransition,
             '&:hover': { bgcolor: 'action.selected', color: 'text.primary' },
             '&.Mui-selected': {
               bgcolor: 'primary.main',

--- a/src/features/fight_replay/components/TimelineSlider.tsx
+++ b/src/features/fight_replay/components/TimelineSlider.tsx
@@ -139,13 +139,19 @@ export const LoopChip: React.FC<{
         component="button"
         type="button"
         aria-label="Clear A–B loop"
+        title="Clear A–B loop (U)"
         onClick={onClearLoop}
         sx={{
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
-          width: 16,
-          height: 16,
+          // Hit area expanded to ~28px (padding) while a negative margin keeps the chip's visible
+          // footprint unchanged — the glyph stays small but the target clears the touch floor.
+          minWidth: 28,
+          minHeight: 28,
+          width: 28,
+          height: 28,
+          m: '-6px',
           p: 0,
           border: 'none',
           borderRadius: '50%',

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
@@ -489,7 +489,7 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
           </Box>
         </Typography>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, flex: '0 0 auto' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flex: '0 0 auto' }}>
           <DockButton
             icon={<GroupRoundedIcon fontSize="small" />}
             label="Players"
@@ -609,7 +609,15 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
       {/* Settings sheet — playback speed · display toggles · share. Body rendered only while open
           (same reason as above: its ShareButton takes `currentTime`, so a mounted-but-closed sheet
           reconciled at the playback tick). */}
-      <MobileSheet open={sheet === 'settings'} title="Settings" onClose={() => setSheet(null)}>
+      <MobileSheet
+        open={sheet === 'settings'}
+        title="Settings"
+        onClose={() => setSheet(null)}
+        // In marker edit mode the on-screen instructions tell the user to drag markers on the
+        // arena; a drag that bleeds onto this sheet's header must not dismiss it. Close stays
+        // available via the X / backdrop / Escape.
+        draggable={!markersEditMode}
+      >
         {sheet === 'settings' && (
           <>
             <Typography

--- a/src/features/fight_replay/components/mobile/MobileSheet.tsx
+++ b/src/features/fight_replay/components/mobile/MobileSheet.tsx
@@ -27,6 +27,12 @@ interface MobileSheetProps {
   children: React.ReactNode;
   /** Optional element rendered on the right of the title row (e.g. a quick toggle). */
   action?: React.ReactNode;
+  /**
+   * Drag-to-dismiss on the grab strip. Default true. Set false when a sheet overlaps an
+   * interactive arena gesture (e.g. marker edit mode, where dragging a marker can land on the
+   * sheet header and accidentally dismiss it) — close stays available via the X, backdrop, Escape.
+   */
+  draggable?: boolean;
 }
 
 /** Drag distance (fraction of sheet height) past which release dismisses. */
@@ -40,6 +46,7 @@ const MobileSheetComponent: React.FC<MobileSheetProps> = ({
   onClose,
   children,
   action,
+  draggable = true,
 }) => {
   const sheetRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
@@ -97,21 +104,26 @@ const MobileSheetComponent: React.FC<MobileSheetProps> = ({
     active: false,
   });
 
-  const onHeaderPointerDown = useCallback((e: React.PointerEvent) => {
-    // Leave the title-row buttons (close / action) alone.
-    if ((e.target as HTMLElement).closest('button')) return;
-    dragState.current = {
-      startY: e.clientY,
-      startT: performance.now(),
-      lastY: e.clientY,
-      active: true,
-    };
-    try {
-      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
-    } catch {
-      // Synthetic/inactive pointers can't be captured — the drag still tracks via React events.
-    }
-  }, []);
+  const onHeaderPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Drag disabled (e.g. an arena gesture overlaps the header) — never start a dismiss drag.
+      if (!draggable) return;
+      // Leave the title-row buttons (close / action) alone.
+      if ((e.target as HTMLElement).closest('button')) return;
+      dragState.current = {
+        startY: e.clientY,
+        startT: performance.now(),
+        lastY: e.clientY,
+        active: true,
+      };
+      try {
+        (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      } catch {
+        // Synthetic/inactive pointers can't be captured — the drag still tracks via React events.
+      }
+    },
+    [draggable],
+  );
 
   const onHeaderPointerMove = useCallback((e: React.PointerEvent) => {
     const drag = dragState.current;
@@ -202,26 +214,29 @@ const MobileSheetComponent: React.FC<MobileSheetProps> = ({
           pointerEvents: open ? 'auto' : 'none',
         })}
       >
-        {/* Grab strip: handle + title row — the drag-to-dismiss surface. */}
+        {/* Grab strip: handle + title row — the drag-to-dismiss surface (when draggable). */}
         <Box
           onPointerDown={onHeaderPointerDown}
-          onPointerMove={onHeaderPointerMove}
-          onPointerUp={() => endDrag(true)}
-          onPointerCancel={() => endDrag(false)}
-          sx={{ touchAction: 'none', cursor: 'grab' }}
+          onPointerMove={draggable ? onHeaderPointerMove : undefined}
+          onPointerUp={draggable ? () => endDrag(true) : undefined}
+          onPointerCancel={draggable ? () => endDrag(false) : undefined}
+          sx={draggable ? { touchAction: 'none', cursor: 'grab' } : undefined}
         >
-          {/* Grab handle */}
-          <Box
-            aria-hidden
-            sx={{
-              width: 40,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: 'divider',
-              mx: 'auto',
-              mt: 1,
-            }}
-          />
+          {/* Grab handle — only shown when drag-to-dismiss is active, so it never implies a
+              gesture that's been disabled. */}
+          {draggable && (
+            <Box
+              aria-hidden
+              sx={{
+                width: 40,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: 'divider',
+                mx: 'auto',
+                mt: 1,
+              }}
+            />
+          )}
           {/* Title row */}
           <Box
             sx={{
@@ -251,18 +266,36 @@ const MobileSheetComponent: React.FC<MobileSheetProps> = ({
           </Box>
         </Box>
         {/* Scrollable content — its OWN max-height is the sheet's effective cap (see note above).
-            Use dvh so the mobile browser's dynamic toolbar can't push the sheet off-screen. */}
-        <Box
-          sx={{
-            overflowY: 'auto',
-            WebkitOverflowScrolling: 'touch',
-            overscrollBehavior: 'contain',
-            px: 2,
-            pb: 2,
-            maxHeight: 'min(60dvh, 520px)',
-          }}
-        >
-          {children}
+            Use dvh so the mobile browser's dynamic toolbar can't push the sheet off-screen. A
+            bottom fade-gradient overlay hints there's more below when content overflows (the iOS
+            scrollbar is invisible at rest, so without it overflow reads as a hard cut-off). */}
+        <Box sx={{ position: 'relative' }}>
+          <Box
+            sx={{
+              overflowY: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              overscrollBehavior: 'contain',
+              px: 2,
+              pb: 2,
+              maxHeight: 'min(60dvh, 520px)',
+            }}
+          >
+            {children}
+          </Box>
+          <Box
+            aria-hidden
+            sx={(theme) => ({
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: 24,
+              pointerEvents: 'none',
+              background: `linear-gradient(to top, ${
+                theme.palette.mode === 'dark' ? 'rgba(13,18,30,0.98)' : '#fff'
+              }, transparent)`,
+            })}
+          />
         </Box>
       </Box>
     </>

--- a/src/features/fight_replay/constants/replayDesign.ts
+++ b/src/features/fight_replay/constants/replayDesign.ts
@@ -77,6 +77,13 @@ export const TRANSPORT_MOTION = {
 } as const;
 
 /**
+ * Pill geometry for the transport's small control chips (speed selector, share button). One
+ * shared radius so the pill family reads as one set instead of three independently-tuned magic
+ * `11px` literals scattered across components.
+ */
+export const TRANSPORT_PILL_RADIUS = 11;
+
+/**
  * Build the docked transport bar's surface `sx` from the live theme. A subtle top-edge
  * accent wash (cyan in dark mode) lifts the bar off the arena above it and reads as the
  * "control deck" of a player rather than a flat form panel — without floating over the 3D

--- a/src/features/fight_replay/types/mapMarkers.ts
+++ b/src/features/fight_replay/types/mapMarkers.ts
@@ -14,6 +14,4 @@ export interface MapMarkersState {
   format: MarkerFormat;
   zoneId: number;
   markers: ReplayMarker[];
-  /** Preserve the original encoded string when markers were loaded */
-  originalEncodedString?: string;
 }

--- a/src/features/fight_replay/utils/mapMarkerConverters.test.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.test.ts
@@ -19,7 +19,7 @@ import {
 } from './mapMarkerConverters';
 
 function stateFromMarkers(markers: ReplayMarker[], zoneId = 636): MapMarkersState {
-  return { format: 'elms', zoneId, markers, originalEncodedString: undefined };
+  return { format: 'elms', zoneId, markers };
 }
 
 function manualMarker(iconKey: number, pos = { x: 100, y: 0, z: 200 }): ReplayMarker {

--- a/src/features/fight_replay/utils/mapMarkerConverters.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.ts
@@ -208,7 +208,6 @@ export function parseMarkersInput(encoded: string): MapMarkersState {
       format: 'elms',
       zoneId: decoded.zone,
       markers: markersFromElms(decoded),
-      originalEncodedString: trimmed,
     };
   }
 
@@ -225,7 +224,6 @@ export function parseMarkersInput(encoded: string): MapMarkersState {
     format: 'mor',
     zoneId: decodedMor.zone,
     markers: replayMarkers,
-    originalEncodedString: trimmed,
   };
 }
 


### PR DESCRIPTION
Follow-up to #1207 (now merged). An audit-driven cleanup of the consolidated fight-replay, biased toward **subtraction** so the 3D arena is the hero instead of being pushed down a tall stack of always-on chrome. 66 candidate findings were narrowed to 30 adversarially-verified ones; this lands the safe wins and skips the items that were intentional design decisions.

## Declutter (the headline)
- **Collapse the always-on Map Markers deck behind one quiet "Map Markers" toggle** near the title. Auto-opens (and locks open) while editing or when markers are loaded, so the tools/hints are never hidden when needed. Reclaims ~150–200px above the arena for the majority who never place a marker.
- **Gate the transport Chapters popover to fullscreen only** — windowed views already show the page-shell `ChapterRail`, so the popover was duplicating chapter navigation *and* the include-trash toggle. (Verified the rail's render condition is strictly weaker than the popover's, so no access path is lost windowed.)
- **Remove the duplicate Copy Elms / Copy M0R buttons** from the markers modal (the toolbar's `MarkerExportButton` is the single export entry point).
- **Drop the dead `MapMarkersState.originalEncodedString`** field (written, never read).

## Bug fixes
- Move focus into the mobile Speed/Share popover on open (a bare `Popover` doesn't auto-focus its content — keyboard/SR users were stranded on the trigger).
- Add a `draggable={false}` escape hatch to `MobileSheet` and use it for the Settings sheet in marker edit mode, so a marker drag bleeding onto the sheet header can't accidentally dismiss it.
- Fix `ChaptersPopoverButton`'s `aria-haspopup` (`dialog` → `menu`; it opens a non-modal popover).
- Stop the window keydown listener re-binding on play/pause + speed changes (read playing state + loop bounds from refs; speed via the functional updater).

## Polish / a11y
- Gate the speed-pill and play-orb transitions behind `prefers-reduced-motion`.
- `aria-expanded` on the SpeedSelector overflow trigger.
- Fix the hidden-actor visibility-icon contrast (`text.disabled` → `text.secondary`).
- Tokenize the transport pill radius (`TRANSPORT_PILL_RADIUS`).
- Enlarge the loop-clear ✕ and marker color-swatch touch targets; widen the mobile dock button gap; add a scroll-fade affordance to `MobileSheet`.
- Surface out-of-range imported marker size and preserved opacity in the edit dialog.

## Verification
tsc + eslint clean; 42 suites / 360 fight_replay tests green.

Intentionally **declined** (documented design intent): removing the page-shell ChapterRail, merging the three HUD panels, hiding the marker edit-mode gesture hints, removing the play-orb halo ring — see the audit notes.