### PR TITLE
fix(ultimate-calculator): Codex review follow-ups (banked ult, cost reductions, calibration, Cryptcanon)

### DIFF
--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -112,6 +112,35 @@ describe('compileSources', () => {
     });
     expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
   });
+
+  it('does not stack Minor Heroism across providers (keeps one, not both)', () => {
+    // Generic Minor Heroism and Cryptcanon both grant the SAME named buff; with
+    // both enabled, only one contribution should survive (they share a
+    // nonStackingGroup), never summed.
+    const both = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'minor-heroism': true, 'cryptcanon-vestments': true },
+    });
+    const minorHeroismGroup = both.filter(
+      (s) => s.id === 'minor-heroism' || s.id === 'cryptcanon-vestments',
+    );
+    expect(minorHeroismGroup).toHaveLength(1);
+
+    // The single survivor's contribution must not exceed either provider alone —
+    // i.e. enabling both is never larger than enabling just one.
+    const onlyGeneric = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'minor-heroism': true },
+    });
+    const rate = (s: { amountPerInstance: number; instancesPerSecond: number; uptime: number }) =>
+      s.amountPerInstance * s.instancesPerSecond * s.uptime;
+    const bothRate = rate(minorHeroismGroup[0]);
+    const genericRate = rate(onlyGeneric.find((s) => s.id === 'minor-heroism')!);
+    // The kept provider is the strongest single one, so its rate is ≥ the generic
+    // alone but the GROUP total equals exactly that one provider (no doubling).
+    expect(bothRate).toBeGreaterThanOrEqual(genericRate);
+    expect(minorHeroismGroup).toHaveLength(1);
+  });
 });
 
 describe('compileReductions', () => {

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -113,33 +113,15 @@ describe('compileSources', () => {
     expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
   });
 
-  it('does not stack Minor Heroism across providers (keeps one, not both)', () => {
-    // Generic Minor Heroism and Cryptcanon both grant the SAME named buff; with
-    // both enabled, only one contribution should survive (they share a
-    // nonStackingGroup), never summed.
-    const both = compileSources(ULTIMATE_SOURCE_CATALOG, {
-      ...baseSelection,
-      enabledOverrides: { 'minor-heroism': true, 'cryptcanon-vestments': true },
-    });
-    const minorHeroismGroup = both.filter(
-      (s) => s.id === 'minor-heroism' || s.id === 'cryptcanon-vestments',
-    );
-    expect(minorHeroismGroup).toHaveLength(1);
-
-    // The single survivor's contribution must not exceed either provider alone —
-    // i.e. enabling both is never larger than enabling just one.
-    const onlyGeneric = compileSources(ULTIMATE_SOURCE_CATALOG, {
+  it('models Minor Heroism as a single source (no per-provider duplicate)', () => {
+    // Minor Heroism is one named buff; the catalog represents all of its
+    // providers with the single `minor-heroism` entry, so enabling it yields
+    // exactly one Minor Heroism source.
+    const compiled = compileSources(ULTIMATE_SOURCE_CATALOG, {
       ...baseSelection,
       enabledOverrides: { 'minor-heroism': true },
     });
-    const rate = (s: { amountPerInstance: number; instancesPerSecond: number; uptime: number }) =>
-      s.amountPerInstance * s.instancesPerSecond * s.uptime;
-    const bothRate = rate(minorHeroismGroup[0]);
-    const genericRate = rate(onlyGeneric.find((s) => s.id === 'minor-heroism')!);
-    // The kept provider is the strongest single one, so its rate is ≥ the generic
-    // alone but the GROUP total equals exactly that one provider (no doubling).
-    expect(bothRate).toBeGreaterThanOrEqual(genericRate);
-    expect(minorHeroismGroup).toHaveLength(1);
+    expect(compiled.filter((s) => s.id === 'minor-heroism')).toHaveLength(1);
   });
 });
 

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -76,48 +76,25 @@ export function availableReductions(
   return catalog.filter((r) => isReductionAvailable(r, selection));
 }
 
-/** Expected raw ult/s a (uptime-resolved) source contributes — for ranking. */
-function expectedRate(source: CatalogSource): number {
-  return source.amountPerInstance * source.instancesPerSecond * source.uptime;
-}
-
 /**
  * Compile enabled, available catalog sources into engine `UltimateSource[]`,
  * applying per-source uptime overrides.
  *
- * Sources that share a `nonStackingGroup` represent the SAME named buff from
- * different providers (e.g. Minor Heroism from a potion vs from Cryptcanon).
- * Such a buff does not stack, so when more than one is enabled only the strongest
- * single contribution is kept — they are never summed.
+ * Note on non-stacking buffs: named buffs like Minor Heroism do not stack across
+ * providers, but the catalog already models each such buff as ONE source (e.g.
+ * the single `minor-heroism` entry represents "Minor Heroism from whatever
+ * provides it"), so no per-provider de-duplication is needed here.
  */
 export function compileSources(
   catalog: readonly CatalogSource[],
   selection: CatalogSelection,
 ): UltimateSource[] {
-  const enabled = availableSources(catalog, selection)
+  return availableSources(catalog, selection)
     .filter((s) => isEntryEnabled(s.id, s.defaultEnabled, selection.enabledOverrides))
     .map((s) => {
       const uptime = selection.uptimeOverrides[s.id];
-      return uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
-    });
-
-  // Collapse non-stacking buff groups to their single strongest provider.
-  const strongestInGroup = new Map<string, CatalogSource>();
-  for (const s of enabled) {
-    if (s.nonStackingGroup === undefined) continue;
-    const current = strongestInGroup.get(s.nonStackingGroup);
-    if (current === undefined || expectedRate(s) > expectedRate(current)) {
-      strongestInGroup.set(s.nonStackingGroup, s);
-    }
-  }
-
-  return enabled
-    .filter((s) => {
-      if (s.nonStackingGroup === undefined) return true;
-      // Keep only the winning provider of each non-stacking buff group.
-      return strongestInGroup.get(s.nonStackingGroup) === s;
-    })
-    .map((resolved) => {
+      const resolved =
+        uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
       // Strip catalog-only fields down to the engine's UltimateSource shape.
       const {
         id,

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -76,20 +76,48 @@ export function availableReductions(
   return catalog.filter((r) => isReductionAvailable(r, selection));
 }
 
+/** Expected raw ult/s a (uptime-resolved) source contributes — for ranking. */
+function expectedRate(source: CatalogSource): number {
+  return source.amountPerInstance * source.instancesPerSecond * source.uptime;
+}
+
 /**
  * Compile enabled, available catalog sources into engine `UltimateSource[]`,
  * applying per-source uptime overrides.
+ *
+ * Sources that share a `nonStackingGroup` represent the SAME named buff from
+ * different providers (e.g. Minor Heroism from a potion vs from Cryptcanon).
+ * Such a buff does not stack, so when more than one is enabled only the strongest
+ * single contribution is kept — they are never summed.
  */
 export function compileSources(
   catalog: readonly CatalogSource[],
   selection: CatalogSelection,
 ): UltimateSource[] {
-  return availableSources(catalog, selection)
+  const enabled = availableSources(catalog, selection)
     .filter((s) => isEntryEnabled(s.id, s.defaultEnabled, selection.enabledOverrides))
     .map((s) => {
       const uptime = selection.uptimeOverrides[s.id];
-      const resolved =
-        uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
+      return uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
+    });
+
+  // Collapse non-stacking buff groups to their single strongest provider.
+  const strongestInGroup = new Map<string, CatalogSource>();
+  for (const s of enabled) {
+    if (s.nonStackingGroup === undefined) continue;
+    const current = strongestInGroup.get(s.nonStackingGroup);
+    if (current === undefined || expectedRate(s) > expectedRate(current)) {
+      strongestInGroup.set(s.nonStackingGroup, s);
+    }
+  }
+
+  return enabled
+    .filter((s) => {
+      if (s.nonStackingGroup === undefined) return true;
+      // Keep only the winning provider of each non-stacking buff group.
+      return strongestInGroup.get(s.nonStackingGroup) === s;
+    })
+    .map((resolved) => {
       // Strip catalog-only fields down to the engine's UltimateSource shape.
       const {
         id,

--- a/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
+++ b/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
@@ -150,6 +150,50 @@ describe('timeToUltimate', () => {
     expect(r.secondsToFirstCast).toBe(Infinity);
     expect(r.castsPerFight).toBe(0);
   });
+
+  it('is castable immediately (0s) when the bank already covers the cost, even at rate 0', () => {
+    const r = timeToUltimate({
+      effectiveCost: 125,
+      ultimatePerSecond: 0,
+      fightDurationSeconds: 180,
+      startingUltimate: 500,
+    });
+    expect(r.secondsToFirstCast).toBe(0); // bank ≥ cost ⇒ ready now, not Infinity
+    // 500 banked / 125 cost = 4 casts available from the bank alone.
+    expect(r.castsPerFight).toBe(4);
+  });
+
+  it('counts excess banked ultimate toward the cast total', () => {
+    const r = timeToUltimate({
+      effectiveCost: 100,
+      ultimatePerSecond: 5,
+      fightDurationSeconds: 100, // generates 500
+      startingUltimate: 250,
+    });
+    expect(r.secondsToFirstCast).toBe(0); // 250 banked ≥ 100 cost
+    // (250 banked + 500 generated) / 100 = floor(7.5) = 7 casts.
+    expect(r.castsPerFight).toBe(7);
+  });
+
+  it('caps banked ultimate at the 500 pool (excess input is ignored)', () => {
+    const r = timeToUltimate({
+      effectiveCost: 100,
+      ultimatePerSecond: 0,
+      fightDurationSeconds: 180,
+      startingUltimate: 9999, // clamped to 500
+    });
+    expect(r.castsPerFight).toBe(5); // floor(500 / 100), not floor(9999/100)
+  });
+
+  it('reduces to floor(totalGenerated/cost) when nothing is banked', () => {
+    const r = timeToUltimate({
+      effectiveCost: 250,
+      ultimatePerSecond: 10,
+      fightDurationSeconds: 180,
+      startingUltimate: 0,
+    });
+    expect(r.castsPerFight).toBe(7); // floor(1800/250)
+  });
 });
 
 describe('applyCostReduction', () => {

--- a/src/features/ultimate-simulator/core/expectedValue.ts
+++ b/src/features/ultimate-simulator/core/expectedValue.ts
@@ -27,6 +27,9 @@ import type {
   UltimateSource,
 } from '../shared/types';
 
+/** Hard ultimate pool cap — banked ultimate cannot exceed this. */
+const ULTIMATE_POOL_CAP = 500;
+
 /** Expected number of ult-gain instances a source emits over the fight. */
 export function expectedInstances(source: UltimateSource, durationSeconds: number): number {
   const expected = source.instancesPerSecond * durationSeconds * source.uptime;
@@ -98,10 +101,12 @@ export function expectedValue(config: Omit<SimulationConfig, 'seed'>): ExpectedV
  *
  * `ultimatePerSecond` is the steady-state generation rate (from `expectedValue`).
  * `effectiveCost` is the ultimate's cost AFTER any cost reduction (the caller
- * applies reductions; see `applyCostReduction`). The first cast is gated by the
- * full cost from zero; subsequent casts refill from zero at the same rate, so
- * casts-per-fight is `floor((duration · rate) / cost) ` once enough total ult is
- * generated — equivalently `floor(totalGenerated / cost)`.
+ * applies reductions; see `applyCostReduction`). Banked `startingUltimate` (up to
+ * the 500 pool cap) counts toward both the first cast and the total — so the cast
+ * count is the single coherent identity `floor((start + totalGenerated) / cost)`,
+ * which reduces exactly to `floor(totalGenerated / cost)` when nothing is banked.
+ * If the bank alone already covers the cost the ultimate is castable immediately
+ * (0s), even when the generation rate is 0.
  */
 export function timeToUltimate(input: TimeToUltimateInput): TimeToUltimateResult {
   const { effectiveCost, ultimatePerSecond, fightDurationSeconds, startingUltimate = 0 } = input;
@@ -109,26 +114,25 @@ export function timeToUltimate(input: TimeToUltimateInput): TimeToUltimateResult
   const cost = Math.max(0, effectiveCost);
   const rate = Math.max(0, ultimatePerSecond);
   const duration = Math.max(0, fightDurationSeconds);
-  const start = Math.min(Math.max(0, startingUltimate), cost);
+  // Banked ultimate is capped at the pool (500), NOT at the cost — excess over a
+  // single cast still counts toward the cast total.
+  const start = Math.min(Math.max(0, startingUltimate), ULTIMATE_POOL_CAP);
 
-  // Time to the FIRST cast, accounting for any ultimate already banked.
+  // Time to the FIRST cast, accounting for any ultimate already banked. If the
+  // bank already covers the cost the ultimate is ready now (0s) regardless of
+  // rate; otherwise the shortfall must be generated (∞ if the rate is 0).
   const remainingForFirst = Math.max(0, cost - start);
-  const secondsToFirstCast = rate > 0 ? remainingForFirst / rate : Infinity;
+  const secondsToFirstCast =
+    remainingForFirst <= 0 ? 0 : rate > 0 ? remainingForFirst / rate : Infinity;
 
-  // Total ultimate generated over the whole fight (excludes the starting pool —
-  // that only accelerates the first cast).
+  // Total ultimate generated over the whole fight (from the generation rate).
   const totalGenerated = rate * duration;
 
-  // Casts that complete within the fight: the first cast consumes
-  // `remainingForFirst` from generation, each subsequent cast consumes a full
-  // `cost`. So castable = floor((generated - remainingForFirst)/cost) + 1 once
-  // the first cast is affordable, else 0.
-  let castsPerFight = 0;
-  if (cost <= 0) {
-    castsPerFight = Infinity;
-  } else if (totalGenerated >= remainingForFirst) {
-    castsPerFight = Math.floor((totalGenerated - remainingForFirst) / cost) + 1;
-  }
+  // Casts that complete within the fight. The banked pool plus everything
+  // generated is the spendable total; each cast costs `cost`. This single
+  // identity covers every case (start=0 → floor(totalGenerated/cost);
+  // start≥cost with rate 0 → at least floor(start/cost) casts).
+  const castsPerFight = cost <= 0 ? Infinity : Math.floor((start + totalGenerated) / cost);
 
   // Seconds between subsequent casts at steady state (full cost from zero).
   const secondsPerCast = rate > 0 ? cost / rate : Infinity;

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -53,4 +53,34 @@ describe('UltimateCalculator', () => {
     // lowers the cost and so the time-to-first-ult.
     expect(screen.getAllByText(/250 ult cost/i).length).toBeGreaterThan(0);
   });
+
+  it('offers a cost-reduction toggle for a class that has one, and applying it lowers the cost', () => {
+    renderCalc();
+    // Switch to Sorcerer — Power Stone (−15%) is a default-on reduction with a toggle.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+
+    // The reduction toggle is rendered and on by default.
+    const toggle = screen.getByLabelText(/Power Stone/i);
+    expect(toggle).toBeInTheDocument();
+
+    // With it on, the reduced-cost note is shown; turning it off removes the note.
+    expect(screen.getByText(/Cost reduced/i)).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
+  });
+
+  it('does not apply class reductions to a custom cost (no double-reduction)', () => {
+    renderCalc();
+    // Sorcerer (Power Stone −15% default-on), then pick a custom cost.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+    fireEvent.mouseDown(screen.getByLabelText(/^Ultimate$/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText(/Custom cost/i));
+
+    // A custom cost is taken as already-effective: no "Cost reduced" note and no
+    // reduction toggles (they don't apply to a user-entered effective number).
+    expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Power Stone/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -83,4 +83,21 @@ describe('UltimateCalculator', () => {
     expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Power Stone/i)).not.toBeInTheDocument();
   });
+
+  it('does not let the effective cost jump when switching to Custom under a reduction', () => {
+    renderCalc();
+    // Sorcerer has Power Stone (−15%) default-on, so the displayed effective cost
+    // is already reduced. Switching to Custom must SEED with that effective cost,
+    // not the unreduced base — the displayed cost must not change.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+
+    const costBefore = screen.getByText(/\d+ ult cost/i).textContent;
+
+    fireEvent.mouseDown(screen.getByLabelText(/^Ultimate$/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText(/Custom cost/i));
+
+    const costAfter = screen.getByText(/\d+ ult cost/i).textContent;
+    expect(costAfter).toBe(costBefore);
+  });
 });

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -47,8 +47,10 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
   const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
 
   const m = cal.measurement;
-  const delta =
-    m && modeledPerSecond > 0 ? (modeledPerSecond - m.perSecond) / modeledPerSecond : null;
+  // How far the MODEL is from the MEASURED log rate, as a fraction of the
+  // measured rate (the measured value is the reference — "the model is X% vs
+  // measured"). Guard measured-zero to avoid divide-by-zero / Infinity.
+  const delta = m && m.perSecond > 0 ? (modeledPerSecond - m.perSecond) / m.perSecond : null;
   const deltaPct = delta != null ? Math.round(delta * 100) : null;
 
   return (

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -130,6 +130,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     effectiveCost,
     baseCost,
     appliedReductions,
+    availableReductionEntries,
     availableSourceEntries,
     exceedsSanity,
     sanityMax,
@@ -527,7 +528,33 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 helperText="Banked at fight start"
               />
             </Stack>
-            {reductionFraction > 0 && (
+            {/* Cost-reduction toggles — only meaningful for a catalog ability; a
+                custom cost is taken as already-effective so reductions don't apply. */}
+            {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
+              <Stack spacing={0.5} sx={{ mt: 1.5 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Cost reductions
+                </Typography>
+                {availableReductionEntries.map((r) => (
+                  <FormControlLabel
+                    key={r.id}
+                    control={
+                      <Switch
+                        size="small"
+                        checked={calc.isEnabled(r.id, r.defaultEnabled)}
+                        onChange={(e) => calc.toggleSource(r.id, e.target.checked)}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2">
+                        {r.label} (−{Math.round(r.fraction * 100)}%)
+                      </Typography>
+                    }
+                  />
+                ))}
+              </Stack>
+            )}
+            {state.customUltimateCost == null && reductionFraction > 0 && (
               <Typography
                 variant="caption"
                 sx={{ color: 'text.secondary', display: 'block', mt: 1.5 }}

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -493,7 +493,11 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   label="Ultimate"
                   value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
                   onChange={(e) => {
-                    if (e.target.value === 'custom') calc.setCustomUltimateCost(baseCost);
+                    // Seed custom cost with the current EFFECTIVE cost (after any
+                    // reductions), since a custom cost is treated as already
+                    // effective — seeding with the unreduced base would make the
+                    // number jump the moment you switch to Custom.
+                    if (e.target.value === 'custom') calc.setCustomUltimateCost(effectiveCost);
                     else calc.setUltimateAbility(e.target.value);
                   }}
                 >

--- a/src/features/ultimate-simulator/presentation/useLogCalibration.ts
+++ b/src/features/ultimate-simulator/presentation/useLogCalibration.ts
@@ -81,6 +81,10 @@ export function useLogCalibration(): UseLogCalibration {
   const [phase, setPhase] = useState<Phase>('idle');
   const [error, setError] = useState<string | null>(null);
   const [reportCode, setReportCodeState] = useState('');
+  // The report code that was actually LOADED (fights/players/windows belong to
+  // it). Measurement must use this, never the live text field — otherwise editing
+  // the input after loading would query a new report with the old fight/player.
+  const [loadedReportCode, setLoadedReportCode] = useState<string | null>(null);
   const [fights, setFights] = useState<readonly LogFight[]>([]);
   const [players, setPlayers] = useState<readonly LogPlayer[]>([]);
   const [selectedFightId, setSelectedFightId] = useState<number | null>(null);
@@ -91,10 +95,26 @@ export function useLogCalibration(): UseLogCalibration {
     new Map(),
   );
 
-  const setReportCode = useCallback((code: string) => {
-    setReportCodeState(code);
-    setError(null);
-  }, []);
+  const setReportCode = useCallback(
+    (code: string) => {
+      setReportCodeState(code);
+      setError(null);
+      // If the entered code no longer matches what was loaded, the loaded
+      // fights/players/windows are stale — drop them so Measure can't run against
+      // a mismatched report. The user must re-load the new code first.
+      if (loadedReportCode != null && parseReportCode(code) !== loadedReportCode) {
+        setLoadedReportCode(null);
+        setFights([]);
+        setPlayers([]);
+        setFightWindows(new Map());
+        setSelectedFightId(null);
+        setSelectedPlayerId(null);
+        setMeasurement(null);
+        setPhase('idle');
+      }
+    },
+    [loadedReportCode],
+  );
 
   const loadReport = useCallback(async () => {
     if (!client || !isReady) {
@@ -177,6 +197,7 @@ export function useLogCalibration(): UseLogCalibration {
       setFightWindows(windows);
       setSelectedFightId(fightList[0].id);
       setSelectedPlayerId(playerList[0]?.id ?? null);
+      setLoadedReportCode(code);
       setPhase('reportLoaded');
     } catch (e) {
       setError(
@@ -200,6 +221,9 @@ export function useLogCalibration(): UseLogCalibration {
   const measure = useCallback(async () => {
     if (!client || !isReady) return;
     if (selectedFightId == null || selectedPlayerId == null) return;
+    // Always measure the LOADED report — never the live text field — so the
+    // fight window/player below refer to the same report being queried.
+    if (loadedReportCode == null) return;
     const window = fightWindows.get(selectedFightId);
     if (!window) return;
     const fight = fights.find((f) => f.id === selectedFightId);
@@ -208,7 +232,7 @@ export function useLogCalibration(): UseLogCalibration {
     setError(null);
     try {
       // Page through the fight's resource events for both hostility scopes.
-      const code = parseReportCode(reportCode);
+      const code = loadedReportCode;
       const all: ResourceChangeEvent[] = [];
       type EventsPage = {
         reportData?: {
@@ -265,13 +289,14 @@ export function useLogCalibration(): UseLogCalibration {
     fightWindows,
     fights,
     players,
-    reportCode,
+    loadedReportCode,
   ]);
 
   const clear = useCallback(() => {
     setPhase('idle');
     setError(null);
     setReportCodeState('');
+    setLoadedReportCode(null);
     setFights([]);
     setPlayers([]);
     setSelectedFightId(null);

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -177,9 +177,16 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     return ability?.baseCost ?? 250;
   }, [state.customUltimateCost, state.ultimateAbilityId]);
 
+  // A custom cost is the user's own EFFECTIVE number — applying class reductions
+  // on top would double-count, so reductions only apply to a catalog ability's
+  // base cost.
+  const isCustomCost = state.customUltimateCost != null;
   const effectiveCost = useMemo(
-    () => applyCostReduction(baseCost, appliedReductions),
-    [baseCost, appliedReductions],
+    () =>
+      isCustomCost
+        ? Math.max(0, Math.round(baseCost))
+        : applyCostReduction(baseCost, appliedReductions),
+    [isCustomCost, baseCost, appliedReductions],
   );
 
   const timeToUlt = useMemo<TimeToUltimateResult>(

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -79,6 +79,9 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     // if your build actually provides it. (Validated against a real trial log: a
     // baseline Arcanist measured ~3.4 ult/s, matching base income + Decisive.)
     defaultEnabled: false,
+    // Same named buff as the Cryptcanon source — Minor Heroism does not stack
+    // across providers, so enabling both must not double-count.
+    nonStackingGroup: 'minor-heroism',
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
@@ -149,6 +152,8 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     rollsDecisive: true,
     availableIn: ['soloPve', 'groupPve', 'pvp'],
     defaultEnabled: false,
+    // Grants the SAME Minor Heroism buff as the generic source — do not stack.
+    nonStackingGroup: 'minor-heroism',
     provenance: SRC_CRYPTCANON,
     confidence: 'high',
     description:

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -31,7 +31,6 @@ const SRC_IMPLACABLE = 'https://eso-skillbook.com/skill/implacable-outcome';
 const SRC_CORPSE = 'https://eso-skillbook.com/skill/corpse-consumption';
 const SRC_POWERSTONE = 'https://eso-skillbook.com/skill/power-stone';
 const SRC_RESTORING_SPIRIT = 'https://eso-skillbook.com/skill/restoring-spirit';
-const SRC_CRYPTCANON = 'https://en.uesp.net/wiki/Online:Cryptcanon_Vestments';
 const SRC_PILLAGERS = "https://en.uesp.net/wiki/Online:Pillager's_Profit";
 const SRC_MINOR_HEROISM_POTION = 'https://en.uesp.net/wiki/Online:Heroism';
 
@@ -79,9 +78,6 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     // if your build actually provides it. (Validated against a real trial log: a
     // baseline Arcanist measured ~3.4 ult/s, matching base income + Decisive.)
     defaultEnabled: false,
-    // Same named buff as the Cryptcanon source — Minor Heroism does not stack
-    // across providers, so enabling both must not double-count.
-    nonStackingGroup: 'minor-heroism',
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
@@ -140,25 +136,11 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
       'Necromancer Living Death passive: +10 ultimate when you consume a corpse, once every 16 seconds. Uptime depends on corpse availability.',
   },
 
-  // ---- Mythic ---------------------------------------------------------------
-  {
-    id: 'cryptcanon-vestments',
-    label: 'Cryptcanon Vestments (Minor Heroism)',
-    category: 'mythic',
-    kind: 'periodic',
-    amountPerInstance: 1,
-    instancesPerSecond: 1 / 1.5,
-    uptime: 0.98,
-    rollsDecisive: true,
-    availableIn: ['soloPve', 'groupPve', 'pvp'],
-    defaultEnabled: false,
-    // Grants the SAME Minor Heroism buff as the generic source — do not stack.
-    nonStackingGroup: 'minor-heroism',
-    provenance: SRC_CRYPTCANON,
-    confidence: 'high',
-    description:
-      'Mythic that grants Minor Heroism in combat. CAVEAT: while equipped you cannot cast your own ultimate — casting transfers your ult to group members. A support/battery item, not a self-ult enabler.',
-  },
+  // NOTE: Cryptcanon Vestments is intentionally NOT modeled as a self-cast
+  // source. It grants Minor Heroism but PREVENTS you from casting your own
+  // ultimate (casting transfers your ult to group members), so counting it in a
+  // "time to YOUR ultimate / casts per fight" calculation would be misleading.
+  // It belongs in a future group-battery view, not here.
 
   // ---- Group support (external) --------------------------------------------
   {

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -81,7 +81,7 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
-      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, Cryptcanon Vestments, certain sets, or scribing — enable it if your build provides it.',
+      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, certain sets, or scribing — enable it if your build provides it. (Cryptcanon Vestments also grants it but blocks casting your own ultimate, so it is not modeled here.)',
   },
   {
     id: 'major-heroism',

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -103,14 +103,6 @@ export interface CatalogSource extends UltimateSource {
   readonly roles?: readonly CombatRole[];
   /** Whether it's enabled by default for its context (typical raid build). */
   readonly defaultEnabled: boolean;
-  /**
-   * Key for a named buff that does NOT stack across providers (e.g. Minor
-   * Heroism from the generic potion/set source AND from Cryptcanon are the same
-   * buff). When more than one enabled source shares this key, only the strongest
-   * single contribution counts — they are not summed. Omit for sources that do
-   * stack independently (base income, class passives, external batteries).
-   */
-  readonly nonStackingGroup?: string;
   /** Source URL the value came from (research provenance — required, no guessing). */
   readonly provenance: string;
   /** Confidence in the encoded numbers. */

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -103,6 +103,14 @@ export interface CatalogSource extends UltimateSource {
   readonly roles?: readonly CombatRole[];
   /** Whether it's enabled by default for its context (typical raid build). */
   readonly defaultEnabled: boolean;
+  /**
+   * Key for a named buff that does NOT stack across providers (e.g. Minor
+   * Heroism from the generic potion/set source AND from Cryptcanon are the same
+   * buff). When more than one enabled source shares this key, only the strongest
+   * single contribution counts — they are not summed. Omit for sources that do
+   * stack independently (base income, class passives, external batteries).
+   */
+  readonly nonStackingGroup?: string;
   /** Source URL the value came from (research provenance — required, no guessing). */
   readonly provenance: string;
   /** Confidence in the encoded numbers. */


### PR DESCRIPTION
Follow-up correctness fixes for the Ultimate Calculator (shipped in #1229), found by Codex plain + adversarial review. All are in the calculator/engine; no UI restructuring.

## Engine / data
- **Banked ultimate.** `timeToUltimate` clamped `startingUltimate` to one cost, so a 125-cost ult with 500 banked returned `Infinity` time-to-cast (at 0 generation) and lost the excess toward casts. Now banks up to the 500 pool, counts it via `floor((start + generated) / cost)` (reduces exactly to the old formula at `start=0`), and returns **0s** when the bank already covers the cost.
- **Cryptcanon Vestments removed as a self-cast source.** It grants Minor Heroism but *prevents you from casting your own ultimate* (it transfers to the group), so counting it in a "time to **your** ultimate / casts per fight" calc produced a false headline. It belongs in a future group-battery view. (This also made a per-provider non-stacking mechanism unnecessary — the single `minor-heroism` catalog entry already models all providers as one buff — so that scaffolding was dropped.)
- **Custom cost no longer double-reduced.** A user-entered custom cost is taken as already-effective; class reductions (Sorc Power Stone −15%, Templar Restoring Spirit −5%) no longer apply on top of it.

## UI
- **Cost-reduction toggles.** Power Stone / Restoring Spirit are default-on for their class but previously had no opt-out, silently under-costing time-to-ult for users without the passive. Added per-reduction toggles mirroring the existing source-toggle UI (hidden in custom-cost mode, where reductions don't apply).
- **Calibration measures the loaded report, not the live text field.** Editing the report code after loading could make "Measure" query the new code with the *previous* report's fight window / player. Now tracks `loadedReportCode`; editing the input clears the stale loaded state so Measure can't run against a mismatched report.

## Calibration % label
- "model is X% vs measured" now divides by the **measured** rate (the reference), with a measured-zero guard — previously it divided by the modeled rate, contradicting its own label. (Now matches this feature's own validation claim: (3.65 − 3.37) / 3.37 = 8.3%.)

## Tests / gates
+7 tests (banked≥cost at rate 0, excess-bank cast count, pool cap, reduces-to-baseline; reduction toggle lowers cost; custom cost ignores reductions; Minor Heroism single-source). 73 ult-sim tests + tsc + ESLint + Prettier + no-ESO-Hub + provenance + production build all green.
