### PR TITLE
feat(roster-builder): scope Per-Fight Builds to the Built-for trials

### DIFF
--- a/src/components/PerFightBuilds.tsx
+++ b/src/components/PerFightBuilds.tsx
@@ -24,7 +24,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 
 import { KnownSetIDs } from '../types/abilities';
 import type { RaidRoster } from '../types/roster';
@@ -38,6 +38,7 @@ import type {
 import {
   TRIAL_ENCOUNTERS,
   getTrialById,
+  resolveTrialId,
   createDefaultTrialOverrides,
   encounterHasOverrides,
   isOverrideEmpty,
@@ -490,6 +491,46 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
       [trialOverrides?.trialId],
     );
 
+    // Trials this roster is tagged "Built for" (top-level picker), resolved to
+    // encounter-data trial ids. Drives which trials the Per-Fight Builds selector
+    // offers, so the two selectors stay in sync.
+    const scopedTrialIds = useMemo<string[]>(() => {
+      const ids = (roster.trials ?? [])
+        .map((tag) => resolveTrialId(tag))
+        .filter((id): id is string => Boolean(id));
+      // Dedupe while preserving order.
+      return Array.from(new Set(ids));
+    }, [roster.trials]);
+
+    // The trials shown in the dropdown: scoped to the "Built for" tags when any
+    // are set, otherwise the full list (backward compatible / untagged rosters).
+    const trialOptions = useMemo<readonly Trial[]>(() => {
+      if (scopedTrialIds.length === 0) return TRIAL_ENCOUNTERS;
+      const scoped = scopedTrialIds
+        .map((id) => getTrialById(id))
+        .filter((t): t is Trial => Boolean(t));
+      // If a per-fight trial is already selected but isn't in the tag set
+      // (e.g. tags changed after customizing), keep it visible so its work isn't hidden.
+      if (selectedTrial && !scoped.some((t) => t.id === selectedTrial.id)) {
+        return [selectedTrial, ...scoped];
+      }
+      return scoped;
+    }, [scopedTrialIds, selectedTrial]);
+
+    // Auto-select the trial when exactly one is tagged and nothing is chosen yet,
+    // so the encounter timeline appears without a redundant second pick. Guarded by
+    // a ref keyed on the scoped-trial set so it fires once per change — otherwise an
+    // explicit "None" pick would be re-selected immediately, making "None" a dead option.
+    const autoSelectedForRef = useRef<string | null>(null);
+    useEffect(() => {
+      const key = scopedTrialIds.join('|');
+      if (autoSelectedForRef.current === key) return; // already handled this set
+      autoSelectedForRef.current = key; // mark as seen regardless of outcome
+      if (scopedTrialIds.length !== 1) return; // only auto-pick the unambiguous case
+      if (trialOverrides?.trialId) return; // user already has a selection
+      onUpdateTrialOverrides(createDefaultTrialOverrides(scopedTrialIds[0]));
+    }, [scopedTrialIds, trialOverrides?.trialId, onUpdateTrialOverrides]);
+
     // Players list derived from roster
     const players = useMemo(() => getPlayersFromRoster(roster), [roster]);
 
@@ -634,7 +675,13 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
 
         <AccordionDetails sx={{ px: 1.5, pt: 1.5, pb: 2 }}>
           <Stack spacing={2}>
-            {/* Trial selector */}
+            {/* Trial selector — scoped to the roster's "Built for" trials when set */}
+            {scopedTrialIds.length > 0 && (
+              <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', mt: -0.5 }}>
+                Showing the {scopedTrialIds.length === 1 ? 'trial' : 'trials'} this roster is{' '}
+                <strong>built for</strong>. Add more in the “Built for (Trials)” picker above.
+              </Typography>
+            )}
             <FormControl fullWidth size="small">
               <InputLabel>Select Trial</InputLabel>
               <Select
@@ -652,7 +699,7 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                 <MenuItem value="">
                   <em>None — No per-fight customization</em>
                 </MenuItem>
-                {TRIAL_ENCOUNTERS.map((trial) => (
+                {trialOptions.map((trial) => (
                   <MenuItem key={trial.id} value={trial.id}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Chip

--- a/src/types/trial-encounters.bridge.test.ts
+++ b/src/types/trial-encounters.bridge.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the trial-id bridge that keeps the Roster Builder's two trial
+ * selectors in sync: the top-level "Built for (Trials)" picker tags rosters
+ * with loadout-manager short codes (e.g. 'RG', 'MOL', 'KA'), while Per-Fight
+ * Builds keys off encounter-data slugs (e.g. 'rockgrove'). `resolveTrialId`
+ * bridges the two, and must stay total/1:1 across all 15 trials.
+ */
+
+import { resolveTrialId, getTrialById, TRIAL_ENCOUNTERS } from './trial-encounters';
+import { TRIALS } from '../features/loadout-manager/data/trialConfigs';
+
+describe('resolveTrialId', () => {
+  it('resolves short codes case-insensitively', () => {
+    expect(resolveTrialId('RG')).toBe('rockgrove');
+    expect(resolveTrialId('rg')).toBe('rockgrove');
+    expect(resolveTrialId('Rg')).toBe('rockgrove');
+  });
+
+  it('resolves codes whose casing differs from trialConfigs (MOL→MoL, HOF→HoF)', () => {
+    // trialConfigs uses 'MOL'/'HOF'; encounter shortNames are 'MoL'/'HoF'.
+    expect(resolveTrialId('MOL')).toBe('maw_of_lorkhaj');
+    expect(resolveTrialId('HOF')).toBe('halls_of_fabrication');
+  });
+
+  it('resolves the apostrophe trials (KA, SE)', () => {
+    expect(resolveTrialId('KA')).toBe('kynes_aegis');
+    expect(resolveTrialId('SE')).toBe('sanitys_edge');
+  });
+
+  it('passes a full encounter-data slug through unchanged', () => {
+    expect(resolveTrialId('rockgrove')).toBe('rockgrove');
+    expect(resolveTrialId('ossein_cage')).toBe('ossein_cage');
+  });
+
+  it('returns undefined for empty or unknown tags', () => {
+    expect(resolveTrialId('')).toBeUndefined();
+    expect(resolveTrialId('NOPE')).toBeUndefined();
+    expect(resolveTrialId('not_a_trial')).toBeUndefined();
+  });
+
+  it('resolves every trialConfigs trial code to a real encounter trial (1:1, no gaps)', () => {
+    const trialCodes = TRIALS.filter((t) => t.type === 'trial').map((t) => t.id);
+    // There are 15 ESO trials; guard against silent loss of one.
+    expect(trialCodes.length).toBe(15);
+    for (const code of trialCodes) {
+      const slug = resolveTrialId(code);
+      expect(slug).toBeDefined();
+      // The resolved slug must point at a real encounter-data trial.
+      expect(getTrialById(slug as string)).toBeDefined();
+    }
+  });
+
+  it('every encounter trial is reachable from exactly one trialConfigs code', () => {
+    const trialCodes = TRIALS.filter((t) => t.type === 'trial').map((t) => t.id);
+    const reached = new Set(trialCodes.map((c) => resolveTrialId(c)).filter(Boolean));
+    expect(reached.size).toBe(TRIAL_ENCOUNTERS.length);
+    for (const t of TRIAL_ENCOUNTERS) {
+      expect(reached.has(t.id)).toBe(true);
+    }
+  });
+});

--- a/src/types/trial-encounters.ts
+++ b/src/types/trial-encounters.ts
@@ -1219,6 +1219,29 @@ export function getTrialById(trialId: string): Trial | undefined {
   return TRIAL_ENCOUNTERS.find((t) => t.id === trialId);
 }
 
+/**
+ * Map of a trial's short code (case-normalized) → its full encounter-data id.
+ * The "Built for (Trials)" picker tags rosters with short codes from
+ * loadout-manager's trialConfigs (e.g. 'RG', 'MOL', 'KA'); this bridges those
+ * to the encounter-data slugs used by Per-Fight Builds (e.g. 'rockgrove').
+ */
+const TRIAL_ID_BY_SHORT_NAME = new Map(
+  TRIAL_ENCOUNTERS.map((t) => [t.shortName.toUpperCase(), t.id] as const),
+);
+
+/**
+ * Resolve a "Built for" trial tag (a trialConfigs short code like 'RG' or a
+ * full encounter slug like 'rockgrove') to the encounter-data trial id.
+ * Returns undefined if it doesn't correspond to a trial with encounter data.
+ */
+export function resolveTrialId(tag: string): string | undefined {
+  if (!tag) return undefined;
+  // Already a full encounter-data id?
+  if (TRIAL_ENCOUNTERS.some((t) => t.id === tag)) return tag;
+  // Otherwise treat as a short code (case-insensitive).
+  return TRIAL_ID_BY_SHORT_NAME.get(tag.toUpperCase());
+}
+
 /** Create a default (empty) TrialBuildOverrides for a given trial */
 export function createDefaultTrialOverrides(trialId: string): TrialBuildOverrides {
   return {


### PR DESCRIPTION
## Problem

The Roster Builder now has **two independent trial selectors**:

1. The top-level **"Built for (Trials)"** multi-select picker (added in #1198) that tags a roster with the trials it's planned for.
2. The **"Select Trial"** dropdown inside **Per-Fight Builds** (which lists all 15 trials and their encounter timelines).

They didn't talk to each other. You could tag a roster "built for Rockgrove" up top, then still have to scroll down and re-pick Rockgrove again from a list of all 15 trials to customize per-fight builds. Redundant and easy to get out of sync.

## Fix — sync the two selectors

The top picker now **scopes** Per-Fight Builds:

- **Bridge helper `resolveTrialId()`** maps loadout-manager short codes (`RG`, `MOL`, `KA`…) to encounter-data slugs (`rockgrove`…), case-insensitively. The two datasets use different casing (`MOL`/`HOF` vs `MoL`/`HoF`) and the apostrophe trials (`KA`, `SE`) needed care — the bridge is verified **1:1 total across all 15 trials**.
- **Scoped dropdown:** when a roster is tagged "built for" one or more trials, the Per-Fight Builds dropdown offers **only those trials**. Untagged rosters still get the full list of all 15 (backward compatible).
- **Auto-select:** when exactly one trial is tagged, Per-Fight Builds auto-selects it so the encounter timeline appears immediately — no redundant second pick. Guarded by a ref keyed on the scoped set, so an explicit **"None"** choice sticks instead of being re-selected.
- **Contextual caption** points back to the top picker for adding more trials.

## Notes

- **No encounter IDs changed.** The change to `trial-encounters.ts` is purely additive (the bridge helper). Per-fight overrides are keyed by encounter id and encoded into shared `?r=` roster URLs, so id stability is a hard invariant — preserved by construction.
- This builds on the 167-encounter Per-Fight Builds data already in `main` (#1227).

## Testing

- `tsc`, `eslint`, `prettier`, `vite build` — all clean.
- New unit test `trial-encounters.bridge.test.ts` locks the bridge (case-insensitive codes, apostrophe trials, slug passthrough, unknown→undefined, and a 1:1-across-15-trials guard) so a future rename fails loudly. 136 roster/trial tests green.
- **Live-verified** on a dev server across the three states:
  - **Untagged** (the user's originally reported state): dropdown shows all 15 trials.
  - **One trial tagged** (Rockgrove): dropdown scopes to Rockgrove, auto-selects it, full enemy-type timeline renders, caption shows; "None" is selectable and sticks.
  - **Two trials tagged** (Rockgrove + Kyne's Aegis): dropdown narrows to exactly those two (apostrophe trial selectable), auto-select correctly does NOT fire.
