### PR TITLE
feat(calculator): all-class Ultimate Calculator tab + Full Mode Aurora restyle (re-land + Codex fixes)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const AppAuth = React.lazy(() =>
   import('./AppAuth').then((module) => ({ default: module.AppAuth })),
 );
 const Calculator = React.lazy(() =>
-  import('./components/Calculator').then((module) => ({ default: module.Calculator })),
+  import('./components/CalculatorPage').then((module) => ({ default: module.CalculatorPage })),
 );
 const TextEditor = React.lazy(() =>
   import('./components/TextEditor').then((module) => ({ default: module.TextEditor })),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import { AnalyticsListener } from './components/AnalyticsListener';
 import { BuildEditorSkeleton } from './components/BuildEditorSkeleton';
+import { CalculatorTabsSkeleton } from './components/CalculatorTabsSkeleton';
 import { CookieConsent } from './components/CookieConsent';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { HashRouteRedirect } from './components/HashRouteRedirect';
@@ -259,6 +260,10 @@ const CalculatorLoadingFallback: React.FC = () => {
     window.location.hash.replace('#', '').toLowerCase() === 'ultimate';
   return (
     <DelayedFallback>
+      {/* CalculatorPage always renders the Stats/Ultimate tab strip above the
+          calculator, so reserve its space here — otherwise it pops in and pushes
+          the content down when the page chunk resolves. */}
+      <CalculatorTabsSkeleton selected={isUltimate ? 'ultimate' : 'stats'} />
       {isUltimate ? (
         <Container maxWidth="lg" sx={{ py: 3 }}>
           <UltimateCalculatorSkeleton />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Container } from '@mui/material';
 import { SnackbarProvider } from 'notistack';
 import React, { Suspense, useEffect, useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -21,6 +21,7 @@ import { ScrollRestoration } from './components/ScrollRestoration';
 import { SiteBackground } from './components/shared';
 import { SmartCalculatorSkeleton } from './components/SmartCalculatorSkeleton';
 import { TextEditorSkeleton } from './components/TextEditorSkeleton';
+import { UltimateCalculatorSkeleton } from './components/UltimateCalculatorSkeleton';
 import { UpdateNotification } from './components/UpdateNotification';
 import { LoggerProvider, LogLevel } from './contexts/LoggerContext';
 import { DiscordOAuthRedirect } from './DiscordOAuthRedirect';
@@ -249,12 +250,25 @@ const ReportFightsLoadingFallback: React.FC = () => (
   </DelayedFallback>
 );
 
-// Calculator specific loading fallback
-const CalculatorLoadingFallback: React.FC = () => (
-  <DelayedFallback>
-    <SmartCalculatorSkeleton />
-  </DelayedFallback>
-);
+// Calculator specific loading fallback. The page defaults to the Stats tab, but a
+// `#ultimate` deep-link opens straight onto the Ultimate tab — match the skeleton
+// to the tab the page is about to render so the layout doesn't swap on mount.
+const CalculatorLoadingFallback: React.FC = () => {
+  const isUltimate =
+    typeof window !== 'undefined' &&
+    window.location.hash.replace('#', '').toLowerCase() === 'ultimate';
+  return (
+    <DelayedFallback>
+      {isUltimate ? (
+        <Container maxWidth="lg" sx={{ py: 3 }}>
+          <UltimateCalculatorSkeleton />
+        </Container>
+      ) : (
+        <SmartCalculatorSkeleton />
+      )}
+    </DelayedFallback>
+  );
+};
 
 // Roster Builder specific loading fallback
 const RosterBuilderLoadingFallback: React.FC = () => (

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1100,313 +1100,6 @@ const CalculatorCard = styled(Paper, {
   minHeight: 'auto',
 }));
 
-// JavaScript-based sticky positioning hook
-const useStickyFooter = (
-  liteMode: boolean,
-  theme: Theme,
-  isMobile: boolean,
-): {
-  footerRef: React.RefObject<HTMLDivElement | null>;
-  placeholderRef: React.RefObject<HTMLDivElement | null>;
-  placeholderHeight: string;
-  footerStyle: React.CSSProperties;
-  isSticky: boolean;
-} => {
-  const footerRef = useRef<HTMLDivElement>(null);
-  const placeholderRef = useRef<HTMLDivElement>(null);
-  const [isSticky, setIsSticky] = useState(false);
-  const [footerStyle, setFooterStyle] = useState<React.CSSProperties>({});
-  const [placeholderHeight, setPlaceholderHeight] = useState<string>('auto');
-
-  const rafRef = useRef<number | null>(null);
-  const cardRectSignatureRef = useRef<string>('');
-  const placeholderWidthRef = useRef<number>(0);
-
-  // Cache for measurements to avoid redundant DOM queries
-  const measurementCacheRef = useRef<{
-    cardRect: DOMRect | null;
-    footerRect: DOMRect | null;
-    placeholderRect: DOMRect | null;
-    viewportHeight: number;
-    timestamp: number;
-  }>({
-    cardRect: null,
-    footerRect: null,
-    placeholderRect: null,
-    viewportHeight: 0,
-    timestamp: 0,
-  });
-
-  // Throttle measurements to avoid excessive calculations
-  const lastMeasurementTimeRef = useRef<number>(0);
-  const MEASUREMENT_THROTTLE = 16; // ~60fps
-
-  const runMeasurement = useCallback(() => {
-    const now = performance.now();
-
-    // Throttle measurements to 60fps
-    if (now - lastMeasurementTimeRef.current < MEASUREMENT_THROTTLE) {
-      return;
-    }
-    lastMeasurementTimeRef.current = now;
-
-    const footerEl = footerRef.current;
-    const placeholderEl = placeholderRef.current;
-
-    if (!footerEl) {
-      return;
-    }
-
-    const calculatorCard = footerEl.closest('[data-calculator-card]') as HTMLElement | null;
-    if (!calculatorCard) {
-      return;
-    }
-
-    // Use cached measurements if available and recent
-    const cache = measurementCacheRef.current;
-    const viewportHeight = window.innerHeight;
-
-    let cardRect = cache.cardRect;
-    let footerRect = cache.footerRect;
-    let placeholderRect = cache.placeholderRect;
-
-    // Only recalculate if viewport changed or cache is stale
-    if (cache.viewportHeight !== viewportHeight || now - cache.timestamp > 50) {
-      cardRect = calculatorCard.getBoundingClientRect();
-      footerRect = footerEl.getBoundingClientRect();
-      placeholderRect = placeholderEl?.getBoundingClientRect() || null;
-
-      measurementCacheRef.current = {
-        cardRect,
-        footerRect,
-        placeholderRect,
-        viewportHeight,
-        timestamp: now,
-      };
-    }
-
-    // Add null checks for safety
-    if (!cardRect || !footerRect) {
-      return;
-    }
-
-    const cardBottomThreshold = viewportHeight - 8;
-    const shouldStick = cardRect.bottom >= cardBottomThreshold && cardRect.top < viewportHeight;
-
-    if (!shouldStick) {
-      if (isSticky) {
-        setIsSticky(false);
-        setFooterStyle({});
-        setPlaceholderHeight('auto');
-      }
-      return;
-    }
-
-    const cardStyles = window.getComputedStyle(calculatorCard);
-    const paddingLeft = parseFloat(cardStyles.paddingLeft) || 0;
-    const paddingRight = parseFloat(cardStyles.paddingRight) || 0;
-
-    const width = placeholderRect
-      ? placeholderRect.width
-      : Math.max(0, cardRect.width - paddingLeft - paddingRight);
-    const left = placeholderRect ? placeholderRect.left : cardRect.left + paddingLeft;
-
-    const baseBottom = 16;
-    // Add space for feedback button on mobile (16px for button + 8px spacing = 24px)
-    const mobileFeedbackOffset = isMobile ? 24 : 0;
-    const adjustedBaseBottom = baseBottom + mobileFeedbackOffset;
-    const maxBottom = Math.max(
-      adjustedBaseBottom,
-      viewportHeight - cardRect.top - footerRect.height,
-    );
-    const minBottom = Math.max(0, viewportHeight - cardRect.bottom);
-    const desiredBottom = minBottom > 0 ? minBottom : adjustedBaseBottom;
-    const clampedBottom = Math.min(desiredBottom, maxBottom);
-
-    // Batch all state updates together
-    const footerHeight = `${Math.round(footerRect.height)}px`;
-    const newSignature = `${Math.round(cardRect.left)}|${Math.round(cardRect.width)}|${Math.round(cardRect.top)}`;
-    const widthChanged = Math.round(placeholderWidthRef.current) !== Math.round(width);
-    const styleChanged = cardRectSignatureRef.current !== newSignature || widthChanged || !isSticky;
-
-    // Only update state if something actually changed
-    if (styleChanged || placeholderHeight !== footerHeight) {
-      const nextStyle: React.CSSProperties = {
-        position: 'fixed',
-        left: `${Math.round(left)}px`,
-        width: `${Math.round(width)}px`,
-        bottom: `${Math.round(clampedBottom)}px`,
-        zIndex: isMobile ? 1001 : 11, // Ensure footer is above feedback button on mobile
-        boxSizing: 'border-box',
-        // Preserve background styling - prevent transparency in full mode
-        background: liteMode
-          ? 'transparent'
-          : theme.palette.mode === 'dark'
-            ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(3, 7, 18, 0.98) 100%)'
-            : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 250, 252, 0.9) 100%)',
-        borderRadius: liteMode ? '0' : '12px',
-        boxShadow: liteMode
-          ? 'none'
-          : theme.palette.mode === 'dark'
-            ? '0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
-            : '0 8px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.8)',
-      };
-
-      // Batch state updates
-      requestAnimationFrame(() => {
-        if (placeholderHeight !== footerHeight) {
-          setPlaceholderHeight(footerHeight);
-        }
-
-        if (styleChanged) {
-          cardRectSignatureRef.current = newSignature;
-          placeholderWidthRef.current = width;
-          setFooterStyle(nextStyle);
-          if (!isSticky) {
-            setIsSticky(true);
-          }
-        }
-      });
-    }
-  }, [isSticky, placeholderHeight, liteMode, theme.palette.mode, isMobile]);
-
-  // Debounced measurement scheduler
-  const scheduleMeasurement = useCallback(() => {
-    if (rafRef.current !== null) {
-      return;
-    }
-    rafRef.current = window.requestAnimationFrame(() => {
-      rafRef.current = null;
-      runMeasurement();
-    });
-  }, [runMeasurement]);
-
-  // Throttled scroll handler
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const lastScrollTimeRef = useRef<number>(0);
-  const SCROLL_THROTTLE = 16; // ~60fps
-
-  const handleScroll = useCallback(() => {
-    const now = performance.now();
-
-    // Throttle scroll events
-    if (now - lastScrollTimeRef.current < SCROLL_THROTTLE) {
-      return;
-    }
-    lastScrollTimeRef.current = now;
-
-    // Clear any pending timeout
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
-
-    // Debounce the actual measurement
-    scrollTimeoutRef.current = setTimeout(() => {
-      scheduleMeasurement();
-    }, 32); // ~30fps for smooth scrolling
-  }, [scheduleMeasurement]);
-
-  // Throttled resize handler
-  const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const lastResizeTimeRef = useRef<number>(0);
-  const RESIZE_THROTTLE = 100; // Slower for resize events
-
-  const handleResize = useCallback(() => {
-    const now = performance.now();
-
-    // Throttle resize events more aggressively
-    if (now - lastResizeTimeRef.current < RESIZE_THROTTLE) {
-      return;
-    }
-    lastResizeTimeRef.current = now;
-
-    // Clear any pending timeout
-    if (resizeTimeoutRef.current) {
-      clearTimeout(resizeTimeoutRef.current);
-    }
-
-    // Invalidate cache on resize to force recalculation
-    measurementCacheRef.current.timestamp = 0;
-
-    // Debounce the actual measurement
-    resizeTimeoutRef.current = setTimeout(() => {
-      scheduleMeasurement();
-    }, 150);
-  }, [scheduleMeasurement]);
-
-  useEffect(() => {
-    // Initial measurement
-    runMeasurement();
-
-    // Add event listeners with passive option for better performance
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    window.addEventListener('resize', handleResize, { passive: true });
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('resize', handleResize);
-
-      // Cleanup timeouts
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-
-      // Cleanup RAF
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [runMeasurement, handleScroll, handleResize, scheduleMeasurement]);
-
-  // Optimized ResizeObserver with debouncing
-  useEffect(() => {
-    if (typeof ResizeObserver === 'undefined') {
-      return;
-    }
-
-    let resizeTimeout: NodeJS.Timeout | null = null;
-
-    const observer = new ResizeObserver(() => {
-      // Invalidate cache on resize to force recalculation
-      measurementCacheRef.current.timestamp = 0;
-
-      // Debounce resize observer callbacks
-      if (resizeTimeout) {
-        clearTimeout(resizeTimeout);
-      }
-
-      resizeTimeout = setTimeout(() => {
-        scheduleMeasurement();
-      }, 100); // Debounce resize observer events
-    });
-
-    // Only observe elements that actually exist
-    if (footerRef.current) {
-      observer.observe(footerRef.current);
-    }
-
-    const calculatorCard = footerRef.current?.closest(
-      '[data-calculator-card]',
-    ) as HTMLElement | null;
-    if (calculatorCard) {
-      observer.observe(calculatorCard);
-    }
-
-    return () => {
-      observer.disconnect();
-      if (resizeTimeout) {
-        clearTimeout(resizeTimeout);
-      }
-    };
-  }, [scheduleMeasurement]);
-
-  return { footerRef, placeholderRef, footerStyle, placeholderHeight, isSticky };
-};
-
 const _TotalSection = styled(Box)<{ isLiteMode: boolean }>(
   ({ theme: _theme, isLiteMode: _isLiteMode }) => ({
     position: 'relative',
@@ -2066,14 +1759,8 @@ const CalculatorComponent: React.FC = () => {
     [armorResistanceData.cp],
   );
 
-  // JavaScript-based sticky footer
-  const {
-    footerRef,
-    placeholderRef,
-    placeholderHeight,
-    footerStyle,
-    isSticky: _isSticky,
-  } = useStickyFooter(liteMode, theme, isMobile);
+  // Results summary sticks to the viewport bottom via native CSS position:sticky
+  // (see the footer JSX below) — no JS scroll measurement.
 
   // Calculate total values
   const calculateItemValue = useCallback((item: CalculatorItem): number => {
@@ -5994,29 +5681,45 @@ const CalculatorComponent: React.FC = () => {
               </TabPanel>
             </Box>
 
-            {/* Footer positioned outside TabPanels but inside CalculatorCard */}
-            <Box ref={placeholderRef} sx={{ minHeight: placeholderHeight }}>
+            {/* Results summary — native CSS sticky. Floats just above the
+                viewport bottom while the (long) item list scrolls behind it,
+                then rests at the end of the card. The outer box positions; the
+                inner box is the glass surface. Replaces the old JS hook. */}
+            <Box
+              sx={{
+                position: 'sticky',
+                // Lift above the mobile feedback FAB; small gap on desktop.
+                bottom: { xs: '40px', sm: '16px' },
+                zIndex: { xs: 1001, sm: 11 },
+                mt: '20px',
+                // Let pointer events fall through the transparent margin so the
+                // list underneath the rounded corners stays interactive.
+                pointerEvents: 'none',
+              }}
+            >
               <Box
-                ref={footerRef}
                 sx={{
-                  px: 0, // Remove horizontal padding
-                  pb: 0, // Remove bottom padding
-                  position: 'relative',
-                  zIndex: 5,
-                  backgroundColor: liteMode
+                  pointerEvents: 'auto',
+                  borderRadius: liteMode ? 0 : '14px',
+                  // Near-opaque so the list scrolling behind stays hidden.
+                  background: liteMode
                     ? 'transparent'
                     : theme.palette.mode === 'dark'
-                      ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(3, 7, 18, 0.98) 100%)'
-                      : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 250, 252, 0.9) 100%)',
-                  borderRadius: liteMode ? '0' : '12px',
+                      ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.96) 0%, rgba(3, 7, 18, 0.97) 100%)'
+                      : 'linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.94) 100%)',
+                  border: liteMode
+                    ? 'none'
+                    : `1px solid ${
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56, 189, 248, 0.18)'
+                          : 'rgba(15, 23, 42, 0.08)'
+                      }`,
                   boxShadow: liteMode
                     ? 'none'
                     : theme.palette.mode === 'dark'
-                      ? '0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
-                      : '0 8px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.8)',
-                  marginTop: '20px',
+                      ? 'inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 36px rgba(0, 0, 0, 0.4)'
+                      : 'inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 12px 36px rgba(15, 23, 42, 0.12)',
                 }}
-                style={footerStyle}
               >
                 {selectedTab === 0 &&
                   renderSummaryFooter({

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1055,6 +1055,78 @@ const QuantityInput: React.FC<{
 type GameMode = 'pve' | 'pvp' | 'both';
 type SummaryStatus = 'at-cap' | 'over-cap' | 'under-cap';
 
+// ---------------------------------------------------------------------------
+// Full Mode palette ("Aurora")
+// ---------------------------------------------------------------------------
+// Full Mode's colors are centralized here. Lite mode is intentionally NOT
+// affected — only the `!liteMode` style surfaces read from these tokens.
+interface FullModeThemeTokens {
+  cardBg: string;
+  rowEnabledBg: string;
+  rowEnabledBorder: string;
+  rowDisabledBg: string;
+  rowDisabledBorder: string;
+  rowHoverBorder: string;
+  rowHoverShadow: string;
+  accent: string;
+  valueColor: string;
+  sectionBg: string;
+  sectionBorder: string;
+  footerBg: string;
+  // Tab/action header strip — a tinted bar that blends with the card, not a slate slab.
+  chromeBg: string;
+}
+
+const FULL_MODE_TOKENS: { light: FullModeThemeTokens; dark: FullModeThemeTokens } = {
+  light: {
+    cardBg:
+      'linear-gradient(135deg, rgb(110 170 240 / 22%) 0%, rgb(152 131 227 / 14%) 50%, rgb(173 192 255 / 7%) 100%)',
+    rowEnabledBg: 'linear-gradient(135deg, rgb(128 211 255 / 20%) 0%, rgb(56 189 248 / 15%) 100%)',
+    rowEnabledBorder: '1px solid rgb(105 162 255 / 45%)',
+    rowDisabledBg: 'rgb(255 255 255 / 55%)',
+    rowDisabledBorder: '1px solid transparent',
+    rowHoverBorder: '1px solid rgb(78 38 177 / 38%)',
+    rowHoverShadow: '0 6px 16px rgb(110 170 240 / 28%)',
+    accent: '#4e26b1',
+    valueColor: 'rgb(18 103 155)',
+    // Keep the Aurora card visible THROUGH the section — light translucent tint +
+    // clear border + soft shadow give edge definition without an opaque slab.
+    sectionBg: 'linear-gradient(180deg, rgba(173,192,255,0.18) 0%, rgba(152,131,227,0.11) 100%)',
+    sectionBorder: '1px solid rgba(120,140,210,0.45)',
+    // Near-opaque so the running totals stay readable over scrolling content.
+    footerBg: 'linear-gradient(135deg, rgba(224,231,250,0.97) 0%, rgba(244,247,253,0.97) 100%)',
+    // Aurora-tinted chrome bars (controls / tabs / actions): a different color that
+    // still blends — like lite mode. Stronger periwinkle in light so the bars read
+    // as distinct surfaces against the pale card instead of washing out.
+    chromeBg: 'linear-gradient(135deg, rgba(168,191,246,0.92) 0%, rgba(198,213,247,0.86) 100%)',
+  },
+  dark: {
+    // Richer, sustained blue→violet→blue glow so the aurora clearly reads as a
+    // colored surface floating on #1258's dark cosmic background — and carries the
+    // whole way down the tall Full-mode card (no 135deg fade-out into the list).
+    cardBg:
+      'linear-gradient(160deg, rgb(86 140 240 / 42%) 0%, rgb(140 110 228 / 34%) 50%, rgb(72 150 215 / 26%) 100%)',
+    rowEnabledBg: 'linear-gradient(135deg, rgba(56,189,248,0.4) 0%, rgba(0,225,255,0.3) 100%)',
+    rowEnabledBorder: '1px solid rgba(56,189,248,0.65)',
+    rowDisabledBg: 'rgb(0 0 0 / 28%)',
+    rowDisabledBorder: '1px solid transparent',
+    rowHoverBorder: '1px solid rgba(159,135,219,0.55)',
+    rowHoverShadow: '0 6px 16px rgba(56,189,248,0.32)',
+    accent: 'rgb(159 135 219)',
+    // Near-white (with a cool cyan textShadow) so value text clears WCAG AA over the
+    // vivid enabled-row gradient now that the card glow is brighter.
+    valueColor: 'rgb(236 246 255)',
+    // Translucent Aurora-hued frost so the blue→purple card glow still reads
+    // through the panel; the border + shadow supply the section definition.
+    sectionBg: 'linear-gradient(180deg, rgba(130,160,235,0.16) 0%, rgba(150,130,225,0.11) 100%)',
+    sectionBorder: '1px solid rgba(150,170,235,0.5)',
+    footerBg: 'linear-gradient(135deg, rgba(30,41,80,0.92) 0%, rgba(3,7,18,0.96) 100%)',
+    // Aurora-tinted chrome bars (controls / tabs / actions): a different color that
+    // still blends with the card glow — like lite mode, not the opaque slate slab.
+    chromeBg: 'linear-gradient(135deg, rgba(120,160,240,0.22) 0%, rgba(150,130,225,0.15) 100%)',
+  },
+};
+
 // Styled components
 const CalculatorContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'liteMode',
@@ -1079,8 +1151,8 @@ const CalculatorContainer = styled(Box, {
 }));
 
 const CalculatorCard = styled(Paper, {
-  shouldForwardProp: (prop) => prop !== 'liteMode',
-})<{ liteMode?: boolean }>(({ theme, liteMode }) => ({
+  shouldForwardProp: (prop) => prop !== 'liteMode' && prop !== 'fullCardBg',
+})<{ liteMode?: boolean; fullCardBg?: string }>(({ theme, liteMode, fullCardBg }) => ({
   width: '100%',
   maxWidth: liteMode ? '100%' : '1200px',
   margin: '0 auto',
@@ -1093,9 +1165,10 @@ const CalculatorCard = styled(Paper, {
   },
   background: liteMode
     ? 'linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%)'
-    : theme.palette.mode === 'dark'
-      ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
-      : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
+    : (fullCardBg ??
+      (theme.palette.mode === 'dark'
+        ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+        : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)')),
   borderRadius: liteMode ? 22 : 22,
   minHeight: 'auto',
 }));
@@ -1539,6 +1612,8 @@ const CalculatorComponent: React.FC = () => {
     [logger],
   );
   const [liteMode, setLiteMode] = useState(isMobile);
+  // Full Mode color palette (Lite mode keeps its own bespoke styling).
+  const fullTokens = theme.palette.mode === 'dark' ? FULL_MODE_TOKENS.dark : FULL_MODE_TOKENS.light;
   const [gameMode, setGameMode] = useState<GameMode>('both');
   const [variantModalOpen, setVariantModalOpen] = useState(false);
   const [currentEditingIndex, setCurrentEditingIndex] = useState<number | null>(null);
@@ -2578,38 +2653,29 @@ const CalculatorComponent: React.FC = () => {
             ? '1px solid transparent'
             : '1px solid rgba(214, 168, 255, 0.2)';
       } else {
-        // Default background for other items
+        // Default background for other items.
+        // Lite mode keeps its bespoke palette; full mode reads the active variant tokens.
         background = item.enabled
           ? liteMode
             ? theme.palette.mode === 'dark'
               ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.4) 0%, rgba(0, 225, 255, 0.3) 100%)'
               : 'linear-gradient(135deg, rgb(128 211 255 / 20%) 0%, rgb(56 189 248 / 15%) 100%)'
-            : theme.palette.mode === 'dark'
-              ? 'linear-gradient(135deg, rgba(56, 189, 248, 0.4) 0%, rgba(0, 225, 255, 0.3) 100%)'
-              : 'linear-gradient(135deg, rgb(128 211 255 / 20%) 0%, rgb(56 189 248 / 15%) 100%)'
+            : fullTokens.rowEnabledBg
           : liteMode
             ? theme.palette.mode === 'dark'
               ? 'rgb(0 0 0 / 28%)'
               : 'rgb(255 255 255 / 41%)'
-            : theme.palette.mode === 'dark'
-              ? 'rgba(15, 23, 42, 0.6)'
-              : 'rgba(241, 245, 249, 0.8)';
+            : fullTokens.rowDisabledBg;
 
         border = item.enabled
           ? liteMode
             ? theme.palette.mode === 'dark'
               ? '1px solid rgba(56, 189, 248, 0.6) !important'
               : '1px solid rgb(105 162 255 / 40%) !important'
-            : theme.palette.mode === 'dark'
-              ? '1px solid rgba(56, 189, 248, 0.8)'
-              : liteMode
-                ? '1px solid rgb(40 145 200 / 35%)'
-                : '1px solid rgb(40 145 200 / 35%)'
+            : fullTokens.rowEnabledBorder
           : liteMode
             ? '1px solid transparent'
-            : theme.palette.mode === 'dark'
-              ? '1px solid rgba(255, 255, 255, 0.12)'
-              : '1px solid rgba(203, 213, 225, 0.3)';
+            : fullTokens.rowDisabledBorder;
       }
 
       return {
@@ -2630,15 +2696,12 @@ const CalculatorComponent: React.FC = () => {
         '&:hover': !item.locked
           ? {
               transform: liteMode ? 'none' : 'translateY(-1px)',
-              border:
-                theme.palette.mode === 'dark'
+              border: liteMode
+                ? theme.palette.mode === 'dark'
                   ? '1px solid rgba(56, 189, 248, 0.2)'
-                  : '1px solid rgb(40 145 200 / 30%)',
-              boxShadow: liteMode
-                ? 'none'
-                : theme.palette.mode === 'dark'
-                  ? '0 4px 12px rgba(56, 189, 248, 0.3)'
-                  : '0 4px 12px rgb(40 145 200 / 25%)',
+                  : '1px solid rgb(40 145 200 / 30%)'
+                : fullTokens.rowHoverBorder,
+              boxShadow: liteMode ? 'none' : fullTokens.rowHoverShadow,
               '& .MuiCheckbox-root': {
                 backgroundColor: liteMode
                   ? theme.palette.mode === 'dark'
@@ -2652,7 +2715,7 @@ const CalculatorComponent: React.FC = () => {
           : {},
       };
     },
-    [theme.palette.mode, liteMode, isMobile],
+    [theme.palette.mode, liteMode, isMobile, fullTokens],
   );
 
   // Render item component - optimized to reduce re-renders
@@ -2736,7 +2799,7 @@ const CalculatorComponent: React.FC = () => {
         minWidth: liteMode ? '32px' : isExtraSmall ? '48px' : isMobile ? '44px' : '32px',
         minHeight: liteMode ? '32px' : isExtraSmall ? '48px' : isMobile ? '44px' : '32px',
         '&.Mui-checked': {
-          color: liteMode ? '#4e26b1' : 'rgb(159 135 219)',
+          color: liteMode ? '#4e26b1' : fullTokens.accent,
         },
         // Enhanced touch feedback
         '&:hover': {
@@ -2818,7 +2881,11 @@ const CalculatorComponent: React.FC = () => {
       };
 
       const valueStyles = {
-        color: theme.palette.mode === 'dark' ? 'rgb(199 234 255)' : 'rgb(40 145 200)',
+        color: liteMode
+          ? theme.palette.mode === 'dark'
+            ? 'rgb(199 234 255)'
+            : 'rgb(40 145 200)'
+          : fullTokens.valueColor,
         fontWeight: 700,
         fontFamily: 'monospace',
         textShadow: theme.palette.mode === 'dark' ? '0 0 10px rgba(199 234 255,0.25)' : 'none',
@@ -3267,6 +3334,7 @@ const CalculatorComponent: React.FC = () => {
       cycleArmorResistanceVariant,
       updateArmorResistanceQuality,
       armorResistanceData.gear,
+      fullTokens,
     ],
   );
 
@@ -3293,6 +3361,16 @@ const CalculatorComponent: React.FC = () => {
         disableGutters
         sx={{
           mb: 2,
+          // Distinct panel surface so sections read as floating cards instead of
+          // blending into the calculator background. The `background` shorthand also
+          // clears MUI's dark elevation overlay (a background-image), so a gradient
+          // sectionBg renders correctly.
+          background: fullTokens.sectionBg,
+          border: fullTokens.sectionBorder,
+          boxShadow:
+            theme.palette.mode === 'dark'
+              ? '0 6px 20px rgba(0, 0, 0, 0.28)'
+              : '0 6px 18px rgba(40, 80, 160, 0.10)',
           '&.Mui-expanded': {
             mb: 2,
           },
@@ -3964,7 +4042,11 @@ const CalculatorComponent: React.FC = () => {
           }}
         >
           {/* Main Calculator */}
-          <CalculatorCard liteMode={liteMode} data-calculator-card="true">
+          <CalculatorCard
+            liteMode={liteMode}
+            fullCardBg={liteMode ? undefined : fullTokens.cardBg}
+            data-calculator-card="true"
+          >
             {/* Controls */}
             <Box
               sx={{
@@ -3986,9 +4068,7 @@ const CalculatorComponent: React.FC = () => {
                   ? theme.palette.mode === 'dark'
                     ? 'linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%)'
                     : 'rgba(255, 255, 255, 0.65)'
-                  : theme.palette.mode === 'dark'
-                    ? 'rgba(15, 23, 42, 0.9)'
-                    : 'rgba(255, 255, 255, 0.98)',
+                  : fullTokens.chromeBg,
                 position: 'relative',
                 // Enhanced mobile responsiveness
                 // Better mobile layout with stacked controls
@@ -4481,13 +4561,7 @@ const CalculatorComponent: React.FC = () => {
                     theme.palette.mode === 'dark'
                       ? 'rgb(128 211 255 / 18%)'
                       : 'rgb(40 145 200 / 15%)',
-                  background: liteMode
-                    ? theme.palette.mode === 'dark'
-                      ? 'rgba(15, 23, 42, 0.0)'
-                      : 'rgba(255, 255, 255, 0.0)'
-                    : theme.palette.mode === 'dark'
-                      ? 'rgba(15, 23, 42, 0.7)'
-                      : 'rgba(255, 255, 255, 0.95)',
+                  background: liteMode ? 'transparent' : fullTokens.chromeBg,
 
                   position: 'relative',
                   borderRadius: liteMode ? '8px 8px 0 0' : '8px 8px 0 0',
@@ -4676,13 +4750,9 @@ const CalculatorComponent: React.FC = () => {
                     p: 2,
                     alignItems: 'center',
                     borderRadius: '10px',
-                    backgroundColor: liteMode
-                      ? theme.palette.mode === 'dark'
-                        ? 'rgba(15, 23, 42, 0.0)'
-                        : 'rgba(255, 255, 255, 0.0)'
-                      : theme.palette.mode === 'dark'
-                        ? 'rgba(15, 23, 42, 0.3)'
-                        : 'rgba(255, 255, 255, 0.5)',
+                    // Transparent: this panel sits inside the tab-bar wrapper, which already
+                    // paints chromeBg — re-painting it here would double-stack the tint.
+                    backgroundColor: 'transparent',
                     borderColor:
                       theme.palette.mode === 'dark'
                         ? 'rgb(128 211 255 / 15%)'
@@ -5702,11 +5772,7 @@ const CalculatorComponent: React.FC = () => {
                   pointerEvents: 'auto',
                   borderRadius: liteMode ? 0 : '14px',
                   // Near-opaque so the list scrolling behind stays hidden.
-                  background: liteMode
-                    ? 'transparent'
-                    : theme.palette.mode === 'dark'
-                      ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.96) 0%, rgba(3, 7, 18, 0.97) 100%)'
-                      : 'linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.94) 100%)',
+                  background: liteMode ? 'transparent' : fullTokens.footerBg,
                   border: liteMode
                     ? 'none'
                     : `1px solid ${

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1058,9 +1058,13 @@ type SummaryStatus = 'at-cap' | 'over-cap' | 'under-cap';
 // Styled components
 const CalculatorContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'liteMode',
-})<{ liteMode?: boolean }>(({ theme, liteMode: _liteMode }) => ({
+})<{ liteMode?: boolean }>(({ liteMode: _liteMode }) => ({
   // minHeight: '100vh', // Removed - interferes with sticky positioning
-  background: theme.palette.mode === 'dark' ? theme.palette.background.default : 'transparent',
+  // Transparent in both themes so the global cosmic SiteBackground shows through
+  // and the rounded CalculatorCard floats on it — matching the Ultimate tab.
+  // (Dark mode previously painted an opaque background.default slab slightly
+  // wider than the card, leaving a flat, square-cornered band around it.)
+  background: 'transparent',
   position: 'static', // Changed from relative
   width: '100%',
   maxWidth: '100vw',

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -1,0 +1,87 @@
+/**
+ * /calculator host page — a top-level tab switcher between the existing stat
+ * calculator (Penetration / Critical / Armor) and the new Ultimate Calculator.
+ *
+ * The Stats tab renders the original `Calculator` unchanged, so its sticky
+ * footer and internal pen/crit/armor tabs keep working exactly as before — this
+ * wrapper only adds the outer tab and never touches the stat calculator's markup.
+ */
+
+import { BoltOutlined, TuneOutlined } from '@mui/icons-material';
+import { Box, Container, Tab, Tabs } from '@mui/material';
+import React, { Suspense, useState } from 'react';
+
+import { Calculator } from './Calculator';
+import { SmartCalculatorSkeleton } from './SmartCalculatorSkeleton';
+
+const UltimateCalculator = React.lazy(() =>
+  import('@features/ultimate-simulator/presentation/components/UltimateCalculator').then((m) => ({
+    default: m.UltimateCalculator,
+  })),
+);
+
+type TopTab = 'stats' | 'ultimate';
+
+const VALID_TABS: readonly TopTab[] = ['stats', 'ultimate'];
+
+/** Read the initial tab from the URL hash (#ultimate) for shareable deep-links. */
+function initialTab(): TopTab {
+  if (typeof window === 'undefined') return 'stats';
+  const hash = window.location.hash.replace('#', '').toLowerCase();
+  return (VALID_TABS as readonly string[]).includes(hash) ? (hash as TopTab) : 'stats';
+}
+
+export const CalculatorPage: React.FC = () => {
+  const [tab, setTab] = useState<TopTab>(initialTab);
+
+  const handleChange = (_: React.SyntheticEvent, next: TopTab): void => {
+    setTab(next);
+    if (typeof window !== 'undefined') {
+      window.history.replaceState(null, '', next === 'stats' ? ' ' : `#${next}`);
+    }
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Container maxWidth="lg" sx={{ pt: { xs: 1.5, sm: 2.5 } }}>
+        <Tabs
+          value={tab}
+          onChange={handleChange}
+          aria-label="Calculator type"
+          variant="standard"
+          sx={{
+            minHeight: 44,
+            '& .MuiTab-root': { textTransform: 'none', fontWeight: 600, minHeight: 44 },
+          }}
+        >
+          <Tab
+            value="stats"
+            icon={<TuneOutlined fontSize="small" />}
+            iconPosition="start"
+            label="Stats (Pen / Crit / Armor)"
+          />
+          <Tab
+            value="ultimate"
+            icon={<BoltOutlined fontSize="small" />}
+            iconPosition="start"
+            label="Ultimate"
+          />
+        </Tabs>
+      </Container>
+
+      {/* Keep the stat calculator mounted (display:none) so switching back is
+          instant and its sticky-footer measurements aren't torn down. */}
+      <Box sx={{ display: tab === 'stats' ? 'block' : 'none' }}>
+        <Calculator />
+      </Box>
+
+      {tab === 'ultimate' && (
+        <Container maxWidth="lg" sx={{ py: 3 }}>
+          <Suspense fallback={<SmartCalculatorSkeleton />}>
+            <UltimateCalculator />
+          </Suspense>
+        </Container>
+      )}
+    </Box>
+  );
+};

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -49,10 +49,49 @@ export const CalculatorPage: React.FC = () => {
           onChange={handleChange}
           aria-label="Calculator type"
           variant="standard"
-          sx={{
-            minHeight: 44,
-            '& .MuiTab-root': { textTransform: 'none', fontWeight: 600, minHeight: 44 },
-          }}
+          sx={(theme) => ({
+            minHeight: 46,
+            display: 'inline-flex',
+            p: 0.5,
+            borderRadius: 3,
+            border: `1px solid ${theme.palette.divider}`,
+            background:
+              theme.palette.mode === 'dark'
+                ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+                : 'rgba(255,255,255,0.6)',
+            // Hide the default underline indicator — selection is shown by the
+            // filled pill behind the active tab instead.
+            '& .MuiTabs-indicator': { display: 'none' },
+            '& .MuiTabs-flexContainer': { gap: 0.5 },
+            '& .MuiTab-root': {
+              textTransform: 'none',
+              fontWeight: 600,
+              minHeight: 38,
+              borderRadius: 2.25,
+              px: { xs: 1.5, sm: 2 },
+              color: theme.palette.text.secondary,
+              transition: 'background-color 0.18s ease, color 0.18s ease',
+              '&:hover': {
+                color: theme.palette.text.primary,
+                backgroundColor:
+                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.06)' : 'rgba(15,23,42,0.04)',
+              },
+            },
+            '& .Mui-selected': {
+              color:
+                theme.palette.mode === 'dark'
+                  ? `${theme.palette.primary.main} !important`
+                  : '#ffffff !important',
+              background:
+                theme.palette.mode === 'dark'
+                  ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                  : 'linear-gradient(135deg, #0f172a, #1e293b)',
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0 0 18px rgba(56,189,248,0.15), inset 0 0 0 1px rgba(56,189,248,0.35)'
+                  : '0 4px 12px rgba(15,23,42,0.18)',
+            },
+          })}
         >
           <Tab
             value="stats"

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { BoltOutlined, TuneOutlined } from '@mui/icons-material';
-import { Box, Container, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Container, Tab, Tabs } from '@mui/material';
 import React, { Suspense, useState } from 'react';
 
 import { Calculator } from './Calculator';
@@ -43,94 +43,77 @@ export const CalculatorPage: React.FC = () => {
 
   return (
     <Box sx={{ width: '100%' }}>
-      {/* Top-level page navigation. Rendered as a full-width underline tab bar
-          (not a pill group) so it reads as primary, app-level navigation and is
-          visually distinct from the secondary segmented pill controls (PvE/PvP,
-          Pen/Crit/Armor, Solo/Group/PvP) that live inside each panel — fixing
-          the "tabs inside tabs" / double-pill confusion. */}
       <Container maxWidth="lg" sx={{ pt: { xs: 1.5, sm: 2.5 } }}>
-        <Box
-          component="nav"
-          aria-label="Calculator sections"
+        <Tabs
+          value={tab}
+          onChange={handleChange}
+          aria-label="Calculator type"
+          variant="standard"
           sx={(theme) => ({
-            borderBottom: `1px solid ${theme.palette.divider}`,
-          })}
-        >
-          <Typography
-            component="span"
-            sx={(theme) => ({
-              display: 'block',
-              mb: 1,
-              fontSize: '0.6875rem',
-              fontWeight: 700,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
+            minHeight: 46,
+            display: 'inline-flex',
+            p: 0.5,
+            borderRadius: 3,
+            border: `1px solid ${theme.palette.divider}`,
+            background:
+              theme.palette.mode === 'dark'
+                ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+                : 'rgba(255,255,255,0.6)',
+            // Hide the default underline indicator — selection is shown by the
+            // filled pill behind the active tab instead.
+            '& .MuiTabs-indicator': { display: 'none' },
+            '& .MuiTabs-flexContainer': { gap: 0.5 },
+            '& .MuiTab-root': {
+              textTransform: 'none',
+              fontWeight: 600,
+              minHeight: 38,
+              borderRadius: 2.25,
+              px: { xs: 1.5, sm: 2 },
+              color: theme.palette.text.secondary,
+              transition: 'background-color 0.18s ease, color 0.18s ease',
+              '&:hover': {
+                color: theme.palette.text.primary,
+                backgroundColor:
+                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.06)' : 'rgba(15,23,42,0.04)',
+              },
+            },
+            '& .Mui-selected': {
               color:
                 theme.palette.mode === 'dark'
-                  ? 'rgba(148,163,184,0.85)'
-                  : theme.palette.text.secondary,
-            })}
-          >
-            Calculator
-          </Typography>
-          <Tabs
-            value={tab}
-            onChange={handleChange}
-            aria-label="Calculator type"
-            variant="standard"
-            sx={(theme) => {
-              const accent = theme.palette.mode === 'dark' ? 'rgb(56,189,248)' : 'rgb(40,145,200)';
-              return {
-                minHeight: 52,
-                // A clear cyan underline marks the active section — a tab-bar
-                // affordance that differs from the filled inner pills.
-                '& .MuiTabs-indicator': {
-                  height: 3,
-                  borderRadius: '3px 3px 0 0',
-                  backgroundColor: accent,
-                  boxShadow: theme.palette.mode === 'dark' ? `0 0 12px ${accent}` : 'none',
-                },
-                '& .MuiTabs-flexContainer': { gap: { xs: 1, sm: 2.5 } },
-                '& .MuiTab-root': {
-                  textTransform: 'none',
-                  fontWeight: 600,
-                  fontSize: { xs: '0.9375rem', sm: '1.0625rem' },
-                  minHeight: 52,
-                  px: { xs: 0.5, sm: 1 },
-                  color: theme.palette.text.secondary,
-                  transition: 'color 0.18s ease',
-                  '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
-                  '&:hover': { color: theme.palette.text.primary },
-                },
-                '& .Mui-selected': {
-                  color: `${accent} !important`,
-                  fontWeight: 700,
-                },
-              };
-            }}
-          >
-            <Tab
-              value="stats"
-              icon={<TuneOutlined fontSize="small" />}
-              iconPosition="start"
-              label={
-                <Box component="span">
-                  Stats
-                  <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
-                    {' '}
-                    (Pen / Crit / Armor)
-                  </Box>
+                  ? `${theme.palette.primary.main} !important`
+                  : '#ffffff !important',
+              background:
+                theme.palette.mode === 'dark'
+                  ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                  : 'linear-gradient(135deg, #0f172a, #1e293b)',
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0 0 18px rgba(56,189,248,0.15), inset 0 0 0 1px rgba(56,189,248,0.35)'
+                  : '0 4px 12px rgba(15,23,42,0.18)',
+            },
+          })}
+        >
+          <Tab
+            value="stats"
+            icon={<TuneOutlined fontSize="small" />}
+            iconPosition="start"
+            label={
+              <Box component="span">
+                Stats
+                <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+                  {' '}
+                  (Pen / Crit / Armor)
                 </Box>
-              }
-            />
-            <Tab
-              value="ultimate"
-              icon={<BoltOutlined fontSize="small" />}
-              iconPosition="start"
-              label="Ultimate"
-            />
-          </Tabs>
-        </Box>
+              </Box>
+            }
+          />
+          <Tab
+            value="ultimate"
+            icon={<BoltOutlined fontSize="small" />}
+            iconPosition="start"
+            label="Ultimate"
+          />
+        </Tabs>
       </Container>
 
       {/* Keep the stat calculator mounted (display:none) so switching back is

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -97,7 +97,15 @@ export const CalculatorPage: React.FC = () => {
             value="stats"
             icon={<TuneOutlined fontSize="small" />}
             iconPosition="start"
-            label="Stats (Pen / Crit / Armor)"
+            label={
+              <Box component="span">
+                Stats
+                <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+                  {' '}
+                  (Pen / Crit / Armor)
+                </Box>
+              </Box>
+            }
           />
           <Tab
             value="ultimate"

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -12,7 +12,7 @@ import { Box, Container, Tab, Tabs } from '@mui/material';
 import React, { Suspense, useState } from 'react';
 
 import { Calculator } from './Calculator';
-import { SmartCalculatorSkeleton } from './SmartCalculatorSkeleton';
+import { UltimateCalculatorSkeleton } from './UltimateCalculatorSkeleton';
 
 const UltimateCalculator = React.lazy(() =>
   import('@features/ultimate-simulator/presentation/components/UltimateCalculator').then((m) => ({
@@ -124,7 +124,7 @@ export const CalculatorPage: React.FC = () => {
 
       {tab === 'ultimate' && (
         <Container maxWidth="lg" sx={{ py: 3 }}>
-          <Suspense fallback={<SmartCalculatorSkeleton />}>
+          <Suspense fallback={<UltimateCalculatorSkeleton />}>
             <UltimateCalculator />
           </Suspense>
         </Container>

--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -8,7 +8,7 @@
  */
 
 import { BoltOutlined, TuneOutlined } from '@mui/icons-material';
-import { Box, Container, Tab, Tabs } from '@mui/material';
+import { Box, Container, Tab, Tabs, Typography } from '@mui/material';
 import React, { Suspense, useState } from 'react';
 
 import { Calculator } from './Calculator';
@@ -43,77 +43,94 @@ export const CalculatorPage: React.FC = () => {
 
   return (
     <Box sx={{ width: '100%' }}>
+      {/* Top-level page navigation. Rendered as a full-width underline tab bar
+          (not a pill group) so it reads as primary, app-level navigation and is
+          visually distinct from the secondary segmented pill controls (PvE/PvP,
+          Pen/Crit/Armor, Solo/Group/PvP) that live inside each panel — fixing
+          the "tabs inside tabs" / double-pill confusion. */}
       <Container maxWidth="lg" sx={{ pt: { xs: 1.5, sm: 2.5 } }}>
-        <Tabs
-          value={tab}
-          onChange={handleChange}
-          aria-label="Calculator type"
-          variant="standard"
+        <Box
+          component="nav"
+          aria-label="Calculator sections"
           sx={(theme) => ({
-            minHeight: 46,
-            display: 'inline-flex',
-            p: 0.5,
-            borderRadius: 3,
-            border: `1px solid ${theme.palette.divider}`,
-            background:
-              theme.palette.mode === 'dark'
-                ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
-                : 'rgba(255,255,255,0.6)',
-            // Hide the default underline indicator — selection is shown by the
-            // filled pill behind the active tab instead.
-            '& .MuiTabs-indicator': { display: 'none' },
-            '& .MuiTabs-flexContainer': { gap: 0.5 },
-            '& .MuiTab-root': {
-              textTransform: 'none',
-              fontWeight: 600,
-              minHeight: 38,
-              borderRadius: 2.25,
-              px: { xs: 1.5, sm: 2 },
-              color: theme.palette.text.secondary,
-              transition: 'background-color 0.18s ease, color 0.18s ease',
-              '&:hover': {
-                color: theme.palette.text.primary,
-                backgroundColor:
-                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.06)' : 'rgba(15,23,42,0.04)',
-              },
-            },
-            '& .Mui-selected': {
-              color:
-                theme.palette.mode === 'dark'
-                  ? `${theme.palette.primary.main} !important`
-                  : '#ffffff !important',
-              background:
-                theme.palette.mode === 'dark'
-                  ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
-                  : 'linear-gradient(135deg, #0f172a, #1e293b)',
-              boxShadow:
-                theme.palette.mode === 'dark'
-                  ? '0 0 18px rgba(56,189,248,0.15), inset 0 0 0 1px rgba(56,189,248,0.35)'
-                  : '0 4px 12px rgba(15,23,42,0.18)',
-            },
+            borderBottom: `1px solid ${theme.palette.divider}`,
           })}
         >
-          <Tab
-            value="stats"
-            icon={<TuneOutlined fontSize="small" />}
-            iconPosition="start"
-            label={
-              <Box component="span">
-                Stats
-                <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
-                  {' '}
-                  (Pen / Crit / Armor)
+          <Typography
+            component="span"
+            sx={(theme) => ({
+              display: 'block',
+              mb: 1,
+              fontSize: '0.6875rem',
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color:
+                theme.palette.mode === 'dark'
+                  ? 'rgba(148,163,184,0.85)'
+                  : theme.palette.text.secondary,
+            })}
+          >
+            Calculator
+          </Typography>
+          <Tabs
+            value={tab}
+            onChange={handleChange}
+            aria-label="Calculator type"
+            variant="standard"
+            sx={(theme) => {
+              const accent = theme.palette.mode === 'dark' ? 'rgb(56,189,248)' : 'rgb(40,145,200)';
+              return {
+                minHeight: 52,
+                // A clear cyan underline marks the active section — a tab-bar
+                // affordance that differs from the filled inner pills.
+                '& .MuiTabs-indicator': {
+                  height: 3,
+                  borderRadius: '3px 3px 0 0',
+                  backgroundColor: accent,
+                  boxShadow: theme.palette.mode === 'dark' ? `0 0 12px ${accent}` : 'none',
+                },
+                '& .MuiTabs-flexContainer': { gap: { xs: 1, sm: 2.5 } },
+                '& .MuiTab-root': {
+                  textTransform: 'none',
+                  fontWeight: 600,
+                  fontSize: { xs: '0.9375rem', sm: '1.0625rem' },
+                  minHeight: 52,
+                  px: { xs: 0.5, sm: 1 },
+                  color: theme.palette.text.secondary,
+                  transition: 'color 0.18s ease',
+                  '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+                  '&:hover': { color: theme.palette.text.primary },
+                },
+                '& .Mui-selected': {
+                  color: `${accent} !important`,
+                  fontWeight: 700,
+                },
+              };
+            }}
+          >
+            <Tab
+              value="stats"
+              icon={<TuneOutlined fontSize="small" />}
+              iconPosition="start"
+              label={
+                <Box component="span">
+                  Stats
+                  <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+                    {' '}
+                    (Pen / Crit / Armor)
+                  </Box>
                 </Box>
-              </Box>
-            }
-          />
-          <Tab
-            value="ultimate"
-            icon={<BoltOutlined fontSize="small" />}
-            iconPosition="start"
-            label="Ultimate"
-          />
-        </Tabs>
+              }
+            />
+            <Tab
+              value="ultimate"
+              icon={<BoltOutlined fontSize="small" />}
+              iconPosition="start"
+              label="Ultimate"
+            />
+          </Tabs>
+        </Box>
       </Container>
 
       {/* Keep the stat calculator mounted (display:none) so switching back is

--- a/src/components/CalculatorSkeleton.tsx
+++ b/src/components/CalculatorSkeleton.tsx
@@ -637,18 +637,21 @@ export const CalculatorSkeleton: React.FC<CalculatorSkeletonProps> = ({
       sx={{
         mt: 4,
         p: 3,
+        // Mirror the real summary footer surface (now a sticky glass card, sans
+        // backdrop blur — the JS sticky-footer hook was replaced by CSS sticky).
         background:
           theme.palette.mode === 'dark'
-            ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(3, 7, 18, 0.98) 100%)'
-            : 'linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 250, 252, 0.9) 100%)',
-        borderRadius: 2,
-        border: `1px solid ${sectionBorderColor}`,
+            ? 'linear-gradient(135deg, rgba(15, 23, 42, 0.96) 0%, rgba(3, 7, 18, 0.97) 100%)'
+            : 'linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.94) 100%)',
+        borderRadius: '14px',
+        border:
+          theme.palette.mode === 'dark'
+            ? '1px solid rgba(56, 189, 248, 0.18)'
+            : '1px solid rgba(15, 23, 42, 0.08)',
         boxShadow:
           theme.palette.mode === 'dark'
-            ? '0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
-            : '0 8px 32px rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.8)',
-        backdropFilter: 'blur(12px)',
-        WebkitBackdropFilter: 'blur(12px)',
+            ? 'inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 36px rgba(0, 0, 0, 0.4)'
+            : 'inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 12px 36px rgba(15, 23, 42, 0.12)',
       }}
     >
       {/* Matches renderSummaryFooter structure */}
@@ -773,8 +776,10 @@ export const CalculatorSkeleton: React.FC<CalculatorSkeletonProps> = ({
       data-testid={dataTestId}
       sx={{
         minHeight: '100vh',
-        background:
-          theme.palette.mode === 'dark' ? theme.palette.background.default : 'transparent',
+        // Transparent in both themes so the global cosmic SiteBackground shows
+        // through and the card floats — matches the post-refactor Calculator
+        // (it no longer paints an opaque background.default slab in dark mode).
+        background: 'transparent',
         position: 'relative',
         width: '100%',
         maxWidth: '100vw',
@@ -801,7 +806,7 @@ export const CalculatorSkeleton: React.FC<CalculatorSkeletonProps> = ({
             background: cardBackground,
             backdropFilter: 'blur(20px)',
             WebkitBackdropFilter: 'blur(20px)',
-            borderRadius: 2,
+            borderRadius: '22px',
             border: `1px solid ${cardBorderColor}`,
             boxShadow:
               theme.palette.mode === 'dark'

--- a/src/components/CalculatorSkeletonLite.tsx
+++ b/src/components/CalculatorSkeletonLite.tsx
@@ -371,8 +371,9 @@ export const CalculatorSkeletonLite: React.FC<CalculatorSkeletonLiteProps> = ({
       data-testid={dataTestId}
       sx={{
         minHeight: '100vh',
-        background:
-          theme.palette.mode === 'dark' ? theme.palette.background.default : 'transparent',
+        // Transparent in both themes so the card floats on the cosmic
+        // SiteBackground — matches the post-refactor Calculator.
+        background: 'transparent',
         position: 'relative',
         width: '100%',
         maxWidth: '100vw',
@@ -393,7 +394,7 @@ export const CalculatorSkeletonLite: React.FC<CalculatorSkeletonLiteProps> = ({
           background: cardBackground,
           backdropFilter: 'blur(20px)',
           WebkitBackdropFilter: 'blur(20px)',
-          borderRadius: 1,
+          borderRadius: '22px',
           border: `1px solid ${cardBorderColor}`,
           boxShadow:
             theme.palette.mode === 'dark'

--- a/src/components/CalculatorTabsSkeleton.tsx
+++ b/src/components/CalculatorTabsSkeleton.tsx
@@ -1,0 +1,89 @@
+/**
+ * Static placeholder for the /calculator page's top tab strip (Stats / Ultimate).
+ *
+ * The App-level Suspense fallback replaces the *entire* `CalculatorPage` while
+ * its chunk loads — including the tab bar that `CalculatorPage` always renders
+ * above the calculator. Without this, the tab strip pops in when the chunk
+ * resolves and pushes the skeleton/content down. Rendering this shell (with the
+ * about-to-be-active tab pre-selected) reserves that space so first paint
+ * matches the loaded page.
+ *
+ * It mirrors `CalculatorPage`'s `<Tabs>` styling so the swap is seamless; the
+ * labels/icons are the real ones (they're static chrome, not data) so there's
+ * no shimmer-to-content flash.
+ */
+
+import { BoltOutlined, TuneOutlined } from '@mui/icons-material';
+import { Box, Container, useTheme } from '@mui/material';
+import React from 'react';
+
+interface CalculatorTabsSkeletonProps {
+  /** Which tab the loading page is about to show. */
+  selected?: 'stats' | 'ultimate';
+}
+
+export const CalculatorTabsSkeleton: React.FC<CalculatorTabsSkeletonProps> = ({
+  selected = 'stats',
+}) => {
+  const theme = useTheme();
+  const dark = theme.palette.mode === 'dark';
+
+  const selectedSx = {
+    color: dark ? `${theme.palette.primary.main}` : '#ffffff',
+    background: dark
+      ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+      : 'linear-gradient(135deg, #0f172a, #1e293b)',
+    boxShadow: dark
+      ? '0 0 18px rgba(56,189,248,0.15), inset 0 0 0 1px rgba(56,189,248,0.35)'
+      : '0 4px 12px rgba(15,23,42,0.18)',
+  };
+
+  const pillSx = (isSelected: boolean): object => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 0.75,
+    minHeight: 38,
+    borderRadius: 2.25,
+    px: { xs: 1.5, sm: 2 },
+    fontWeight: 600,
+    fontSize: '0.875rem',
+    textTransform: 'none',
+    color: theme.palette.text.secondary,
+    '& svg': { fontSize: 20 },
+    ...(isSelected ? selectedSx : {}),
+  });
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: { xs: 1.5, sm: 2.5 } }}>
+      <Box
+        aria-hidden
+        sx={{
+          minHeight: 46,
+          display: 'inline-flex',
+          p: 0.5,
+          gap: 0.5,
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.divider}`,
+          background: dark
+            ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+            : 'rgba(255,255,255,0.6)',
+        }}
+      >
+        <Box sx={pillSx(selected === 'stats')}>
+          <TuneOutlined fontSize="small" />
+          <Box component="span">
+            Stats
+            <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+              {' '}
+              (Pen / Crit / Armor)
+            </Box>
+          </Box>
+        </Box>
+        <Box sx={pillSx(selected === 'ultimate')}>
+          <BoltOutlined fontSize="small" />
+          <Box component="span">Ultimate</Box>
+        </Box>
+      </Box>
+    </Container>
+  );
+};

--- a/src/components/UltimateCalculatorSkeleton.tsx
+++ b/src/components/UltimateCalculatorSkeleton.tsx
@@ -283,79 +283,88 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
             <Box sx={{ flex: 1, height: '1px', backgroundColor: theme.palette.divider }} />
           </Stack>
 
-          {/* Source category groups (first expanded showing a source card + slider) */}
-          {[0, 1, 2, 3, 4].map((g) => (
-            <Box key={g} sx={{ mb: 1 }}>
-              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', py: 0.75 }}>
-                <Box
-                  sx={{
-                    width: 5,
-                    height: 5,
-                    borderRadius: '50%',
-                    background: accent,
-                    flexShrink: 0,
-                  }}
-                />
-                <Skeleton variant="text" width={120 + ((g * 11) % 40)} height={14} />
-                <Box sx={{ flex: 1 }} />
-                <Skeleton variant="circular" width={16} height={16} />
-              </Stack>
-              {g === 0 && (
-                <Stack spacing={1} sx={{ mt: 0.5 }}>
-                  {[0, 1].map((s) => (
-                    <Box
-                      key={s}
-                      sx={{
-                        borderRadius: 1.4,
-                        px: 1.5,
-                        py: 1.25,
-                        border: `1px solid ${s === 0 ? 'rgba(56,189,248,0.5)' : theme.palette.divider}`,
-                        background:
-                          s === 0
-                            ? dark
-                              ? 'linear-gradient(135deg, rgba(56,189,248,0.15) 0%, rgba(56,189,248,0.04) 100%)'
-                              : 'linear-gradient(135deg, rgba(40,145,200,0.08) 0%, rgba(40,145,200,0.02) 100%)'
-                            : dark
-                              ? 'rgba(2,6,16,0.35)'
-                              : 'rgba(15,23,42,0.015)',
-                      }}
+          {/* Source category groups — mirrors the default Arcanist group-DPS
+              state: "Base income" and "Class passive" auto-expand (each has an
+              enabled source), the other three stay folded. Matching this shape
+              avoids a left-panel reflow when the real component mounts. */}
+          {[0, 1, 2, 3, 4].map((g) => {
+            const expanded = g === 0 || g === 2;
+            return (
+              <Box key={g} sx={{ mb: 1 }}>
+                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', py: 0.75 }}>
+                  <Box
+                    sx={{
+                      width: 5,
+                      height: 5,
+                      borderRadius: '50%',
+                      background: accent,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Skeleton variant="text" width={84 + ((g * 13) % 36)} height={14} />
+                  {/* "N on" count chip — shown on groups with an enabled source. */}
+                  {expanded && (
+                    <Skeleton
+                      variant="rectangular"
+                      width={30}
+                      height={14}
+                      sx={{ ml: 0.5, borderRadius: 1 }}
+                    />
+                  )}
+                  <Box sx={{ flex: 1 }} />
+                  <Skeleton variant="circular" width={16} height={16} />
+                </Stack>
+                {expanded && (
+                  <Box
+                    sx={{
+                      mt: 0.5,
+                      borderRadius: 1.4,
+                      px: 1.5,
+                      py: 1.25,
+                      border: '1px solid rgba(56,189,248,0.5)',
+                      background: dark
+                        ? 'linear-gradient(135deg, rgba(56,189,248,0.15) 0%, rgba(56,189,248,0.04) 100%)'
+                        : 'linear-gradient(135deg, rgba(40,145,200,0.08) 0%, rgba(40,145,200,0.02) 100%)',
+                    }}
+                  >
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      sx={{ alignItems: 'center', justifyContent: 'space-between' }}
                     >
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+                        <Skeleton
+                          variant="rectangular"
+                          width={34}
+                          height={20}
+                          sx={{ borderRadius: 10 }}
+                        />
+                        <Skeleton variant="text" width={150} height={15} />
+                      </Stack>
+                    </Stack>
+                    {/* Uptime label + value, then the slider (enabled source). */}
+                    <Box sx={{ mt: 1, pt: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
                       <Stack
                         direction="row"
-                        spacing={1}
-                        sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+                        sx={{ justifyContent: 'space-between', alignItems: 'center' }}
                       >
-                        <Stack
-                          direction="row"
-                          spacing={1}
-                          sx={{ alignItems: 'center', minWidth: 0 }}
-                        >
-                          <Skeleton
-                            variant="rectangular"
-                            width={34}
-                            height={20}
-                            sx={{ borderRadius: 10 }}
-                          />
-                          <Skeleton variant="text" width={150} height={15} />
-                        </Stack>
-                        <Skeleton variant="text" width={36} height={12} />
+                        <Skeleton variant="text" width={48} height={12} />
+                        <Skeleton variant="text" width={30} height={12} />
                       </Stack>
-                      {s === 0 && (
-                        <Box sx={{ px: '12px', mt: 1 }}>
-                          <Skeleton
-                            variant="rectangular"
-                            width="100%"
-                            height={6}
-                            sx={{ borderRadius: 3 }}
-                          />
-                        </Box>
-                      )}
+                      <Box sx={{ px: '12px', mt: 0.5 }}>
+                        <Skeleton
+                          variant="rectangular"
+                          width="100%"
+                          height={6}
+                          sx={{ borderRadius: 3 }}
+                        />
+                      </Box>
                     </Box>
-                  ))}
-                </Stack>
-              )}
-            </Box>
-          ))}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
 
           {/* Reset button */}
           <Skeleton variant="text" width={130} height={16} sx={{ mt: 1.5 }} />

--- a/src/components/UltimateCalculatorSkeleton.tsx
+++ b/src/components/UltimateCalculatorSkeleton.tsx
@@ -271,11 +271,32 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
           {/* Fight duration */}
           <Skeleton variant="rectangular" height={40} sx={{ mb: 2, borderRadius: '10px' }} />
 
-          {/* Decisive trait toggle */}
-          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 2 }}>
-            <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
-            <Skeleton variant="text" width={170} height={16} />
-          </Stack>
+          {/* Decisive trait toggle — on by default, so the nested weapon-quality
+              select + two-handed switch panel is shown at first paint. */}
+          <Box sx={{ mb: 2 }}>
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
+              <Skeleton variant="text" width={170} height={16} />
+            </Stack>
+            <Stack
+              spacing={1.5}
+              sx={{
+                mt: 1,
+                p: 1.5,
+                borderRadius: 1.4,
+                border: `1px solid ${dark ? 'rgba(56,189,248,0.28)' : 'rgba(40,145,200,0.3)'}`,
+                background: dark
+                  ? 'linear-gradient(135deg, rgba(56,189,248,0.08), rgba(56,189,248,0.02))'
+                  : 'rgba(40,145,200,0.04)',
+              }}
+            >
+              <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
+              <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
+                <Skeleton variant="text" width={150} height={16} />
+              </Stack>
+            </Stack>
+          </Box>
 
           {/* Divider + "ULTIMATE SOURCES" eyebrow */}
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1.5 }}>
@@ -359,6 +380,9 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
                           sx={{ borderRadius: 3 }}
                         />
                       </Box>
+                      {/* Source description (the enabled cards show one). */}
+                      <Skeleton variant="text" width="92%" height={11} sx={{ mt: 0.5 }} />
+                      <Skeleton variant="text" width="68%" height={11} />
                     </Box>
                   </Box>
                 )}
@@ -412,11 +436,17 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
               <Skeleton variant="rectangular" width={48} height={22} sx={{ borderRadius: 999 }} />
             </Box>
 
-            {/* Ultimate select + Starting ultimate */}
+            {/* Ultimate select + Starting ultimate (with its "Banked at start"
+                helper line), then the "* approximate cost" catalog note. */}
             <Stack spacing={2}>
               <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
-              <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
+              <Box>
+                <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
+                <Skeleton variant="text" width={90} height={11} sx={{ mt: 0.5, ml: 1.75 }} />
+              </Box>
             </Stack>
+            <Skeleton variant="text" width="96%" height={11} sx={{ mt: 1 }} />
+            <Skeleton variant="text" width="58%" height={11} />
           </Paper>
 
           {/* Card 2 — Per-source breakdown table */}

--- a/src/components/UltimateCalculatorSkeleton.tsx
+++ b/src/components/UltimateCalculatorSkeleton.tsx
@@ -467,8 +467,11 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
                 <Skeleton variant="text" width={36} height={14} sx={{ ml: 'auto' }} />
               </Box>
 
-              {/* Body rows + total */}
-              {[0, 1, 2, 3, 4, 5].map((r) => tableRow(r))}
+              {/* Body rows + total. The default Arcanist group-DPS state enables
+                  two sources (base income + the class passive), so the real table
+                  renders two contribution rows before the Total — match that count
+                  so the table doesn't collapse when the calculator mounts. */}
+              {[0, 1].map((r) => tableRow(r))}
               {tableRow(99, { total: true })}
             </Box>
           </Paper>

--- a/src/components/UltimateCalculatorSkeleton.tsx
+++ b/src/components/UltimateCalculatorSkeleton.tsx
@@ -248,18 +248,15 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
         <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
           {sectionHeader(140)}
 
-          {/* Context toggle (Solo / Group / PvP) */}
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(3, 1fr)',
-              gap: 0.5,
-              mb: 2,
-            }}
-          >
-            {[0, 1, 2].map((i) => (
-              <Skeleton key={i} variant="rectangular" height={48} sx={{ borderRadius: '10px' }} />
-            ))}
+          {/* Context toggle — a "Context" label over three two-line buttons
+              (Solo / Group / PvP, each with a sub-label), matching the real height. */}
+          <Box sx={{ mb: 2 }}>
+            <Skeleton variant="text" width={70} height={14} sx={{ mb: 0.75 }} />
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 0.5 }}>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} variant="rectangular" height={60} sx={{ borderRadius: '10px' }} />
+              ))}
+            </Box>
           </Box>
 
           {/* Class + Role selects */}
@@ -274,7 +271,7 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
           {/* Decisive trait toggle — on by default, so the nested weapon-quality
               select + two-handed switch panel is shown at first paint. */}
           <Box sx={{ mb: 2 }}>
-            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', minHeight: 38 }}>
               <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
               <Skeleton variant="text" width={170} height={16} />
             </Stack>
@@ -291,7 +288,7 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
               }}
             >
               <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
-              <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', minHeight: 38 }}>
                 <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
                 <Skeleton variant="text" width={150} height={16} />
               </Stack>
@@ -299,7 +296,11 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
           </Box>
 
           {/* Divider + "ULTIMATE SOURCES" eyebrow */}
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1.5 }}>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ alignItems: 'center', mt: 0.5, mb: 1.5, minHeight: 24 }}
+          >
             <Skeleton variant="text" width={120} height={12} />
             <Box sx={{ flex: 1, height: '1px', backgroundColor: theme.palette.divider }} />
           </Stack>
@@ -348,10 +349,16 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
                         : 'linear-gradient(135deg, rgba(40,145,200,0.08) 0%, rgba(40,145,200,0.02) 100%)',
                     }}
                   >
+                    {/* Toggle + label + provenance link — the real card reserves a
+                        44px min-height header row. */}
                     <Stack
                       direction="row"
                       spacing={1}
-                      sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        minHeight: 44,
+                      }}
                     >
                       <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
                         <Skeleton
@@ -362,17 +369,20 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
                         />
                         <Skeleton variant="text" width={150} height={15} />
                       </Stack>
+                      <Skeleton variant="text" width={42} height={12} sx={{ flexShrink: 0 }} />
                     </Stack>
                     {/* Uptime label + value, then the slider (enabled source). */}
-                    <Box sx={{ mt: 1, pt: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
+                    <Box sx={{ mt: 0.75, pt: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
                       <Stack
                         direction="row"
                         sx={{ justifyContent: 'space-between', alignItems: 'center' }}
                       >
                         <Skeleton variant="text" width={48} height={12} />
-                        <Skeleton variant="text" width={30} height={12} />
+                        <Skeleton variant="text" width={30} height={14} />
                       </Stack>
-                      <Box sx={{ px: '12px', mt: 0.5 }}>
+                      {/* Slider — reserve the small MUI Slider's height (rail + its
+                          10px touch padding top and bottom). */}
+                      <Box sx={{ px: '12px', py: '10px' }}>
                         <Skeleton
                           variant="rectangular"
                           width="100%"
@@ -380,9 +390,18 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
                           sx={{ borderRadius: 3 }}
                         />
                       </Box>
-                      {/* Source description (the enabled cards show one). */}
-                      <Skeleton variant="text" width="92%" height={11} sx={{ mt: 0.5 }} />
-                      <Skeleton variant="text" width="68%" height={11} />
+                      {/* Source description — the default Arcanist sources wrap
+                          past two lines; the long base-income text wraps an extra
+                          line at narrow widths, so reserve a 4th line on xs only. */}
+                      <Skeleton variant="text" width="100%" height={11} />
+                      <Skeleton variant="text" width="96%" height={11} />
+                      <Skeleton
+                        variant="text"
+                        width="88%"
+                        height={11}
+                        sx={{ display: { xs: 'block', sm: 'none' } }}
+                      />
+                      <Skeleton variant="text" width="60%" height={11} />
                     </Box>
                   </Box>
                 )}
@@ -390,8 +409,13 @@ export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProp
             );
           })}
 
-          {/* Reset button */}
-          <Skeleton variant="text" width={130} height={16} sx={{ mt: 1.5 }} />
+          {/* Reset button (a text Button with a leading icon). */}
+          <Skeleton
+            variant="rounded"
+            width={150}
+            height={30}
+            sx={{ mt: 1.5, borderRadius: '8px' }}
+          />
         </Paper>
 
         {/* ----------------------- RIGHT: results (sticky on lg) ----------------------- */}

--- a/src/components/UltimateCalculatorSkeleton.tsx
+++ b/src/components/UltimateCalculatorSkeleton.tsx
@@ -1,0 +1,491 @@
+/**
+ * Loading skeleton for the Ultimate Calculator tab.
+ *
+ * The Ultimate tab lazy-loads a heavy chunk; while it streams in we show this
+ * placeholder. It mirrors the real component's frame so the layout doesn't jump
+ * when the calculator mounts: the intro row, the full-width headline hero
+ * (one dominant number + three stat tiles), and the two-column body that splits
+ * into a left input panel and a right results stack (ultimate picker, per-source
+ * breakdown table, "verify against your log" panel) — the results stack sticking
+ * to the top on wide screens exactly like the real one.
+ *
+ * Surfaces (panel gradients, accent, radii) are kept in lock-step with
+ * `UltimateCalculator.tsx` (panelSx / hero / table) so the swap is seamless.
+ */
+
+import { Box, Paper, Skeleton, Stack, useTheme, alpha } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material';
+import React from 'react';
+
+interface UltimateCalculatorSkeletonProps {
+  /** Test ID for testing/skeleton detection. */
+  'data-testid'?: string;
+}
+
+/** Mirror of UltimateCalculator's `panelSx` so the skeleton panels match. */
+const panelSx = (theme: Theme): SxProps<Theme> => ({
+  p: { xs: 2, sm: 2.5 },
+  borderRadius: 2.8, // 28px — panel tier
+  border: `1px solid ${
+    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
+  }`,
+  background:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg, rgba(14,22,42,0.74) 0%, rgba(3,9,20,0.82) 100%)'
+      : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 14px 36px rgba(0,0,0,0.44), inset 0 1px 0 rgba(255,255,255,0.05)'
+      : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
+});
+
+export const UltimateCalculatorSkeleton: React.FC<UltimateCalculatorSkeletonProps> = ({
+  'data-testid': dataTestId = 'ultimate-calculator-skeleton',
+}) => {
+  const theme = useTheme();
+  const dark = theme.palette.mode === 'dark';
+  const accent = dark ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
+
+  /** Accent eyebrow + title, matching SectionHeader (30×30 icon chip + title). */
+  const sectionHeader = (titleWidth: number, action?: React.ReactNode): React.JSX.Element => (
+    <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1.75 }}>
+      <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', minWidth: 0 }}>
+        <Box
+          aria-hidden
+          sx={{
+            width: 30,
+            height: 30,
+            borderRadius: 2,
+            background: `${accent}1f`,
+            border: `1px solid ${accent}33`,
+            flexShrink: 0,
+          }}
+        />
+        <Skeleton variant="text" width={titleWidth} height={24} />
+      </Stack>
+      {action}
+    </Stack>
+  );
+
+  /** A hero stat tile (matches StatBlock surface: 14px card on the panel). */
+  const statTile = (key: number): React.JSX.Element => (
+    <Box
+      key={key}
+      sx={{
+        minWidth: 0,
+        px: { xs: 1.25, sm: 1.75 },
+        py: { xs: 1.25, sm: 1.5 },
+        borderRadius: 1.4, // 14px — card tier
+        height: '100%',
+        background: dark
+          ? 'linear-gradient(180deg, rgba(56,189,248,0.09) 0%, rgba(56,189,248,0.02) 100%)'
+          : 'rgba(255,255,255,0.6)',
+        border: `1px solid ${dark ? 'rgba(56,189,248,0.16)' : theme.palette.divider}`,
+        boxShadow: dark
+          ? 'inset 0 1px 0 rgba(255,255,255,0.07), 0 6px 16px rgba(0,0,0,0.34)'
+          : '0 2px 8px rgba(15,23,42,0.05)',
+      }}
+    >
+      <Skeleton variant="text" width="70%" height={10} sx={{ mb: 0.75 }} />
+      <Skeleton variant="text" width={64} height={26} />
+      <Skeleton variant="text" width="55%" height={11} sx={{ mt: 0.25 }} />
+    </Box>
+  );
+
+  /** One per-source breakdown table row (label + mini-bar + three numbers). */
+  const tableRow = (key: number, opts?: { total?: boolean }): React.JSX.Element => {
+    const total = opts?.total ?? false;
+    return (
+      <Box
+        key={key}
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 56px', sm: '1fr 56px 64px 64px' },
+          alignItems: 'center',
+          gap: 1.5,
+          px: 1.5,
+          py: 1,
+          minHeight: 48,
+          ...(total
+            ? {
+                borderTop: `2px solid ${alpha(accent, 0.4)}`,
+                background: alpha(accent, dark ? 0.16 : 0.1),
+              }
+            : {
+                backgroundColor: alpha(accent, key % 2 === 0 ? 0.07 : 0.025),
+              }),
+        }}
+      >
+        {/* Source cell: label + share bar + % */}
+        <Box sx={{ minWidth: 0 }}>
+          <Skeleton variant="text" width={total ? 56 : `${60 + ((key * 7) % 30)}%`} height={16} />
+          {!total && (
+            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mt: 0.5 }}>
+              <Skeleton
+                variant="rectangular"
+                width="100%"
+                height={5}
+                sx={{ borderRadius: 3, flex: 1 }}
+              />
+              <Skeleton variant="text" width={28} height={12} />
+            </Stack>
+          )}
+        </Box>
+        <Skeleton
+          variant="text"
+          width={36}
+          height={16}
+          sx={{ ml: 'auto', display: { xs: 'none', sm: 'block' } }}
+        />
+        <Skeleton
+          variant="text"
+          width={36}
+          height={16}
+          sx={{ ml: 'auto', display: { xs: 'none', sm: 'block' } }}
+        />
+        <Skeleton variant="text" width={40} height={16} sx={{ ml: 'auto' }} />
+      </Box>
+    );
+  };
+
+  return (
+    <Box data-testid={dataTestId} sx={{ width: '100%' }}>
+      {/* ===================== INTRO ===================== */}
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 0.75 }}>
+        <Box
+          aria-hidden
+          sx={{
+            flexShrink: 0,
+            width: 40,
+            height: 40,
+            borderRadius: 2.5,
+            background: dark
+              ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+              : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))',
+            border: `1px solid ${accent}40`,
+            boxShadow: dark ? '0 0 22px rgba(56,189,248,0.18)' : 'none',
+          }}
+        />
+        <Box sx={{ minWidth: 0 }}>
+          <Skeleton variant="text" width={210} height={30} />
+          <Skeleton variant="text" width={150} height={12} />
+        </Box>
+      </Stack>
+      <Box sx={{ mb: 2.5, maxWidth: 640 }}>
+        <Skeleton variant="text" width="88%" height={16} />
+        <Skeleton variant="text" width="52%" height={16} />
+      </Box>
+
+      {/* ===================== HEADLINE HERO (full width) ===================== */}
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 2, sm: 2.75 },
+          mb: 2.5,
+          borderRadius: 2.8,
+          position: 'relative',
+          overflow: 'hidden',
+          border: `1px solid ${dark ? 'rgba(56,189,248,0.18)' : theme.palette.divider}`,
+          background: dark
+            ? 'linear-gradient(135deg, rgba(56,189,248,0.16) 0%, rgba(13,22,42,0.6) 50%, rgba(3,8,18,0.72) 100%)'
+            : 'linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(248,250,252,0.85) 60%, rgba(255,255,255,0.95) 100%)',
+          boxShadow: dark
+            ? '0 18px 50px rgba(0,0,0,0.46), 0 0 80px rgba(56,189,248,0.10), inset 0 1px 0 rgba(255,255,255,0.06)'
+            : '0 6px 20px rgba(15,23,42,0.07)',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', md: 'row' },
+            gap: { xs: 2, md: 3 },
+            alignItems: { md: 'stretch' },
+          }}
+        >
+          {/* PRIMARY — dominant number + gauge */}
+          <Box
+            sx={{
+              flex: { md: '0 0 40%' },
+              minWidth: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              px: { xs: 0.5, sm: 1 },
+            }}
+          >
+            <Skeleton variant="text" width={130} height={12} />
+            <Stack direction="row" spacing={0.6} sx={{ alignItems: 'baseline', mt: 0.5 }}>
+              <Skeleton variant="text" width={150} height={56} />
+              <Skeleton variant="text" width={42} height={18} />
+            </Stack>
+            <Box sx={{ mt: 1.25 }}>
+              <Skeleton variant="rectangular" width="100%" height={7} sx={{ borderRadius: 4 }} />
+              <Stack direction="row" sx={{ justifyContent: 'space-between', mt: 0.6 }}>
+                <Skeleton variant="text" width={140} height={12} />
+                <Skeleton variant="text" width={80} height={12} />
+              </Stack>
+            </Box>
+          </Box>
+
+          {/* SECONDARY — three stat tiles, 3-up at every breakpoint */}
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              display: 'grid',
+              gap: { xs: 1, sm: 1.25 },
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+            }}
+          >
+            {[0, 1, 2].map((i) => statTile(i))}
+          </Box>
+        </Box>
+      </Paper>
+
+      {/* ===================== TWO-COLUMN BODY ===================== */}
+      <Box sx={{ display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2.5 }}>
+        {/* ----------------------- LEFT: inputs ----------------------- */}
+        <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
+          {sectionHeader(140)}
+
+          {/* Context toggle (Solo / Group / PvP) */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: 0.5,
+              mb: 2,
+            }}
+          >
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} variant="rectangular" height={48} sx={{ borderRadius: '10px' }} />
+            ))}
+          </Box>
+
+          {/* Class + Role selects */}
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <Skeleton variant="rectangular" height={40} sx={{ flex: 1, borderRadius: '10px' }} />
+            <Skeleton variant="rectangular" height={40} sx={{ flex: 1, borderRadius: '10px' }} />
+          </Stack>
+
+          {/* Fight duration */}
+          <Skeleton variant="rectangular" height={40} sx={{ mb: 2, borderRadius: '10px' }} />
+
+          {/* Decisive trait toggle */}
+          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 2 }}>
+            <Skeleton variant="rectangular" width={34} height={20} sx={{ borderRadius: 10 }} />
+            <Skeleton variant="text" width={170} height={16} />
+          </Stack>
+
+          {/* Divider + "ULTIMATE SOURCES" eyebrow */}
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1.5 }}>
+            <Skeleton variant="text" width={120} height={12} />
+            <Box sx={{ flex: 1, height: '1px', backgroundColor: theme.palette.divider }} />
+          </Stack>
+
+          {/* Source category groups (first expanded showing a source card + slider) */}
+          {[0, 1, 2, 3, 4].map((g) => (
+            <Box key={g} sx={{ mb: 1 }}>
+              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', py: 0.75 }}>
+                <Box
+                  sx={{
+                    width: 5,
+                    height: 5,
+                    borderRadius: '50%',
+                    background: accent,
+                    flexShrink: 0,
+                  }}
+                />
+                <Skeleton variant="text" width={120 + ((g * 11) % 40)} height={14} />
+                <Box sx={{ flex: 1 }} />
+                <Skeleton variant="circular" width={16} height={16} />
+              </Stack>
+              {g === 0 && (
+                <Stack spacing={1} sx={{ mt: 0.5 }}>
+                  {[0, 1].map((s) => (
+                    <Box
+                      key={s}
+                      sx={{
+                        borderRadius: 1.4,
+                        px: 1.5,
+                        py: 1.25,
+                        border: `1px solid ${s === 0 ? 'rgba(56,189,248,0.5)' : theme.palette.divider}`,
+                        background:
+                          s === 0
+                            ? dark
+                              ? 'linear-gradient(135deg, rgba(56,189,248,0.15) 0%, rgba(56,189,248,0.04) 100%)'
+                              : 'linear-gradient(135deg, rgba(40,145,200,0.08) 0%, rgba(40,145,200,0.02) 100%)'
+                            : dark
+                              ? 'rgba(2,6,16,0.35)'
+                              : 'rgba(15,23,42,0.015)',
+                      }}
+                    >
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+                      >
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          sx={{ alignItems: 'center', minWidth: 0 }}
+                        >
+                          <Skeleton
+                            variant="rectangular"
+                            width={34}
+                            height={20}
+                            sx={{ borderRadius: 10 }}
+                          />
+                          <Skeleton variant="text" width={150} height={15} />
+                        </Stack>
+                        <Skeleton variant="text" width={36} height={12} />
+                      </Stack>
+                      {s === 0 && (
+                        <Box sx={{ px: '12px', mt: 1 }}>
+                          <Skeleton
+                            variant="rectangular"
+                            width="100%"
+                            height={6}
+                            sx={{ borderRadius: 3 }}
+                          />
+                        </Box>
+                      )}
+                    </Box>
+                  ))}
+                </Stack>
+              )}
+            </Box>
+          ))}
+
+          {/* Reset button */}
+          <Skeleton variant="text" width={130} height={16} sx={{ mt: 1.5 }} />
+        </Paper>
+
+        {/* ----------------------- RIGHT: results (sticky on lg) ----------------------- */}
+        <Stack
+          spacing={2.5}
+          sx={{
+            flex: '1 1 480px',
+            minWidth: 0,
+            alignSelf: { lg: 'flex-start' },
+            position: { lg: 'sticky' },
+            top: { lg: 16 },
+          }}
+        >
+          {/* Card 1 — Which ultimate? */}
+          <Paper elevation={0} sx={panelSx(theme)}>
+            {sectionHeader(150)}
+
+            {/* Cost readout */}
+            <Box
+              sx={{
+                mb: 2,
+                px: 2,
+                py: 1.5,
+                borderRadius: 1.4,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+                border: `1px solid ${dark ? 'rgba(56,189,248,0.28)' : 'rgba(40,145,200,0.3)'}`,
+                background: dark
+                  ? 'linear-gradient(135deg, rgba(56,189,248,0.1), rgba(56,189,248,0.02))'
+                  : 'linear-gradient(135deg, rgba(40,145,200,0.06), rgba(40,145,200,0.01))',
+              }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Skeleton variant="text" width={80} height={12} />
+                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'baseline' }}>
+                  <Skeleton variant="text" width={56} height={40} />
+                  <Skeleton variant="text" width={26} height={16} />
+                </Stack>
+              </Box>
+              <Skeleton variant="rectangular" width={48} height={22} sx={{ borderRadius: 999 }} />
+            </Box>
+
+            {/* Ultimate select + Starting ultimate */}
+            <Stack spacing={2}>
+              <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
+              <Skeleton variant="rectangular" height={40} sx={{ borderRadius: '10px' }} />
+            </Stack>
+          </Paper>
+
+          {/* Card 2 — Per-source breakdown table */}
+          <Paper elevation={0} sx={panelSx(theme)}>
+            {sectionHeader(
+              170,
+              <Skeleton
+                variant="rectangular"
+                width={120}
+                height={30}
+                sx={{ borderRadius: '8px' }}
+              />,
+            )}
+
+            <Box
+              sx={{
+                borderRadius: '12px',
+                overflow: 'hidden',
+                border: `1px solid ${alpha(accent, 0.28)}`,
+              }}
+            >
+              {/* Branded blue header bar */}
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr 56px', sm: '1fr 56px 64px 64px' },
+                  alignItems: 'center',
+                  gap: 1.5,
+                  px: 1.5,
+                  py: 1,
+                  background: `linear-gradient(180deg, ${alpha(accent, 0.22)}, ${alpha(accent, 0.1)})`,
+                  borderBottom: `1px solid ${alpha(accent, 0.35)}`,
+                }}
+              >
+                <Skeleton variant="text" width={60} height={14} />
+                <Skeleton
+                  variant="text"
+                  width={32}
+                  height={14}
+                  sx={{ ml: 'auto', display: { xs: 'none', sm: 'block' } }}
+                />
+                <Skeleton
+                  variant="text"
+                  width={44}
+                  height={14}
+                  sx={{ ml: 'auto', display: { xs: 'none', sm: 'block' } }}
+                />
+                <Skeleton variant="text" width={36} height={14} sx={{ ml: 'auto' }} />
+              </Box>
+
+              {/* Body rows + total */}
+              {[0, 1, 2, 3, 4, 5].map((r) => tableRow(r))}
+              {tableRow(99, { total: true })}
+            </Box>
+          </Paper>
+
+          {/* Card 3 — Verify against your own log (collapsed accordion) */}
+          <Paper elevation={0} sx={{ ...panelSx(theme), p: 0, overflow: 'hidden' }}>
+            <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', px: 2, py: 1.75 }}>
+              <Box
+                aria-hidden
+                sx={{
+                  width: 30,
+                  height: 30,
+                  borderRadius: 2,
+                  background: `${accent}1f`,
+                  border: `1px solid ${accent}33`,
+                  flexShrink: 0,
+                }}
+              />
+              <Skeleton variant="text" width={200} height={22} />
+              <Skeleton variant="rectangular" width={34} height={18} sx={{ borderRadius: 1 }} />
+              <Box sx={{ flex: 1 }} />
+              <Skeleton variant="circular" width={22} height={22} />
+            </Stack>
+          </Paper>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/__tests__/CalculatorPage.test.tsx
+++ b/src/components/__tests__/CalculatorPage.test.tsx
@@ -1,0 +1,65 @@
+import { ThemeProvider, createTheme } from '@mui/material';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Mock the heavy children so the test exercises only the tab-switching wrapper.
+jest.mock('../Calculator', () => ({
+  Calculator: () => <div data-testid="stat-calculator">STAT CALCULATOR</div>,
+}));
+jest.mock('../SmartCalculatorSkeleton', () => ({
+  SmartCalculatorSkeleton: () => <div>loading…</div>,
+}));
+jest.mock(
+  '@features/ultimate-simulator/presentation/components/UltimateCalculator',
+  () => ({
+    UltimateCalculator: () => <div data-testid="ultimate-calculator">ULTIMATE CALCULATOR</div>,
+  }),
+  { virtual: true },
+);
+
+import { CalculatorPage } from '../CalculatorPage';
+
+const theme = createTheme();
+
+function renderPage() {
+  return render(
+    <ThemeProvider theme={theme}>
+      <CalculatorPage />
+    </ThemeProvider>,
+  );
+}
+
+describe('CalculatorPage', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  it('shows both top-level tabs and defaults to Stats', () => {
+    renderPage();
+    expect(screen.getByRole('tab', { name: /Stats/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Ultimate/i })).toBeInTheDocument();
+    // Stat calculator is rendered by default.
+    expect(screen.getByTestId('stat-calculator')).toBeInTheDocument();
+  });
+
+  it('switches to the Ultimate tab and lazy-loads the calculator', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('tab', { name: /Ultimate/i }));
+    await waitFor(() => expect(screen.getByTestId('ultimate-calculator')).toBeInTheDocument());
+  });
+
+  it('keeps the stat calculator mounted (hidden) when on the Ultimate tab', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('tab', { name: /Ultimate/i }));
+    await waitFor(() => screen.getByTestId('ultimate-calculator'));
+    // Still in the DOM (mounted, just display:none) so switching back is instant
+    // and the stat calc's sticky-footer measurements aren't torn down.
+    expect(screen.getByTestId('stat-calculator')).toBeInTheDocument();
+  });
+
+  it('honors a #ultimate deep-link on first render', async () => {
+    window.location.hash = '#ultimate';
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('ultimate-calculator')).toBeInTheDocument());
+  });
+});

--- a/src/components/__tests__/CalculatorPage.test.tsx
+++ b/src/components/__tests__/CalculatorPage.test.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 jest.mock('../Calculator', () => ({
   Calculator: () => <div data-testid="stat-calculator">STAT CALCULATOR</div>,
 }));
-jest.mock('../SmartCalculatorSkeleton', () => ({
-  SmartCalculatorSkeleton: () => <div>loading…</div>,
+jest.mock('../UltimateCalculatorSkeleton', () => ({
+  UltimateCalculatorSkeleton: () => <div>loading…</div>,
 }));
 jest.mock(
   '@features/ultimate-simulator/presentation/components/UltimateCalculator',

--- a/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/calibration.test.ts
@@ -1,95 +1,177 @@
-import { calibrateFromEvents, RESOURCE_CHANGE_TYPE } from '../calibration';
-import type { ResourceChangeEvent } from '../../../../types/combatlogEvents';
+import { calibrateFromEvents, isUltimateResourceEvent } from '../calibration';
+import type { ResourceChangeEvent, Resources } from '../../../../types/combatlogEvents';
 
-function ultEvent(partial: Partial<ResourceChangeEvent>): ResourceChangeEvent {
+const MAX_ULT = 500;
+
+function resources(ultimate: number): Resources {
+  return {
+    hitPoints: 30000,
+    maxHitPoints: 30000,
+    magicka: 20000,
+    maxMagicka: 20000,
+    stamina: 20000,
+    maxStamina: 20000,
+    ultimate,
+    maxUltimate: MAX_ULT,
+    werewolf: 0,
+    maxWerewolf: 0,
+    absorb: 0,
+    championPoints: 3600,
+    x: 0,
+    y: 0,
+    facing: 0,
+  };
+}
+
+/** An event carrying actor `targetID`'s ultimate snapshot at `ultimate`. */
+function snapshotEvent(
+  targetID: number,
+  ultimate: number,
+  partial: Partial<ResourceChangeEvent> = {},
+): ResourceChangeEvent {
   return {
     timestamp: 0,
     type: 'resourcechange',
-    sourceID: 1,
+    sourceID: targetID,
     sourceIsFriendly: true,
-    targetID: 1,
+    targetID,
     targetIsFriendly: true,
     abilityGameID: 0,
     fight: 1,
     resourceChange: 0,
-    resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate,
+    resourceChangeType: 0,
     otherResourceChange: 0,
-    maxResourceAmount: 500,
+    maxResourceAmount: MAX_ULT,
     waste: 0,
     castTrackID: 0,
-    // sourceResources/targetResources are not read by the analyzer.
-    sourceResources: undefined as never,
-    targetResources: undefined as never,
+    sourceResources: resources(ultimate),
+    targetResources: resources(ultimate),
     ...partial,
   };
 }
 
-describe('calibrateFromEvents', () => {
-  it('buckets ultimate gains by ability and sums net/waste', () => {
+describe('calibrateFromEvents (snapshot / conservation method)', () => {
+  it('sums positive ultimate-snapshot deltas as total generation', () => {
+    // Ultimate rises 0 → 3 → 7 → 12 (gains 3,4,5 = 12 generated).
     const events = [
-      ultEvent({ abilityGameID: 100, resourceChange: 3, waste: 0 }),
-      ultEvent({ abilityGameID: 100, resourceChange: 3, waste: 1 }),
-      ultEvent({ abilityGameID: 200, resourceChange: 4, waste: 0 }),
+      snapshotEvent(1, 0),
+      snapshotEvent(1, 3),
+      snapshotEvent(1, 7),
+      snapshotEvent(1, 12),
     ];
-    const result = calibrateFromEvents({ events, fightDurationSeconds: 10 });
-
-    expect(result.totalNetUltimate).toBe(10);
-    expect(result.totalWastedUltimate).toBe(1);
-    expect(result.perSecond).toBeCloseTo(1.0, 5);
-    expect(result.bySource).toHaveLength(2);
-    // Sorted by netUltimate desc: ability 100 (6) before 200 (4).
-    expect(result.bySource[0].abilityGameID).toBe(100);
-    expect(result.bySource[0].netUltimate).toBe(6);
-    expect(result.bySource[0].events).toBe(2);
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 6, targetActorID: 1 });
+    expect(r.totalGenerated).toBe(12);
+    expect(r.totalSpent).toBe(0);
+    expect(r.approxCasts).toBe(0);
+    expect(r.perSecond).toBeCloseTo(2.0, 5);
+    expect(r.samples).toBe(4);
+    expect(r.hitCap).toBe(false);
   });
 
-  it('ignores non-ultimate resource changes', () => {
+  it('sorts snapshots by timestamp so event order does not matter', () => {
+    // Same 0→3→7→12 series, but passed OUT OF ORDER (e.g. concatenated scopes).
     const events = [
-      ultEvent({
-        abilityGameID: 1,
-        resourceChange: 5,
-        resourceChangeType: RESOURCE_CHANGE_TYPE.magicka,
-      }),
-      ultEvent({
-        abilityGameID: 1,
-        resourceChange: 5,
-        resourceChangeType: RESOURCE_CHANGE_TYPE.stamina,
-      }),
-      ultEvent({
-        abilityGameID: 1,
-        resourceChange: 5,
-        resourceChangeType: RESOURCE_CHANGE_TYPE.ultimate,
-      }),
+      snapshotEvent(1, 7, { timestamp: 300 }),
+      snapshotEvent(1, 0, { timestamp: 0 }),
+      snapshotEvent(1, 12, { timestamp: 450 }),
+      snapshotEvent(1, 3, { timestamp: 150 }),
     ];
-    const result = calibrateFromEvents({ events, fightDurationSeconds: 1 });
-    expect(result.totalNetUltimate).toBe(5);
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 6, targetActorID: 1 });
+    expect(r.totalGenerated).toBe(12); // would be wrong if unsorted
+    expect(r.totalSpent).toBe(0);
+    expect(r.approxCasts).toBe(0);
   });
 
-  it('ignores ultimate SPENDS (non-positive change)', () => {
+  it('counts spends (negative deltas) without subtracting from generation', () => {
+    // 0 → 250 (gen 250) → cast to 0 (spent 250) → 100 (gen 100). gen=350, spent=250.
     const events = [
-      ultEvent({ abilityGameID: 1, resourceChange: -250 }),
-      ultEvent({ abilityGameID: 1, resourceChange: 3 }),
+      snapshotEvent(1, 0),
+      snapshotEvent(1, 250),
+      snapshotEvent(1, 0),
+      snapshotEvent(1, 100),
     ];
-    const result = calibrateFromEvents({ events, fightDurationSeconds: 1 });
-    expect(result.totalNetUltimate).toBe(3);
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 10, targetActorID: 1 });
+    expect(r.totalGenerated).toBe(350);
+    expect(r.totalSpent).toBe(250);
+    expect(r.approxCasts).toBe(1);
   });
 
-  it('filters to the target actor when provided', () => {
+  it('obeys the conservation identity gen = spent + (final - initial)', () => {
+    // Mirror the real Arc Daddy fight: initial 198, final 76, spent 743 → gen 621.
     const events = [
-      ultEvent({ abilityGameID: 1, resourceChange: 3, targetID: 7 }),
-      ultEvent({ abilityGameID: 1, resourceChange: 9, targetID: 8 }),
+      snapshotEvent(4, 198),
+      snapshotEvent(4, 261), // +63
+      snapshotEvent(4, 11), // cast -250
+      snapshotEvent(4, 200), // +189
+      snapshotEvent(4, 50), // cast -150
+      snapshotEvent(4, 369), // +319 ... arrange to land on the identity
+      snapshotEvent(4, 26), // cast -343
+      snapshotEvent(4, 76), // +50
     ];
-    const result = calibrateFromEvents({ events, fightDurationSeconds: 1, targetActorID: 7 });
-    expect(result.totalNetUltimate).toBe(3);
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 186, targetActorID: 4 });
+    const initial = 198;
+    const final = 76;
+    expect(r.totalGenerated - r.totalSpent).toBe(final - initial);
+    expect(r.totalGenerated).toBe(r.totalSpent + (final - initial));
   });
 
-  it('resolves ability labels from masterData when supplied', () => {
-    const events = [ultEvent({ abilityGameID: 999, resourceChange: 1 })];
-    const result = calibrateFromEvents({
-      events,
-      fightDurationSeconds: 1,
-      abilityNames: new Map([[999, 'Minor Heroism']]),
-    });
-    expect(result.bySource[0].label).toBe('Minor Heroism');
+  it('measures only the requested actor', () => {
+    const events = [
+      snapshotEvent(7, 0),
+      snapshotEvent(8, 0),
+      snapshotEvent(7, 10),
+      snapshotEvent(8, 99),
+    ];
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 1, targetActorID: 7 });
+    expect(r.totalGenerated).toBe(10);
+    expect(r.samples).toBe(2);
+  });
+
+  it('reads the snapshot from sourceResources when the actor is the source', () => {
+    const events = [
+      snapshotEvent(5, 0, { sourceID: 5, targetID: 99, targetResources: resources(0) }),
+      snapshotEvent(5, 20, { sourceID: 5, targetID: 99, targetResources: resources(0) }),
+    ];
+    // Actor 5 appears as SOURCE; its ultimate is in sourceResources.
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 1, targetActorID: 5 });
+    expect(r.totalGenerated).toBe(20);
+  });
+
+  it('flags hitCap when ultimate reaches the 500 pool cap (gen is a lower bound)', () => {
+    const events = [snapshotEvent(1, 480), snapshotEvent(1, 500), snapshotEvent(1, 500)];
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 5, targetActorID: 1 });
+    expect(r.hitCap).toBe(true);
+  });
+
+  it('returns zeros when the actor was never snapshotted', () => {
+    const events = [snapshotEvent(1, 50), snapshotEvent(1, 80)];
+    const r = calibrateFromEvents({ events, fightDurationSeconds: 10, targetActorID: 42 });
+    expect(r.samples).toBe(0);
+    expect(r.totalGenerated).toBe(0);
+    expect(r.perSecond).toBe(0);
+  });
+});
+
+describe('isUltimateResourceEvent', () => {
+  it('identifies ultimate events by maxResourceAmount === maxUltimate', () => {
+    expect(isUltimateResourceEvent(snapshotEvent(1, 100, { maxResourceAmount: MAX_ULT }))).toBe(
+      true,
+    );
+    // maxResourceAmount matching magicka, not ultimate → not an ultimate event.
+    expect(isUltimateResourceEvent(snapshotEvent(1, 100, { maxResourceAmount: 20000 }))).toBe(
+      false,
+    );
+  });
+
+  it('falls back to the verified type code (2) when no snapshot is present', () => {
+    const bare: ResourceChangeEvent = {
+      ...snapshotEvent(1, 0),
+      sourceResources: undefined as never,
+      targetResources: undefined as never,
+      maxResourceAmount: 0,
+      resourceChangeType: 2,
+    };
+    expect(isUltimateResourceEvent(bare)).toBe(true);
+    expect(isUltimateResourceEvent({ ...bare, resourceChangeType: 0 })).toBe(false);
   });
 });

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -112,6 +112,35 @@ describe('compileSources', () => {
     });
     expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
   });
+
+  it('does not stack Minor Heroism across providers (keeps one, not both)', () => {
+    // Generic Minor Heroism and Cryptcanon both grant the SAME named buff; with
+    // both enabled, only one contribution should survive (they share a
+    // nonStackingGroup), never summed.
+    const both = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'minor-heroism': true, 'cryptcanon-vestments': true },
+    });
+    const minorHeroismGroup = both.filter(
+      (s) => s.id === 'minor-heroism' || s.id === 'cryptcanon-vestments',
+    );
+    expect(minorHeroismGroup).toHaveLength(1);
+
+    // The single survivor's contribution must not exceed either provider alone —
+    // i.e. enabling both is never larger than enabling just one.
+    const onlyGeneric = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'minor-heroism': true },
+    });
+    const rate = (s: { amountPerInstance: number; instancesPerSecond: number; uptime: number }) =>
+      s.amountPerInstance * s.instancesPerSecond * s.uptime;
+    const bothRate = rate(minorHeroismGroup[0]);
+    const genericRate = rate(onlyGeneric.find((s) => s.id === 'minor-heroism')!);
+    // The kept provider is the strongest single one, so its rate is ≥ the generic
+    // alone but the GROUP total equals exactly that one provider (no doubling).
+    expect(bothRate).toBeGreaterThanOrEqual(genericRate);
+    expect(minorHeroismGroup).toHaveLength(1);
+  });
 });
 
 describe('compileReductions', () => {

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -113,33 +113,15 @@ describe('compileSources', () => {
     expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
   });
 
-  it('does not stack Minor Heroism across providers (keeps one, not both)', () => {
-    // Generic Minor Heroism and Cryptcanon both grant the SAME named buff; with
-    // both enabled, only one contribution should survive (they share a
-    // nonStackingGroup), never summed.
-    const both = compileSources(ULTIMATE_SOURCE_CATALOG, {
-      ...baseSelection,
-      enabledOverrides: { 'minor-heroism': true, 'cryptcanon-vestments': true },
-    });
-    const minorHeroismGroup = both.filter(
-      (s) => s.id === 'minor-heroism' || s.id === 'cryptcanon-vestments',
-    );
-    expect(minorHeroismGroup).toHaveLength(1);
-
-    // The single survivor's contribution must not exceed either provider alone —
-    // i.e. enabling both is never larger than enabling just one.
-    const onlyGeneric = compileSources(ULTIMATE_SOURCE_CATALOG, {
+  it('models Minor Heroism as a single source (no per-provider duplicate)', () => {
+    // Minor Heroism is one named buff; the catalog represents all of its
+    // providers with the single `minor-heroism` entry, so enabling it yields
+    // exactly one Minor Heroism source.
+    const compiled = compileSources(ULTIMATE_SOURCE_CATALOG, {
       ...baseSelection,
       enabledOverrides: { 'minor-heroism': true },
     });
-    const rate = (s: { amountPerInstance: number; instancesPerSecond: number; uptime: number }) =>
-      s.amountPerInstance * s.instancesPerSecond * s.uptime;
-    const bothRate = rate(minorHeroismGroup[0]);
-    const genericRate = rate(onlyGeneric.find((s) => s.id === 'minor-heroism')!);
-    // The kept provider is the strongest single one, so its rate is ≥ the generic
-    // alone but the GROUP total equals exactly that one provider (no doubling).
-    expect(bothRate).toBeGreaterThanOrEqual(genericRate);
-    expect(minorHeroismGroup).toHaveLength(1);
+    expect(compiled.filter((s) => s.id === 'minor-heroism')).toHaveLength(1);
   });
 });
 

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -1,0 +1,205 @@
+import {
+  COST_REDUCTION_CATALOG,
+  ULTIMATE_ABILITIES,
+  ULTIMATE_SOURCE_CATALOG,
+} from '../../shared/constants/catalog';
+import type { CatalogSelection } from '../compileCatalog';
+import {
+  availableReductions,
+  availableSources,
+  compileReductions,
+  compileSources,
+  isEntryEnabled,
+  isReductionAvailable,
+  isSourceAvailable,
+} from '../compileCatalog';
+
+const baseSelection: CatalogSelection = {
+  context: 'groupPve',
+  esoClass: 'arcanist',
+  role: 'dps',
+  enabledOverrides: {},
+  uptimeOverrides: {},
+};
+
+describe('isSourceAvailable', () => {
+  it('filters group-only sources out of solo context', () => {
+    const major = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === 'major-heroism')!;
+    expect(isSourceAvailable(major, { ...baseSelection, context: 'soloPve' })).toBe(false);
+    expect(isSourceAvailable(major, { ...baseSelection, context: 'groupPve' })).toBe(true);
+  });
+
+  it('filters class passives to their class', () => {
+    const implacable = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === 'arcanist-implacable-outcome')!;
+    expect(isSourceAvailable(implacable, { ...baseSelection, esoClass: 'arcanist' })).toBe(true);
+    expect(isSourceAvailable(implacable, { ...baseSelection, esoClass: 'sorcerer' })).toBe(false);
+  });
+
+  it('keeps universal sources for every class and context', () => {
+    const base = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === 'base-light-attack')!;
+    expect(isSourceAvailable(base, { ...baseSelection, esoClass: 'warden', context: 'pvp' })).toBe(
+      true,
+    );
+  });
+});
+
+describe('isReductionAvailable', () => {
+  it('filters Power Stone to Sorcerer', () => {
+    const ps = COST_REDUCTION_CATALOG.find((r) => r.id === 'sorcerer-power-stone')!;
+    expect(isReductionAvailable(ps, { context: 'groupPve', esoClass: 'sorcerer' })).toBe(true);
+    expect(isReductionAvailable(ps, { context: 'groupPve', esoClass: 'arcanist' })).toBe(false);
+  });
+});
+
+describe('isEntryEnabled', () => {
+  it('override wins over default', () => {
+    expect(isEntryEnabled('x', true, {})).toBe(true);
+    expect(isEntryEnabled('x', true, { x: false })).toBe(false);
+    expect(isEntryEnabled('x', false, { x: true })).toBe(true);
+  });
+});
+
+describe('compileSources', () => {
+  it('returns only enabled, available sources as engine UltimateSource shape', () => {
+    const sources = compileSources(ULTIMATE_SOURCE_CATALOG, baseSelection);
+    // Arcanist group DPS defaults: base income + implacable (Minor Heroism is
+    // opt-in, off by default).
+    const ids = sources.map((s) => s.id);
+    expect(ids).toContain('base-light-attack');
+    expect(ids).toContain('arcanist-implacable-outcome');
+    // Minor Heroism is default-off (opt-in build choice).
+    expect(ids).not.toContain('minor-heroism');
+    // A non-arcanist class passive must not appear.
+    expect(ids).not.toContain('necromancer-corpse-consumption');
+    // Each compiled source is the bare engine shape (no catalog-only fields).
+    for (const s of sources) {
+      expect(s).not.toHaveProperty('category');
+      expect(s).not.toHaveProperty('provenance');
+      expect(typeof s.amountPerInstance).toBe('number');
+    }
+  });
+
+  it('respects enabled overrides', () => {
+    const off = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'minor-heroism': false },
+    });
+    expect(off.map((s) => s.id)).not.toContain('minor-heroism');
+
+    const on = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'major-heroism': true },
+    });
+    expect(on.map((s) => s.id)).toContain('major-heroism');
+  });
+
+  it('applies and clamps uptime overrides', () => {
+    const sources = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      // Minor Heroism is default-off — enable it so its uptime override applies.
+      enabledOverrides: { 'minor-heroism': true },
+      uptimeOverrides: { 'base-light-attack': 1.5, 'minor-heroism': -1 },
+    });
+    expect(sources.find((s) => s.id === 'base-light-attack')!.uptime).toBe(1);
+    expect(sources.find((s) => s.id === 'minor-heroism')!.uptime).toBe(0);
+  });
+
+  it('drops external group support in solo context', () => {
+    const solo = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      context: 'soloPve',
+      enabledOverrides: { 'pillagers-profit-external': true },
+    });
+    expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
+  });
+});
+
+describe('compileReductions', () => {
+  it('compiles available reductions with enabled state', () => {
+    const reductions = compileReductions(COST_REDUCTION_CATALOG, {
+      ...baseSelection,
+      esoClass: 'sorcerer',
+    });
+    const ps = reductions.find((r) => r.id === 'sorcerer-power-stone');
+    expect(ps).toBeDefined();
+    expect(ps!.enabled).toBe(true); // defaultEnabled for its class
+    expect(ps!.fraction).toBeCloseTo(0.15, 6);
+  });
+
+  it('omits reductions for the wrong class', () => {
+    const reductions = compileReductions(COST_REDUCTION_CATALOG, baseSelection); // arcanist
+    expect(reductions.map((r) => r.id)).not.toContain('sorcerer-power-stone');
+    expect(reductions.map((r) => r.id)).not.toContain('templar-restoring-spirit');
+  });
+});
+
+describe('catalog data integrity', () => {
+  it('every source carries provenance and confidence (no guessing)', () => {
+    for (const s of ULTIMATE_SOURCE_CATALOG) {
+      expect(s.provenance).toMatch(/^https?:\/\//);
+      expect(['high', 'medium', 'low']).toContain(s.confidence);
+    }
+  });
+
+  it('every cost reduction and ability carries provenance', () => {
+    for (const r of COST_REDUCTION_CATALOG) {
+      expect(r.provenance).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it('availableSources/availableReductions are subsets of the catalog', () => {
+    const s = availableSources(ULTIMATE_SOURCE_CATALOG, baseSelection);
+    expect(s.length).toBeLessThanOrEqual(ULTIMATE_SOURCE_CATALOG.length);
+    const r = availableReductions(COST_REDUCTION_CATALOG, baseSelection);
+    expect(r.length).toBeLessThanOrEqual(COST_REDUCTION_CATALOG.length);
+  });
+
+  it('only cites UESP or ESO-Skillbook as provenance (repo data-source policy)', () => {
+    // Allowlist the permitted hosts rather than denylisting the forbidden one, so
+    // this test never contains the banned substring (the repo guard is a literal
+    // source-text scan) and any future disallowed host is caught too.
+    const allowedHosts = ['en.uesp.net', 'eso-skillbook.com'];
+    const all = [...ULTIMATE_SOURCE_CATALOG, ...COST_REDUCTION_CATALOG, ...ULTIMATE_ABILITIES];
+    for (const e of all) {
+      const host = new URL(e.provenance).host;
+      expect(allowedHosts).toContain(host);
+    }
+  });
+
+  // Lock the ultimate costs to the values verified against primary sources
+  // (ESO-Skillbook / UESP, U50). A silent regression here would mislead the
+  // time-to-ultimate output.
+  it('encodes the verified U50 ultimate costs', () => {
+    const cost = (id: string): number | undefined =>
+      ULTIMATE_ABILITIES.find((a) => a.id === id)?.baseCost;
+    expect(cost('dawnbreaker')).toBe(125);
+    expect(cost('standard-of-might')).toBe(200);
+    expect(cost('shifting-standard')).toBe(200);
+    expect(cost('corrosive-armor')).toBe(200);
+    expect(cost('storm-atronach')).toBe(200);
+    expect(cost('negate-magic')).toBe(225);
+    expect(cost('incapacitating-strike')).toBe(70);
+    expect(cost('nova')).toBe(225);
+    expect(cost('permafrost')).toBe(200);
+    expect(cost('colossus')).toBe(175);
+    expect(cost('the-unblinking-eye')).toBe(175);
+  });
+
+  it('encodes the verified generation rates and cost-reduction percentages', () => {
+    const src = (id: string) => ULTIMATE_SOURCE_CATALOG.find((s) => s.id === id);
+    // Base light-attack income = 3 ult/sec.
+    expect(src('base-light-attack')?.amountPerInstance).toBe(3);
+    expect(src('base-light-attack')?.instancesPerSecond).toBe(1);
+    // Minor Heroism = 1 ult / 1.5s; Major Heroism = 3 ult / 1.5s.
+    expect(src('minor-heroism')?.amountPerInstance).toBe(1);
+    expect(src('minor-heroism')?.instancesPerSecond).toBeCloseTo(1 / 1.5, 6);
+    expect(src('major-heroism')?.amountPerInstance).toBe(3);
+    // Class ult-gen passives.
+    expect(src('arcanist-implacable-outcome')?.amountPerInstance).toBe(4);
+    expect(src('necromancer-corpse-consumption')?.amountPerInstance).toBe(10);
+    // Cost reductions.
+    const red = (id: string) => COST_REDUCTION_CATALOG.find((r) => r.id === id);
+    expect(red('sorcerer-power-stone')?.fraction).toBeCloseTo(0.15, 6);
+    expect(red('templar-restoring-spirit')?.fraction).toBeCloseTo(0.05, 6);
+  });
+});

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -277,7 +277,9 @@ describe('catalog data integrity', () => {
     };
     // New generators exist and are encoded.
     expect(src('bloodspawn')).toBeDefined();
-    expect(src('dragonknight-mountains-blessing')?.amountPerInstance).toBe(3);
+    // Blessing at the Peak grants +1 ultimate per Earthen Heart cast (verified
+    // against the repo's curated DK skill-line data — NOT the earlier unsourced 3).
+    expect(src('dragonknight-mountains-blessing')?.amountPerInstance).toBe(1);
     expect(src('templar-prism')?.amountPerInstance).toBe(3);
     expect(src('nightblade-catalyst')?.amountPerInstance).toBe(22);
     // Every new generator stays a minor contributor — no Pillager's-style blowup

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -24,8 +24,17 @@ const baseSelection: CatalogSelection = {
 
 describe('isSourceAvailable', () => {
   it('filters group-only sources out of solo context', () => {
+    // Pillager's Profit is an external healer source — group-only.
+    const pillagers = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === 'pillagers-profit-external')!;
+    expect(isSourceAvailable(pillagers, { ...baseSelection, context: 'soloPve' })).toBe(false);
+    expect(isSourceAvailable(pillagers, { ...baseSelection, context: 'groupPve' })).toBe(true);
+  });
+
+  it('keeps Major Heroism available solo (self-applied providers exist)', () => {
+    // Major Heroism is modeled as one buff available in every context — solo it
+    // comes from a self-applied source (e.g. the DK Basalt-Blooded Warrior set).
     const major = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === 'major-heroism')!;
-    expect(isSourceAvailable(major, { ...baseSelection, context: 'soloPve' })).toBe(false);
+    expect(isSourceAvailable(major, { ...baseSelection, context: 'soloPve' })).toBe(true);
     expect(isSourceAvailable(major, { ...baseSelection, context: 'groupPve' })).toBe(true);
   });
 
@@ -246,5 +255,63 @@ describe('catalog data integrity', () => {
     const red = (id: string) => COST_REDUCTION_CATALOG.find((r) => r.id === id);
     expect(red('sorcerer-power-stone')?.fraction).toBeCloseTo(0.15, 6);
     expect(red('templar-restoring-spirit')?.fraction).toBeCloseTo(0.05, 6);
+  });
+
+  // ---- Catalog expansion (sets / class passives / more ultimates) ----------
+  it('encodes the expanded generator rates within the sanity ceiling', () => {
+    const src = (id: string) => ULTIMATE_SOURCE_CATALOG.find((s) => s.id === id);
+    const rate = (id: string): number => {
+      const s = src(id)!;
+      return s.amountPerInstance * s.instancesPerSecond * s.uptime;
+    };
+    // New generators exist and are encoded.
+    expect(src('bloodspawn')).toBeDefined();
+    expect(src('dragonknight-mountains-blessing')?.amountPerInstance).toBe(3);
+    expect(src('templar-prism')?.amountPerInstance).toBe(3);
+    expect(src('nightblade-catalyst')?.amountPerInstance).toBe(22);
+    // Every new generator stays a minor contributor — no Pillager's-style blowup
+    // (a single source far below the base light-attack income of ~2.85 ult/s).
+    for (const id of [
+      'bloodspawn',
+      'dragonknight-mountains-blessing',
+      'templar-prism',
+      'nightblade-catalyst',
+    ]) {
+      expect(rate(id)).toBeLessThan(2);
+    }
+    // Major Heroism is now available solo too (self-applied sources exist), and is
+    // still a single non-stacking entry (no per-provider duplicates).
+    expect(src('major-heroism')?.availableIn).toContain('soloPve');
+    expect(ULTIMATE_SOURCE_CATALOG.filter((s) => s.id === 'major-heroism')).toHaveLength(1);
+  });
+
+  it('makes Templar Prism a default-on generator for Templar only', () => {
+    // Prism is near-always-on Templar income (like Implacable for Arcanist), so it
+    // is default-enabled — but only compiles in for the Templar class.
+    const templar = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      esoClass: 'templar',
+    });
+    expect(templar.map((s) => s.id)).toContain('templar-prism');
+    const arcanist = compileSources(ULTIMATE_SOURCE_CATALOG, baseSelection); // arcanist
+    expect(arcanist.map((s) => s.id)).not.toContain('templar-prism');
+  });
+
+  it('adds the expanded ultimate cost-targets (weapon/guild + class bases)', () => {
+    const cost = (id: string): number | undefined =>
+      ULTIMATE_ABILITIES.find((a) => a.id === id)?.baseCost;
+    expect(cost('lacerate')).toBe(150); // Dual Wield
+    expect(cost('rapid-fire')).toBe(175); // Bow
+    expect(cost('meteor')).toBe(200); // Mages Guild
+    expect(cost('war-horn')).toBe(250); // Alliance War
+    expect(cost('radial-sweep')).toBe(75); // Templar (cheapest)
+    expect(cost('reanimate')).toBe(335); // Necromancer (priciest)
+    // Every ability still carries a valid owner the picker can group by.
+    const owners = new Set([
+      'global',
+      'weapon',
+      ...['arcanist', 'dragonknight', 'necromancer', 'nightblade', 'sorcerer', 'templar', 'warden'],
+    ]);
+    for (const a of ULTIMATE_ABILITIES) expect(owners.has(a.owner)).toBe(true);
   });
 });

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -166,6 +166,17 @@ describe('compileSources', () => {
     });
     expect(compiled.filter((s) => s.id === 'minor-heroism')).toHaveLength(1);
   });
+
+  it('keeps source ids and cost-reduction ids disjoint', () => {
+    // Both generation sources and cost reductions are toggled through the SAME
+    // `enabledOverrides` map (keyed by id). That only stays correct while the two
+    // id spaces never collide — a shared id would cross-wire one toggle to flip
+    // both. This guards that invariant so a future catalog addition can't silently
+    // break it (see LOW-1 in the catalog audit).
+    const sourceIds = new Set(ULTIMATE_SOURCE_CATALOG.map((s) => s.id));
+    const collisions = COST_REDUCTION_CATALOG.filter((r) => sourceIds.has(r.id)).map((r) => r.id);
+    expect(collisions).toEqual([]);
+  });
 });
 
 describe('compileReductions', () => {
@@ -285,15 +296,29 @@ describe('catalog data integrity', () => {
     expect(ULTIMATE_SOURCE_CATALOG.filter((s) => s.id === 'major-heroism')).toHaveLength(1);
   });
 
-  it('makes Templar Prism a default-on generator for Templar only', () => {
-    // Prism is near-always-on Templar income (like Implacable for Arcanist), so it
-    // is default-enabled — but only compiles in for the Templar class.
-    const templar = compileSources(ULTIMATE_SOURCE_CATALOG, {
-      ...baseSelection,
-      esoClass: 'templar',
+  it('offers Templar Prism to Templar only, default-OFF until toggled on', () => {
+    // Prism procs on a Dawn's Wrath cast — a loadout choice, not a class-universal
+    // mechanic — so it is available to Templar but NOT default-on (a Templar
+    // tank/healer may run no Dawn's Wrath skills). It must be explicitly enabled.
+    const templarSelection = { ...baseSelection, esoClass: 'templar' as const };
+
+    // Available to Templar...
+    expect(availableSources(ULTIMATE_SOURCE_CATALOG, templarSelection).map((s) => s.id)).toContain(
+      'templar-prism',
+    );
+    // ...but NOT compiled in by default (default-off).
+    expect(
+      compileSources(ULTIMATE_SOURCE_CATALOG, templarSelection).map((s) => s.id),
+    ).not.toContain('templar-prism');
+    // Turning it on compiles it in.
+    const enabled = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...templarSelection,
+      enabledOverrides: { 'templar-prism': true },
     });
-    expect(templar.map((s) => s.id)).toContain('templar-prism');
-    const arcanist = compileSources(ULTIMATE_SOURCE_CATALOG, baseSelection); // arcanist
+    expect(enabled.map((s) => s.id)).toContain('templar-prism');
+
+    // Not available to a non-Templar (Arcanist) at all.
+    const arcanist = availableSources(ULTIMATE_SOURCE_CATALOG, baseSelection); // arcanist
     expect(arcanist.map((s) => s.id)).not.toContain('templar-prism');
   });
 

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -244,7 +244,9 @@ describe('catalog data integrity', () => {
     expect(cost('storm-atronach')).toBe(200);
     expect(cost('negate-magic')).toBe(225);
     expect(cost('incapacitating-strike')).toBe(70);
-    expect(cost('nova')).toBe(225);
+    // Nova family has a SPLIT cost: base Nova / Solar Prison = 250, Solar
+    // Disturbance morph = 225 (verified on ESO-Skillbook). We list the base (250).
+    expect(cost('nova')).toBe(250);
     expect(cost('permafrost')).toBe(200);
     expect(cost('colossus')).toBe(175);
     expect(cost('the-unblinking-eye')).toBe(175);

--- a/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
+++ b/src/features/ultimate-simulator/application/__tests__/compileCatalog.test.ts
@@ -113,6 +113,40 @@ describe('compileSources', () => {
     expect(solo.map((s) => s.id)).not.toContain('pillagers-profit-external');
   });
 
+  it("scales Pillager's per-cast amount to the healer's ultimate cost (10% of it)", () => {
+    // Pillager's grants 2% of the spent ult per tick × 5 ticks = 10% of the cost.
+    // The per-cast amount must follow the healer's ult cost from the selection.
+    const at500 = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'pillagers-profit-external': true },
+      pillagerHealerUltCost: 500,
+    });
+    const at200 = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'pillagers-profit-external': true },
+      pillagerHealerUltCost: 200,
+    });
+    const amt = (sources: ReturnType<typeof compileSources>) =>
+      sources.find((s) => s.id === 'pillagers-profit-external')!.amountPerInstance;
+    expect(amt(at500)).toBe(50); // 10% of 500 — the user's "50 from a full cast"
+    expect(amt(at200)).toBe(20); // 10% of 200
+
+    // Sanity: even at max healer ult, the rate stays a minor contributor, not the
+    // ~4 ult/s the old flat-50 encoding produced.
+    const src = at500.find((s) => s.id === 'pillagers-profit-external')!;
+    const ultPerSecond = src.amountPerInstance * src.instancesPerSecond * src.uptime;
+    expect(ultPerSecond).toBeLessThan(1.2); // 50 / 45 ≈ 1.11
+  });
+
+  it('falls back to the catalog default when no healer ult cost is given', () => {
+    const compiled = compileSources(ULTIMATE_SOURCE_CATALOG, {
+      ...baseSelection,
+      enabledOverrides: { 'pillagers-profit-external': true },
+    });
+    // No pillagerHealerUltCost → catalog default amountPerInstance (25 = 10% of ~250).
+    expect(compiled.find((s) => s.id === 'pillagers-profit-external')!.amountPerInstance).toBe(25);
+  });
+
   it('models Minor Heroism as a single source (no per-provider duplicate)', () => {
     // Minor Heroism is one named buff; the catalog represents all of its
     // providers with the single `minor-heroism` entry, so enabling it yields

--- a/src/features/ultimate-simulator/application/calibration.ts
+++ b/src/features/ultimate-simulator/application/calibration.ts
@@ -13,110 +13,154 @@
 import type { ResourceChangeEvent } from '../../../types/combatlogEvents';
 
 /**
- * ESO Logs `resourceChangeType` enum values. 0/6 are confirmed in this codebase
- * (RotationAnalysisPanel.tsx); 10 = Ultimate is the ESO Logs / Hodor combat-log
- * convention.
+ * ESO Logs `resourcechange` event `resourceChangeType` values — EMPIRICALLY
+ * VERIFIED against a real trial log (Lucent Citadel report kZAvqFwYcRTLB97W,
+ * fight 2), NOT the ESO `POWERTYPE` enum.
  *
- * VERIFY against a real event sample before treating ultimate buckets as ground
- * truth — if a calibration run yields zero ultimate events, this constant is the
- * first thing to check.
+ * IMPORTANT: an earlier version of this file assumed ESO Logs used the ESO
+ * `POWERTYPE` enum (magicka=0, stamina=6, ultimate=10). That is WRONG for the
+ * combat-log `resourcechange` stream. The discriminator: every event carries
+ * `maxResourceAmount`; matching it to the snapshot's `maxUltimate`/`maxMagicka`/
+ * `maxStamina` reveals the real scheme. In live data:
+ *   - type 0 → magicka  (maxResourceAmount === maxMagicka)
+ *   - type 1 → stamina  (maxResourceAmount === maxStamina)
+ *   - type 2 → ULTIMATE (maxResourceAmount === maxUltimate, i.e. 500)
+ * The "POWERTYPE=10" research was about the in-game API constant, which ESO Logs
+ * does not use for this field. The codebase's magicka/stamina handling reads the
+ * resource SNAPSHOT fields (targetResources.magicka, etc.), never this type code,
+ * which is why the mismatch went unnoticed.
+ *
+ * The robust way to attribute ultimate is to verify a candidate event's
+ * `maxResourceAmount === targetResources.maxUltimate` rather than trusting a bare
+ * type number — see `isUltimateGain`, which uses that check as the source of truth
+ * and treats the type number as a fast-path hint only.
  */
 export const RESOURCE_CHANGE_TYPE = {
   magicka: 0,
-  stamina: 6,
-  ultimate: 10,
+  stamina: 1,
+  ultimate: 2,
 } as const;
-
-/** Empirical generation attributed to one ability (game) ID over a fight. */
-export interface AbilityUltimateStat {
-  readonly abilityGameID: number;
-  /** Resolved display name if masterData was provided, else the numeric ID. */
-  readonly label: string;
-  /** Net ultimate granted (sum of positive resourceChange), excluding waste. */
-  readonly netUltimate: number;
-  /** Ultimate that was wasted (overcapped). */
-  readonly wastedUltimate: number;
-  /** Number of contributing events (≈ instances). */
-  readonly events: number;
-  /** netUltimate / fightDurationSeconds. */
-  readonly ultimatePerSecond: number;
-}
 
 export interface CalibrationResult {
   readonly fightDurationSeconds: number;
-  /** Total net ultimate generated for the target actor over the fight. */
-  readonly totalNetUltimate: number;
-  readonly totalWastedUltimate: number;
+  /**
+   * Total ultimate GENERATED over the fight (sum of positive deltas in the
+   * actor's ultimate snapshot). This is the conservation-closed gross
+   * generation: gen = spent + (final − initial), exact except for overcap waste.
+   */
+  readonly totalGenerated: number;
+  /** Ultimate spent (sum of negative deltas) — sanity / casts. */
+  readonly totalSpent: number;
+  /** Approximate ultimate casts (negative-delta segments). */
+  readonly approxCasts: number;
+  /** totalGenerated / fightDurationSeconds. */
   readonly perSecond: number;
-  /** Per-ability breakdown, sorted by netUltimate descending. */
-  readonly bySource: readonly AbilityUltimateStat[];
+  /** Snapshot samples seen for the actor (0 ⇒ actor not snapshotted in stream). */
+  readonly samples: number;
+  /**
+   * Whether the actor's ultimate hit the 500 cap during the fight. If true,
+   * `totalGenerated` UNDERCOUNTS by the overcapped amount (waste isn't visible in
+   * snapshots), so treat it as a lower bound.
+   */
+  readonly hitCap: boolean;
 }
 
 export interface CalibrationInput {
   readonly events: readonly ResourceChangeEvent[];
   readonly fightDurationSeconds: number;
-  /** Restrict to this actor's gains (the modeled Arcanist). Omit = all actors. */
-  readonly targetActorID?: number;
-  /** Optional abilityGameID → display name map (from report masterData). */
-  readonly abilityNames?: ReadonlyMap<number, string>;
+  /** Which actor's ultimate to measure (required — measure one actor at a time). */
+  readonly targetActorID: number;
 }
 
-/** Is this event an ultimate-resource gain for the target actor? */
-function isUltimateGain(event: ResourceChangeEvent, targetActorID?: number): boolean {
-  if (event.resourceChangeType !== RESOURCE_CHANGE_TYPE.ultimate) return false;
-  if (event.resourceChange <= 0) return false;
-  // Ultimate accrues to the actor as the TARGET of the resourcechange event.
-  if (targetActorID !== undefined && event.targetID !== targetActorID) return false;
-  return true;
+/** Hard ultimate pool cap — used to flag overcap (waste invisible in snapshots). */
+const ULTIMATE_POOL_CAP = 500;
+
+/**
+ * Identify whether a resourcechange event targets the ULTIMATE pool. Source of
+ * truth = the event's `maxResourceAmount` equals the actor's `maxUltimate`
+ * snapshot — robust across reports/patches even if the bare `resourceChangeType`
+ * numbering shifts. Falls back to the empirically-verified type code (2) when no
+ * snapshot is present. Exported for callers that want to filter ult events
+ * directly; note `calibrateFromEvents` measures generation via snapshots, not
+ * these events' `resourceChange` (which undercounts — see its doc comment).
+ */
+export function isUltimateResourceEvent(event: ResourceChangeEvent): boolean {
+  const maxUlt = event.targetResources?.maxUltimate ?? event.sourceResources?.maxUltimate;
+  if (typeof maxUlt === 'number' && maxUlt > 0) {
+    return event.maxResourceAmount === maxUlt;
+  }
+  return event.resourceChangeType === RESOURCE_CHANGE_TYPE.ultimate;
+}
+
+/** The actor's ultimate value in this event's snapshot, or null if absent. */
+function ultimateSnapshot(event: ResourceChangeEvent, actorID: number): number | null {
+  if (event.targetID === actorID && event.targetResources) return event.targetResources.ultimate;
+  if (event.sourceID === actorID && event.sourceResources) return event.sourceResources.ultimate;
+  return null;
 }
 
 /**
- * Bucket ultimate-gain events by ability into empirical per-source rates.
+ * Measure an actor's real ultimate generation from a fight's Resources events.
  *
- * Note on Decisive: ESO Logs typically folds the Decisive +1 into the host
- * ability's resourceChange rather than emitting a separate event, so Decisive
- * usually has no bucket of its own here — its contribution shows up as slightly
- * larger per-instance amounts on the sources it rolls against. That is expected;
- * the simulator models Decisive explicitly, and calibration measures the totals.
+ * WHY SNAPSHOTS, NOT resourceChange SUMS: ESO Logs does NOT emit a per-ability
+ * resourcechange event for most ultimate gains — the bulk of ultimate accrues
+ * implicitly (light-attack income, Heroism ticks) and only surfaces in the
+ * `ultimate` field of resource SNAPSHOTS carried on other events. Summing the
+ * `resourceChange` of ult-typed events therefore drastically undercounts (it
+ * misses casts too). So PER-SOURCE attribution is NOT derivable from logs.
+ *
+ * What IS exact: total generation, by conservation. Ultimate rises monotonically
+ * between casts, so summing the positive deltas of the ultimate-snapshot series
+ * captures every rising segment regardless of sample spacing. The only leak is
+ * overcap waste (invisible in snapshots) — flagged via `hitCap`. Equivalently,
+ * gen = spent + (final − initial).
+ *
+ * Robust to event ordering: the actor's snapshots are sorted by timestamp here,
+ * so callers may pass events in any order (e.g. concatenated hostility scopes).
+ * Validated against a real trial log (Lucent Citadel kZAvqFwYcRTLB97W, fight 2):
+ * this exact algorithm yields 627 generated / 186s ≈ 3.37 ult/s for a baseline
+ * Arcanist, conservation-closed (627 − 749 spent = 76 − 198 final−initial).
  */
 export function calibrateFromEvents(input: CalibrationInput): CalibrationResult {
-  const { events, fightDurationSeconds, targetActorID, abilityNames } = input;
-
-  const buckets = new Map<number, { net: number; wasted: number; count: number }>();
-  let totalNet = 0;
-  let totalWasted = 0;
-
-  for (const event of events) {
-    if (!isUltimateGain(event, targetActorID)) continue;
-    const id = event.abilityGameID;
-    const bucket = buckets.get(id) ?? { net: 0, wasted: 0, count: 0 };
-    bucket.net += event.resourceChange;
-    bucket.wasted += event.waste ?? 0;
-    bucket.count += 1;
-    buckets.set(id, bucket);
-
-    totalNet += event.resourceChange;
-    totalWasted += event.waste ?? 0;
-  }
-
+  const { events, fightDurationSeconds, targetActorID } = input;
   const safeDuration = fightDurationSeconds > 0 ? fightDurationSeconds : 1;
 
-  const bySource: AbilityUltimateStat[] = Array.from(buckets.entries())
-    .map(([abilityGameID, b]) => ({
-      abilityGameID,
-      label: abilityNames?.get(abilityGameID) ?? `Ability ${abilityGameID}`,
-      netUltimate: b.net,
-      wastedUltimate: b.wasted,
-      events: b.count,
-      ultimatePerSecond: b.net / safeDuration,
-    }))
-    .sort((a, b) => b.netUltimate - a.netUltimate);
+  // Collect the actor's (timestamp, ultimate) snapshots, then sort by time so the
+  // delta walk is correct regardless of the order events were passed in. Sort is
+  // stable on timestamp; equal-timestamp samples keep their original order.
+  const snapshots: { t: number; u: number }[] = [];
+  for (const event of events) {
+    const u = ultimateSnapshot(event, targetActorID);
+    if (u != null) snapshots.push({ t: event.timestamp, u });
+  }
+  snapshots.sort((a, b) => a.t - b.t);
+  const series = snapshots.map((s) => s.u);
+
+  let generated = 0;
+  let spent = 0;
+  let approxCasts = 0;
+  let hitCap = false;
+  let prev: number | null = null;
+  for (const u of series) {
+    if (u >= ULTIMATE_POOL_CAP) hitCap = true;
+    if (prev != null) {
+      const delta = u - prev;
+      if (delta > 0) generated += delta;
+      else if (delta < 0) {
+        spent += -delta;
+        approxCasts += 1;
+      }
+    }
+    prev = u;
+  }
 
   return {
     fightDurationSeconds,
-    totalNetUltimate: totalNet,
-    totalWastedUltimate: totalWasted,
-    perSecond: totalNet / safeDuration,
-    bySource,
+    totalGenerated: generated,
+    totalSpent: spent,
+    approxCasts,
+    perSecond: generated / safeDuration,
+    samples: series.length,
+    hitCap,
   };
 }

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -76,48 +76,25 @@ export function availableReductions(
   return catalog.filter((r) => isReductionAvailable(r, selection));
 }
 
-/** Expected raw ult/s a (uptime-resolved) source contributes — for ranking. */
-function expectedRate(source: CatalogSource): number {
-  return source.amountPerInstance * source.instancesPerSecond * source.uptime;
-}
-
 /**
  * Compile enabled, available catalog sources into engine `UltimateSource[]`,
  * applying per-source uptime overrides.
  *
- * Sources that share a `nonStackingGroup` represent the SAME named buff from
- * different providers (e.g. Minor Heroism from a potion vs from Cryptcanon).
- * Such a buff does not stack, so when more than one is enabled only the strongest
- * single contribution is kept — they are never summed.
+ * Note on non-stacking buffs: named buffs like Minor Heroism do not stack across
+ * providers, but the catalog already models each such buff as ONE source (e.g.
+ * the single `minor-heroism` entry represents "Minor Heroism from whatever
+ * provides it"), so no per-provider de-duplication is needed here.
  */
 export function compileSources(
   catalog: readonly CatalogSource[],
   selection: CatalogSelection,
 ): UltimateSource[] {
-  const enabled = availableSources(catalog, selection)
+  return availableSources(catalog, selection)
     .filter((s) => isEntryEnabled(s.id, s.defaultEnabled, selection.enabledOverrides))
     .map((s) => {
       const uptime = selection.uptimeOverrides[s.id];
-      return uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
-    });
-
-  // Collapse non-stacking buff groups to their single strongest provider.
-  const strongestInGroup = new Map<string, CatalogSource>();
-  for (const s of enabled) {
-    if (s.nonStackingGroup === undefined) continue;
-    const current = strongestInGroup.get(s.nonStackingGroup);
-    if (current === undefined || expectedRate(s) > expectedRate(current)) {
-      strongestInGroup.set(s.nonStackingGroup, s);
-    }
-  }
-
-  return enabled
-    .filter((s) => {
-      if (s.nonStackingGroup === undefined) return true;
-      // Keep only the winning provider of each non-stacking buff group.
-      return strongestInGroup.get(s.nonStackingGroup) === s;
-    })
-    .map((resolved) => {
+      const resolved =
+        uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
       // Strip catalog-only fields down to the engine's UltimateSource shape.
       const {
         id,

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -76,20 +76,48 @@ export function availableReductions(
   return catalog.filter((r) => isReductionAvailable(r, selection));
 }
 
+/** Expected raw ult/s a (uptime-resolved) source contributes — for ranking. */
+function expectedRate(source: CatalogSource): number {
+  return source.amountPerInstance * source.instancesPerSecond * source.uptime;
+}
+
 /**
  * Compile enabled, available catalog sources into engine `UltimateSource[]`,
  * applying per-source uptime overrides.
+ *
+ * Sources that share a `nonStackingGroup` represent the SAME named buff from
+ * different providers (e.g. Minor Heroism from a potion vs from Cryptcanon).
+ * Such a buff does not stack, so when more than one is enabled only the strongest
+ * single contribution is kept — they are never summed.
  */
 export function compileSources(
   catalog: readonly CatalogSource[],
   selection: CatalogSelection,
 ): UltimateSource[] {
-  return availableSources(catalog, selection)
+  const enabled = availableSources(catalog, selection)
     .filter((s) => isEntryEnabled(s.id, s.defaultEnabled, selection.enabledOverrides))
     .map((s) => {
       const uptime = selection.uptimeOverrides[s.id];
-      const resolved =
-        uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
+      return uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
+    });
+
+  // Collapse non-stacking buff groups to their single strongest provider.
+  const strongestInGroup = new Map<string, CatalogSource>();
+  for (const s of enabled) {
+    if (s.nonStackingGroup === undefined) continue;
+    const current = strongestInGroup.get(s.nonStackingGroup);
+    if (current === undefined || expectedRate(s) > expectedRate(current)) {
+      strongestInGroup.set(s.nonStackingGroup, s);
+    }
+  }
+
+  return enabled
+    .filter((s) => {
+      if (s.nonStackingGroup === undefined) return true;
+      // Keep only the winning provider of each non-stacking buff group.
+      return strongestInGroup.get(s.nonStackingGroup) === s;
+    })
+    .map((resolved) => {
       // Strip catalog-only fields down to the engine's UltimateSource shape.
       const {
         id,

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -1,0 +1,131 @@
+/**
+ * Compile catalog entries into engine inputs.
+ *
+ * The catalog (data) describes every ultimate source the calculator knows; the
+ * engine (core) only understands generic `UltimateSource`/`CostReduction`. This
+ * module bridges them: given the user's context/class/role and their per-entry
+ * toggles + uptime overrides, it filters the catalog down to what's available
+ * and produces the exact arrays the engine consumes.
+ *
+ * Pure and unit-testable — no React, no network.
+ */
+
+import type { CostReduction } from '../core/cost';
+import type { UltimateSource } from '../shared/types';
+import type {
+  CatalogCostReduction,
+  CatalogSource,
+  CombatContext,
+  CombatRole,
+  EsoClass,
+} from '../shared/types/catalog';
+
+export interface CatalogSelection {
+  readonly context: CombatContext;
+  readonly esoClass: EsoClass;
+  readonly role: CombatRole;
+  /** Per-entry enabled override, keyed by id. Missing → use defaultEnabled. */
+  readonly enabledOverrides: Readonly<Record<string, boolean>>;
+  /** Per-source uptime override (0..1), keyed by id. Missing → catalog default. */
+  readonly uptimeOverrides: Readonly<Record<string, number>>;
+}
+
+/** Is a source available given the current context / class / role? */
+export function isSourceAvailable(
+  source: CatalogSource,
+  selection: Pick<CatalogSelection, 'context' | 'esoClass' | 'role'>,
+): boolean {
+  if (!source.availableIn.includes(selection.context)) return false;
+  if (source.classes && !source.classes.includes(selection.esoClass)) return false;
+  if (source.roles && !source.roles.includes(selection.role)) return false;
+  return true;
+}
+
+/** Is a cost reduction available given the current context / class? */
+export function isReductionAvailable(
+  reduction: CatalogCostReduction,
+  selection: Pick<CatalogSelection, 'context' | 'esoClass'>,
+): boolean {
+  if (!reduction.availableIn.includes(selection.context)) return false;
+  if (reduction.classes && !reduction.classes.includes(selection.esoClass)) return false;
+  return true;
+}
+
+/** Whether an entry is currently enabled (override wins over default). */
+export function isEntryEnabled(
+  id: string,
+  defaultEnabled: boolean,
+  overrides: Readonly<Record<string, boolean>>,
+): boolean {
+  return overrides[id] ?? defaultEnabled;
+}
+
+/** The available catalog sources for a selection (regardless of enabled). */
+export function availableSources(
+  catalog: readonly CatalogSource[],
+  selection: CatalogSelection,
+): readonly CatalogSource[] {
+  return catalog.filter((s) => isSourceAvailable(s, selection));
+}
+
+/** The available cost reductions for a selection (regardless of enabled). */
+export function availableReductions(
+  catalog: readonly CatalogCostReduction[],
+  selection: CatalogSelection,
+): readonly CatalogCostReduction[] {
+  return catalog.filter((r) => isReductionAvailable(r, selection));
+}
+
+/**
+ * Compile enabled, available catalog sources into engine `UltimateSource[]`,
+ * applying per-source uptime overrides.
+ */
+export function compileSources(
+  catalog: readonly CatalogSource[],
+  selection: CatalogSelection,
+): UltimateSource[] {
+  return availableSources(catalog, selection)
+    .filter((s) => isEntryEnabled(s.id, s.defaultEnabled, selection.enabledOverrides))
+    .map((s) => {
+      const uptime = selection.uptimeOverrides[s.id];
+      const resolved =
+        uptime === undefined ? s : { ...s, uptime: Math.min(1, Math.max(0, uptime)) };
+      // Strip catalog-only fields down to the engine's UltimateSource shape.
+      const {
+        id,
+        label,
+        kind,
+        amountPerInstance,
+        instancesPerSecond,
+        uptime: up,
+        rollsDecisive,
+        note,
+      } = resolved;
+      return {
+        id,
+        label,
+        kind,
+        amountPerInstance,
+        instancesPerSecond,
+        uptime: up,
+        rollsDecisive,
+        note,
+      };
+    });
+}
+
+/**
+ * Compile enabled, available cost reductions into engine `CostReduction[]`.
+ * The engine's `enabled` flag is set from the selection (default or override).
+ */
+export function compileReductions(
+  catalog: readonly CatalogCostReduction[],
+  selection: CatalogSelection,
+): CostReduction[] {
+  return availableReductions(catalog, selection).map((r) => ({
+    id: r.id,
+    label: r.label,
+    fraction: r.fraction,
+    enabled: isEntryEnabled(r.id, r.defaultEnabled, selection.enabledOverrides),
+  }));
+}

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -119,9 +119,10 @@ export function compileSources(
         rollsDecisive,
         note,
       } = resolved;
-      // Pillager's Profit's per-cast amount scales with the healer's ultimate
-      // cost (10% of it). Parameterize it from the selection when provided so
-      // the user can match their actual healer; otherwise keep the catalog default.
+      // Pillager's Profit's per-cast amount scales with the SET WEARER's ultimate
+      // cost (10% of it) — usually the healer, a different player from the one we
+      // compute time-to-ult for. Parameterize it from the selection when provided
+      // so the user can match the actual wearer; otherwise keep the catalog default.
       const effectiveAmount =
         id === PILLAGERS_PROFIT_SOURCE_ID && selection.pillagerHealerUltCost != null
           ? PILLAGERS_PROFIT_FRACTION_PER_CAST * Math.max(0, selection.pillagerHealerUltCost)

--- a/src/features/ultimate-simulator/application/compileCatalog.ts
+++ b/src/features/ultimate-simulator/application/compileCatalog.ts
@@ -28,7 +28,20 @@ export interface CatalogSelection {
   readonly enabledOverrides: Readonly<Record<string, boolean>>;
   /** Per-source uptime override (0..1), keyed by id. Missing → catalog default. */
   readonly uptimeOverrides: Readonly<Record<string, number>>;
+  /**
+   * The ultimate cost the group healer spends, for Pillager's Profit. The set
+   * grants 2% of that cost per tick × 5 ticks = 10% of the cost per affecting
+   * cast, so the per-cast amount scales with the healer's ultimate. Missing →
+   * use the catalog default. (See PILLAGERS_PROFIT_SOURCE_ID.)
+   */
+  readonly pillagerHealerUltCost?: number;
 }
+
+/** Catalog id of the Pillager's Profit external source (parameterized by healer ult cost). */
+export const PILLAGERS_PROFIT_SOURCE_ID = 'pillagers-profit-external';
+
+/** Fraction of the healer's spent ultimate a member receives per affecting cast (2% × 5 ticks). */
+export const PILLAGERS_PROFIT_FRACTION_PER_CAST = 0.1;
 
 /** Is a source available given the current context / class / role? */
 export function isSourceAvailable(
@@ -106,11 +119,18 @@ export function compileSources(
         rollsDecisive,
         note,
       } = resolved;
+      // Pillager's Profit's per-cast amount scales with the healer's ultimate
+      // cost (10% of it). Parameterize it from the selection when provided so
+      // the user can match their actual healer; otherwise keep the catalog default.
+      const effectiveAmount =
+        id === PILLAGERS_PROFIT_SOURCE_ID && selection.pillagerHealerUltCost != null
+          ? PILLAGERS_PROFIT_FRACTION_PER_CAST * Math.max(0, selection.pillagerHealerUltCost)
+          : amountPerInstance;
       return {
         id,
         label,
         kind,
-        amountPerInstance,
+        amountPerInstance: effectiveAmount,
         instancesPerSecond,
         uptime: up,
         rollsDecisive,

--- a/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
+++ b/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
@@ -150,6 +150,50 @@ describe('timeToUltimate', () => {
     expect(r.secondsToFirstCast).toBe(Infinity);
     expect(r.castsPerFight).toBe(0);
   });
+
+  it('is castable immediately (0s) when the bank already covers the cost, even at rate 0', () => {
+    const r = timeToUltimate({
+      effectiveCost: 125,
+      ultimatePerSecond: 0,
+      fightDurationSeconds: 180,
+      startingUltimate: 500,
+    });
+    expect(r.secondsToFirstCast).toBe(0); // bank ≥ cost ⇒ ready now, not Infinity
+    // 500 banked / 125 cost = 4 casts available from the bank alone.
+    expect(r.castsPerFight).toBe(4);
+  });
+
+  it('counts excess banked ultimate toward the cast total', () => {
+    const r = timeToUltimate({
+      effectiveCost: 100,
+      ultimatePerSecond: 5,
+      fightDurationSeconds: 100, // generates 500
+      startingUltimate: 250,
+    });
+    expect(r.secondsToFirstCast).toBe(0); // 250 banked ≥ 100 cost
+    // (250 banked + 500 generated) / 100 = floor(7.5) = 7 casts.
+    expect(r.castsPerFight).toBe(7);
+  });
+
+  it('caps banked ultimate at the 500 pool (excess input is ignored)', () => {
+    const r = timeToUltimate({
+      effectiveCost: 100,
+      ultimatePerSecond: 0,
+      fightDurationSeconds: 180,
+      startingUltimate: 9999, // clamped to 500
+    });
+    expect(r.castsPerFight).toBe(5); // floor(500 / 100), not floor(9999/100)
+  });
+
+  it('reduces to floor(totalGenerated/cost) when nothing is banked', () => {
+    const r = timeToUltimate({
+      effectiveCost: 250,
+      ultimatePerSecond: 10,
+      fightDurationSeconds: 180,
+      startingUltimate: 0,
+    });
+    expect(r.castsPerFight).toBe(7); // floor(1800/250)
+  });
 });
 
 describe('applyCostReduction', () => {

--- a/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
+++ b/src/features/ultimate-simulator/core/__tests__/expectedValue.test.ts
@@ -1,0 +1,180 @@
+import { applyCostReduction, totalReductionFraction, CostReduction } from '../cost';
+import {
+  expectedDecisivePerInstance,
+  expectedInstances,
+  expectedValue,
+  timeToUltimate,
+} from '../expectedValue';
+import { runMonteCarlo } from '../monteCarlo';
+import type { DecisiveConfig, UltimateSource } from '../../shared/types';
+
+const SOURCES: UltimateSource[] = [
+  {
+    id: 'base',
+    label: 'Base',
+    kind: 'periodic',
+    amountPerInstance: 3,
+    instancesPerSecond: 1,
+    uptime: 0.99,
+    rollsDecisive: true,
+  },
+  {
+    id: 'minor-heroism',
+    label: 'Minor Heroism',
+    kind: 'periodic',
+    amountPerInstance: 1,
+    instancesPerSecond: 1 / 1.5,
+    uptime: 0.95,
+    rollsDecisive: true,
+  },
+  {
+    id: 'external',
+    label: 'External battery',
+    kind: 'perCast',
+    amountPerInstance: 50,
+    instancesPerSecond: 1 / 45,
+    uptime: 1,
+    rollsDecisive: false, // externally granted — does not roll the wearer's Decisive
+  },
+];
+
+const DECISIVE_1H: DecisiveConfig = { procChance: 0.275, rollsPerInstance: 1 };
+const DECISIVE_2H: DecisiveConfig = { procChance: 0.275, rollsPerInstance: 2 };
+const DURATION = 180;
+
+describe('expectedInstances', () => {
+  it('is instancesPerSecond × duration × uptime', () => {
+    expect(expectedInstances(SOURCES[0], DURATION)).toBeCloseTo(1 * 180 * 0.99, 6);
+    expect(expectedInstances(SOURCES[1], DURATION)).toBeCloseTo((1 / 1.5) * 180 * 0.95, 6);
+  });
+
+  it('never returns negative', () => {
+    const dead: UltimateSource = { ...SOURCES[0], instancesPerSecond: 0 };
+    expect(expectedInstances(dead, DURATION)).toBe(0);
+  });
+});
+
+describe('expectedDecisivePerInstance', () => {
+  it('is rollsPerInstance × procChance (mean of Binomial)', () => {
+    expect(expectedDecisivePerInstance(DECISIVE_1H)).toBeCloseTo(0.275, 6);
+    expect(expectedDecisivePerInstance(DECISIVE_2H)).toBeCloseTo(0.55, 6);
+  });
+
+  it('is 0 when no Decisive', () => {
+    expect(expectedDecisivePerInstance(null)).toBe(0);
+  });
+});
+
+describe('expectedValue', () => {
+  it('only applies Decisive to sources that roll it', () => {
+    const result = expectedValue({
+      fightDurationSeconds: DURATION,
+      sources: SOURCES,
+      decisive: DECISIVE_1H,
+    });
+    const external = result.contributions.find((c) => c.sourceId === 'external');
+    expect(external?.decisiveUltimate).toBe(0); // rollsDecisive: false
+    const base = result.contributions.find((c) => c.sourceId === 'base');
+    expect(base?.decisiveUltimate).toBeGreaterThan(0);
+  });
+
+  it('sorts contributions by total descending', () => {
+    const result = expectedValue({
+      fightDurationSeconds: DURATION,
+      sources: SOURCES,
+      decisive: DECISIVE_1H,
+    });
+    const totals = result.contributions.map((c) => c.baseUltimate + c.decisiveUltimate);
+    const sorted = [...totals].sort((a, b) => b - a);
+    expect(totals).toEqual(sorted);
+  });
+
+  // The headline guarantee: closed-form EV equals the Monte Carlo MEAN. This is
+  // the regression the advisor flagged — a 2× Decisive bug would break it.
+  it('matches the Monte Carlo mean to within standard error (1H)', () => {
+    const config = { fightDurationSeconds: DURATION, sources: SOURCES, decisive: DECISIVE_1H };
+    const ev = expectedValue(config);
+    const mc = runMonteCarlo(config, { runs: 40000, baseSeed: 1 });
+    // Within ~4 standard errors — generous but still catches systematic bias.
+    expect(Math.abs(ev.totalUltimate - mc.meanTotal)).toBeLessThan(4 * mc.standardError + 1e-6);
+  });
+
+  it('matches the Monte Carlo mean for 2H Decisive (catches a 2× error)', () => {
+    const config = { fightDurationSeconds: DURATION, sources: SOURCES, decisive: DECISIVE_2H };
+    const ev = expectedValue(config);
+    const mc = runMonteCarlo(config, { runs: 40000, baseSeed: 7 });
+    expect(Math.abs(ev.totalUltimate - mc.meanTotal)).toBeLessThan(4 * mc.standardError + 1e-6);
+    // And 2H Decisive contribution is ~2× the 1H contribution.
+    const ev1h = expectedValue({ ...config, decisive: DECISIVE_1H });
+    expect(ev.decisiveUltimate).toBeCloseTo(ev1h.decisiveUltimate * 2, 4);
+  });
+
+  it('is fully deterministic (same input → identical output)', () => {
+    const config = { fightDurationSeconds: DURATION, sources: SOURCES, decisive: DECISIVE_1H };
+    expect(expectedValue(config)).toEqual(expectedValue(config));
+  });
+});
+
+describe('timeToUltimate', () => {
+  it('computes seconds-to-first-cast and casts-per-fight', () => {
+    const r = timeToUltimate({
+      effectiveCost: 250,
+      ultimatePerSecond: 10,
+      fightDurationSeconds: 180,
+    });
+    expect(r.secondsToFirstCast).toBeCloseTo(25, 6); // 250 / 10
+    expect(r.secondsPerCast).toBeCloseTo(25, 6);
+    // 180s × 10 = 1800 generated; floor(1800/250) = 7 casts.
+    expect(r.castsPerFight).toBe(7);
+    expect(r.totalGenerated).toBeCloseTo(1800, 6);
+  });
+
+  it('banks starting ultimate toward the first cast only', () => {
+    const r = timeToUltimate({
+      effectiveCost: 250,
+      ultimatePerSecond: 10,
+      fightDurationSeconds: 180,
+      startingUltimate: 100,
+    });
+    expect(r.secondsToFirstCast).toBeCloseTo(15, 6); // (250-100)/10
+    // generated 1800; first cast needs 150 from gen, then floor((1800-150)/250)+1 = 7
+    expect(r.castsPerFight).toBe(7);
+  });
+
+  it('returns Infinity time when generation rate is 0', () => {
+    const r = timeToUltimate({
+      effectiveCost: 250,
+      ultimatePerSecond: 0,
+      fightDurationSeconds: 180,
+    });
+    expect(r.secondsToFirstCast).toBe(Infinity);
+    expect(r.castsPerFight).toBe(0);
+  });
+});
+
+describe('applyCostReduction', () => {
+  const r = (id: string, fraction: number, enabled = true): CostReduction => ({
+    id,
+    label: id,
+    fraction,
+    enabled,
+  });
+
+  it('stacks reductions multiplicatively', () => {
+    // 0.90 × 0.85 = 0.765 of 100 = 76.5 → rounds to 77 (NOT 75).
+    expect(applyCostReduction(100, [r('a', 0.1), r('b', 0.15)])).toBe(77);
+  });
+
+  it('ignores disabled reductions', () => {
+    expect(applyCostReduction(100, [r('a', 0.5, false)])).toBe(100);
+  });
+
+  it('clamps fractions and floors at 0', () => {
+    expect(applyCostReduction(100, [r('a', 2)])).toBe(0); // fraction clamped to 1
+    expect(applyCostReduction(-50, [])).toBe(0);
+  });
+
+  it('totalReductionFraction reports the combined effective reduction', () => {
+    expect(totalReductionFraction([r('a', 0.1), r('b', 0.15)])).toBeCloseTo(1 - 0.765, 6);
+  });
+});

--- a/src/features/ultimate-simulator/core/cost.ts
+++ b/src/features/ultimate-simulator/core/cost.ts
@@ -1,0 +1,46 @@
+/**
+ * Ultimate cost reduction.
+ *
+ * ESO ultimate-cost reductions are percentage reductions that stack
+ * multiplicatively (each applies to the already-reduced cost), so a 10% and a
+ * 15% reduction together leave 0.90 × 0.85 = 76.5% of the base cost, not 75%.
+ * This module encodes only that arithmetic — the actual reduction sources and
+ * their values live in the data catalog (research-sourced), not here.
+ */
+
+/** A single named ultimate-cost reduction (fraction in [0,1]; 0.10 = −10%). */
+export interface CostReduction {
+  readonly id: string;
+  readonly label: string;
+  /** Fraction of cost removed, 0..1. */
+  readonly fraction: number;
+  /** Whether the reduction is currently active. */
+  readonly enabled: boolean;
+}
+
+/**
+ * Apply a set of multiplicative cost reductions to a base ultimate cost.
+ *
+ * Only `enabled` reductions count. The result is rounded to the nearest whole
+ * ultimate (ESO costs are integers) and floored at 0.
+ */
+export function applyCostReduction(baseCost: number, reductions: readonly CostReduction[]): number {
+  const base = Math.max(0, baseCost);
+  let multiplier = 1;
+  for (const r of reductions) {
+    if (!r.enabled) continue;
+    const f = Math.min(1, Math.max(0, r.fraction));
+    multiplier *= 1 - f;
+  }
+  return Math.max(0, Math.round(base * multiplier));
+}
+
+/** Total effective reduction fraction from a set of reductions (for display). */
+export function totalReductionFraction(reductions: readonly CostReduction[]): number {
+  let multiplier = 1;
+  for (const r of reductions) {
+    if (!r.enabled) continue;
+    multiplier *= 1 - Math.min(1, Math.max(0, r.fraction));
+  }
+  return 1 - multiplier;
+}

--- a/src/features/ultimate-simulator/core/expectedValue.ts
+++ b/src/features/ultimate-simulator/core/expectedValue.ts
@@ -27,6 +27,9 @@ import type {
   UltimateSource,
 } from '../shared/types';
 
+/** Hard ultimate pool cap — banked ultimate cannot exceed this. */
+const ULTIMATE_POOL_CAP = 500;
+
 /** Expected number of ult-gain instances a source emits over the fight. */
 export function expectedInstances(source: UltimateSource, durationSeconds: number): number {
   const expected = source.instancesPerSecond * durationSeconds * source.uptime;
@@ -98,10 +101,12 @@ export function expectedValue(config: Omit<SimulationConfig, 'seed'>): ExpectedV
  *
  * `ultimatePerSecond` is the steady-state generation rate (from `expectedValue`).
  * `effectiveCost` is the ultimate's cost AFTER any cost reduction (the caller
- * applies reductions; see `applyCostReduction`). The first cast is gated by the
- * full cost from zero; subsequent casts refill from zero at the same rate, so
- * casts-per-fight is `floor((duration · rate) / cost) ` once enough total ult is
- * generated — equivalently `floor(totalGenerated / cost)`.
+ * applies reductions; see `applyCostReduction`). Banked `startingUltimate` (up to
+ * the 500 pool cap) counts toward both the first cast and the total — so the cast
+ * count is the single coherent identity `floor((start + totalGenerated) / cost)`,
+ * which reduces exactly to `floor(totalGenerated / cost)` when nothing is banked.
+ * If the bank alone already covers the cost the ultimate is castable immediately
+ * (0s), even when the generation rate is 0.
  */
 export function timeToUltimate(input: TimeToUltimateInput): TimeToUltimateResult {
   const { effectiveCost, ultimatePerSecond, fightDurationSeconds, startingUltimate = 0 } = input;
@@ -109,26 +114,25 @@ export function timeToUltimate(input: TimeToUltimateInput): TimeToUltimateResult
   const cost = Math.max(0, effectiveCost);
   const rate = Math.max(0, ultimatePerSecond);
   const duration = Math.max(0, fightDurationSeconds);
-  const start = Math.min(Math.max(0, startingUltimate), cost);
+  // Banked ultimate is capped at the pool (500), NOT at the cost — excess over a
+  // single cast still counts toward the cast total.
+  const start = Math.min(Math.max(0, startingUltimate), ULTIMATE_POOL_CAP);
 
-  // Time to the FIRST cast, accounting for any ultimate already banked.
+  // Time to the FIRST cast, accounting for any ultimate already banked. If the
+  // bank already covers the cost the ultimate is ready now (0s) regardless of
+  // rate; otherwise the shortfall must be generated (∞ if the rate is 0).
   const remainingForFirst = Math.max(0, cost - start);
-  const secondsToFirstCast = rate > 0 ? remainingForFirst / rate : Infinity;
+  const secondsToFirstCast =
+    remainingForFirst <= 0 ? 0 : rate > 0 ? remainingForFirst / rate : Infinity;
 
-  // Total ultimate generated over the whole fight (excludes the starting pool —
-  // that only accelerates the first cast).
+  // Total ultimate generated over the whole fight (from the generation rate).
   const totalGenerated = rate * duration;
 
-  // Casts that complete within the fight: the first cast consumes
-  // `remainingForFirst` from generation, each subsequent cast consumes a full
-  // `cost`. So castable = floor((generated - remainingForFirst)/cost) + 1 once
-  // the first cast is affordable, else 0.
-  let castsPerFight = 0;
-  if (cost <= 0) {
-    castsPerFight = Infinity;
-  } else if (totalGenerated >= remainingForFirst) {
-    castsPerFight = Math.floor((totalGenerated - remainingForFirst) / cost) + 1;
-  }
+  // Casts that complete within the fight. The banked pool plus everything
+  // generated is the spendable total; each cast costs `cost`. This single
+  // identity covers every case (start=0 → floor(totalGenerated/cost);
+  // start≥cost with rate 0 → at least floor(start/cost) casts).
+  const castsPerFight = cost <= 0 ? Infinity : Math.floor((start + totalGenerated) / cost);
 
   // Seconds between subsequent casts at steady state (full cost from zero).
   const secondsPerCast = rate > 0 ? cost / rate : Infinity;

--- a/src/features/ultimate-simulator/core/expectedValue.ts
+++ b/src/features/ultimate-simulator/core/expectedValue.ts
@@ -1,0 +1,144 @@
+/**
+ * Closed-form expected-value engine — the calculator's primary path.
+ *
+ * For a *calculator* the user wants an exact, instant answer ("X ult/s → fills
+ * in Y s"), not a wobbling estimate. By linearity of expectation the mean
+ * ultimate generation is exact in closed form — no seeds, no iteration:
+ *
+ *   E[total] = Σ_sources E[instances] × (amountPerInstance
+ *                                        + rollsDecisive · rollsPerInstance · procChance)
+ *   E[instances] = instancesPerSecond × duration × uptime
+ *
+ * This matches `runMonteCarlo`'s mean to within its standard error (verified to
+ * ~0.001% over 200k runs). Monte Carlo is retained only for the *distribution*
+ * (variance / confidence interval / min-max), which closed form cannot give.
+ *
+ * Everything here is class-agnostic: it operates on the generic source model, so
+ * the same engine drives Arcanist, every other class, or a fully custom build.
+ */
+
+import type {
+  DecisiveConfig,
+  ExpectedValueResult,
+  SimulationConfig,
+  SourceContribution,
+  TimeToUltimateInput,
+  TimeToUltimateResult,
+  UltimateSource,
+} from '../shared/types';
+
+/** Expected number of ult-gain instances a source emits over the fight. */
+export function expectedInstances(source: UltimateSource, durationSeconds: number): number {
+  const expected = source.instancesPerSecond * durationSeconds * source.uptime;
+  return expected > 0 ? expected : 0;
+}
+
+/**
+ * Expected Decisive bonus ultimate per ult-gain instance for a given weapon.
+ *
+ * Each instance rolls `rollsPerInstance` independent Bernoulli(+1) trials at
+ * `procChance`, so the per-instance expectation is `rollsPerInstance · procChance`
+ * (the mean of a Binomial(rollsPerInstance, procChance) — identical whether you
+ * model 2H as two +1 rolls or as a doubled rate; only the variance differs, which
+ * is why the closed-form mean is exact).
+ */
+export function expectedDecisivePerInstance(decisive: DecisiveConfig | null): number {
+  if (!decisive) return 0;
+  return decisive.rollsPerInstance * decisive.procChance;
+}
+
+/**
+ * Exact expected ultimate generation over the fight (and per second), with a
+ * per-source breakdown split into base vs Decisive contribution.
+ */
+export function expectedValue(config: Omit<SimulationConfig, 'seed'>): ExpectedValueResult {
+  const { fightDurationSeconds, sources, decisive } = config;
+  const decisivePerInstance = expectedDecisivePerInstance(decisive);
+
+  const contributions: SourceContribution[] = [];
+  let baseUltimate = 0;
+  let decisiveUltimate = 0;
+
+  for (const source of sources) {
+    const instances = expectedInstances(source, fightDurationSeconds);
+    const base = instances * source.amountPerInstance;
+    const bonus = source.rollsDecisive ? instances * decisivePerInstance : 0;
+
+    baseUltimate += base;
+    decisiveUltimate += bonus;
+    contributions.push({
+      sourceId: source.id,
+      label: source.label,
+      baseUltimate: base,
+      decisiveUltimate: bonus,
+      instances,
+    });
+  }
+
+  const totalUltimate = baseUltimate + decisiveUltimate;
+  // Sort the breakdown by total contribution descending so the dominant sources
+  // surface first in the UI.
+  contributions.sort(
+    (a, b) => b.baseUltimate + b.decisiveUltimate - (a.baseUltimate + a.decisiveUltimate),
+  );
+
+  return {
+    totalUltimate,
+    baseUltimate,
+    decisiveUltimate,
+    ultimatePerSecond: fightDurationSeconds > 0 ? totalUltimate / fightDurationSeconds : 0,
+    contributions,
+  };
+}
+
+/**
+ * Time-to-ultimate: the raid/dungeon-useful output. Given an ultimate's effective
+ * cost and a generation rate, how long until it's ready and how many casts fit in
+ * the fight.
+ *
+ * `ultimatePerSecond` is the steady-state generation rate (from `expectedValue`).
+ * `effectiveCost` is the ultimate's cost AFTER any cost reduction (the caller
+ * applies reductions; see `applyCostReduction`). The first cast is gated by the
+ * full cost from zero; subsequent casts refill from zero at the same rate, so
+ * casts-per-fight is `floor((duration · rate) / cost) ` once enough total ult is
+ * generated — equivalently `floor(totalGenerated / cost)`.
+ */
+export function timeToUltimate(input: TimeToUltimateInput): TimeToUltimateResult {
+  const { effectiveCost, ultimatePerSecond, fightDurationSeconds, startingUltimate = 0 } = input;
+
+  const cost = Math.max(0, effectiveCost);
+  const rate = Math.max(0, ultimatePerSecond);
+  const duration = Math.max(0, fightDurationSeconds);
+  const start = Math.min(Math.max(0, startingUltimate), cost);
+
+  // Time to the FIRST cast, accounting for any ultimate already banked.
+  const remainingForFirst = Math.max(0, cost - start);
+  const secondsToFirstCast = rate > 0 ? remainingForFirst / rate : Infinity;
+
+  // Total ultimate generated over the whole fight (excludes the starting pool —
+  // that only accelerates the first cast).
+  const totalGenerated = rate * duration;
+
+  // Casts that complete within the fight: the first cast consumes
+  // `remainingForFirst` from generation, each subsequent cast consumes a full
+  // `cost`. So castable = floor((generated - remainingForFirst)/cost) + 1 once
+  // the first cast is affordable, else 0.
+  let castsPerFight = 0;
+  if (cost <= 0) {
+    castsPerFight = Infinity;
+  } else if (totalGenerated >= remainingForFirst) {
+    castsPerFight = Math.floor((totalGenerated - remainingForFirst) / cost) + 1;
+  }
+
+  // Seconds between subsequent casts at steady state (full cost from zero).
+  const secondsPerCast = rate > 0 ? cost / rate : Infinity;
+
+  return {
+    effectiveCost: cost,
+    ultimatePerSecond: rate,
+    secondsToFirstCast,
+    secondsPerCast,
+    castsPerFight,
+    totalGenerated,
+  };
+}

--- a/src/features/ultimate-simulator/index.ts
+++ b/src/features/ultimate-simulator/index.ts
@@ -1,26 +1,54 @@
 /**
- * Public API for the Arcanist Ultimate Simulator feature.
+ * Public API for the Ultimate Calculator feature.
+ *
+ * An all-class ultimate generation & time-to-ultimate tool. The engine is a
+ * class-agnostic closed-form expected-value model (with an optional Monte Carlo
+ * distribution); the catalog is the research-sourced data layer; the calculator
+ * UI mounts as the "Ultimate" tab of /calculator.
  */
 
 // Types & constants
 export * from './shared/types';
+export * from './shared/types/catalog';
 export * from './shared/constants';
+export * from './shared/constants/catalog';
 
 // Core engine
 export { createRng } from './core/rng';
 export { simulateFight } from './core/simulate';
 export { runMonteCarlo } from './core/monteCarlo';
 export type { MonteCarloOptions } from './core/monteCarlo';
+export {
+  expectedValue,
+  timeToUltimate,
+  expectedInstances,
+  expectedDecisivePerInstance,
+} from './core/expectedValue';
+export { applyCostReduction, totalReductionFraction } from './core/cost';
+export type { CostReduction } from './core/cost';
+
+// Catalog → engine compiler
+export {
+  compileSources,
+  compileReductions,
+  availableSources,
+  availableReductions,
+  isSourceAvailable,
+  isReductionAvailable,
+  isEntryEnabled,
+} from './application/compileCatalog';
+export type { CatalogSelection } from './application/compileCatalog';
 
 // Calibration (log = source of truth)
-export { calibrateFromEvents, RESOURCE_CHANGE_TYPE } from './application/calibration';
-export type {
-  CalibrationInput,
-  CalibrationResult,
-  AbilityUltimateStat,
+export {
+  calibrateFromEvents,
+  isUltimateResourceEvent,
+  RESOURCE_CHANGE_TYPE,
 } from './application/calibration';
+export type { CalibrationInput, CalibrationResult } from './application/calibration';
 
 // Presentation
-export { useUltimateSimulator } from './presentation/useUltimateSimulator';
-export { UltimateSimulator } from './presentation/components/UltimateSimulator';
-export { UltimateSimulatorPage } from './presentation/pages/UltimateSimulatorPage';
+export { useUltimateCalculator } from './presentation/useUltimateCalculator';
+export { useLogCalibration, parseReportCode } from './presentation/useLogCalibration';
+export { UltimateCalculator } from './presentation/components/UltimateCalculator';
+export { LogCalibrationPanel } from './presentation/components/LogCalibrationPanel';

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -53,4 +53,34 @@ describe('UltimateCalculator', () => {
     // lowers the cost and so the time-to-first-ult.
     expect(screen.getAllByText(/250 ult cost/i).length).toBeGreaterThan(0);
   });
+
+  it('offers a cost-reduction toggle for a class that has one, and applying it lowers the cost', () => {
+    renderCalc();
+    // Switch to Sorcerer — Power Stone (−15%) is a default-on reduction with a toggle.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+
+    // The reduction toggle is rendered and on by default.
+    const toggle = screen.getByLabelText(/Power Stone/i);
+    expect(toggle).toBeInTheDocument();
+
+    // With it on, the reduced-cost note is shown; turning it off removes the note.
+    expect(screen.getByText(/Cost reduced/i)).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
+  });
+
+  it('does not apply class reductions to a custom cost (no double-reduction)', () => {
+    renderCalc();
+    // Sorcerer (Power Stone −15% default-on), then pick a custom cost.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+    fireEvent.mouseDown(screen.getByLabelText(/^Ultimate$/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText(/Custom cost/i));
+
+    // A custom cost is taken as already-effective: no "Cost reduced" note and no
+    // reduction toggles (they don't apply to a user-entered effective number).
+    expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Power Stone/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -1,0 +1,56 @@
+import { ThemeProvider, createTheme } from '@mui/material';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+
+import { UltimateCalculator } from '../components/UltimateCalculator';
+
+const theme = createTheme();
+
+function renderCalc() {
+  return render(
+    <ThemeProvider theme={theme}>
+      <UltimateCalculator />
+    </ThemeProvider>,
+  );
+}
+
+const readTotal = (): number =>
+  Number(screen.getByTestId('ult-grand-total').textContent?.replace(/,/g, '') ?? '0');
+
+describe('UltimateCalculator', () => {
+  it('renders the headline stats and a per-source breakdown', () => {
+    renderCalc();
+    expect(screen.getByRole('heading', { name: /Ultimate Calculator/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Ultimate \/ second/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Time to first ult/i)).toBeInTheDocument();
+    expect(screen.getByText(/Casts \/ fight/i)).toBeInTheDocument();
+    // Default (Arcanist group DPS) sources are visible.
+    expect(screen.getAllByText(/Light\/Heavy-attack income/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Minor Heroism/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Implacable Outcome/i).length).toBeGreaterThan(0);
+    expect(readTotal()).toBeGreaterThan(0);
+  });
+
+  it('drops the total when Decisive is turned off', () => {
+    renderCalc();
+    const withDecisive = readTotal();
+    fireEvent.click(screen.getByLabelText(/Decisive weapon trait/i));
+    expect(readTotal()).toBeLessThan(withDecisive);
+  });
+
+  it('shows class-specific sources only for the matching class', () => {
+    renderCalc();
+    // Switch class to Sorcerer — Implacable Outcome (Arcanist) should disappear.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    const listbox = within(screen.getByRole('listbox'));
+    fireEvent.click(listbox.getByText('Sorcerer'));
+    expect(screen.queryByText(/Implacable Outcome/i)).not.toBeInTheDocument();
+  });
+
+  it('reflects a custom ultimate cost in time-to-first-ult', () => {
+    renderCalc();
+    // Default ult is "Typical ultimate (250)"; switching to Dawnbreaker (125)
+    // lowers the cost and so the time-to-first-ult.
+    expect(screen.getAllByText(/250 ult cost/i).length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -83,4 +83,21 @@ describe('UltimateCalculator', () => {
     expect(screen.queryByText(/Cost reduced/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Power Stone/i)).not.toBeInTheDocument();
   });
+
+  it('does not let the effective cost jump when switching to Custom under a reduction', () => {
+    renderCalc();
+    // Sorcerer has Power Stone (−15%) default-on, so the displayed effective cost
+    // is already reduced. Switching to Custom must SEED with that effective cost,
+    // not the unreduced base — the displayed cost must not change.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+
+    const costBefore = screen.getByText(/\d+ ult cost/i).textContent;
+
+    fireEvent.mouseDown(screen.getByLabelText(/^Ultimate$/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText(/Custom cost/i));
+
+    const costAfter = screen.getByText(/\d+ ult cost/i).textContent;
+    expect(costAfter).toBe(costBefore);
+  });
 });

--- a/src/features/ultimate-simulator/presentation/__tests__/useLogCalibration.test.ts
+++ b/src/features/ultimate-simulator/presentation/__tests__/useLogCalibration.test.ts
@@ -1,4 +1,22 @@
-import { parseReportCode } from '../useLogCalibration';
+import { isCursorAdvancing, parseReportCode } from '../useLogCalibration';
+
+describe('isCursorAdvancing', () => {
+  it('advances only for a finite cursor strictly greater than the page start', () => {
+    expect(isCursorAdvancing(100, 200)).toBe(true);
+  });
+
+  it('stops on a repeated or backwards cursor (malformed paginator → no infinite loop)', () => {
+    expect(isCursorAdvancing(100, 100)).toBe(false); // repeated
+    expect(isCursorAdvancing(100, 50)).toBe(false); // backwards
+  });
+
+  it('stops on a null/undefined/non-finite cursor', () => {
+    expect(isCursorAdvancing(100, null)).toBe(false);
+    expect(isCursorAdvancing(100, undefined)).toBe(false);
+    expect(isCursorAdvancing(100, Infinity)).toBe(false);
+    expect(isCursorAdvancing(100, NaN)).toBe(false);
+  });
+});
 
 describe('parseReportCode', () => {
   it('returns a bare 16-char code unchanged', () => {

--- a/src/features/ultimate-simulator/presentation/__tests__/useLogCalibration.test.ts
+++ b/src/features/ultimate-simulator/presentation/__tests__/useLogCalibration.test.ts
@@ -1,0 +1,28 @@
+import { parseReportCode } from '../useLogCalibration';
+
+describe('parseReportCode', () => {
+  it('returns a bare 16-char code unchanged', () => {
+    expect(parseReportCode('kZAvqFwYcRTLB97W')).toBe('kZAvqFwYcRTLB97W');
+  });
+
+  it('extracts the code from a full esologs report URL', () => {
+    expect(parseReportCode('https://www.esologs.com/reports/kZAvqFwYcRTLB97W')).toBe(
+      'kZAvqFwYcRTLB97W',
+    );
+    expect(parseReportCode('https://www.esologs.com/reports/kZAvqFwYcRTLB97W#fight=2')).toBe(
+      'kZAvqFwYcRTLB97W',
+    );
+  });
+
+  it('trims whitespace', () => {
+    expect(parseReportCode('  kZAvqFwYcRTLB97W  ')).toBe('kZAvqFwYcRTLB97W');
+  });
+
+  it('extracts a code embedded in arbitrary text', () => {
+    expect(parseReportCode('check kZAvqFwYcRTLB97W please')).toBe('kZAvqFwYcRTLB97W');
+  });
+
+  it('returns the input as-is when no 16-char code is present (validated by caller)', () => {
+    expect(parseReportCode('short')).toBe('short');
+  });
+});

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -47,8 +47,10 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
   const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
 
   const m = cal.measurement;
-  const delta =
-    m && modeledPerSecond > 0 ? (modeledPerSecond - m.perSecond) / modeledPerSecond : null;
+  // How far the MODEL is from the MEASURED log rate, as a fraction of the
+  // measured rate (the measured value is the reference — "the model is X% vs
+  // measured"). Guard measured-zero to avoid divide-by-zero / Infinity.
+  const delta = m && m.perSecond > 0 ? (modeledPerSecond - m.perSecond) / m.perSecond : null;
   const deltaPct = delta != null ? Math.round(delta * 100) : null;
 
   return (

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -8,7 +8,7 @@
  * calibration.ts) — so it validates the headline number, not the breakdown.
  */
 
-import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { ExpandMore as ExpandMoreIcon, FactCheckOutlined } from '@mui/icons-material';
 import {
   Accordion,
   AccordionDetails,
@@ -60,7 +60,24 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
       sx={{ borderRadius: 3, '&:before': { display: 'none' }, overflow: 'hidden' }}
     >
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center' }}>
+          <Box
+            aria-hidden
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 30,
+              height: 30,
+              borderRadius: 2,
+              color: accent,
+              background: `${accent}1f`,
+              border: `1px solid ${accent}33`,
+              '& svg': { fontSize: 18 },
+            }}
+          >
+            <FactCheckOutlined />
+          </Box>
           <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
             Verify against your own log
           </Typography>
@@ -155,13 +172,15 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
 
             {m && cal.phase === 'measured' && (
               <Box
+                className="u-fade-in"
                 sx={{
-                  borderRadius: 2,
+                  borderRadius: 3,
                   p: 2,
+                  border: `1px solid ${theme.palette.divider}`,
                   background:
                     theme.palette.mode === 'dark'
-                      ? 'rgba(56,189,248,0.06)'
-                      : 'rgba(40,145,200,0.05)',
+                      ? 'linear-gradient(135deg, rgba(56,189,248,0.08) 0%, rgba(15,23,42,0.3) 100%)'
+                      : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(248,250,252,0.6) 100%)',
                 }}
               >
                 {m.samples === 0 ? (
@@ -173,27 +192,83 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
                 ) : (
                   <>
                     <Stack
-                      direction="row"
-                      spacing={4}
-                      sx={{ flexWrap: 'wrap', rowGap: 2, mb: 1.5 }}
+                      direction={{ xs: 'column', sm: 'row' }}
+                      spacing={1.5}
+                      sx={{ alignItems: { sm: 'stretch' }, mb: 1.5 }}
                     >
-                      <Box>
-                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                      <Box
+                        sx={{
+                          flex: 1,
+                          minWidth: 0,
+                          p: 1.5,
+                          borderRadius: 2.5,
+                          background:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(56,189,248,0.08)'
+                              : 'rgba(40,145,200,0.06)',
+                          border: `1px solid ${accent}3a`,
+                        }}
+                      >
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: 'text.secondary',
+                            textTransform: 'uppercase',
+                            letterSpacing: 0.5,
+                            fontWeight: 600,
+                            display: 'block',
+                          }}
+                        >
                           Measured ({m.playerName})
                         </Typography>
-                        <Typography variant="h5" sx={{ fontWeight: 700, color: accent }}>
-                          {fmt(m.perSecond)} ult/s
+                        <Typography
+                          className="u-tabular"
+                          variant="h5"
+                          sx={{ fontWeight: 700, color: accent, lineHeight: 1.15 }}
+                        >
+                          {fmt(m.perSecond)}{' '}
+                          <Box component="span" sx={{ fontSize: '0.6em' }}>
+                            ult/s
+                          </Box>
                         </Typography>
                         <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                           {Math.round(m.totalGenerated)} generated · {m.approxCasts} casts
                         </Typography>
                       </Box>
-                      <Box>
-                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                      <Box
+                        sx={{
+                          flex: 1,
+                          minWidth: 0,
+                          p: 1.5,
+                          borderRadius: 2.5,
+                          background:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(148,163,184,0.05)'
+                              : 'rgba(255,255,255,0.5)',
+                          border: `1px solid ${theme.palette.divider}`,
+                        }}
+                      >
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: 'text.secondary',
+                            textTransform: 'uppercase',
+                            letterSpacing: 0.5,
+                            fontWeight: 600,
+                            display: 'block',
+                          }}
+                        >
                           Modeled (current build)
                         </Typography>
-                        <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                          {fmt(modeledPerSecond)} ult/s
+                        <Typography
+                          className="u-tabular"
+                          variant="h5"
+                          sx={{ fontWeight: 700, lineHeight: 1.15 }}
+                        >
+                          {fmt(modeledPerSecond)}{' '}
+                          <Box component="span" sx={{ fontSize: '0.6em' }}>
+                            ult/s
+                          </Box>
                         </Typography>
                         {deltaPct != null && (
                           <Typography variant="caption" sx={{ color: 'text.secondary' }}>

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -1,0 +1,241 @@
+/**
+ * "Verify against your own log" panel — the calibration feature surfaced in the UI.
+ *
+ * Paste an ESO Logs report code, pick a boss fight + player, and the panel
+ * measures that player's REAL ultimate generation from the log (conservation /
+ * snapshot method) and compares it to the model's current ult/sec. Measurement
+ * is total-only — ESO Logs does not expose per-source ultimate gains (see
+ * calibration.ts) — so it validates the headline number, not the breakdown.
+ */
+
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React from 'react';
+
+import { useLogCalibration } from '../useLogCalibration';
+
+const fmt = (n: number, digits = 2): string =>
+  Number.isFinite(n)
+    ? n.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits })
+    : '—';
+
+export interface LogCalibrationPanelProps {
+  /** The model's current modeled ult/sec, for the side-by-side comparison. */
+  modeledPerSecond: number;
+}
+
+export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modeledPerSecond }) => {
+  const theme = useTheme();
+  const cal = useLogCalibration();
+  const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
+
+  const m = cal.measurement;
+  const delta =
+    m && modeledPerSecond > 0 ? (modeledPerSecond - m.perSecond) / modeledPerSecond : null;
+  const deltaPct = delta != null ? Math.round(delta * 100) : null;
+
+  return (
+    <Accordion
+      variant="outlined"
+      disableGutters
+      sx={{ borderRadius: 3, '&:before': { display: 'none' }, overflow: 'hidden' }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            Verify against your own log
+          </Typography>
+          <Chip label="beta" size="small" sx={{ height: 18, fontSize: 10 }} />
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+          Measure your real ultimate generation from an ESO Logs report and compare it to the model.
+          (Total ult/s only — logs don&apos;t record per-source ultimate gains.)
+        </Typography>
+
+        <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap', rowGap: 1.5, mb: 2 }}>
+          <TextField
+            label="Report code or URL"
+            size="small"
+            value={cal.reportCode}
+            onChange={(e) => cal.setReportCode(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void cal.loadReport();
+            }}
+            placeholder="e.g. kZAvqFwYcRTLB97W"
+            sx={{ flex: 1, minWidth: 220 }}
+            disabled={cal.phase === 'loadingReport' || cal.phase === 'measuring'}
+          />
+          <Button
+            variant="contained"
+            onClick={() => void cal.loadReport()}
+            disabled={!cal.ready || cal.phase === 'loadingReport' || cal.phase === 'measuring'}
+            sx={{ textTransform: 'none' }}
+          >
+            {cal.phase === 'loadingReport' ? <CircularProgress size={20} /> : 'Load report'}
+          </Button>
+        </Stack>
+
+        {!cal.ready && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Connecting to ESO Logs… try again in a moment if Load report is disabled.
+          </Alert>
+        )}
+        {cal.error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {cal.error}
+          </Alert>
+        )}
+
+        {(cal.phase === 'reportLoaded' ||
+          cal.phase === 'measuring' ||
+          cal.phase === 'measured') && (
+          <Stack spacing={2}>
+            <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap', rowGap: 1.5 }}>
+              <FormControl size="small" sx={{ minWidth: 220, flex: 1 }}>
+                <InputLabel id="cal-fight-label">Fight</InputLabel>
+                <Select
+                  labelId="cal-fight-label"
+                  label="Fight"
+                  value={cal.selectedFightId ?? ''}
+                  onChange={(e) => cal.setFight(Number(e.target.value))}
+                >
+                  {cal.fights.map((f) => (
+                    <MenuItem key={f.id} value={f.id}>
+                      {f.kill ? '✓ ' : ''}
+                      {f.name} — {Math.floor(f.durationSeconds / 60)}m {f.durationSeconds % 60}s
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl size="small" sx={{ minWidth: 200, flex: 1 }}>
+                <InputLabel id="cal-player-label">Player</InputLabel>
+                <Select
+                  labelId="cal-player-label"
+                  label="Player"
+                  value={cal.selectedPlayerId ?? ''}
+                  onChange={(e) => cal.setPlayer(Number(e.target.value))}
+                >
+                  {cal.players.map((p) => (
+                    <MenuItem key={p.id} value={p.id}>
+                      {p.name} ({p.subType})
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Button
+                variant="contained"
+                onClick={() => void cal.measure()}
+                disabled={cal.phase === 'measuring' || cal.selectedPlayerId == null}
+                sx={{ textTransform: 'none' }}
+              >
+                {cal.phase === 'measuring' ? <CircularProgress size={20} /> : 'Measure'}
+              </Button>
+            </Stack>
+
+            {m && cal.phase === 'measured' && (
+              <Box
+                sx={{
+                  borderRadius: 2,
+                  p: 2,
+                  background:
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(56,189,248,0.06)'
+                      : 'rgba(40,145,200,0.05)',
+                }}
+              >
+                {m.samples === 0 ? (
+                  <Alert severity="warning">
+                    No ultimate snapshots were recorded for {m.playerName} in this fight. ESO Logs
+                    only snapshots some actors — try a different player (ideally one who cast their
+                    ultimate during the fight).
+                  </Alert>
+                ) : (
+                  <>
+                    <Stack
+                      direction="row"
+                      spacing={4}
+                      sx={{ flexWrap: 'wrap', rowGap: 2, mb: 1.5 }}
+                    >
+                      <Box>
+                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          Measured ({m.playerName})
+                        </Typography>
+                        <Typography variant="h5" sx={{ fontWeight: 700, color: accent }}>
+                          {fmt(m.perSecond)} ult/s
+                        </Typography>
+                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          {Math.round(m.totalGenerated)} generated · {m.approxCasts} casts
+                        </Typography>
+                      </Box>
+                      <Box>
+                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          Modeled (current build)
+                        </Typography>
+                        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                          {fmt(modeledPerSecond)} ult/s
+                        </Typography>
+                        {deltaPct != null && (
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                            model is {deltaPct >= 0 ? '+' : ''}
+                            {deltaPct}% vs measured
+                          </Typography>
+                        )}
+                      </Box>
+                    </Stack>
+                    {m.hitCap && (
+                      <Alert severity="info" sx={{ mb: 1 }}>
+                        This player hit the 500 ultimate cap during the fight, so the measured value
+                        is a lower bound (overcapped ultimate isn&apos;t visible in logs).
+                      </Alert>
+                    )}
+                    {deltaPct != null && Math.abs(deltaPct) <= 15 && !m.hitCap && (
+                      <Alert severity="success">
+                        Within {Math.abs(deltaPct)}% — the model matches this log well. Differences
+                        come from your real uptimes vs the toggles above.
+                      </Alert>
+                    )}
+                    {deltaPct != null && Math.abs(deltaPct) > 15 && !m.hitCap && (
+                      <Alert severity="info">
+                        {Math.abs(deltaPct)}% apart. Tune the source toggles/uptimes to match this
+                        player&apos;s actual build (e.g. whether they ran Minor Heroism), then the
+                        numbers should converge.
+                      </Alert>
+                    )}
+                  </>
+                )}
+              </Box>
+            )}
+
+            <Button
+              size="small"
+              variant="text"
+              onClick={cal.clear}
+              sx={{ alignSelf: 'flex-start' }}
+            >
+              Clear
+            </Button>
+          </Stack>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -57,7 +57,24 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
     <Accordion
       variant="outlined"
       disableGutters
-      sx={{ borderRadius: 3, '&:before': { display: 'none' }, overflow: 'hidden' }}
+      sx={{
+        // Match the glass-gradient surface of the sibling result panels (same
+        // gradient/border/shadow as `panelSx` in UltimateCalculator) so this
+        // collapsible "advanced" section reads as part of the same set rather
+        // than a flatter outlined card.
+        borderRadius: 3.5,
+        overflow: 'hidden',
+        border: `1px solid ${theme.palette.divider}`,
+        background:
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+            : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
+        boxShadow:
+          theme.palette.mode === 'dark'
+            ? '0 8px 30px rgba(0, 0, 0, 0.25)'
+            : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
+        '&:before': { display: 'none' },
+      }}
     >
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center' }}>

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -62,7 +62,7 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
         // gradient/border/shadow as `panelSx` in UltimateCalculator) so this
         // collapsible "advanced" section reads as part of the same set rather
         // than a flatter outlined card.
-        borderRadius: 2, // 20px — panel tier (matches panelSx)
+        borderRadius: 2.8, // 28px — panel tier (matches panelSx)
         overflow: 'hidden',
         border: `1px solid ${
           theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -64,14 +64,16 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
         // than a flatter outlined card.
         borderRadius: 3.5,
         overflow: 'hidden',
-        border: `1px solid ${theme.palette.divider}`,
+        border: `1px solid ${
+          theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
+        }`,
         background:
           theme.palette.mode === 'dark'
-            ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+            ? 'linear-gradient(180deg, rgba(14,22,42,0.74) 0%, rgba(3,9,20,0.82) 100%)'
             : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
         boxShadow:
           theme.palette.mode === 'dark'
-            ? '0 8px 30px rgba(0, 0, 0, 0.25)'
+            ? '0 14px 36px rgba(0,0,0,0.44), inset 0 1px 0 rgba(255,255,255,0.05)'
             : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
         '&:before': { display: 'none' },
       }}

--- a/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
+++ b/src/features/ultimate-simulator/presentation/components/LogCalibrationPanel.tsx
@@ -62,7 +62,7 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
         // gradient/border/shadow as `panelSx` in UltimateCalculator) so this
         // collapsible "advanced" section reads as part of the same set rather
         // than a flatter outlined card.
-        borderRadius: 3.5,
+        borderRadius: 2, // 20px — panel tier (matches panelSx)
         overflow: 'hidden',
         border: `1px solid ${
           theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
@@ -193,7 +193,7 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
               <Box
                 className="u-fade-in"
                 sx={{
-                  borderRadius: 3,
+                  borderRadius: 1.4, // 14px — card tier
                   p: 2,
                   border: `1px solid ${theme.palette.divider}`,
                   background:
@@ -220,7 +220,7 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
                           flex: 1,
                           minWidth: 0,
                           p: 1.5,
-                          borderRadius: 2.5,
+                          borderRadius: 1.2, // 12px — small inner stat card
                           background:
                             theme.palette.mode === 'dark'
                               ? 'rgba(56,189,248,0.08)'
@@ -259,7 +259,7 @@ export const LogCalibrationPanel: React.FC<LogCalibrationPanelProps> = ({ modele
                           flex: 1,
                           minWidth: 0,
                           p: 1.5,
-                          borderRadius: 2.5,
+                          borderRadius: 1.2, // 12px — small inner stat card
                           background:
                             theme.palette.mode === 'dark'
                               ? 'rgba(148,163,184,0.05)'

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -10,7 +10,9 @@
  */
 
 import {
+  AutoFixHighOutlined,
   BoltOutlined,
+  InfoOutlined,
   InsightsOutlined,
   QueryStatsOutlined,
   TuneOutlined,
@@ -24,7 +26,9 @@ import {
   FormControl,
   FormControlLabel,
   InputLabel,
+  LinearProgress,
   Link,
+  ListSubheader,
   MenuItem,
   Paper,
   Select,
@@ -41,6 +45,7 @@ import {
   ToggleButtonGroup,
   Tooltip,
   Typography,
+  alpha,
   useTheme,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
@@ -78,6 +83,102 @@ const ROLE_OPTIONS: { value: CombatRole; label: string }[] = [
 ];
 
 const CONTEXT_OPTIONS: CombatContext[] = ['soloPve', 'groupPve', 'pvp'];
+
+/**
+ * Canonical per-class accent colors (mirrors the repo's class palette in
+ * build-editor/data/esoStaticData.ts). Cosmetic only — used for swatches in the
+ * class + ultimate dropdowns, not for any gameplay number.
+ */
+const CLASS_COLORS: Record<EsoClass, string> = {
+  arcanist: '#43a047',
+  dragonknight: '#e05c00',
+  necromancer: '#7c4dff',
+  nightblade: '#e53935',
+  sorcerer: '#00acc1',
+  templar: '#ffb300',
+  warden: '#26a69a',
+};
+
+/** Owner color for an ultimate option (class color, or accent for shared ults). */
+const ownerColor = (owner: string, fallback: string): string =>
+  owner in CLASS_COLORS ? CLASS_COLORS[owner as EsoClass] : fallback;
+
+/**
+ * Decisive weapon-quality tier colors (the white/green/blue/purple/gold the
+ * labels already name) — a cosmetic restatement, not new data.
+ */
+const QUALITY_COLORS: Record<DecisiveQuality, string> = {
+  normal: '#c7c7c7',
+  fine: '#4caf50',
+  superior: '#2196f3',
+  epic: '#9c27b0',
+  legendary: '#ffc107',
+};
+
+/** A small color dot used in dropdown options (decorative — aria-hidden). */
+const Swatch: React.FC<{ color: string; square?: boolean; size?: number; glow?: boolean }> = ({
+  color,
+  square,
+  size = 10,
+  glow,
+}) => (
+  <Box
+    aria-hidden
+    component="span"
+    sx={{
+      width: size,
+      height: size,
+      borderRadius: square ? 0.5 : '50%',
+      bgcolor: color,
+      boxShadow: glow ? `0 0 6px ${color}66` : 'none',
+      flexShrink: 0,
+    }}
+  />
+);
+
+/**
+ * Build-archetype presets — each flips ONLY existing boolean/selection state
+ * (context / role / class / source on-off) via the hook's setters. Crucially it
+ * NEVER sets an uptime: a toggled-on source inherits its own research-sourced
+ * catalog-default uptime, so no unsourced number is ever introduced.
+ */
+interface BuildPreset {
+  readonly id: string;
+  readonly label: string;
+  readonly context: CombatContext;
+  readonly role: CombatRole;
+  /** Source ids to force on (others left at their catalog defaults). */
+  readonly enableSources: readonly string[];
+  /** Source ids to force off. */
+  readonly disableSources: readonly string[];
+}
+
+const BUILD_PRESETS: readonly BuildPreset[] = [
+  {
+    id: 'trial-dps',
+    label: 'Trial group DPS',
+    context: 'groupPve',
+    role: 'dps',
+    enableSources: ['major-heroism'],
+    disableSources: [],
+  },
+  {
+    id: 'solo-parse',
+    label: 'Solo parse',
+    context: 'soloPve',
+    role: 'dps',
+    enableSources: [],
+    disableSources: ['minor-heroism', 'major-heroism'],
+  },
+  {
+    id: 'pvp',
+    label: 'PvP',
+    context: 'pvp',
+    role: 'dps',
+    enableSources: ['minor-heroism'],
+    disableSources: [],
+  },
+];
 
 const fmt = (n: number, digits = 1): string =>
   Number.isFinite(n)
@@ -153,7 +254,9 @@ const StatBlock: React.FC<{
   sub?: string;
   accent?: string;
   highlight?: boolean;
-}> = ({ label, value, sub, accent, highlight }) => {
+  /** Optional plain-language explanation shown on an info-icon tooltip. */
+  info?: string;
+}> = ({ label, value, sub, accent, highlight, info }) => {
   const theme = useTheme();
   return (
     <Box
@@ -180,19 +283,33 @@ const StatBlock: React.FC<{
             : 'none',
       }}
     >
-      <Typography
-        variant="caption"
-        sx={{
-          color: 'text.secondary',
-          textTransform: 'uppercase',
-          letterSpacing: 0.7,
-          fontWeight: 600,
-          fontSize: 11,
-          display: 'block',
-        }}
-      >
-        {label}
-      </Typography>
+      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+            textTransform: 'uppercase',
+            letterSpacing: 0.7,
+            fontWeight: 600,
+            fontSize: 11,
+          }}
+        >
+          {label}
+        </Typography>
+        {info && (
+          <Tooltip arrow title={info}>
+            <InfoOutlined
+              sx={{
+                fontSize: 13,
+                color: 'text.secondary',
+                opacity: 0.6,
+                cursor: 'help',
+                '&:hover': { opacity: 1 },
+              }}
+            />
+          </Tooltip>
+        )}
+      </Stack>
       <Typography
         className="u-tabular"
         sx={{
@@ -261,6 +378,51 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     };
     return [...ULTIMATE_ABILITIES].sort((a, b) => rank(a.owner) - rank(b.owner));
   }, [state.esoClass]);
+
+  // Sectioned ultimate list for the grouped picker: your class first, then the
+  // shared weapon/guild ults everyone can run, then the rest.
+  const ultimateGroups = React.useMemo(() => {
+    const yours = orderedUltimates.filter((a) => a.owner === state.esoClass);
+    const shared = orderedUltimates.filter((a) => a.owner === 'global' || a.owner === 'weapon');
+    const others = orderedUltimates.filter(
+      (a) => a.owner !== state.esoClass && a.owner !== 'global' && a.owner !== 'weapon',
+    );
+    return [
+      { key: 'yours', label: `${ESO_CLASS_LABELS[state.esoClass]} ultimates`, items: yours },
+      { key: 'shared', label: 'Weapon & guild (any class)', items: shared },
+      { key: 'others', label: 'Other classes', items: others },
+    ].filter((g) => g.items.length > 0);
+  }, [orderedUltimates, state.esoClass]);
+
+  // Render the closed Select control as plain label text (the menu options carry
+  // swatches/chips, but the collapsed control must stay clean — and no test
+  // asserts this surface, so a blank/cluttered control would pass CI silently).
+  const renderSelectedUltimate = React.useCallback((value: unknown): string => {
+    if (value === 'custom') return 'Custom cost…';
+    const ability = ULTIMATE_ABILITIES.find((a) => a.id === value);
+    return ability ? `${ability.label} — ${ability.baseCost}` : '';
+  }, []);
+
+  // Apply a build-archetype preset: flips ONLY context/role/class and boolean
+  // source toggles. It never sets an uptime — a toggled-on source keeps its
+  // research-sourced catalog default, so no unsourced number is introduced.
+  const applyPreset = React.useCallback(
+    (preset: BuildPreset) => {
+      calc.setContext(preset.context);
+      calc.setRole(preset.role);
+      for (const id of preset.enableSources) calc.toggleSource(id, true);
+      for (const id of preset.disableSources) calc.toggleSource(id, false);
+    },
+    [calc],
+  );
+
+  // Best-effort "active" highlight: a preset reads as active when the current
+  // context + role match it (presentation hint only — not an exact build match).
+  const activePresetId = React.useMemo(
+    () =>
+      BUILD_PRESETS.find((p) => p.context === state.context && p.role === state.role)?.id ?? null,
+    [state.context, state.role],
+  );
 
   return (
     <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
@@ -357,21 +519,25 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             sub={`${fmt(expected.totalUltimate, 0)} over ${state.fightDurationSeconds}s`}
             accent={accent}
             highlight
+            info="Average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
           />
           <StatBlock
             label="Time to first ult"
             value={fmtSeconds(timeToUlt.secondsToFirstCast)}
             sub={`${effectiveCost} ult cost`}
+            info={`How long until you can first fire the selected ultimate (effective cost ${effectiveCost}), counting any banked ultimate at fight start.`}
           />
           <StatBlock
             label="Casts / fight"
             value={Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'}
             sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
+            info={`How many times you can fire it in a ${state.fightDurationSeconds}s fight — total generation divided by its effective cost.`}
           />
           <StatBlock
             label="Generated by 60s"
             value={fmt(expected.ultimatePerSecond * 60, 0)}
             sub={`ult (pool caps at ${maxPool})`}
+            info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
           />
         </Stack>
         {exceedsSanity && (
@@ -387,6 +553,56 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
         {/* ============================ INPUTS ============================ */}
         <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
           <SectionHeader icon={<TuneOutlined />} title="Your build" accent={accent} />
+
+          {/* Quick-start presets — flip context/role + boolean source toggles only. */}
+          <Box sx={{ mb: 2 }}>
+            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+              <AutoFixHighOutlined sx={{ fontSize: 15, color: accent }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.6,
+                  fontWeight: 700,
+                }}
+              >
+                Quick start
+              </Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+              {BUILD_PRESETS.map((p) => {
+                const active = activePresetId === p.id;
+                return (
+                  <Chip
+                    key={p.id}
+                    label={p.label}
+                    size="small"
+                    clickable
+                    onClick={() => applyPreset(p)}
+                    variant={active ? 'filled' : 'outlined'}
+                    sx={{
+                      fontWeight: 600,
+                      borderColor: active ? accent : undefined,
+                      color: active ? accent : undefined,
+                      backgroundColor: active
+                        ? theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.12)'
+                          : 'rgba(40,145,200,0.1)'
+                        : undefined,
+                      '&:hover': {
+                        borderColor: accent,
+                        backgroundColor:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(56,189,248,0.08)'
+                            : 'rgba(40,145,200,0.06)',
+                      },
+                    }}
+                  />
+                );
+              })}
+            </Stack>
+          </Box>
 
           {/* Context / class / role */}
           <Stack spacing={2}>
@@ -426,10 +642,19 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   label="Class"
                   value={state.esoClass}
                   onChange={(e) => calc.setClass(e.target.value as EsoClass)}
+                  renderValue={(v) => (
+                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                      <Swatch color={CLASS_COLORS[v as EsoClass]} size={9} />
+                      <span>{ESO_CLASS_LABELS[v as EsoClass]}</span>
+                    </Stack>
+                  )}
                 >
                   {ESO_CLASSES.map((c) => (
                     <MenuItem key={c} value={c}>
-                      {ESO_CLASS_LABELS[c]}
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                        <Swatch color={CLASS_COLORS[c]} glow />
+                        <span>{ESO_CLASS_LABELS[c]}</span>
+                      </Stack>
                     </MenuItem>
                   ))}
                 </Select>
@@ -484,10 +709,24 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       label="Weapon quality"
                       value={state.decisiveQuality}
                       onChange={(e) => calc.setDecisiveQuality(e.target.value as DecisiveQuality)}
+                      renderValue={(v) => (
+                        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                          <Swatch color={QUALITY_COLORS[v as DecisiveQuality]} square size={9} />
+                          <span>
+                            {QUALITY_OPTIONS.find((o) => o.value === v)?.label} —{' '}
+                            {(DECISIVE_PROC_CHANCE[v as DecisiveQuality] * 100).toFixed(1)}%
+                          </span>
+                        </Stack>
+                      )}
                     >
                       {QUALITY_OPTIONS.map((opt) => (
                         <MenuItem key={opt.value} value={opt.value}>
-                          {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
+                          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                            <Swatch color={QUALITY_COLORS[opt.value]} square />
+                            <span>
+                              {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
+                            </span>
+                          </Stack>
                         </MenuItem>
                       ))}
                     </Select>
@@ -722,6 +961,8 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   labelId="ult-ability-label"
                   label="Ultimate"
                   value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
+                  renderValue={renderSelectedUltimate}
+                  MenuProps={{ slotProps: { paper: { sx: { maxHeight: 420 } } } }}
                   onChange={(e) => {
                     // Seed custom cost with the current EFFECTIVE cost (after any
                     // reductions), since a custom cost is treated as already
@@ -731,13 +972,54 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     else calc.setUltimateAbility(e.target.value);
                   }}
                 >
-                  {orderedUltimates.map((a) => (
-                    <MenuItem key={a.id} value={a.id}>
-                      {a.label} — {a.baseCost}
-                      {a.confidence !== 'high' ? ' *' : ''}
-                    </MenuItem>
-                  ))}
-                  <MenuItem value="custom">Custom cost…</MenuItem>
+                  {/* Grouped by owner. Children are emitted as ONE flat array
+                      (ListSubheader + MenuItems per group) — wrapping a group in
+                      a Fragment/Box would break MUI Select's direct-child value
+                      scan and blank the closed control. */}
+                  {ultimateGroups.flatMap((g) => [
+                    <ListSubheader
+                      key={`sub-${g.key}`}
+                      disableSticky
+                      sx={{
+                        lineHeight: 2.2,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        letterSpacing: 0.5,
+                        textTransform: 'uppercase',
+                        color: 'text.secondary',
+                        background: 'transparent',
+                      }}
+                    >
+                      {g.label}
+                    </ListSubheader>,
+                    ...g.items.map((a) => (
+                      <MenuItem key={a.id} value={a.id}>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          sx={{ alignItems: 'center', width: '100%' }}
+                        >
+                          <Swatch color={ownerColor(a.owner, accent)} size={8} />
+                          <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                            {a.label}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            className="u-tabular"
+                            sx={{ color: 'text.secondary', fontWeight: 600 }}
+                          >
+                            {a.baseCost}
+                          </Typography>
+                        </Stack>
+                      </MenuItem>
+                    )),
+                  ])}
+                  <MenuItem value="custom">
+                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                      <Swatch color={theme.palette.text.disabled} size={8} />
+                      <span>Custom cost…</span>
+                    </Stack>
+                  </MenuItem>
                 </Select>
               </FormControl>
               {state.customUltimateCost != null && (
@@ -934,9 +1216,44 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 <TableBody>
                   {expected.contributions.map((c) => {
                     const tot = c.baseUltimate + c.decisiveUltimate;
+                    // Presentation-only share of the grand total, shown as a
+                    // mini bar so the dominant source reads at a glance.
+                    const share = expected.totalUltimate > 0 ? tot / expected.totalUltimate : 0;
                     return (
                       <TableRow key={c.sourceId}>
-                        <TableCell>{c.label}</TableCell>
+                        <TableCell sx={{ minWidth: 150 }}>
+                          <Typography variant="body2">{c.label}</Typography>
+                          <Stack
+                            direction="row"
+                            spacing={0.75}
+                            sx={{ alignItems: 'center', mt: 0.5 }}
+                          >
+                            <LinearProgress
+                              variant="determinate"
+                              value={Math.min(100, share * 100)}
+                              aria-hidden
+                              sx={{
+                                flex: 1,
+                                height: 5,
+                                borderRadius: 3,
+                                backgroundColor: alpha(theme.palette.divider, 0.5),
+                                '& .MuiLinearProgress-bar': {
+                                  borderRadius: 3,
+                                  background: `linear-gradient(90deg, ${accent}, ${
+                                    theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.85)' : accent
+                                  })`,
+                                },
+                              }}
+                            />
+                            <Typography
+                              variant="caption"
+                              className="u-tabular"
+                              sx={{ minWidth: 32, textAlign: 'right', color: 'text.secondary' }}
+                            >
+                              {Math.round(share * 100)}%
+                            </Typography>
+                          </Stack>
+                        </TableCell>
                         <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
                         <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
                         <TableCell align="right">{fmt(tot, 1)}</TableCell>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -130,6 +130,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     effectiveCost,
     baseCost,
     appliedReductions,
+    availableReductionEntries,
     availableSourceEntries,
     exceedsSanity,
     sanityMax,
@@ -527,7 +528,33 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 helperText="Banked at fight start"
               />
             </Stack>
-            {reductionFraction > 0 && (
+            {/* Cost-reduction toggles — only meaningful for a catalog ability; a
+                custom cost is taken as already-effective so reductions don't apply. */}
+            {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
+              <Stack spacing={0.5} sx={{ mt: 1.5 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Cost reductions
+                </Typography>
+                {availableReductionEntries.map((r) => (
+                  <FormControlLabel
+                    key={r.id}
+                    control={
+                      <Switch
+                        size="small"
+                        checked={calc.isEnabled(r.id, r.defaultEnabled)}
+                        onChange={(e) => calc.toggleSource(r.id, e.target.checked)}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2">
+                        {r.label} (−{Math.round(r.fraction * 100)}%)
+                      </Typography>
+                    }
+                  />
+                ))}
+              </Stack>
+            )}
+            {state.customUltimateCost == null && reductionFraction > 0 && (
               <Typography
                 variant="caption"
                 sx={{ color: 'text.secondary', display: 'block', mt: 1.5 }}

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -493,7 +493,11 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   label="Ultimate"
                   value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
                   onChange={(e) => {
-                    if (e.target.value === 'custom') calc.setCustomUltimateCost(baseCost);
+                    // Seed custom cost with the current EFFECTIVE cost (after any
+                    // reductions), since a custom cost is treated as already
+                    // effective — seeding with the unreduced base would make the
+                    // number jump the moment you switch to Custom.
+                    if (e.target.value === 'custom') calc.setCustomUltimateCost(effectiveCost);
                     else calc.setUltimateAbility(e.target.value);
                   }}
                 >

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -10,6 +10,12 @@
  */
 
 import {
+  BoltOutlined,
+  InsightsOutlined,
+  QueryStatsOutlined,
+  TuneOutlined,
+} from '@mui/icons-material';
+import {
   Alert,
   Box,
   Button,
@@ -37,6 +43,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material';
 import React from 'react';
 
 import { totalReductionFraction } from '../../core/cost';
@@ -85,30 +92,122 @@ const fmtSeconds = (n: number): string => {
   return `${m}m ${s}s`;
 };
 
-/** A big headline stat. */
+/**
+ * Shared surface style for the redesigned panels — opts into the app's
+ * signature glass-gradient card look (the same gradient MuiPaper uses) instead
+ * of the flat `variant="outlined"` surface, so the Ultimate tab reads as a
+ * sibling of the rest of the toolkit rather than a bare MUI form.
+ */
+const panelSx = (theme: Theme): SxProps<Theme> => ({
+  p: { xs: 2, sm: 2.5 },
+  borderRadius: 3.5,
+  border: `1px solid ${theme.palette.divider}`,
+  background:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+      : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 8px 30px rgba(0, 0, 0, 0.25)'
+      : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
+});
+
+/** Accent "eyebrow" label that opens each section, with an icon chip. */
+const SectionHeader: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  accent: string;
+  action?: React.ReactNode;
+}> = ({ icon, title, accent, action }) => (
+  <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1.75 }}>
+    <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', minWidth: 0 }}>
+      <Box
+        aria-hidden
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 30,
+          height: 30,
+          borderRadius: 2,
+          color: accent,
+          background: `${accent}1f`,
+          border: `1px solid ${accent}33`,
+          '& svg': { fontSize: 18 },
+        }}
+      >
+        {icon}
+      </Box>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700, letterSpacing: 0.1, lineHeight: 1.2 }}>
+        {title}
+      </Typography>
+    </Stack>
+    {action}
+  </Stack>
+);
+
+/** A big headline stat tile in the hero strip. */
 const StatBlock: React.FC<{
   label: string;
   value: string;
   sub?: string;
   accent?: string;
-}> = ({ label, value, sub, accent }) => {
+  highlight?: boolean;
+}> = ({ label, value, sub, accent, highlight }) => {
   const theme = useTheme();
   return (
-    <Box sx={{ minWidth: 120 }}>
+    <Box
+      sx={{
+        flex: '1 1 0',
+        minWidth: { xs: 132, sm: 0 },
+        px: { xs: 1.5, sm: 2 },
+        py: { xs: 1.5, sm: 1.25 },
+        borderRadius: 3,
+        position: 'relative',
+        background: highlight
+          ? theme.palette.mode === 'dark'
+            ? 'linear-gradient(160deg, rgba(56,189,248,0.16) 0%, rgba(0,225,255,0.06) 100%)'
+            : 'linear-gradient(160deg, rgba(56,189,248,0.16) 0%, rgba(0,225,255,0.05) 100%)'
+          : theme.palette.mode === 'dark'
+            ? 'rgba(148,163,184,0.05)'
+            : 'rgba(255,255,255,0.5)',
+        border: highlight
+          ? `1px solid ${(accent ?? theme.palette.primary.main) + '55'}`
+          : `1px solid ${theme.palette.divider}`,
+        boxShadow:
+          highlight && theme.palette.mode === 'dark'
+            ? '0 0 28px rgba(56,189,248,0.12) inset'
+            : 'none',
+      }}
+    >
       <Typography
         variant="caption"
-        sx={{ color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.5 }}
+        sx={{
+          color: 'text.secondary',
+          textTransform: 'uppercase',
+          letterSpacing: 0.7,
+          fontWeight: 600,
+          fontSize: 11,
+          display: 'block',
+        }}
       >
         {label}
       </Typography>
       <Typography
-        variant="h4"
-        sx={{ fontWeight: 700, lineHeight: 1.1, color: accent ?? theme.palette.text.primary }}
+        className="u-tabular"
+        sx={{
+          fontFamily: 'Space Grotesk, Inter, system-ui',
+          fontWeight: 700,
+          fontSize: { xs: '1.9rem', sm: '2.15rem' },
+          lineHeight: 1.05,
+          mt: 0.25,
+          color: highlight ? (accent ?? theme.palette.primary.main) : theme.palette.text.primary,
+        }}
       >
         {value}
       </Typography>
       {sub && (
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}>
           {sub}
         </Typography>
       )}
@@ -164,43 +263,100 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
   }, [state.esoClass]);
 
   return (
-    <Box className={className} sx={{ width: '100%' }}>
-      <Typography variant="h5" component="h2" sx={{ fontWeight: 700, mb: 0.5 }}>
-        Ultimate Calculator
-      </Typography>
-      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5 }}>
+    <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
+      {/* ===================== INTRO ===================== */}
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 0.75 }}>
+        <Box
+          aria-hidden
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 40,
+            height: 40,
+            borderRadius: 2.5,
+            color: accent,
+            background:
+              theme.palette.mode === 'dark'
+                ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))',
+            border: `1px solid ${accent}40`,
+            boxShadow: theme.palette.mode === 'dark' ? '0 0 22px rgba(56,189,248,0.18)' : 'none',
+            '& svg': { fontSize: 24 },
+          }}
+        >
+          <BoltOutlined />
+        </Box>
+        <Box>
+          <Typography variant="h5" component="h2" sx={{ fontWeight: 700, lineHeight: 1.1 }}>
+            Ultimate Calculator
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.8 }}
+          >
+            Update 50 · all classes
+          </Typography>
+        </Box>
+      </Stack>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5, maxWidth: 760 }}>
         How fast do you build ultimate, and how often can you cast it? Pick your context and build,
         and get exact ultimate&nbsp;/&nbsp;second, time to your first ultimate, and casts per fight.
-        All numbers use Update&nbsp;50 mechanics.
       </Typography>
 
       {/* ===================== HEADLINE (full width, results-first) ===================== */}
       <Paper
-        variant="outlined"
+        elevation={0}
         sx={{
-          p: { xs: 2, sm: 2.5 },
+          p: { xs: 1.5, sm: 2 },
           mb: 2.5,
-          borderRadius: 3,
+          borderRadius: 4,
+          position: 'relative',
+          overflow: 'hidden',
+          border: `1px solid ${theme.palette.divider}`,
           background:
             theme.palette.mode === 'dark'
-              ? 'linear-gradient(135deg, rgba(56,189,248,0.12), rgba(15,23,42,0.25))'
-              : 'linear-gradient(135deg, rgba(40,145,200,0.10), rgba(248,250,252,0.6))',
+              ? 'linear-gradient(135deg, rgba(56,189,248,0.10) 0%, rgba(15,23,42,0.55) 55%, rgba(3,7,18,0.6) 100%)'
+              : 'linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(248,250,252,0.85) 60%, rgba(255,255,255,0.95) 100%)',
+          boxShadow:
+            theme.palette.mode === 'dark'
+              ? '0 10px 40px rgba(0,0,0,0.3), 0 0 60px rgba(56,189,248,0.06)'
+              : '0 6px 20px rgba(15,23,42,0.07)',
+          // Soft accent glow bleeding from the top-left, behind the stats.
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: -80,
+            left: -60,
+            width: 260,
+            height: 260,
+            borderRadius: '50%',
+            background:
+              theme.palette.mode === 'dark'
+                ? 'radial-gradient(circle, rgba(56,189,248,0.18), transparent 70%)'
+                : 'radial-gradient(circle, rgba(56,189,248,0.16), transparent 70%)',
+            pointerEvents: 'none',
+          },
         }}
       >
         <Stack
-          direction="row"
-          spacing={{ xs: 3, sm: 6 }}
-          sx={{
-            flexWrap: 'wrap',
-            rowGap: 2,
-            justifyContent: { xs: 'flex-start', sm: 'space-around' },
-          }}
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={{ xs: 1.25, sm: 1.5 }}
+          divider={
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{ display: { xs: 'none', sm: 'block' }, borderColor: theme.palette.divider }}
+            />
+          }
+          sx={{ position: 'relative' }}
         >
           <StatBlock
             label="Ultimate / second"
             value={fmt(expected.ultimatePerSecond, 2)}
             sub={`${fmt(expected.totalUltimate, 0)} over ${state.fightDurationSeconds}s`}
             accent={accent}
+            highlight
           />
           <StatBlock
             label="Time to first ult"
@@ -229,15 +385,21 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
 
       <Box sx={{ display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2.5 }}>
         {/* ============================ INPUTS ============================ */}
-        <Paper variant="outlined" sx={{ p: 2.5, flex: '1 1 420px', minWidth: 0, borderRadius: 3 }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
-            Your build
-          </Typography>
+        <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
+          <SectionHeader icon={<TuneOutlined />} title="Your build" accent={accent} />
 
           {/* Context / class / role */}
           <Stack spacing={2}>
             <Box>
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.5,
+                  fontWeight: 600,
+                }}
+              >
                 Context
               </Typography>
               <ToggleButtonGroup
@@ -348,8 +510,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               )}
             </Box>
 
-            <Divider textAlign="left">
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            <Divider textAlign="left" sx={{ '&::before': { width: '0%' }, mt: 0.5 }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: accent,
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  letterSpacing: 0.6,
+                }}
+              >
                 Ultimate sources
               </Typography>
             </Divider>
@@ -357,38 +527,78 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             {/* Source toggles, grouped by category */}
             {grouped.map(([category, entries]) => (
               <Box key={category}>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: accent,
-                    fontWeight: 700,
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.5,
-                  }}
-                >
-                  {SOURCE_CATEGORY_LABELS[category]}
-                </Typography>
-                <Stack spacing={1} sx={{ mt: 0.5 }}>
+                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+                  <Box
+                    aria-hidden
+                    sx={{
+                      width: 5,
+                      height: 5,
+                      borderRadius: '50%',
+                      background: accent,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: 'text.secondary',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.6,
+                    }}
+                  >
+                    {SOURCE_CATEGORY_LABELS[category]}
+                  </Typography>
+                </Stack>
+                <Stack spacing={1}>
                   {entries.map((s) => {
                     const enabled = calc.isEnabled(s.id, s.defaultEnabled);
                     return (
                       <Box
                         key={s.id}
                         sx={{
-                          borderRadius: 2,
-                          p: 1,
+                          borderRadius: 2.5,
+                          px: 1.25,
+                          py: 0.75,
+                          position: 'relative',
+                          overflow: 'hidden',
+                          transition:
+                            'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
                           border: `1px solid ${
                             enabled
                               ? theme.palette.mode === 'dark'
-                                ? 'rgba(56,189,248,0.3)'
-                                : 'rgba(40,145,200,0.25)'
-                              : 'transparent'
+                                ? 'rgba(56,189,248,0.32)'
+                                : 'rgba(40,145,200,0.28)'
+                              : theme.palette.divider
                           }`,
-                          backgroundColor: enabled
+                          background: enabled
                             ? theme.palette.mode === 'dark'
-                              ? 'rgba(56,189,248,0.06)'
-                              : 'rgba(40,145,200,0.04)'
+                              ? 'linear-gradient(135deg, rgba(56,189,248,0.10) 0%, rgba(56,189,248,0.02) 100%)'
+                              : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
                             : 'transparent',
+                          // Accent rail on the left edge marks an active source.
+                          '&::before': enabled
+                            ? {
+                                content: '""',
+                                position: 'absolute',
+                                left: 0,
+                                top: 0,
+                                bottom: 0,
+                                width: 3,
+                                background: `linear-gradient(180deg, ${accent}, ${
+                                  theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.7)' : accent
+                                })`,
+                              }
+                            : undefined,
+                          '&:hover': {
+                            borderColor: enabled
+                              ? theme.palette.mode === 'dark'
+                                ? 'rgba(56,189,248,0.5)'
+                                : 'rgba(40,145,200,0.45)'
+                              : theme.palette.mode === 'dark'
+                                ? 'rgba(148,163,184,0.4)'
+                                : 'rgba(15,23,42,0.18)',
+                          },
                         }}
                       >
                         <Stack
@@ -396,7 +606,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                           sx={{ justifyContent: 'space-between', alignItems: 'center' }}
                         >
                           <FormControlLabel
-                            sx={{ mr: 0, flex: 1 }}
+                            sx={{ mr: 0, flex: 1, minWidth: 0 }}
                             control={
                               <Switch
                                 size="small"
@@ -406,12 +616,21 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             }
                             label={
                               <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                                <Typography variant="body2">{s.label}</Typography>
+                                <Typography
+                                  variant="body2"
+                                  sx={{ fontWeight: enabled ? 600 : 400 }}
+                                >
+                                  {s.label}
+                                </Typography>
                                 {s.confidence !== 'high' && (
                                   <Chip
                                     label={s.confidence}
                                     size="small"
-                                    sx={{ height: 16, fontSize: 10 }}
+                                    sx={{
+                                      height: 17,
+                                      fontSize: 10,
+                                      textTransform: 'capitalize',
+                                    }}
                                   />
                                 )}
                               </Stack>
@@ -423,22 +642,34 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                               target="_blank"
                               rel="noopener noreferrer"
                               variant="caption"
-                              sx={{ flexShrink: 0 }}
+                              sx={{ flexShrink: 0, fontWeight: 600 }}
                             >
                               source
                             </Link>
                           )}
                         </Stack>
                         {enabled && (
-                          <Box sx={{ pl: 5, pr: 1 }}>
+                          <Box sx={{ pl: 5, pr: 1, pb: 0.5 }}>
                             <Stack
                               direction="row"
                               sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
                             >
-                              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                              <Typography
+                                variant="caption"
+                                sx={{
+                                  color: 'text.secondary',
+                                  textTransform: 'uppercase',
+                                  letterSpacing: 0.4,
+                                  fontSize: 10,
+                                }}
+                              >
                                 Uptime
                               </Typography>
-                              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                              <Typography
+                                className="u-tabular"
+                                variant="caption"
+                                sx={{ color: accent, fontWeight: 700 }}
+                              >
                                 {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
                               </Typography>
                             </Stack>
@@ -449,6 +680,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                               min={0}
                               max={100}
                               aria-label={`${s.label} uptime`}
+                              sx={{ py: 0.5 }}
                             />
                             {s.description && (
                               <Typography
@@ -481,10 +713,8 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
         {/* ============================ RESULTS ============================ */}
         <Stack spacing={2.5} sx={{ flex: '1 1 480px', minWidth: 0 }}>
           {/* Ultimate picker / cost */}
-          <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
-              Which ultimate?
-            </Typography>
+          <Paper elevation={0} sx={panelSx(theme)}>
+            <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />
             <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
               <FormControl size="small" sx={{ minWidth: 220, flex: 1 }}>
                 <InputLabel id="ult-ability-label">Ultimate</InputLabel>
@@ -535,8 +765,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             {/* Cost-reduction toggles — only meaningful for a catalog ability; a
                 custom cost is taken as already-effective so reductions don't apply. */}
             {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
-              <Stack spacing={0.5} sx={{ mt: 1.5 }}>
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              <Stack spacing={0.5} sx={{ mt: 2 }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    fontWeight: 600,
+                  }}
+                >
                   Cost reductions
                 </Typography>
                 {availableReductionEntries.map((r) => (
@@ -559,98 +797,265 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               </Stack>
             )}
             {state.customUltimateCost == null && reductionFraction > 0 && (
-              <Typography
-                variant="caption"
-                sx={{ color: 'text.secondary', display: 'block', mt: 1.5 }}
+              <Box
+                sx={{
+                  mt: 1.5,
+                  px: 1.5,
+                  py: 1,
+                  borderRadius: 2,
+                  background:
+                    theme.palette.mode === 'dark' ? 'rgba(34,197,94,0.08)' : 'rgba(5,150,105,0.06)',
+                  border: `1px solid ${
+                    theme.palette.mode === 'dark' ? 'rgba(34,197,94,0.25)' : 'rgba(5,150,105,0.2)'
+                  }`,
+                }}
               >
-                Cost reduced {Math.round(reductionFraction * 100)}% ({baseCost} → {effectiveCost})
-                by{' '}
-                {appliedReductions
-                  .filter((r) => r.enabled)
-                  .map((r) => r.label)
-                  .join(', ')}
-                .
-              </Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
+                  Cost reduced{' '}
+                  <Box component="span" sx={{ color: theme.palette.success.main, fontWeight: 700 }}>
+                    {Math.round(reductionFraction * 100)}%
+                  </Box>{' '}
+                  <Box component="span" className="u-tabular">
+                    ({baseCost} → {effectiveCost})
+                  </Box>{' '}
+                  by{' '}
+                  {appliedReductions
+                    .filter((r) => r.enabled)
+                    .map((r) => r.label)
+                    .join(', ')}
+                  .
+                </Typography>
+              </Box>
             )}
           </Paper>
 
           {/* Per-source breakdown */}
-          <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
-            <Stack
-              direction="row"
-              sx={{ justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
-            >
-              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-                Where it comes from
-              </Typography>
-              <Button size="small" onClick={calc.computeDistribution}>
-                {distribution ? 'Recompute spread' : 'Show spread'}
-              </Button>
-            </Stack>
-            <Table size="small" aria-label="per-source ultimate breakdown">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Source</TableCell>
-                  <TableCell align="right">Base</TableCell>
-                  <TableCell align="right">Decisive</TableCell>
-                  <TableCell align="right">Total</TableCell>
-                  <TableCell align="right">ult/s</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {expected.contributions.map((c) => {
-                  const tot = c.baseUltimate + c.decisiveUltimate;
-                  return (
-                    <TableRow key={c.sourceId}>
-                      <TableCell>{c.label}</TableCell>
-                      <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
-                      <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
-                      <TableCell align="right">{fmt(tot, 1)}</TableCell>
-                      <TableCell align="right">
-                        {fmt(
-                          state.fightDurationSeconds > 0 ? tot / state.fightDurationSeconds : 0,
-                          2,
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-                <TableRow>
-                  <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
-                  <TableCell align="right" sx={{ fontWeight: 700 }}>
-                    {fmt(expected.baseUltimate, 0)}
-                  </TableCell>
-                  <TableCell align="right" sx={{ fontWeight: 700 }}>
-                    {fmt(expected.decisiveUltimate, 1)}
-                  </TableCell>
-                  <TableCell align="right" sx={{ fontWeight: 700 }} data-testid="ult-grand-total">
-                    {fmt(expected.totalUltimate, 1)}
-                  </TableCell>
-                  <TableCell align="right" sx={{ fontWeight: 700 }}>
-                    {fmt(expected.ultimatePerSecond, 2)}
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
+          <Paper elevation={0} sx={panelSx(theme)}>
+            <SectionHeader
+              icon={<InsightsOutlined />}
+              title="Where it comes from"
+              accent={accent}
+              action={
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<QueryStatsOutlined sx={{ fontSize: 16 }} />}
+                  onClick={calc.computeDistribution}
+                  sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                >
+                  {distribution ? 'Recompute spread' : 'Show spread'}
+                </Button>
+              }
+            />
+            <Box sx={{ overflowX: 'auto', mx: -0.5 }}>
+              <Table
+                size="small"
+                aria-label="per-source ultimate breakdown"
+                sx={{
+                  '& td, & th': { borderColor: theme.palette.divider },
+                  '& .MuiTableCell-root': { fontVariantNumeric: 'tabular-nums' },
+                  '& tbody tr:nth-of-type(odd) td': {
+                    backgroundColor:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(148,163,184,0.03)'
+                        : 'rgba(15,23,42,0.015)',
+                  },
+                  '& tbody tr:hover td': {
+                    backgroundColor:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(56,189,248,0.06)'
+                        : 'rgba(40,145,200,0.05)',
+                  },
+                }}
+              >
+                <TableHead>
+                  <TableRow>
+                    <TableCell
+                      sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Source
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Base
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Decisive
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Total
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      ult/s
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {expected.contributions.map((c) => {
+                    const tot = c.baseUltimate + c.decisiveUltimate;
+                    return (
+                      <TableRow key={c.sourceId}>
+                        <TableCell>{c.label}</TableCell>
+                        <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
+                        <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
+                        <TableCell align="right">{fmt(tot, 1)}</TableCell>
+                        <TableCell align="right">
+                          {fmt(
+                            state.fightDurationSeconds > 0 ? tot / state.fightDurationSeconds : 0,
+                            2,
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  <TableRow
+                    sx={{
+                      '& td': {
+                        borderTop: `2px solid ${accent}55`,
+                        background:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(56,189,248,0.08) !important'
+                            : 'rgba(40,145,200,0.06) !important',
+                      },
+                    }}
+                  >
+                    <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 700 }}>
+                      {fmt(expected.baseUltimate, 0)}
+                    </TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 700 }}>
+                      {fmt(expected.decisiveUltimate, 1)}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ fontWeight: 700, color: accent }}
+                      data-testid="ult-grand-total"
+                    >
+                      {fmt(expected.totalUltimate, 1)}
+                    </TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 700, color: accent }}>
+                      {fmt(expected.ultimatePerSecond, 2)}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </Box>
 
             {distribution && (
-              <Box sx={{ mt: 2 }}>
-                <Divider sx={{ mb: 1.5 }} />
+              <Box
+                className="u-fade-in"
+                sx={{
+                  mt: 2,
+                  p: 1.75,
+                  borderRadius: 2.5,
+                  background:
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(148,163,184,0.05)'
+                      : 'rgba(15,23,42,0.02)',
+                  border: `1px solid ${theme.palette.divider}`,
+                }}
+              >
                 <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                   Per-fight spread (Monte Carlo, {distribution.runs.toLocaleString()} runs) —
                   Decisive is random, so a single fight varies around the mean:
                 </Typography>
-                <Stack direction="row" spacing={3} sx={{ mt: 1, flexWrap: 'wrap', rowGap: 1 }}>
-                  <Typography variant="body2">
-                    Mean <strong>{fmt(distribution.meanTotal, 1)}</strong> ±{' '}
-                    {fmt(distribution.ci95HalfWidth, 2)} (95% CI)
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                    Range {fmt(distribution.minTotal, 0)}–{fmt(distribution.maxTotal, 0)}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                    Std dev {fmt(distribution.stdDevTotal, 1)}
-                  </Typography>
+                <Stack direction="row" spacing={3} sx={{ mt: 1.25, flexWrap: 'wrap', rowGap: 1.5 }}>
+                  <Box>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 10,
+                        display: 'block',
+                      }}
+                    >
+                      Mean (95% CI)
+                    </Typography>
+                    <Typography
+                      className="u-tabular"
+                      variant="body2"
+                      sx={{ fontWeight: 700, color: accent }}
+                    >
+                      {fmt(distribution.meanTotal, 1)} ± {fmt(distribution.ci95HalfWidth, 2)}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 10,
+                        display: 'block',
+                      }}
+                    >
+                      Range
+                    </Typography>
+                    <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
+                      {fmt(distribution.minTotal, 0)}–{fmt(distribution.maxTotal, 0)}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.4,
+                        fontSize: 10,
+                        display: 'block',
+                      }}
+                    >
+                      Std dev
+                    </Typography>
+                    <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
+                      {fmt(distribution.stdDevTotal, 1)}
+                    </Typography>
+                  </Box>
                 </Stack>
               </Box>
             )}

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -1,0 +1,634 @@
+/**
+ * Ultimate Calculator — all-class ultimate generation & time-to-ult tool.
+ *
+ * Headline numbers come from the exact closed-form engine (instant, no wobble).
+ * The user picks context / class / role, toggles the ult sources their build
+ * runs, sets Decisive + fight length, and picks the ultimate they want to cast;
+ * the panel shows ult/sec, time to first ult, casts per fight, a per-source
+ * breakdown, and an optional Monte Carlo distribution. Every catalog number is
+ * research-sourced (each source links its provenance).
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  Link,
+  MenuItem,
+  Paper,
+  Select,
+  Slider,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React from 'react';
+
+import { totalReductionFraction } from '../../core/cost';
+import { DECISIVE_PROC_CHANCE, type DecisiveQuality } from '../../shared/constants';
+import { ULTIMATE_ABILITIES } from '../../shared/constants/catalog';
+import {
+  COMBAT_CONTEXT_LABELS,
+  ESO_CLASSES,
+  ESO_CLASS_LABELS,
+  SOURCE_CATEGORY_LABELS,
+  type CombatContext,
+  type CombatRole,
+  type EsoClass,
+  type SourceCategory,
+} from '../../shared/types/catalog';
+import { useUltimateCalculator } from '../useUltimateCalculator';
+
+import { LogCalibrationPanel } from './LogCalibrationPanel';
+
+const QUALITY_OPTIONS: { value: DecisiveQuality; label: string }[] = [
+  { value: 'normal', label: 'Normal (white)' },
+  { value: 'fine', label: 'Fine (green)' },
+  { value: 'superior', label: 'Superior (blue)' },
+  { value: 'epic', label: 'Epic (purple)' },
+  { value: 'legendary', label: 'Legendary (gold)' },
+];
+
+const ROLE_OPTIONS: { value: CombatRole; label: string }[] = [
+  { value: 'dps', label: 'DPS' },
+  { value: 'healer', label: 'Healer' },
+  { value: 'tank', label: 'Tank' },
+];
+
+const CONTEXT_OPTIONS: CombatContext[] = ['soloPve', 'groupPve', 'pvp'];
+
+const fmt = (n: number, digits = 1): string =>
+  Number.isFinite(n)
+    ? n.toLocaleString(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits })
+    : '∞';
+
+const fmtSeconds = (n: number): string => {
+  if (!Number.isFinite(n)) return 'never';
+  if (n < 60) return `${fmt(n, 1)}s`;
+  const m = Math.floor(n / 60);
+  const s = Math.round(n % 60);
+  return `${m}m ${s}s`;
+};
+
+/** A big headline stat. */
+const StatBlock: React.FC<{
+  label: string;
+  value: string;
+  sub?: string;
+  accent?: string;
+}> = ({ label, value, sub, accent }) => {
+  const theme = useTheme();
+  return (
+    <Box sx={{ minWidth: 120 }}>
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.5 }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h4"
+        sx={{ fontWeight: 700, lineHeight: 1.1, color: accent ?? theme.palette.text.primary }}
+      >
+        {value}
+      </Typography>
+      {sub && (
+        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          {sub}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export interface UltimateCalculatorProps {
+  className?: string;
+}
+
+export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ className }) => {
+  const theme = useTheme();
+  const calc = useUltimateCalculator();
+  const {
+    state,
+    expected,
+    timeToUlt,
+    effectiveCost,
+    baseCost,
+    appliedReductions,
+    availableSourceEntries,
+    exceedsSanity,
+    sanityMax,
+    maxPool,
+    distribution,
+  } = calc;
+
+  const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
+
+  // Group available sources by category for a tidy toggle list.
+  const grouped = React.useMemo(() => {
+    const map = new Map<SourceCategory, typeof availableSourceEntries>();
+    for (const s of availableSourceEntries) {
+      const arr = (map.get(s.category) ?? []) as typeof availableSourceEntries;
+      map.set(s.category, [...arr, s]);
+    }
+    return Array.from(map.entries());
+  }, [availableSourceEntries]);
+
+  const reductionFraction = totalReductionFraction(appliedReductions);
+
+  // Order the ultimate picker so the current class's ults (and global/weapon
+  // ones, usable by everyone) surface first; other classes' ults follow.
+  const orderedUltimates = React.useMemo(() => {
+    const rank = (owner: string): number => {
+      if (owner === state.esoClass) return 0;
+      if (owner === 'global' || owner === 'weapon') return 1;
+      return 2;
+    };
+    return [...ULTIMATE_ABILITIES].sort((a, b) => rank(a.owner) - rank(b.owner));
+  }, [state.esoClass]);
+
+  return (
+    <Box className={className} sx={{ width: '100%' }}>
+      <Typography variant="h5" component="h2" sx={{ fontWeight: 700, mb: 0.5 }}>
+        Ultimate Calculator
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5 }}>
+        How fast do you build ultimate, and how often can you cast it? Pick your context and build,
+        and get exact ultimate&nbsp;/&nbsp;second, time to your first ultimate, and casts per fight.
+        All numbers use Update&nbsp;50 mechanics.
+      </Typography>
+
+      {/* ===================== HEADLINE (full width, results-first) ===================== */}
+      <Paper
+        variant="outlined"
+        sx={{
+          p: { xs: 2, sm: 2.5 },
+          mb: 2.5,
+          borderRadius: 3,
+          background:
+            theme.palette.mode === 'dark'
+              ? 'linear-gradient(135deg, rgba(56,189,248,0.12), rgba(15,23,42,0.25))'
+              : 'linear-gradient(135deg, rgba(40,145,200,0.10), rgba(248,250,252,0.6))',
+        }}
+      >
+        <Stack
+          direction="row"
+          spacing={{ xs: 3, sm: 6 }}
+          sx={{
+            flexWrap: 'wrap',
+            rowGap: 2,
+            justifyContent: { xs: 'flex-start', sm: 'space-around' },
+          }}
+        >
+          <StatBlock
+            label="Ultimate / second"
+            value={fmt(expected.ultimatePerSecond, 2)}
+            sub={`${fmt(expected.totalUltimate, 0)} over ${state.fightDurationSeconds}s`}
+            accent={accent}
+          />
+          <StatBlock
+            label="Time to first ult"
+            value={fmtSeconds(timeToUlt.secondsToFirstCast)}
+            sub={`${effectiveCost} ult cost`}
+          />
+          <StatBlock
+            label="Casts / fight"
+            value={Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'}
+            sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
+          />
+          <StatBlock
+            label="Generated by 60s"
+            value={fmt(expected.ultimatePerSecond * 60, 0)}
+            sub={`ult (pool caps at ${maxPool})`}
+          />
+        </Stack>
+        {exceedsSanity && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            {fmt(expected.ultimatePerSecond, 2)} ult/s is above the practical sustained ceiling (~
+            {sanityMax}/s, roughly the best a Warden achieves). Double-check the enabled sources and
+            uptimes — this may be optimistic.
+          </Alert>
+        )}
+      </Paper>
+
+      <Box sx={{ display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2.5 }}>
+        {/* ============================ INPUTS ============================ */}
+        <Paper variant="outlined" sx={{ p: 2.5, flex: '1 1 420px', minWidth: 0, borderRadius: 3 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
+            Your build
+          </Typography>
+
+          {/* Context / class / role */}
+          <Stack spacing={2}>
+            <Box>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Context
+              </Typography>
+              <ToggleButtonGroup
+                exclusive
+                fullWidth
+                size="small"
+                value={state.context}
+                onChange={(_, v) => v && calc.setContext(v as CombatContext)}
+                sx={{ mt: 0.5 }}
+              >
+                {CONTEXT_OPTIONS.map((c) => (
+                  <ToggleButton key={c} value={c} sx={{ textTransform: 'none' }}>
+                    {COMBAT_CONTEXT_LABELS[c]}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+            </Box>
+
+            <Stack direction="row" spacing={2}>
+              <FormControl size="small" fullWidth>
+                <InputLabel id="ult-class-label">Class</InputLabel>
+                <Select
+                  labelId="ult-class-label"
+                  label="Class"
+                  value={state.esoClass}
+                  onChange={(e) => calc.setClass(e.target.value as EsoClass)}
+                >
+                  {ESO_CLASSES.map((c) => (
+                    <MenuItem key={c} value={c}>
+                      {ESO_CLASS_LABELS[c]}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl size="small" fullWidth>
+                <InputLabel id="ult-role-label">Role</InputLabel>
+                <Select
+                  labelId="ult-role-label"
+                  label="Role"
+                  value={state.role}
+                  onChange={(e) => calc.setRole(e.target.value as CombatRole)}
+                >
+                  {ROLE_OPTIONS.map((r) => (
+                    <MenuItem key={r.value} value={r.value}>
+                      {r.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Stack>
+
+            <TextField
+              label="Fight duration (seconds)"
+              type="number"
+              size="small"
+              value={state.fightDurationSeconds}
+              onChange={(e) => calc.setFightDuration(Number(e.target.value))}
+              slotProps={{ htmlInput: { min: 1, step: 5 } }}
+            />
+
+            {/* Decisive */}
+            <Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={state.decisiveEnabled}
+                    onChange={(e) => calc.setDecisiveEnabled(e.target.checked)}
+                  />
+                }
+                label={
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    Decisive weapon trait
+                  </Typography>
+                }
+              />
+              {state.decisiveEnabled && (
+                <Stack spacing={1.5} sx={{ mt: 1, pl: 1 }}>
+                  <FormControl size="small" fullWidth>
+                    <InputLabel id="decisive-quality-label">Weapon quality</InputLabel>
+                    <Select
+                      labelId="decisive-quality-label"
+                      label="Weapon quality"
+                      value={state.decisiveQuality}
+                      onChange={(e) => calc.setDecisiveQuality(e.target.value as DecisiveQuality)}
+                    >
+                      {QUALITY_OPTIONS.map((opt) => (
+                        <MenuItem key={opt.value} value={opt.value}>
+                          {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <Tooltip
+                    arrow
+                    title="A two-handed melee weapon (greatsword, battle axe, maul) provides twice the Decisive bonus — it rolls for the extra ultimate twice per gain instead of once."
+                  >
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={state.decisiveTwoHanded}
+                          onChange={(e) => calc.setDecisiveTwoHanded(e.target.checked)}
+                        />
+                      }
+                      label={<Typography variant="body2">Two-handed (rolls twice)</Typography>}
+                    />
+                  </Tooltip>
+                </Stack>
+              )}
+            </Box>
+
+            <Divider textAlign="left">
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                Ultimate sources
+              </Typography>
+            </Divider>
+
+            {/* Source toggles, grouped by category */}
+            {grouped.map(([category, entries]) => (
+              <Box key={category}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: accent,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                  }}
+                >
+                  {SOURCE_CATEGORY_LABELS[category]}
+                </Typography>
+                <Stack spacing={1} sx={{ mt: 0.5 }}>
+                  {entries.map((s) => {
+                    const enabled = calc.isEnabled(s.id, s.defaultEnabled);
+                    return (
+                      <Box
+                        key={s.id}
+                        sx={{
+                          borderRadius: 2,
+                          p: 1,
+                          border: `1px solid ${
+                            enabled
+                              ? theme.palette.mode === 'dark'
+                                ? 'rgba(56,189,248,0.3)'
+                                : 'rgba(40,145,200,0.25)'
+                              : 'transparent'
+                          }`,
+                          backgroundColor: enabled
+                            ? theme.palette.mode === 'dark'
+                              ? 'rgba(56,189,248,0.06)'
+                              : 'rgba(40,145,200,0.04)'
+                            : 'transparent',
+                        }}
+                      >
+                        <Stack
+                          direction="row"
+                          sx={{ justifyContent: 'space-between', alignItems: 'center' }}
+                        >
+                          <FormControlLabel
+                            sx={{ mr: 0, flex: 1 }}
+                            control={
+                              <Switch
+                                size="small"
+                                checked={enabled}
+                                onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
+                              />
+                            }
+                            label={
+                              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                                <Typography variant="body2">{s.label}</Typography>
+                                {s.confidence !== 'high' && (
+                                  <Chip
+                                    label={s.confidence}
+                                    size="small"
+                                    sx={{ height: 16, fontSize: 10 }}
+                                  />
+                                )}
+                              </Stack>
+                            }
+                          />
+                          {s.provenance && (
+                            <Link
+                              href={s.provenance}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              variant="caption"
+                              sx={{ flexShrink: 0 }}
+                            >
+                              source
+                            </Link>
+                          )}
+                        </Stack>
+                        {enabled && (
+                          <Box sx={{ pl: 5, pr: 1 }}>
+                            <Stack
+                              direction="row"
+                              sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+                            >
+                              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                                Uptime
+                              </Typography>
+                              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                                {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
+                              </Typography>
+                            </Stack>
+                            <Slider
+                              size="small"
+                              value={Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}
+                              onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
+                              min={0}
+                              max={100}
+                              aria-label={`${s.label} uptime`}
+                            />
+                            {s.description && (
+                              <Typography
+                                variant="caption"
+                                sx={{ color: 'text.secondary', display: 'block', mt: -0.5 }}
+                              >
+                                {s.description}
+                              </Typography>
+                            )}
+                          </Box>
+                        )}
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              </Box>
+            ))}
+
+            <Button
+              onClick={calc.reset}
+              size="small"
+              variant="text"
+              sx={{ alignSelf: 'flex-start' }}
+            >
+              Reset to defaults
+            </Button>
+          </Stack>
+        </Paper>
+
+        {/* ============================ RESULTS ============================ */}
+        <Stack spacing={2.5} sx={{ flex: '1 1 480px', minWidth: 0 }}>
+          {/* Ultimate picker / cost */}
+          <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1.5 }}>
+              Which ultimate?
+            </Typography>
+            <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
+              <FormControl size="small" sx={{ minWidth: 220, flex: 1 }}>
+                <InputLabel id="ult-ability-label">Ultimate</InputLabel>
+                <Select
+                  labelId="ult-ability-label"
+                  label="Ultimate"
+                  value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
+                  onChange={(e) => {
+                    if (e.target.value === 'custom') calc.setCustomUltimateCost(baseCost);
+                    else calc.setUltimateAbility(e.target.value);
+                  }}
+                >
+                  {orderedUltimates.map((a) => (
+                    <MenuItem key={a.id} value={a.id}>
+                      {a.label} — {a.baseCost}
+                      {a.confidence !== 'high' ? ' *' : ''}
+                    </MenuItem>
+                  ))}
+                  <MenuItem value="custom">Custom cost…</MenuItem>
+                </Select>
+              </FormControl>
+              {state.customUltimateCost != null && (
+                <TextField
+                  label="Custom cost"
+                  type="number"
+                  size="small"
+                  value={state.customUltimateCost}
+                  onChange={(e) => calc.setCustomUltimateCost(Number(e.target.value))}
+                  slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
+                  sx={{ width: 140 }}
+                />
+              )}
+              <TextField
+                label="Starting ultimate"
+                type="number"
+                size="small"
+                value={state.startingUltimate}
+                onChange={(e) => calc.setStartingUltimate(Number(e.target.value))}
+                slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
+                sx={{ width: 150 }}
+                helperText="Banked at fight start"
+              />
+            </Stack>
+            {reductionFraction > 0 && (
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', display: 'block', mt: 1.5 }}
+              >
+                Cost reduced {Math.round(reductionFraction * 100)}% ({baseCost} → {effectiveCost})
+                by{' '}
+                {appliedReductions
+                  .filter((r) => r.enabled)
+                  .map((r) => r.label)
+                  .join(', ')}
+                .
+              </Typography>
+            )}
+          </Paper>
+
+          {/* Per-source breakdown */}
+          <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
+            <Stack
+              direction="row"
+              sx={{ justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
+            >
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                Where it comes from
+              </Typography>
+              <Button size="small" onClick={calc.computeDistribution}>
+                {distribution ? 'Recompute spread' : 'Show spread'}
+              </Button>
+            </Stack>
+            <Table size="small" aria-label="per-source ultimate breakdown">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Source</TableCell>
+                  <TableCell align="right">Base</TableCell>
+                  <TableCell align="right">Decisive</TableCell>
+                  <TableCell align="right">Total</TableCell>
+                  <TableCell align="right">ult/s</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {expected.contributions.map((c) => {
+                  const tot = c.baseUltimate + c.decisiveUltimate;
+                  return (
+                    <TableRow key={c.sourceId}>
+                      <TableCell>{c.label}</TableCell>
+                      <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
+                      <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
+                      <TableCell align="right">{fmt(tot, 1)}</TableCell>
+                      <TableCell align="right">
+                        {fmt(
+                          state.fightDurationSeconds > 0 ? tot / state.fightDurationSeconds : 0,
+                          2,
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    {fmt(expected.baseUltimate, 0)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    {fmt(expected.decisiveUltimate, 1)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }} data-testid="ult-grand-total">
+                    {fmt(expected.totalUltimate, 1)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    {fmt(expected.ultimatePerSecond, 2)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+
+            {distribution && (
+              <Box sx={{ mt: 2 }}>
+                <Divider sx={{ mb: 1.5 }} />
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  Per-fight spread (Monte Carlo, {distribution.runs.toLocaleString()} runs) —
+                  Decisive is random, so a single fight varies around the mean:
+                </Typography>
+                <Stack direction="row" spacing={3} sx={{ mt: 1, flexWrap: 'wrap', rowGap: 1 }}>
+                  <Typography variant="body2">
+                    Mean <strong>{fmt(distribution.meanTotal, 1)}</strong> ±{' '}
+                    {fmt(distribution.ci95HalfWidth, 2)} (95% CI)
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    Range {fmt(distribution.minTotal, 0)}–{fmt(distribution.maxTotal, 0)}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    Std dev {fmt(distribution.stdDevTotal, 1)}
+                  </Typography>
+                </Stack>
+              </Box>
+            )}
+          </Paper>
+
+          {/* Verify against your own ESO Logs report */}
+          <LogCalibrationPanel modeledPerSecond={expected.ultimatePerSecond} />
+        </Stack>
+      </Box>
+    </Box>
+  );
+};

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -10,7 +10,6 @@
  */
 
 import {
-  AutoFixHighOutlined,
   BoltOutlined,
   InfoOutlined,
   InsightsOutlined,
@@ -152,50 +151,6 @@ const Swatch: React.FC<{ color: string; square?: boolean; size?: number; glow?: 
     }}
   />
 );
-
-/**
- * Build-archetype presets — each flips ONLY existing boolean/selection state
- * (context / role / class / source on-off) via the hook's setters. Crucially it
- * NEVER sets an uptime: a toggled-on source inherits its own research-sourced
- * catalog-default uptime, so no unsourced number is ever introduced.
- */
-interface BuildPreset {
-  readonly id: string;
-  readonly label: string;
-  readonly context: CombatContext;
-  readonly role: CombatRole;
-  /** Source ids to force on (others left at their catalog defaults). */
-  readonly enableSources: readonly string[];
-  /** Source ids to force off. */
-  readonly disableSources: readonly string[];
-}
-
-const BUILD_PRESETS: readonly BuildPreset[] = [
-  {
-    id: 'trial-dps',
-    label: 'Trial group DPS',
-    context: 'groupPve',
-    role: 'dps',
-    enableSources: ['major-heroism'],
-    disableSources: [],
-  },
-  {
-    id: 'solo-parse',
-    label: 'Solo parse',
-    context: 'soloPve',
-    role: 'dps',
-    enableSources: [],
-    disableSources: ['minor-heroism', 'major-heroism'],
-  },
-  {
-    id: 'pvp',
-    label: 'PvP',
-    context: 'pvp',
-    role: 'dps',
-    enableSources: ['minor-heroism'],
-    disableSources: [],
-  },
-];
 
 const fmt = (n: number, digits = 1): string =>
   Number.isFinite(n)
@@ -575,35 +530,11 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     return ability ? `${ability.label} — ${ability.baseCost}` : '';
   }, []);
 
-  // Apply a build-archetype preset: flips ONLY context/role/class and boolean
-  // source toggles. It never sets an uptime — a toggled-on source keeps its
-  // research-sourced catalog default, so no unsourced number is introduced.
-  const applyPreset = React.useCallback(
-    (preset: BuildPreset) => {
-      calc.setContext(preset.context);
-      calc.setRole(preset.role);
-      for (const id of preset.enableSources) calc.toggleSource(id, true);
-      for (const id of preset.disableSources) calc.toggleSource(id, false);
-    },
-    [calc],
-  );
-
-  // Best-effort "active" highlight: a preset reads as active when the current
-  // context + role match it (presentation hint only — not an exact build match).
-  const activePresetId = React.useMemo(
-    () =>
-      BUILD_PRESETS.find((p) => p.context === state.context && p.role === state.role)?.id ?? null,
-    [state.context, state.role],
-  );
-
   return (
     <ThemeProvider theme={calcTheme}>
       <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
         {/* ===================== INTRO ===================== */}
-        {/* Icon + the whole text column share one left edge: heading, eyebrow, and
-          blurb all align (the blurb used to start at the container edge while the
-          eyebrow sat indented under the heading). */}
-        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', mb: 2.75 }}>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 0.75 }}>
           <Box
             aria-hidden
             sx={{
@@ -627,32 +558,21 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             <BoltOutlined />
           </Box>
           <Box sx={{ minWidth: 0 }}>
-            <Typography
-              variant="h5"
-              component="h2"
-              sx={{ fontWeight: 700, lineHeight: 1.15, letterSpacing: '-0.01em' }}
-            >
+            <Typography variant="h5" component="h2" sx={{ fontWeight: 700, lineHeight: 1.1 }}>
               Ultimate Calculator
             </Typography>
             <Typography
               variant="caption"
-              sx={{
-                display: 'block',
-                color: 'text.secondary',
-                textTransform: 'uppercase',
-                letterSpacing: 1,
-                fontWeight: 600,
-                mt: 0.25,
-              }}
+              sx={{ color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.8 }}
             >
               Update 50 · all classes
             </Typography>
-            <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1, maxWidth: 600 }}>
-              Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first
-              cast, and casts per fight.
-            </Typography>
           </Box>
         </Stack>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5, maxWidth: 640 }}>
+          Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first cast,
+          and casts per fight.
+        </Typography>
 
         {/* ===================== HEADLINE (full width, results-first) ===================== */}
         <Paper
@@ -875,69 +795,6 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           {/* ============================ INPUTS ============================ */}
           <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
             <SectionHeader icon={<TuneOutlined />} title="Your build" accent={accent} />
-
-            {/* Quick-start presets — flip context/role + boolean source toggles only. */}
-            <Box sx={{ mb: 2 }}>
-              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-                <AutoFixHighOutlined sx={{ fontSize: 15, color: accent }} />
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: 'text.secondary',
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.6,
-                    fontWeight: 700,
-                  }}
-                >
-                  Quick start
-                </Typography>
-              </Stack>
-              <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
-                {BUILD_PRESETS.map((p) => {
-                  const active = activePresetId === p.id;
-                  return (
-                    <Chip
-                      key={p.id}
-                      label={p.label}
-                      clickable
-                      onClick={() => applyPreset(p)}
-                      aria-pressed={active}
-                      sx={{
-                        height: 30,
-                        borderRadius: 2,
-                        fontWeight: 600,
-                        px: 0.25,
-                        border: `1px solid ${active ? accent : theme.palette.divider}`,
-                        color: active ? accentText : 'text.secondary',
-                        background: active
-                          ? theme.palette.mode === 'dark'
-                            ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                            : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
-                          : theme.palette.mode === 'dark'
-                            ? 'rgba(148,163,184,0.06)'
-                            : 'rgba(255,255,255,0.6)',
-                        boxShadow: active
-                          ? theme.palette.mode === 'dark'
-                            ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 14px rgba(56,189,248,0.12)'
-                            : 'inset 0 0 0 1px rgba(40,145,200,0.35)'
-                          : 'none',
-                        transition: 'background-color 0.18s ease, border-color 0.18s ease',
-                        '&:hover': {
-                          borderColor: accent,
-                          background: active
-                            ? theme.palette.mode === 'dark'
-                              ? 'linear-gradient(135deg, rgba(56,189,248,0.26), rgba(0,225,255,0.1))'
-                              : 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                            : theme.palette.mode === 'dark'
-                              ? 'rgba(56,189,248,0.08)'
-                              : 'rgba(40,145,200,0.06)',
-                        },
-                      }}
-                    />
-                  );
-                })}
-              </Stack>
-            </Box>
 
             {/* Context / class / role */}
             <Stack spacing={2}>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -55,7 +55,6 @@ import { totalReductionFraction } from '../../core/cost';
 import { DECISIVE_PROC_CHANCE, type DecisiveQuality } from '../../shared/constants';
 import { ULTIMATE_ABILITIES } from '../../shared/constants/catalog';
 import {
-  COMBAT_CONTEXT_LABELS,
   ESO_CLASSES,
   ESO_CLASS_LABELS,
   SOURCE_CATEGORY_LABELS,
@@ -83,6 +82,18 @@ const ROLE_OPTIONS: { value: CombatRole; label: string }[] = [
 ];
 
 const CONTEXT_OPTIONS: CombatContext[] = ['soloPve', 'groupPve', 'pvp'];
+
+/**
+ * Short, single-line labels for the context segmented control. The full
+ * descriptive strings (COMBAT_CONTEXT_LABELS) wrapped to two uneven lines in a
+ * three-up control; here the primary word stays on one line with a small hint
+ * underneath. Cosmetic only — the underlying CombatContext values are unchanged.
+ */
+const CONTEXT_META: Record<CombatContext, { label: string; hint: string }> = {
+  soloPve: { label: 'Solo', hint: 'Parse · PvE' },
+  groupPve: { label: 'Group', hint: 'Trial · PvE' },
+  pvp: { label: 'PvP', hint: 'Cyrodiil · BG' },
+};
 
 /**
  * Canonical per-class accent colors (mirrors the repo's class palette in
@@ -771,15 +782,71 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               <ToggleButtonGroup
                 exclusive
                 fullWidth
-                size="small"
                 value={state.context}
                 onChange={(_, v) => v && calc.setContext(v as CombatContext)}
                 aria-labelledby="ult-context-label"
-                sx={{ mt: 0.5 }}
+                sx={{
+                  mt: 0.75,
+                  gap: 0.5,
+                  p: 0.5,
+                  borderRadius: 2.5,
+                  border: `1px solid ${theme.palette.divider}`,
+                  background:
+                    theme.palette.mode === 'dark'
+                      ? 'rgba(148,163,184,0.05)'
+                      : 'rgba(255,255,255,0.55)',
+                  // Segmented-control styling that mirrors the top Stats/Ultimate
+                  // switcher: filled accent pill behind the active option.
+                  '& .MuiToggleButtonGroup-grouped': {
+                    border: 0,
+                    borderRadius: '8px !important',
+                    flexDirection: 'column',
+                    gap: 0,
+                    py: 0.85,
+                    minHeight: 48,
+                    color: 'text.secondary',
+                    transition:
+                      'background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease',
+                    '&:hover': {
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.06)'
+                          : 'rgba(15,23,42,0.04)',
+                    },
+                    '&.Mui-selected': {
+                      color: accentText,
+                      background:
+                        theme.palette.mode === 'dark'
+                          ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                          : 'linear-gradient(135deg, rgba(56,189,248,0.16), rgba(0,225,255,0.05))',
+                      boxShadow:
+                        theme.palette.mode === 'dark'
+                          ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 16px rgba(56,189,248,0.12)'
+                          : 'inset 0 0 0 1px rgba(40,145,200,0.4)',
+                      '&:hover': {
+                        background:
+                          theme.palette.mode === 'dark'
+                            ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                            : 'linear-gradient(135deg, rgba(56,189,248,0.2), rgba(0,225,255,0.07))',
+                      },
+                    },
+                  },
+                }}
               >
                 {CONTEXT_OPTIONS.map((c) => (
                   <ToggleButton key={c} value={c} sx={{ textTransform: 'none' }}>
-                    {COMBAT_CONTEXT_LABELS[c]}
+                    <Typography
+                      component="span"
+                      sx={{ fontWeight: 700, fontSize: '0.875rem', lineHeight: 1.15 }}
+                    >
+                      {CONTEXT_META[c].label}
+                    </Typography>
+                    <Typography
+                      component="span"
+                      sx={{ fontSize: 10, opacity: 0.85, lineHeight: 1.2, mt: 0.25 }}
+                    >
+                      {CONTEXT_META[c].hint}
+                    </Typography>
                   </ToggleButton>
                 ))}
               </ToggleButtonGroup>
@@ -948,8 +1015,9 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                         key={s.id}
                         sx={{
                           borderRadius: 2.5,
-                          px: 1.25,
-                          py: 0.75,
+                          px: 1.5,
+                          py: enabled ? 1.25 : 0.5,
+                          pl: 1.75,
                           position: 'relative',
                           overflow: 'hidden',
                           transition:
@@ -993,13 +1061,17 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       >
                         <Stack
                           direction="row"
-                          sx={{ justifyContent: 'space-between', alignItems: 'center' }}
+                          spacing={1}
+                          sx={{
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            minHeight: 44,
+                          }}
                         >
                           <FormControlLabel
-                            sx={{ mr: 0, flex: 1, minWidth: 0 }}
+                            sx={{ mr: 0, flex: 1, minWidth: 0, gap: 0.75 }}
                             control={
                               <Switch
-                                size="small"
                                 checked={enabled}
                                 onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
                               />
@@ -1008,7 +1080,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                               <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
                                 <Typography
                                   variant="body2"
-                                  sx={{ fontWeight: enabled ? 600 : 400 }}
+                                  sx={{ fontWeight: enabled ? 600 : 500, lineHeight: 1.3 }}
                                 >
                                   {s.label}
                                 </Typography>
@@ -1039,7 +1111,13 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                           )}
                         </Stack>
                         {enabled && (
-                          <Box sx={{ pl: 5, pr: 1, pb: 0.5 }}>
+                          <Box
+                            sx={{
+                              mt: 0.75,
+                              pt: 1,
+                              borderTop: `1px solid ${alpha(theme.palette.divider, 0.7)}`,
+                            }}
+                          >
                             <Stack
                               direction="row"
                               sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
@@ -1049,15 +1127,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                 sx={{
                                   color: 'text.secondary',
                                   textTransform: 'uppercase',
-                                  letterSpacing: 0.4,
+                                  letterSpacing: 0.5,
                                   fontSize: 10,
+                                  fontWeight: 700,
                                 }}
                               >
                                 Uptime
                               </Typography>
                               <Typography
                                 className="u-tabular"
-                                variant="caption"
+                                variant="body2"
                                 sx={{ color: accentText, fontWeight: 700 }}
                               >
                                 {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
@@ -1075,7 +1154,12 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             {s.description && (
                               <Typography
                                 variant="caption"
-                                sx={{ color: 'text.secondary', display: 'block', mt: -0.5 }}
+                                sx={{
+                                  color: 'text.secondary',
+                                  display: 'block',
+                                  mt: -0.25,
+                                  lineHeight: 1.45,
+                                }}
                               >
                                 {s.description}
                               </Typography>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -2109,18 +2109,21 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 borderRadius: 3,
                 cursor: 'pointer',
                 border: `1px solid ${
-                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.38)' : 'rgba(40,145,200,0.3)'
+                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.45)'
                 }`,
+                // Frosted, elevated glass that sits clearly ABOVE the page rather
+                // than matching its flat navy — a lighter, more transparent
+                // surface (so the blur reads) plus a brighter cyan edge + glow.
                 background:
                   theme.palette.mode === 'dark'
-                    ? 'linear-gradient(180deg, rgba(14,24,44,0.92), rgba(7,14,28,0.95))'
-                    : 'rgba(255,255,255,0.96)',
-                backdropFilter: 'blur(16px) saturate(1.3)',
-                WebkitBackdropFilter: 'blur(16px) saturate(1.3)',
+                    ? 'linear-gradient(180deg, rgba(30,48,78,0.72) 0%, rgba(17,32,58,0.78) 100%)'
+                    : 'linear-gradient(180deg, rgba(240,250,255,0.82) 0%, rgba(255,255,255,0.84) 100%)',
+                backdropFilter: 'blur(22px) saturate(1.6)',
+                WebkitBackdropFilter: 'blur(22px) saturate(1.6)',
                 boxShadow:
                   theme.palette.mode === 'dark'
-                    ? '0 14px 38px rgba(0,0,0,0.55), 0 0 24px rgba(56,189,248,0.18)'
-                    : '0 12px 30px rgba(15,23,42,0.18)',
+                    ? '0 18px 44px rgba(0,0,0,0.55), 0 0 34px rgba(56,189,248,0.32), inset 0 1px 0 rgba(255,255,255,0.08)'
+                    : '0 16px 36px rgba(15,23,42,0.2), 0 0 22px rgba(40,145,200,0.2)',
                 '&:focus-visible': { outline: `2px solid ${accent}`, outlineOffset: 2 },
               }}
             >

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -364,7 +364,39 @@ const StatBlock: React.FC<{
  *  - Legible in BOTH dark and light mode (translucent fills + 1px borders that
  *    brighten to cyan on hover and show a cyan focus glow ring on focus).
  */
-const buildCalcTheme = (base: Theme): Theme => {
+
+/** MUI Select `onOpen` handler — measures the anchor to choose open direction. */
+type SelectOpenHandler = (event: React.SyntheticEvent) => void;
+
+/**
+ * Select-menu open-direction origins.
+ *
+ * Two problems with MUI's defaults are fixed here:
+ *  1. The default `selectedMenu` positioning aligns the *selected* item over
+ *     the anchor, so a Select whose value is near the end of the list (e.g.
+ *     "Legendary" weapon quality, the last option) opens centred on the field
+ *     instead of below it. Anchoring bottom→top makes menus open downward like
+ *     a normal dropdown.
+ *  2. When the field sits near the bottom of the viewport there isn't room for
+ *     the menu below it. MUI's Popover only *shifts* the menu up to stay
+ *     on-screen — it never flips — so a downward menu slides up and covers the
+ *     field. We detect that case (see `handleSelectOpen`) and flip the origins
+ *     to open *upward* (top→bottom), keeping the field visible.
+ */
+const DROPDOWN_MENU_ORIGINS_DOWN = {
+  anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+  transformOrigin: { vertical: 'top', horizontal: 'left' },
+} as const;
+const DROPDOWN_MENU_ORIGINS_UP = {
+  anchorOrigin: { vertical: 'top', horizontal: 'left' },
+  transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+} as const;
+const dropdownMenuOrigins = (
+  up: boolean,
+): typeof DROPDOWN_MENU_ORIGINS_UP | typeof DROPDOWN_MENU_ORIGINS_DOWN =>
+  up ? DROPDOWN_MENU_ORIGINS_UP : DROPDOWN_MENU_ORIGINS_DOWN;
+
+const buildCalcTheme = (base: Theme, menuUp: boolean, onSelectOpen: SelectOpenHandler): Theme => {
   const dark = base.palette.mode === 'dark';
   // Cyan tokens per the design direction.
   const cyan = dark ? 'rgb(56,189,248)' : 'rgb(40,145,200)';
@@ -497,7 +529,11 @@ const buildCalcTheme = (base: Theme): Theme => {
             // absolute paper is already a containing block, so the `&::before`
             // top sheen below still anchors correctly without `relative`.
             borderRadius: 14,
-            marginTop: 6,
+            // Gap between field and menu, on whichever side the menu opens — a
+            // static marginTop would push an upward-flipped menu down onto the
+            // field, so mirror it to marginBottom when `menuUp`.
+            marginTop: menuUp ? 0 : 6,
+            marginBottom: menuUp ? 6 : 0,
             // Clip the rounded corners horizontally, but allow vertical scroll —
             // `overflow: hidden` here previously broke scrolling in tall menus
             // (e.g. the Ultimate picker). border-radius still clips with auto.
@@ -587,6 +623,16 @@ const buildCalcTheme = (base: Theme): Theme => {
           root: { borderRadius: 10 },
         },
       },
+      // Every Select in this tab (incl. LogCalibrationPanel) opens downward —
+      // or upward when the field is near the viewport bottom — instead of
+      // overlapping the field. `onSelectOpen` measures the anchor and toggles
+      // `menuUp`; see dropdownMenuOrigins / handleSelectOpen.
+      MuiSelect: {
+        defaultProps: {
+          onOpen: onSelectOpen,
+          MenuProps: dropdownMenuOrigins(menuUp),
+        },
+      },
     },
   });
 };
@@ -613,10 +659,30 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     distribution,
   } = calc;
 
+  // Open Select menus upward when the field is too close to the viewport bottom
+  // to fit the menu below it (otherwise MUI shifts a downward menu up over the
+  // field). Measured per-open from the anchor; only one Select menu is open at a
+  // time, so a single shared direction is sufficient.
+  const [menuUp, setMenuUp] = React.useState(false);
+  const handleSelectOpen = React.useCallback<SelectOpenHandler>((event) => {
+    const anchor = event.currentTarget as HTMLElement | null;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    // Flip up only when below is genuinely tight AND above has more room — so
+    // ordinary mid-page selects keep opening downward as expected.
+    setMenuUp(spaceBelow < 320 && spaceAbove > spaceBelow);
+  }, []);
+
   // Feature-scoped theme: cyan-glass Sliders / Selects / inputs for this tab and
   // its LogCalibrationPanel child, derived from the parent theme (mode carries
-  // over). Memoized on the base theme so it only rebuilds on theme/mode change.
-  const calcTheme = React.useMemo(() => buildCalcTheme(theme), [theme]);
+  // over). Rebuilds on theme/mode change, and on `menuUp` so the Select menus
+  // pick up the flipped open-direction origins.
+  const calcTheme = React.useMemo(
+    () => buildCalcTheme(theme, menuUp, handleSelectOpen),
+    [theme, menuUp, handleSelectOpen],
+  );
 
   const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
   // `accent` is tuned for borders/glows and LARGE text (the hero number passes
@@ -1695,7 +1761,13 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     label="Ultimate"
                     value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
                     renderValue={renderSelectedUltimate}
-                    MenuProps={{ slotProps: { paper: { sx: { maxHeight: 420 } } } }}
+                    // Spreads the open-direction origins because an explicit
+                    // MenuProps here replaces (not merges with) the theme
+                    // defaultProps. (`onOpen` still comes from defaultProps.)
+                    MenuProps={{
+                      ...dropdownMenuOrigins(menuUp),
+                      slotProps: { paper: { sx: { maxHeight: 420 } } },
+                    }}
                     onChange={(e) => {
                       // Seed custom cost with the current EFFECTIVE cost (after any
                       // reductions), since a custom cost is treated as already

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -130,6 +130,9 @@ const Swatch: React.FC<{ color: string; square?: boolean; size?: number; glow?: 
       height: size,
       borderRadius: square ? 0.5 : '50%',
       bgcolor: color,
+      // Thin neutral ring so light dots (normal/white, legendary/gold) stay
+      // visible against a light surface; harmless on dark.
+      border: '1px solid rgba(120,130,150,0.45)',
       boxShadow: glow ? `0 0 6px ${color}66` : 'none',
       flexShrink: 0,
     }}
@@ -299,12 +302,21 @@ const StatBlock: React.FC<{
         {info && (
           <Tooltip arrow title={info}>
             <InfoOutlined
+              role="img"
+              aria-label={`${label}: ${info}`}
+              tabIndex={0}
               sx={{
                 fontSize: 13,
                 color: 'text.secondary',
                 opacity: 0.6,
                 cursor: 'help',
+                borderRadius: '50%',
                 '&:hover': { opacity: 1 },
+                '&:focus-visible': {
+                  opacity: 1,
+                  outline: `2px solid ${accent ?? theme.palette.primary.main}`,
+                  outlineOffset: 2,
+                },
               }}
             />
           </Tooltip>
@@ -355,6 +367,11 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
   } = calc;
 
   const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
+  // `accent` is tuned for borders/glows and LARGE text (the hero number passes
+  // WCAG large-text 3:1). For SMALL accent-colored text it fails AA in light mode
+  // (rgb(40,145,200) ≈ 3.4:1), so use this darker token there (rgb(20,110,160) ≈
+  // 5.3:1 on the panels). Dark mode already passes, so it keeps the bright accent.
+  const accentText = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(20, 110, 160)';
 
   // Group available sources by category for a tidy toggle list.
   const grouped = React.useMemo(() => {
@@ -608,6 +625,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           <Stack spacing={2}>
             <Box>
               <Typography
+                id="ult-context-label"
                 variant="caption"
                 sx={{
                   color: 'text.secondary',
@@ -624,6 +642,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 size="small"
                 value={state.context}
                 onChange={(_, v) => v && calc.setContext(v as CombatContext)}
+                aria-labelledby="ult-context-label"
                 sx={{ mt: 0.5 }}
               >
                 {CONTEXT_OPTIONS.map((c) => (
@@ -753,7 +772,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               <Typography
                 variant="caption"
                 sx={{
-                  color: accent,
+                  color: accentText,
                   fontWeight: 700,
                   textTransform: 'uppercase',
                   letterSpacing: 0.6,
@@ -907,7 +926,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                               <Typography
                                 className="u-tabular"
                                 variant="caption"
-                                sx={{ color: accent, fontWeight: 700 }}
+                                sx={{ color: accentText, fontWeight: 700 }}
                               >
                                 {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
                               </Typography>
@@ -929,31 +948,60 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                 {s.description}
                               </Typography>
                             )}
-                            {/* Pillager's per-cast amount scales with the healer's
-                                ultimate cost (10% of it) — let the user match theirs. */}
+                            {/* Pillager's per-cast amount scales with the cost of the
+                                ULTIMATE OF WHOEVER WEARS THE SET (usually your healer) —
+                                a different player's ult, NOT your own. You receive 10% of
+                                their ult's cost. Deliberately decoupled from the main
+                                "Which ultimate?" cost above to avoid implying it tracks
+                                your own ultimate. */}
                             {s.id === 'pillagers-profit-external' && (
-                              <Stack
-                                direction="row"
-                                spacing={1}
-                                sx={{ alignItems: 'center', mt: 1 }}
-                              >
-                                <TextField
-                                  label="Healer's ult cost"
-                                  type="number"
-                                  size="small"
-                                  value={state.pillagerHealerUltCost}
-                                  onChange={(e) =>
-                                    calc.setPillagerHealerUltCost(Number(e.target.value))
-                                  }
-                                  slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
-                                  sx={{ width: 150 }}
-                                />
+                              <Stack spacing={0.5} sx={{ mt: 1 }}>
+                                <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                                  <TextField
+                                    label="Wearer's ult cost"
+                                    type="number"
+                                    size="small"
+                                    value={state.pillagerHealerUltCost}
+                                    onChange={(e) =>
+                                      calc.setPillagerHealerUltCost(Number(e.target.value))
+                                    }
+                                    slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
+                                    sx={{ width: 160 }}
+                                  />
+                                  <Tooltip
+                                    arrow
+                                    title="The cost of the ULTIMATE CAST BY THE PILLAGER'S WEARER — usually your healer, not you. You receive 10% of their ult's cost (once per 45s). This is separate from the 'Which ultimate?' cost above, which is your own ult."
+                                  >
+                                    <InfoOutlined
+                                      role="img"
+                                      aria-label="About the wearer's ult cost: the cost of the ultimate cast by the Pillager's wearer (usually your healer), not your own. You receive 10% of it, once per 45 seconds."
+                                      tabIndex={0}
+                                      sx={{
+                                        fontSize: 16,
+                                        color: 'text.secondary',
+                                        cursor: 'help',
+                                        borderRadius: '50%',
+                                        '&:focus-visible': {
+                                          outline: `2px solid ${accent}`,
+                                          outlineOffset: 2,
+                                        },
+                                      }}
+                                    />
+                                  </Tooltip>
+                                  <Typography
+                                    variant="caption"
+                                    className="u-tabular"
+                                    sx={{ color: 'text.secondary' }}
+                                  >
+                                    → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
+                                  </Typography>
+                                </Stack>
                                 <Typography
                                   variant="caption"
-                                  className="u-tabular"
-                                  sx={{ color: 'text.secondary' }}
+                                  sx={{ color: 'text.secondary', display: 'block' }}
                                 >
-                                  → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
+                                  Whoever wears Pillager&apos;s (usually your healer) — not your own
+                                  ultimate.
                                 </Typography>
                               </Stack>
                             )}
@@ -1021,7 +1069,18 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       {g.label}
                     </ListSubheader>,
                     ...g.items.map((a) => (
-                      <MenuItem key={a.id} value={a.id}>
+                      <MenuItem
+                        key={a.id}
+                        value={a.id}
+                        // Fold the approximate-cost note into the item's accessible
+                        // name rather than a hover Tooltip — focus inside a Select
+                        // menu doesn't reliably surface tooltips for keyboard/SR users.
+                        aria-label={
+                          a.confidence !== 'high'
+                            ? `${a.label}, ${a.baseCost} ultimate (cost approximate — not fully confirmed for Update 50)`
+                            : `${a.label}, ${a.baseCost} ultimate`
+                        }
+                      >
                         <Stack
                           direction="row"
                           spacing={1}
@@ -1032,20 +1091,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             {a.label}
                           </Typography>
                           <Typography
+                            aria-hidden
                             variant="caption"
                             className="u-tabular"
                             sx={{ color: 'text.secondary', fontWeight: 600 }}
                           >
                             {a.baseCost}
                             {a.confidence !== 'high' ? (
-                              <Tooltip
-                                arrow
-                                title="Cost not fully confirmed for Update 50 — treat as approximate."
-                              >
-                                <Box component="span" sx={{ color: accent, ml: 0.25 }}>
-                                  *
-                                </Box>
-                              </Tooltip>
+                              <Box component="span" sx={{ color: accentText, ml: 0.25 }}>
+                                *
+                              </Box>
                             ) : null}
                           </Typography>
                         </Stack>
@@ -1082,6 +1137,17 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 helperText="Banked at fight start"
               />
             </Stack>
+            {state.customUltimateCost == null && (
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', display: 'block', mt: 1 }}
+              >
+                <Box component="span" sx={{ color: accentText, fontWeight: 700 }}>
+                  *
+                </Box>{' '}
+                marks a cost not fully confirmed for Update 50 — treat it as approximate.
+              </Typography>
+            )}
             {/* Cost-reduction toggles — only meaningful for a catalog ability; a
                 custom cost is taken as already-effective so reductions don't apply. */}
             {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
@@ -1324,12 +1390,12 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     </TableCell>
                     <TableCell
                       align="right"
-                      sx={{ fontWeight: 700, color: accent }}
+                      sx={{ fontWeight: 700, color: accentText }}
                       data-testid="ult-grand-total"
                     >
                       {fmt(expected.totalUltimate, 1)}
                     </TableCell>
-                    <TableCell align="right" sx={{ fontWeight: 700, color: accent }}>
+                    <TableCell align="right" sx={{ fontWeight: 700, color: accentText }}>
                       {fmt(expected.ultimatePerSecond, 2)}
                     </TableCell>
                   </TableRow>
@@ -1372,7 +1438,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     <Typography
                       className="u-tabular"
                       variant="body2"
-                      sx={{ fontWeight: 700, color: accent }}
+                      sx={{ fontWeight: 700, color: accentText }}
                     >
                       {fmt(distribution.meanTotal, 1)} ± {fmt(distribution.ci95HalfWidth, 2)}
                     </Typography>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -1037,6 +1037,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             sx={{ color: 'text.secondary', fontWeight: 600 }}
                           >
                             {a.baseCost}
+                            {a.confidence !== 'high' ? (
+                              <Tooltip
+                                arrow
+                                title="Cost not fully confirmed for Update 50 — treat as approximate."
+                              >
+                                <Box component="span" sx={{ color: accent, ml: 0.25 }}>
+                                  *
+                                </Box>
+                              </Tooltip>
+                            ) : null}
                           </Typography>
                         </Stack>
                       </MenuItem>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -25,6 +25,7 @@ import {
   Divider,
   FormControl,
   FormControlLabel,
+  InputAdornment,
   InputLabel,
   LinearProgress,
   Link,
@@ -504,9 +505,9 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           </Typography>
         </Box>
       </Stack>
-      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5, maxWidth: 760 }}>
-        How fast do you build ultimate, and how often can you cast it? Pick your context and build,
-        and get exact ultimate&nbsp;/&nbsp;second, time to your first ultimate, and casts per fight.
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5, maxWidth: 640 }}>
+        Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first cast,
+        and casts per fight.
       </Typography>
 
       {/* ===================== HEADLINE (full width, results-first) ===================== */}
@@ -737,23 +738,36 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   <Chip
                     key={p.id}
                     label={p.label}
-                    size="small"
                     clickable
                     onClick={() => applyPreset(p)}
-                    variant={active ? 'filled' : 'outlined'}
+                    aria-pressed={active}
                     sx={{
+                      height: 30,
+                      borderRadius: 2,
                       fontWeight: 600,
-                      borderColor: active ? accent : undefined,
-                      color: active ? accent : undefined,
-                      backgroundColor: active
+                      px: 0.25,
+                      border: `1px solid ${active ? accent : theme.palette.divider}`,
+                      color: active ? accentText : 'text.secondary',
+                      background: active
                         ? theme.palette.mode === 'dark'
-                          ? 'rgba(56,189,248,0.12)'
-                          : 'rgba(40,145,200,0.1)'
-                        : undefined,
+                          ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                          : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                        : theme.palette.mode === 'dark'
+                          ? 'rgba(148,163,184,0.06)'
+                          : 'rgba(255,255,255,0.6)',
+                      boxShadow: active
+                        ? theme.palette.mode === 'dark'
+                          ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 14px rgba(56,189,248,0.12)'
+                          : 'inset 0 0 0 1px rgba(40,145,200,0.35)'
+                        : 'none',
+                      transition: 'background-color 0.18s ease, border-color 0.18s ease',
                       '&:hover': {
                         borderColor: accent,
-                        backgroundColor:
-                          theme.palette.mode === 'dark'
+                        background: active
+                          ? theme.palette.mode === 'dark'
+                            ? 'linear-gradient(135deg, rgba(56,189,248,0.26), rgba(0,225,255,0.1))'
+                            : 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                          : theme.palette.mode === 'dark'
                             ? 'rgba(56,189,248,0.08)'
                             : 'rgba(40,145,200,0.06)',
                       },
@@ -895,12 +909,23 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             </Stack>
 
             <TextField
-              label="Fight duration (seconds)"
+              label="Fight duration"
               type="number"
               size="small"
               value={state.fightDurationSeconds}
               onChange={(e) => calc.setFightDuration(Number(e.target.value))}
-              slotProps={{ htmlInput: { min: 1, step: 5 } }}
+              slotProps={{
+                htmlInput: { min: 1, step: 5 },
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                        sec
+                      </Typography>
+                    </InputAdornment>
+                  ),
+                },
+              }}
             />
 
             {/* Decisive */}
@@ -919,7 +944,19 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 }
               />
               {state.decisiveEnabled && (
-                <Stack spacing={1.5} sx={{ mt: 1, pl: 1 }}>
+                <Stack
+                  spacing={1.5}
+                  sx={{
+                    mt: 1,
+                    p: 1.5,
+                    borderRadius: 2,
+                    borderLeft: `3px solid ${accent}`,
+                    background:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(56,189,248,0.05)'
+                        : 'rgba(40,145,200,0.04)',
+                  }}
+                >
                   <FormControl size="small" fullWidth>
                     <InputLabel id="decisive-quality-label">Weapon quality</InputLabel>
                     <Select
@@ -1247,7 +1284,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           <Paper elevation={0} sx={panelSx(theme)}>
             <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />
             <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
-              <FormControl size="small" sx={{ minWidth: 220, flex: 1 }}>
+              <FormControl size="small" sx={{ flex: '1 1 100%' }}>
                 <InputLabel id="ult-ability-label">Ultimate</InputLabel>
                 <Select
                   labelId="ult-ability-label"
@@ -1348,9 +1385,20 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 size="small"
                 value={state.startingUltimate}
                 onChange={(e) => calc.setStartingUltimate(Number(e.target.value))}
-                slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
-                sx={{ width: 150 }}
-                helperText="Banked at fight start"
+                slotProps={{
+                  htmlInput: { min: 0, max: 500, step: 5 },
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          ult
+                        </Typography>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+                sx={{ width: 190 }}
+                helperText="Banked at start"
               />
             </Stack>
             {state.customUltimateCost == null && (

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -314,7 +314,13 @@ const StatBlock: React.FC<{
         },
       }}
     >
-      <Stack direction="row" spacing={0.4} sx={{ alignItems: 'center' }}>
+      {/* Reserve two lines so the values below sit on the same baseline across
+          all three cards, regardless of whether a label wraps. */}
+      <Stack
+        direction="row"
+        spacing={0.4}
+        sx={{ alignItems: 'flex-start', minHeight: { xs: 25, sm: 27 } }}
+      >
         <Typography
           variant="caption"
           sx={{
@@ -323,7 +329,7 @@ const StatBlock: React.FC<{
             letterSpacing: 0.5,
             fontWeight: 700,
             fontSize: { xs: 9.5, sm: 10 },
-            lineHeight: 1.25,
+            lineHeight: 1.3,
           }}
         >
           {label}
@@ -357,9 +363,10 @@ const StatBlock: React.FC<{
         sx={{
           fontFamily: 'Space Grotesk, Inter, system-ui',
           fontWeight: 700,
-          fontSize: { xs: '1.4rem', sm: '1.7rem' },
-          lineHeight: 1.1,
-          mt: 0.5,
+          fontSize: { xs: '1.45rem', sm: '1.7rem' },
+          lineHeight: 1.05,
+          letterSpacing: '-0.01em',
+          mt: 0.75,
           color: theme.palette.text.primary,
           whiteSpace: 'nowrap',
         }}
@@ -484,13 +491,17 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
   return (
     <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
       {/* ===================== INTRO ===================== */}
-      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mb: 0.75 }}>
+      {/* Icon + the whole text column share one left edge: heading, eyebrow, and
+          blurb all align (the blurb used to start at the container edge while the
+          eyebrow sat indented under the heading). */}
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', mb: 2.75 }}>
         <Box
           aria-hidden
           sx={{
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
+            flexShrink: 0,
             width: 40,
             height: 40,
             borderRadius: 2.5,
@@ -506,22 +517,33 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
         >
           <BoltOutlined />
         </Box>
-        <Box>
-          <Typography variant="h5" component="h2" sx={{ fontWeight: 700, lineHeight: 1.1 }}>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            variant="h5"
+            component="h2"
+            sx={{ fontWeight: 700, lineHeight: 1.15, letterSpacing: '-0.01em' }}
+          >
             Ultimate Calculator
           </Typography>
           <Typography
             variant="caption"
-            sx={{ color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.8 }}
+            sx={{
+              display: 'block',
+              color: 'text.secondary',
+              textTransform: 'uppercase',
+              letterSpacing: 1,
+              fontWeight: 600,
+              mt: 0.25,
+            }}
           >
             Update 50 · all classes
           </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1, maxWidth: 600 }}>
+            Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first
+            cast, and casts per fight.
+          </Typography>
         </Box>
       </Stack>
-      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2.5, maxWidth: 640 }}>
-        Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first cast,
-        and casts per fight.
-      </Typography>
 
       {/* ===================== HEADLINE (full width, results-first) ===================== */}
       <Paper
@@ -633,17 +655,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 />
               </Tooltip>
             </Stack>
-            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'baseline', mt: 0.25 }}>
+            <Stack direction="row" spacing={0.6} sx={{ alignItems: 'baseline', mt: 0.5 }}>
               <Typography
                 className="u-tabular"
                 sx={{
                   fontFamily: 'Space Grotesk, Inter, system-ui',
                   fontWeight: 700,
-                  fontSize: { xs: '3.1rem', sm: '3.6rem' },
-                  lineHeight: 0.95,
+                  fontSize: { xs: '2.6rem', sm: '3.1rem' },
+                  lineHeight: 1,
+                  letterSpacing: '-0.02em',
                   color: accent,
-                  textShadow:
-                    theme.palette.mode === 'dark' ? '0 0 32px rgba(56,189,248,0.35)' : 'none',
                 }}
               >
                 {fmt(expected.ultimatePerSecond, 2)}
@@ -652,7 +673,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 sx={{
                   color: 'text.secondary',
                   fontWeight: 600,
-                  fontSize: { xs: '1rem', sm: '1.1rem' },
+                  fontSize: { xs: '0.95rem', sm: '1.05rem' },
                 }}
               >
                 ult/s

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -15,6 +15,7 @@ import {
   InfoOutlined,
   InsightsOutlined,
   QueryStatsOutlined,
+  RestartAltOutlined,
   TuneOutlined,
 } from '@mui/icons-material';
 import {
@@ -1271,7 +1272,8 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               onClick={calc.reset}
               size="small"
               variant="text"
-              sx={{ alignSelf: 'flex-start' }}
+              startIcon={<RestartAltOutlined sx={{ fontSize: 16 }} />}
+              sx={{ alignSelf: 'flex-start', color: 'text.secondary', mt: 0.5 }}
             >
               Reset to defaults
             </Button>
@@ -1569,18 +1571,6 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     >
                       Total
                     </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        color: 'text.secondary',
-                      }}
-                    >
-                      ult/s
-                    </TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -1631,12 +1621,6 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                           {fmt(c.decisiveUltimate, 1)}
                         </TableCell>
                         <TableCell align="right">{fmt(tot, 1)}</TableCell>
-                        <TableCell align="right">
-                          {fmt(
-                            state.fightDurationSeconds > 0 ? tot / state.fightDurationSeconds : 0,
-                            2,
-                          )}
-                        </TableCell>
                       </TableRow>
                     );
                   })}
@@ -1670,9 +1654,6 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       data-testid="ult-grand-total"
                     >
                       {fmt(expected.totalUltimate, 1)}
-                    </TableCell>
-                    <TableCell align="right" sx={{ fontWeight: 700, color: accentText }}>
-                      {fmt(expected.ultimatePerSecond, 2)}
                     </TableCell>
                   </TableRow>
                 </TableBody>
@@ -1754,6 +1735,66 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     </Typography>
                   </Box>
                 </Stack>
+
+                {/* Min–mean–max range bar: the whole track spans the observed
+                    min→max, with the mean marked so the spread reads visually. */}
+                {distribution.maxTotal > distribution.minTotal && (
+                  <Box sx={{ mt: 1.75 }}>
+                    <Box
+                      aria-hidden
+                      sx={{
+                        position: 'relative',
+                        height: 8,
+                        borderRadius: 4,
+                        background: `linear-gradient(90deg, ${alpha(accent, 0.18)}, ${alpha(
+                          accent,
+                          0.5,
+                        )})`,
+                        border: `1px solid ${alpha(theme.palette.divider, 0.8)}`,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          top: -3,
+                          bottom: -3,
+                          left: `${Math.min(
+                            100,
+                            Math.max(
+                              0,
+                              ((distribution.meanTotal - distribution.minTotal) /
+                                (distribution.maxTotal - distribution.minTotal)) *
+                                100,
+                            ),
+                          )}%`,
+                          width: 2,
+                          transform: 'translateX(-1px)',
+                          background: theme.palette.mode === 'dark' ? '#fff' : accentText,
+                          borderRadius: 2,
+                          boxShadow: `0 0 6px ${accent}`,
+                        }}
+                      />
+                    </Box>
+                    <Stack
+                      direction="row"
+                      sx={{ justifyContent: 'space-between', mt: 0.5 }}
+                      className="u-tabular"
+                    >
+                      <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 10 }}>
+                        {fmt(distribution.minTotal, 0)}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{ color: accentText, fontWeight: 700, fontSize: 10 }}
+                      >
+                        mean {fmt(distribution.meanTotal, 0)}
+                      </Typography>
+                      <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 10 }}>
+                        {fmt(distribution.maxTotal, 0)}
+                      </Typography>
+                    </Stack>
+                  </Box>
+                )}
               </Box>
             )}
           </Paper>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -445,47 +445,81 @@ const buildCalcTheme = (base: Theme): Theme => {
           },
         },
       },
-      // The open dropdown popover + its items — was stock MUI; now a cyan-glass
-      // panel with rounded, inset-highlighted items to match the inputs.
+      // The open dropdown popover + its items — was stock MUI; now a pronounced
+      // cyan-glass panel: tinted gradient surface, a glowing cyan edge, a thin
+      // accent line across the top, and items that light up with a cyan fill +
+      // a left accent rail on hover/selection so it reads clearly "premium".
       MuiMenu: {
         styleOverrides: {
           paper: {
-            borderRadius: 12,
+            position: 'relative',
+            borderRadius: 14,
             marginTop: 6,
+            overflow: 'hidden',
             backgroundImage: 'none',
-            backgroundColor: dark ? 'rgba(10,17,33,0.92)' : 'rgba(255,255,255,0.97)',
-            backdropFilter: 'blur(14px) saturate(1.3)',
-            WebkitBackdropFilter: 'blur(14px) saturate(1.3)',
-            border: `1px solid ${dark ? 'rgba(56,189,248,0.16)' : 'rgba(40,145,200,0.18)'}`,
+            background: dark
+              ? 'linear-gradient(180deg, rgba(18,34,58,0.94) 0%, rgba(6,13,28,0.96) 100%)'
+              : 'linear-gradient(180deg, rgba(244,251,255,0.98) 0%, rgba(255,255,255,0.98) 100%)',
+            backdropFilter: 'blur(18px) saturate(1.4)',
+            WebkitBackdropFilter: 'blur(18px) saturate(1.4)',
+            border: `1px solid ${dark ? 'rgba(56,189,248,0.30)' : 'rgba(40,145,200,0.28)'}`,
             boxShadow: dark
-              ? '0 16px 40px rgba(0,0,0,0.55), 0 0 0 1px rgba(56,189,248,0.08), inset 0 1px 0 rgba(255,255,255,0.05)'
-              : '0 16px 40px rgba(15,23,42,0.16), 0 0 0 1px rgba(40,145,200,0.08)',
+              ? '0 24px 60px rgba(0,0,0,0.62), 0 0 26px rgba(56,189,248,0.16), inset 0 1px 0 rgba(255,255,255,0.07)'
+              : '0 20px 48px rgba(15,23,42,0.18), 0 0 18px rgba(40,145,200,0.10), inset 0 1px 0 rgba(255,255,255,0.9)',
+            // A thin cyan sheen across the very top edge of the popover.
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 2,
+              background: dark
+                ? 'linear-gradient(90deg, transparent, rgba(0,225,255,0.7), transparent)'
+                : 'linear-gradient(90deg, transparent, rgba(40,145,200,0.6), transparent)',
+              pointerEvents: 'none',
+            },
           },
-          list: { paddingTop: 6, paddingBottom: 6 },
+          list: { paddingTop: 7, paddingBottom: 7 },
         },
       },
       MuiMenuItem: {
         styleOverrides: {
           root: {
-            borderRadius: 8,
-            marginLeft: 6,
-            marginRight: 6,
-            paddingTop: 7,
-            paddingBottom: 7,
-            transition: 'background-color 0.15s ease, color 0.15s ease',
+            borderRadius: 9,
+            marginLeft: 7,
+            marginRight: 7,
+            paddingTop: 9,
+            paddingBottom: 9,
+            transition: 'background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease',
             '&:hover': {
-              backgroundColor: dark ? 'rgba(56,189,248,0.10)' : 'rgba(40,145,200,0.08)',
+              background: dark
+                ? 'linear-gradient(90deg, rgba(56,189,248,0.20), rgba(56,189,248,0.06))'
+                : 'linear-gradient(90deg, rgba(40,145,200,0.16), rgba(40,145,200,0.04))',
+              boxShadow: `inset 3px 0 0 ${cyan}`,
             },
             '&.Mui-focusVisible': {
-              backgroundColor: dark ? 'rgba(56,189,248,0.14)' : 'rgba(40,145,200,0.10)',
+              background: dark
+                ? 'linear-gradient(90deg, rgba(56,189,248,0.24), rgba(56,189,248,0.08))'
+                : 'linear-gradient(90deg, rgba(40,145,200,0.18), rgba(40,145,200,0.05))',
+              boxShadow: `inset 3px 0 0 ${cyan}`,
             },
             '&.Mui-selected': {
-              backgroundColor: dark ? 'rgba(56,189,248,0.16)' : 'rgba(40,145,200,0.12)',
+              color: dark ? 'rgb(186,236,255)' : 'rgb(20,110,160)',
+              fontWeight: 600,
+              background: dark
+                ? 'linear-gradient(90deg, rgba(56,189,248,0.32), rgba(0,225,255,0.10))'
+                : 'linear-gradient(90deg, rgba(40,145,200,0.22), rgba(40,145,200,0.06))',
+              boxShadow: `inset 3px 0 0 ${cyan}, ${dark ? '0 0 16px rgba(56,189,248,0.18)' : 'none'}`,
               '&:hover': {
-                backgroundColor: dark ? 'rgba(56,189,248,0.22)' : 'rgba(40,145,200,0.16)',
+                background: dark
+                  ? 'linear-gradient(90deg, rgba(56,189,248,0.4), rgba(0,225,255,0.14))'
+                  : 'linear-gradient(90deg, rgba(40,145,200,0.28), rgba(40,145,200,0.1))',
               },
               '&.Mui-focusVisible': {
-                backgroundColor: dark ? 'rgba(56,189,248,0.2)' : 'rgba(40,145,200,0.15)',
+                background: dark
+                  ? 'linear-gradient(90deg, rgba(56,189,248,0.36), rgba(0,225,255,0.12))'
+                  : 'linear-gradient(90deg, rgba(40,145,200,0.26), rgba(40,145,200,0.08))',
               },
             },
           },

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -261,13 +261,13 @@ const StatBlock: React.FC<{
   info?: string;
 }> = ({ label, value, sub, accent, highlight, info }) => {
   const theme = useTheme();
+  const tileAccent = accent ?? theme.palette.primary.main;
   return (
     <Box
       sx={{
-        flex: '1 1 0',
-        minWidth: { xs: 132, sm: 0 },
+        minWidth: 0,
         px: { xs: 1.5, sm: 2 },
-        py: { xs: 1.5, sm: 1.25 },
+        py: { xs: 1.5, sm: 1.5 },
         borderRadius: 3,
         position: 'relative',
         background: highlight
@@ -277,13 +277,21 @@ const StatBlock: React.FC<{
           : theme.palette.mode === 'dark'
             ? 'rgba(148,163,184,0.05)'
             : 'rgba(255,255,255,0.5)',
-        border: highlight
-          ? `1px solid ${(accent ?? theme.palette.primary.main) + '55'}`
-          : `1px solid ${theme.palette.divider}`,
+        border: highlight ? `1px solid ${tileAccent}55` : `1px solid ${theme.palette.divider}`,
         boxShadow:
           highlight && theme.palette.mode === 'dark'
             ? '0 0 28px rgba(56,189,248,0.12) inset'
             : 'none',
+        // Motion-safe hover: border + shadow only (no transform), so the tiles
+        // feel responsive without violating prefers-reduced-motion.
+        transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+        '&:hover': {
+          borderColor: `${tileAccent}${highlight ? '88' : '55'}`,
+          boxShadow:
+            theme.palette.mode === 'dark'
+              ? `0 6px 22px rgba(0,0,0,0.28), 0 0 0 1px ${tileAccent}22`
+              : '0 6px 18px rgba(15,23,42,0.08)',
+        },
       }}
     >
       <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
@@ -330,7 +338,7 @@ const StatBlock: React.FC<{
           fontSize: { xs: '1.9rem', sm: '2.15rem' },
           lineHeight: 1.05,
           mt: 0.25,
-          color: highlight ? (accent ?? theme.palette.primary.main) : theme.palette.text.primary,
+          color: highlight ? tileAccent : theme.palette.text.primary,
         }}
       >
         {value}
@@ -518,17 +526,19 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           },
         }}
       >
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          spacing={{ xs: 1.25, sm: 1.5 }}
-          divider={
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{ display: { xs: 'none', sm: 'block' }, borderColor: theme.palette.divider }}
-            />
-          }
-          sx={{ position: 'relative' }}
+        <Box
+          sx={{
+            position: 'relative',
+            display: 'grid',
+            gap: { xs: 1.25, sm: 1.5 },
+            // 2×2 on phones (compact, no long scroll), a single 4-up row from the
+            // small breakpoint onward. Each tile is its own bordered card, so no
+            // separating dividers are needed.
+            gridTemplateColumns: {
+              xs: 'repeat(2, minmax(0, 1fr))',
+              sm: 'repeat(4, minmax(0, 1fr))',
+            },
+          }}
         >
           <StatBlock
             label="Ultimate / second"
@@ -556,7 +566,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             sub={`ult (pool caps at ${maxPool})`}
             info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
           />
-        </Stack>
+        </Box>
         {exceedsSanity && (
           <Alert severity="info" sx={{ mt: 2 }}>
             {fmt(expected.ultimatePerSecond, 2)} ult/s is above the practical sustained ceiling (~

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -488,7 +488,14 @@ const buildCalcTheme = (base: Theme): Theme => {
       MuiMenu: {
         styleOverrides: {
           paper: {
-            position: 'relative',
+            // NOTE: do NOT set `position: relative` here. MUI's PopoverPaper is
+            // `position: absolute` and the Select's Popover sizes the menu to the
+            // anchor via an inline `min-width`. A theme override of `position`
+            // beats that base rule, so a relative (block) paper stretches to its
+            // containing block — capped only by `max-width: calc(100% - 32px)` —
+            // making the menu span almost the whole viewport on desktop. The
+            // absolute paper is already a containing block, so the `&::before`
+            // top sheen below still anchors correctly without `relative`.
             borderRadius: 14,
             marginTop: 6,
             // Clip the rounded corners horizontally, but allow vertical scroll —

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -929,6 +929,34 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                 {s.description}
                               </Typography>
                             )}
+                            {/* Pillager's per-cast amount scales with the healer's
+                                ultimate cost (10% of it) — let the user match theirs. */}
+                            {s.id === 'pillagers-profit-external' && (
+                              <Stack
+                                direction="row"
+                                spacing={1}
+                                sx={{ alignItems: 'center', mt: 1 }}
+                              >
+                                <TextField
+                                  label="Healer's ult cost"
+                                  type="number"
+                                  size="small"
+                                  value={state.pillagerHealerUltCost}
+                                  onChange={(e) =>
+                                    calc.setPillagerHealerUltCost(Number(e.target.value))
+                                  }
+                                  slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
+                                  sx={{ width: 150 }}
+                                />
+                                <Typography
+                                  variant="caption"
+                                  className="u-tabular"
+                                  sx={{ color: 'text.secondary' }}
+                                >
+                                  → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
+                                </Typography>
+                              </Stack>
+                            )}
                           </Box>
                         )}
                       </Box>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -250,43 +250,38 @@ const SectionHeader: React.FC<{
   </Stack>
 );
 
-/** A big headline stat tile in the hero strip. */
+/**
+ * A supporting headline stat tile in the hero strip. The dominant
+ * "Ultimate / second" metric is rendered separately (see PrimaryStat); these
+ * are the compact secondary stats that sit beside it.
+ */
 const StatBlock: React.FC<{
   label: string;
   value: string;
   sub?: string;
   accent?: string;
-  highlight?: boolean;
   /** Optional plain-language explanation shown on an info-icon tooltip. */
   info?: string;
-}> = ({ label, value, sub, accent, highlight, info }) => {
+}> = ({ label, value, sub, accent, info }) => {
   const theme = useTheme();
   const tileAccent = accent ?? theme.palette.primary.main;
   return (
     <Box
       sx={{
         minWidth: 0,
-        px: { xs: 1.5, sm: 2 },
-        py: { xs: 1.5, sm: 1.5 },
-        borderRadius: 3,
+        px: { xs: 1.25, sm: 1.75 },
+        py: { xs: 1.25, sm: 1.5 },
+        borderRadius: 2.5,
         position: 'relative',
-        background: highlight
-          ? theme.palette.mode === 'dark'
-            ? 'linear-gradient(160deg, rgba(56,189,248,0.16) 0%, rgba(0,225,255,0.06) 100%)'
-            : 'linear-gradient(160deg, rgba(56,189,248,0.16) 0%, rgba(0,225,255,0.05) 100%)'
-          : theme.palette.mode === 'dark'
-            ? 'rgba(148,163,184,0.05)'
-            : 'rgba(255,255,255,0.5)',
-        border: highlight ? `1px solid ${tileAccent}55` : `1px solid ${theme.palette.divider}`,
-        boxShadow:
-          highlight && theme.palette.mode === 'dark'
-            ? '0 0 28px rgba(56,189,248,0.12) inset'
-            : 'none',
+        height: '100%',
+        background:
+          theme.palette.mode === 'dark' ? 'rgba(148,163,184,0.05)' : 'rgba(255,255,255,0.5)',
+        border: `1px solid ${theme.palette.divider}`,
         // Motion-safe hover: border + shadow only (no transform), so the tiles
         // feel responsive without violating prefers-reduced-motion.
         transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
         '&:hover': {
-          borderColor: `${tileAccent}${highlight ? '88' : '55'}`,
+          borderColor: `${tileAccent}55`,
           boxShadow:
             theme.palette.mode === 'dark'
               ? `0 6px 22px rgba(0,0,0,0.28), 0 0 0 1px ${tileAccent}22`
@@ -294,15 +289,16 @@ const StatBlock: React.FC<{
         },
       }}
     >
-      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+      <Stack direction="row" spacing={0.4} sx={{ alignItems: 'center' }}>
         <Typography
           variant="caption"
           sx={{
             color: 'text.secondary',
             textTransform: 'uppercase',
-            letterSpacing: 0.7,
-            fontWeight: 600,
-            fontSize: 11,
+            letterSpacing: 0.5,
+            fontWeight: 700,
+            fontSize: { xs: 9.5, sm: 10 },
+            lineHeight: 1.25,
           }}
         >
           {label}
@@ -314,15 +310,16 @@ const StatBlock: React.FC<{
               aria-label={`${label}: ${info}`}
               tabIndex={0}
               sx={{
-                fontSize: 13,
+                fontSize: 12,
                 color: 'text.secondary',
                 opacity: 0.6,
                 cursor: 'help',
                 borderRadius: '50%',
+                flexShrink: 0,
                 '&:hover': { opacity: 1 },
                 '&:focus-visible': {
                   opacity: 1,
-                  outline: `2px solid ${accent ?? theme.palette.primary.main}`,
+                  outline: `2px solid ${tileAccent}`,
                   outlineOffset: 2,
                 },
               }}
@@ -335,16 +332,26 @@ const StatBlock: React.FC<{
         sx={{
           fontFamily: 'Space Grotesk, Inter, system-ui',
           fontWeight: 700,
-          fontSize: { xs: '1.9rem', sm: '2.15rem' },
-          lineHeight: 1.05,
-          mt: 0.25,
-          color: highlight ? tileAccent : theme.palette.text.primary,
+          fontSize: { xs: '1.4rem', sm: '1.7rem' },
+          lineHeight: 1.1,
+          mt: 0.5,
+          color: theme.palette.text.primary,
+          whiteSpace: 'nowrap',
         }}
       >
         {value}
       </Typography>
       {sub && (
-        <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+            display: 'block',
+            mt: 0.25,
+            fontSize: { xs: 10.5, sm: 11.5 },
+            lineHeight: 1.3,
+          }}
+        >
           {sub}
         </Typography>
       )}
@@ -495,7 +502,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
       <Paper
         elevation={0}
         sx={{
-          p: { xs: 1.5, sm: 2 },
+          p: { xs: 2, sm: 2.75 },
           mb: 2.5,
           borderRadius: 4,
           position: 'relative',
@@ -529,43 +536,158 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
         <Box
           sx={{
             position: 'relative',
-            display: 'grid',
-            gap: { xs: 1.25, sm: 1.5 },
-            // 2×2 on phones (compact, no long scroll), a single 4-up row from the
-            // small breakpoint onward. Each tile is its own bordered card, so no
-            // separating dividers are needed.
-            gridTemplateColumns: {
-              xs: 'repeat(2, minmax(0, 1fr))',
-              sm: 'repeat(4, minmax(0, 1fr))',
-            },
+            display: 'flex',
+            flexDirection: { xs: 'column', md: 'row' },
+            gap: { xs: 2, md: 3 },
+            alignItems: { md: 'stretch' },
           }}
         >
-          <StatBlock
-            label="Ultimate / second"
-            value={fmt(expected.ultimatePerSecond, 2)}
-            sub={`${fmt(expected.totalUltimate, 0)} over ${state.fightDurationSeconds}s`}
-            accent={accent}
-            highlight
-            info="Average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
-          />
-          <StatBlock
-            label="Time to first ult"
-            value={fmtSeconds(timeToUlt.secondsToFirstCast)}
-            sub={`${effectiveCost} ult cost`}
-            info={`How long until you can first fire the selected ultimate (effective cost ${effectiveCost}), counting any banked ultimate at fight start.`}
-          />
-          <StatBlock
-            label="Casts / fight"
-            value={Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'}
-            sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
-            info={`How many times you can fire it in a ${state.fightDurationSeconds}s fight — total generation divided by its effective cost.`}
-          />
-          <StatBlock
-            label="Generated by 60s"
-            value={fmt(expected.ultimatePerSecond * 60, 0)}
-            sub={`ult (pool caps at ${maxPool})`}
-            info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
-          />
+          {/* PRIMARY — the dominant result, with a gauge vs the sustained ceiling. */}
+          <Box
+            sx={{
+              flex: { md: '0 0 40%' },
+              minWidth: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              px: { xs: 0.5, sm: 1 },
+            }}
+          >
+            <Stack direction="row" spacing={0.6} sx={{ alignItems: 'center' }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                  textTransform: 'uppercase',
+                  letterSpacing: 1,
+                  fontWeight: 700,
+                  fontSize: 11,
+                }}
+              >
+                Ultimate / second
+              </Typography>
+              <Tooltip
+                arrow
+                title="Average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
+              >
+                <InfoOutlined
+                  role="img"
+                  aria-label="Ultimate / second: average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
+                  tabIndex={0}
+                  sx={{
+                    fontSize: 14,
+                    color: 'text.secondary',
+                    opacity: 0.6,
+                    cursor: 'help',
+                    borderRadius: '50%',
+                    '&:hover': { opacity: 1 },
+                    '&:focus-visible': {
+                      opacity: 1,
+                      outline: `2px solid ${accent}`,
+                      outlineOffset: 2,
+                    },
+                  }}
+                />
+              </Tooltip>
+            </Stack>
+            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'baseline', mt: 0.25 }}>
+              <Typography
+                className="u-tabular"
+                sx={{
+                  fontFamily: 'Space Grotesk, Inter, system-ui',
+                  fontWeight: 700,
+                  fontSize: { xs: '3.1rem', sm: '3.6rem' },
+                  lineHeight: 0.95,
+                  color: accent,
+                  textShadow:
+                    theme.palette.mode === 'dark' ? '0 0 32px rgba(56,189,248,0.35)' : 'none',
+                }}
+              >
+                {fmt(expected.ultimatePerSecond, 2)}
+              </Typography>
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontWeight: 600,
+                  fontSize: { xs: '1rem', sm: '1.1rem' },
+                }}
+              >
+                ult/s
+              </Typography>
+            </Stack>
+            {/* Gauge: this rate against the practical sustained ceiling. */}
+            <Box sx={{ mt: 1.25 }}>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(100, (expected.ultimatePerSecond / sanityMax) * 100)}
+                aria-hidden
+                sx={{
+                  height: 7,
+                  borderRadius: 4,
+                  backgroundColor: alpha(theme.palette.divider, 0.6),
+                  '& .MuiLinearProgress-bar': {
+                    borderRadius: 4,
+                    background: `linear-gradient(90deg, ${accent}, ${
+                      theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.9)' : accent
+                    })`,
+                  },
+                }}
+              />
+              <Stack
+                direction="row"
+                sx={{ justifyContent: 'space-between', alignItems: 'baseline', mt: 0.6 }}
+              >
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  <Box
+                    component="span"
+                    className="u-tabular"
+                    sx={{ fontWeight: 700, color: accentText }}
+                  >
+                    {fmt(expected.totalUltimate, 0)}
+                  </Box>{' '}
+                  ult over {state.fightDurationSeconds}s
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.secondary', opacity: 0.8 }}>
+                  ceiling ~{sanityMax}/s
+                </Typography>
+              </Stack>
+            </Box>
+          </Box>
+
+          {/* SECONDARY — supporting stats, 3-up across every breakpoint. */}
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              display: 'grid',
+              gap: { xs: 1, sm: 1.25 },
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+            }}
+          >
+            <StatBlock
+              label="Time to first ult"
+              value={fmtSeconds(timeToUlt.secondsToFirstCast)}
+              sub={`${effectiveCost} ult cost`}
+              accent={accent}
+              info={`How long until you can first fire the selected ultimate (effective cost ${effectiveCost}), counting any banked ultimate at fight start.`}
+            />
+            <StatBlock
+              label="Casts / fight"
+              value={
+                Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'
+              }
+              sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
+              accent={accent}
+              info={`How many times you can fire it in a ${state.fightDurationSeconds}s fight — total generation divided by its effective cost.`}
+            />
+            <StatBlock
+              label="By 60s"
+              value={fmt(expected.ultimatePerSecond * 60, 0)}
+              sub={`ult · cap ${maxPool}`}
+              accent={accent}
+              info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
+            />
+          </Box>
         </Box>
         {exceedsSanity && (
           <Alert severity="info" sx={{ mt: 2 }}>
@@ -1285,6 +1407,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                         fontSize: 11,
                         fontWeight: 700,
                         color: 'text.secondary',
+                        display: { xs: 'none', sm: 'table-cell' },
                       }}
                     >
                       Base
@@ -1297,6 +1420,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                         fontSize: 11,
                         fontWeight: 700,
                         color: 'text.secondary',
+                        display: { xs: 'none', sm: 'table-cell' },
                       }}
                     >
                       Decisive
@@ -1368,8 +1492,12 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             </Typography>
                           </Stack>
                         </TableCell>
-                        <TableCell align="right">{fmt(c.baseUltimate, 0)}</TableCell>
-                        <TableCell align="right">{fmt(c.decisiveUltimate, 1)}</TableCell>
+                        <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                          {fmt(c.baseUltimate, 0)}
+                        </TableCell>
+                        <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                          {fmt(c.decisiveUltimate, 1)}
+                        </TableCell>
                         <TableCell align="right">{fmt(tot, 1)}</TableCell>
                         <TableCell align="right">
                           {fmt(
@@ -1392,10 +1520,16 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     }}
                   >
                     <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
-                    <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    <TableCell
+                      align="right"
+                      sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
+                    >
                       {fmt(expected.baseUltimate, 0)}
                     </TableCell>
-                    <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    <TableCell
+                      align="right"
+                      sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
+                    >
                       {fmt(expected.decisiveUltimate, 1)}
                     </TableCell>
                     <TableCell

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -1570,7 +1570,21 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           </Paper>
 
           {/* ============================ RESULTS ============================ */}
-          <Stack spacing={2.5} sx={{ flex: '1 1 480px', minWidth: 0 }}>
+          <Stack
+            spacing={2.5}
+            sx={{
+              flex: '1 1 480px',
+              minWidth: 0,
+              // On wide (lg) screens the build column is much taller, so the
+              // results otherwise float beside a tall stretch of empty space.
+              // Stick them to the top so they stay in view while scrolling the
+              // build. alignSelf:flex-start stops the column stretching (which
+              // would defeat sticky). Header is position:static, so top:16 is safe.
+              alignSelf: { lg: 'flex-start' },
+              position: { lg: 'sticky' },
+              top: { lg: 16 },
+            }}
+          >
             {/* Ultimate picker / cost */}
             <Paper elevation={0} sx={panelSx(theme)}>
               <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -51,6 +51,7 @@ import {
   useTheme,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import React from 'react';
 
 import { totalReductionFraction } from '../../core/cost';
@@ -391,6 +392,108 @@ const StatBlock: React.FC<{
   );
 };
 
+/**
+ * Build the feature-scoped MUI theme that gives every Slider / Select /
+ * TextField inside this tab (and its `LogCalibrationPanel` child) the
+ * "all-cyan with depth" treatment, without touching the global theme. Built
+ * from the parent theme via `createTheme(base, …)` so mode + palette carry
+ * over; all cyan tokens are derived from the current mode here.
+ *
+ * Constraints honoured:
+ *  - Color/shadow transitions only (no transform motion) — safe under
+ *    prefers-reduced-motion.
+ *  - Legible in BOTH dark and light mode (translucent fills + 1px borders that
+ *    brighten to cyan on hover and show a cyan focus glow ring on focus).
+ */
+const buildCalcTheme = (base: Theme): Theme => {
+  const dark = base.palette.mode === 'dark';
+  // Cyan tokens per the design direction.
+  const cyan = dark ? 'rgb(56,189,248)' : 'rgb(40,145,200)';
+  const cyanBright = 'rgb(0,225,255)';
+  const focusRing = '0 0 0 3px rgba(56,189,248,0.25)';
+  // Slider filled-track gradient (dark leans into the bright cyan for glow).
+  const trackGradient = dark
+    ? `linear-gradient(90deg, ${cyan}, ${cyanBright})`
+    : `linear-gradient(90deg, ${cyan}, rgb(56,189,248))`;
+  // Translucent glass fill for inputs.
+  const inputFill = dark ? 'rgba(56,189,248,0.05)' : 'rgba(56,189,248,0.04)';
+  const inputFillHover = dark ? 'rgba(56,189,248,0.09)' : 'rgba(56,189,248,0.06)';
+  const inputBorder = dark ? 'rgba(56,189,248,0.18)' : 'rgba(40,145,200,0.28)';
+  const inputBorderHover = dark ? 'rgba(56,189,248,0.55)' : 'rgba(40,145,200,0.6)';
+  const railColor = dark ? 'rgba(148,163,184,0.28)' : 'rgba(15,23,42,0.16)';
+
+  return createTheme(base, {
+    components: {
+      MuiSlider: {
+        styleOverrides: {
+          root: {
+            // Comfortable touch target without growing the visible rail.
+            paddingTop: 10,
+            paddingBottom: 10,
+            color: cyan,
+          },
+          rail: {
+            height: 5,
+            borderRadius: 4,
+            opacity: 1,
+            backgroundColor: railColor,
+          },
+          track: {
+            height: 5,
+            borderRadius: 4,
+            border: 'none',
+            backgroundImage: trackGradient,
+            boxShadow: dark ? `0 0 8px rgba(0,225,255,0.35)` : 'none',
+          },
+          thumb: {
+            width: 16,
+            height: 16,
+            backgroundColor: dark ? '#eaf9ff' : '#ffffff',
+            border: `2px solid ${cyan}`,
+            boxShadow: dark
+              ? '0 1px 4px rgba(0,0,0,0.5), 0 0 0 1px rgba(0,225,255,0.25)'
+              : '0 1px 3px rgba(15,23,42,0.25)',
+            // Color/shadow-only transition (reduced-motion safe).
+            transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
+            '&:hover, &.Mui-focusVisible': {
+              boxShadow: focusRing,
+            },
+            '&.Mui-active': {
+              boxShadow: '0 0 0 5px rgba(56,189,248,0.3)',
+            },
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            borderRadius: 10,
+            backgroundColor: inputFill,
+            transition: 'background-color 0.2s ease, box-shadow 0.2s ease',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: inputBorder,
+              transition: 'border-color 0.2s ease',
+            },
+            '&:hover': {
+              backgroundColor: inputFillHover,
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: inputBorderHover,
+            },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: cyan,
+              borderWidth: 1,
+            },
+            '&.Mui-focused': {
+              boxShadow: focusRing,
+            },
+          },
+        },
+      },
+    },
+  });
+};
+
 export interface UltimateCalculatorProps {
   className?: string;
 }
@@ -412,6 +515,11 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     maxPool,
     distribution,
   } = calc;
+
+  // Feature-scoped theme: cyan-glass Sliders / Selects / inputs for this tab and
+  // its LogCalibrationPanel child, derived from the parent theme (mode carries
+  // over). Memoized on the base theme so it only rebuilds on theme/mode change.
+  const calcTheme = React.useMemo(() => buildCalcTheme(theme), [theme]);
 
   const accent = theme.palette.mode === 'dark' ? 'rgb(56, 189, 248)' : 'rgb(40, 145, 200)';
   // `accent` is tuned for borders/glows and LARGE text (the hero number passes
@@ -489,997 +597,353 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
   );
 
   return (
-    <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
-      {/* ===================== INTRO ===================== */}
-      {/* Icon + the whole text column share one left edge: heading, eyebrow, and
+    <ThemeProvider theme={calcTheme}>
+      <Box className={`${className ?? ''} u-fade-in`} sx={{ width: '100%' }}>
+        {/* ===================== INTRO ===================== */}
+        {/* Icon + the whole text column share one left edge: heading, eyebrow, and
           blurb all align (the blurb used to start at the container edge while the
           eyebrow sat indented under the heading). */}
-      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', mb: 2.75 }}>
-        <Box
-          aria-hidden
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-            width: 40,
-            height: 40,
-            borderRadius: 2.5,
-            color: accent,
-            background:
-              theme.palette.mode === 'dark'
-                ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))',
-            border: `1px solid ${accent}40`,
-            boxShadow: theme.palette.mode === 'dark' ? '0 0 22px rgba(56,189,248,0.18)' : 'none',
-            '& svg': { fontSize: 24 },
-          }}
-        >
-          <BoltOutlined />
-        </Box>
-        <Box sx={{ minWidth: 0 }}>
-          <Typography
-            variant="h5"
-            component="h2"
-            sx={{ fontWeight: 700, lineHeight: 1.15, letterSpacing: '-0.01em' }}
-          >
-            Ultimate Calculator
-          </Typography>
-          <Typography
-            variant="caption"
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', mb: 2.75 }}>
+          <Box
+            aria-hidden
             sx={{
-              display: 'block',
-              color: 'text.secondary',
-              textTransform: 'uppercase',
-              letterSpacing: 1,
-              fontWeight: 600,
-              mt: 0.25,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              width: 40,
+              height: 40,
+              borderRadius: 2.5,
+              color: accent,
+              background:
+                theme.palette.mode === 'dark'
+                  ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                  : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))',
+              border: `1px solid ${accent}40`,
+              boxShadow: theme.palette.mode === 'dark' ? '0 0 22px rgba(56,189,248,0.18)' : 'none',
+              '& svg': { fontSize: 24 },
             }}
           >
-            Update 50 · all classes
-          </Typography>
-          <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1, maxWidth: 600 }}>
-            Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first
-            cast, and casts per fight.
-          </Typography>
-        </Box>
-      </Stack>
+            <BoltOutlined />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              variant="h5"
+              component="h2"
+              sx={{ fontWeight: 700, lineHeight: 1.15, letterSpacing: '-0.01em' }}
+            >
+              Ultimate Calculator
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{
+                display: 'block',
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+                letterSpacing: 1,
+                fontWeight: 600,
+                mt: 0.25,
+              }}
+            >
+              Update 50 · all classes
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1, maxWidth: 600 }}>
+              Set your context and build for exact ultimate&nbsp;/&nbsp;second, time to your first
+              cast, and casts per fight.
+            </Typography>
+          </Box>
+        </Stack>
 
-      {/* ===================== HEADLINE (full width, results-first) ===================== */}
-      <Paper
-        elevation={0}
-        sx={{
-          p: { xs: 2, sm: 2.75 },
-          mb: 2.5,
-          borderRadius: 4,
-          position: 'relative',
-          overflow: 'hidden',
-          border: `1px solid ${
-            theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.18)' : theme.palette.divider
-          }`,
-          background:
-            theme.palette.mode === 'dark'
-              ? 'linear-gradient(135deg, rgba(56,189,248,0.16) 0%, rgba(13,22,42,0.6) 50%, rgba(3,8,18,0.72) 100%)'
-              : 'linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(248,250,252,0.85) 60%, rgba(255,255,255,0.95) 100%)',
-          boxShadow:
-            theme.palette.mode === 'dark'
-              ? '0 18px 50px rgba(0,0,0,0.46), 0 0 80px rgba(56,189,248,0.10), inset 0 1px 0 rgba(255,255,255,0.06)'
-              : '0 6px 20px rgba(15,23,42,0.07)',
-          // Two soft cyan glows (top-left + bottom-right) bleeding behind the
-          // stats to give the panel atmospheric depth.
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            top: -90,
-            left: -70,
-            width: 300,
-            height: 300,
-            borderRadius: '50%',
-            background:
-              theme.palette.mode === 'dark'
-                ? 'radial-gradient(circle, rgba(0,225,255,0.22), transparent 70%)'
-                : 'radial-gradient(circle, rgba(56,189,248,0.16), transparent 70%)',
-            pointerEvents: 'none',
-          },
-          '&::after': {
-            content: '""',
-            position: 'absolute',
-            bottom: -120,
-            right: -80,
-            width: 320,
-            height: 320,
-            borderRadius: '50%',
-            background:
-              theme.palette.mode === 'dark'
-                ? 'radial-gradient(circle, rgba(56,189,248,0.12), transparent 70%)'
-                : 'radial-gradient(circle, rgba(56,189,248,0.08), transparent 70%)',
-            pointerEvents: 'none',
-          },
-        }}
-      >
-        <Box
+        {/* ===================== HEADLINE (full width, results-first) ===================== */}
+        <Paper
+          elevation={0}
           sx={{
+            p: { xs: 2, sm: 2.75 },
+            mb: 2.5,
+            borderRadius: 4,
             position: 'relative',
-            zIndex: 1,
-            display: 'flex',
-            flexDirection: { xs: 'column', md: 'row' },
-            gap: { xs: 2, md: 3 },
-            alignItems: { md: 'stretch' },
+            overflow: 'hidden',
+            border: `1px solid ${
+              theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.18)' : theme.palette.divider
+            }`,
+            background:
+              theme.palette.mode === 'dark'
+                ? 'linear-gradient(135deg, rgba(56,189,248,0.16) 0%, rgba(13,22,42,0.6) 50%, rgba(3,8,18,0.72) 100%)'
+                : 'linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(248,250,252,0.85) 60%, rgba(255,255,255,0.95) 100%)',
+            boxShadow:
+              theme.palette.mode === 'dark'
+                ? '0 18px 50px rgba(0,0,0,0.46), 0 0 80px rgba(56,189,248,0.10), inset 0 1px 0 rgba(255,255,255,0.06)'
+                : '0 6px 20px rgba(15,23,42,0.07)',
+            // Two soft cyan glows (top-left + bottom-right) bleeding behind the
+            // stats to give the panel atmospheric depth.
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: -90,
+              left: -70,
+              width: 300,
+              height: 300,
+              borderRadius: '50%',
+              background:
+                theme.palette.mode === 'dark'
+                  ? 'radial-gradient(circle, rgba(0,225,255,0.22), transparent 70%)'
+                  : 'radial-gradient(circle, rgba(56,189,248,0.16), transparent 70%)',
+              pointerEvents: 'none',
+            },
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              bottom: -120,
+              right: -80,
+              width: 320,
+              height: 320,
+              borderRadius: '50%',
+              background:
+                theme.palette.mode === 'dark'
+                  ? 'radial-gradient(circle, rgba(56,189,248,0.12), transparent 70%)'
+                  : 'radial-gradient(circle, rgba(56,189,248,0.08), transparent 70%)',
+              pointerEvents: 'none',
+            },
           }}
         >
-          {/* PRIMARY — the dominant result, with a gauge vs the sustained ceiling. */}
           <Box
             sx={{
-              flex: { md: '0 0 40%' },
-              minWidth: 0,
+              position: 'relative',
+              zIndex: 1,
               display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              px: { xs: 0.5, sm: 1 },
+              flexDirection: { xs: 'column', md: 'row' },
+              gap: { xs: 2, md: 3 },
+              alignItems: { md: 'stretch' },
             }}
           >
-            <Stack direction="row" spacing={0.6} sx={{ alignItems: 'center' }}>
-              <Typography
-                variant="caption"
-                sx={{
-                  color: 'text.secondary',
-                  textTransform: 'uppercase',
-                  letterSpacing: 1,
-                  fontWeight: 700,
-                  fontSize: 11,
-                }}
-              >
-                Ultimate / second
-              </Typography>
-              <Tooltip
-                arrow
-                title="Average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
-              >
-                <InfoOutlined
-                  role="img"
-                  aria-label="Ultimate / second: average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
-                  tabIndex={0}
+            {/* PRIMARY — the dominant result, with a gauge vs the sustained ceiling. */}
+            <Box
+              sx={{
+                flex: { md: '0 0 40%' },
+                minWidth: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                px: { xs: 0.5, sm: 1 },
+              }}
+            >
+              <Stack direction="row" spacing={0.6} sx={{ alignItems: 'center' }}>
+                <Typography
+                  variant="caption"
                   sx={{
-                    fontSize: 14,
                     color: 'text.secondary',
-                    opacity: 0.6,
-                    cursor: 'help',
-                    borderRadius: '50%',
-                    '&:hover': { opacity: 1 },
-                    '&:focus-visible': {
-                      opacity: 1,
-                      outline: `2px solid ${accent}`,
-                      outlineOffset: 2,
-                    },
+                    textTransform: 'uppercase',
+                    letterSpacing: 1,
+                    fontWeight: 700,
+                    fontSize: 11,
                   }}
-                />
-              </Tooltip>
-            </Stack>
-            <Stack direction="row" spacing={0.6} sx={{ alignItems: 'baseline', mt: 0.5 }}>
-              <Typography
-                className="u-tabular"
-                sx={{
-                  fontFamily: 'Space Grotesk, Inter, system-ui',
-                  fontWeight: 700,
-                  fontSize: { xs: '2.6rem', sm: '3.1rem' },
-                  lineHeight: 1,
-                  letterSpacing: '-0.02em',
-                  color: accent,
-                }}
-              >
-                {fmt(expected.ultimatePerSecond, 2)}
-              </Typography>
-              <Typography
-                sx={{
-                  color: 'text.secondary',
-                  fontWeight: 600,
-                  fontSize: { xs: '0.95rem', sm: '1.05rem' },
-                }}
-              >
-                ult/s
-              </Typography>
-            </Stack>
-            {/* Gauge: this rate against the practical sustained ceiling. */}
-            <Box sx={{ mt: 1.25 }}>
-              <LinearProgress
-                variant="determinate"
-                value={Math.min(100, (expected.ultimatePerSecond / sanityMax) * 100)}
-                aria-hidden
-                sx={{
-                  height: 7,
-                  borderRadius: 4,
-                  backgroundColor: alpha(theme.palette.divider, 0.6),
-                  '& .MuiLinearProgress-bar': {
-                    borderRadius: 4,
-                    background: `linear-gradient(90deg, ${accent}, ${
-                      theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.9)' : accent
-                    })`,
-                  },
-                }}
-              />
-              <Stack
-                direction="row"
-                sx={{ justifyContent: 'space-between', alignItems: 'baseline', mt: 0.6 }}
-              >
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                  <Box
-                    component="span"
-                    className="u-tabular"
-                    sx={{ fontWeight: 700, color: accentText }}
-                  >
-                    {fmt(expected.totalUltimate, 0)}
-                  </Box>{' '}
-                  ult over {state.fightDurationSeconds}s
+                >
+                  Ultimate / second
                 </Typography>
-                <Typography variant="caption" sx={{ color: 'text.secondary', opacity: 0.8 }}>
-                  ceiling ~{sanityMax}/s
+                <Tooltip
+                  arrow
+                  title="Average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
+                >
+                  <InfoOutlined
+                    role="img"
+                    aria-label="Ultimate / second: average ultimate generated per second across the whole fight, from every enabled source plus Decisive."
+                    tabIndex={0}
+                    sx={{
+                      fontSize: 14,
+                      color: 'text.secondary',
+                      opacity: 0.6,
+                      cursor: 'help',
+                      borderRadius: '50%',
+                      '&:hover': { opacity: 1 },
+                      '&:focus-visible': {
+                        opacity: 1,
+                        outline: `2px solid ${accent}`,
+                        outlineOffset: 2,
+                      },
+                    }}
+                  />
+                </Tooltip>
+              </Stack>
+              <Stack direction="row" spacing={0.6} sx={{ alignItems: 'baseline', mt: 0.5 }}>
+                <Typography
+                  className="u-tabular"
+                  sx={{
+                    fontFamily: 'Space Grotesk, Inter, system-ui',
+                    fontWeight: 700,
+                    fontSize: { xs: '2.6rem', sm: '3.1rem' },
+                    lineHeight: 1,
+                    letterSpacing: '-0.02em',
+                    color: accent,
+                  }}
+                >
+                  {fmt(expected.ultimatePerSecond, 2)}
+                </Typography>
+                <Typography
+                  sx={{
+                    color: 'text.secondary',
+                    fontWeight: 600,
+                    fontSize: { xs: '0.95rem', sm: '1.05rem' },
+                  }}
+                >
+                  ult/s
                 </Typography>
               </Stack>
-            </Box>
-          </Box>
-
-          {/* SECONDARY — supporting stats, 3-up across every breakpoint. */}
-          <Box
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              display: 'grid',
-              gap: { xs: 1, sm: 1.25 },
-              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-            }}
-          >
-            <StatBlock
-              label="Time to first ult"
-              value={fmtSeconds(timeToUlt.secondsToFirstCast)}
-              sub={`${effectiveCost} ult cost`}
-              accent={accent}
-              info={`How long until you can first fire the selected ultimate (effective cost ${effectiveCost}), counting any banked ultimate at fight start.`}
-            />
-            <StatBlock
-              label="Casts / fight"
-              value={
-                Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'
-              }
-              sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
-              accent={accent}
-              info={`How many times you can fire it in a ${state.fightDurationSeconds}s fight — total generation divided by its effective cost.`}
-            />
-            <StatBlock
-              label="By 60s"
-              value={fmt(expected.ultimatePerSecond * 60, 0)}
-              sub={`ult · cap ${maxPool}`}
-              accent={accent}
-              info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
-            />
-          </Box>
-        </Box>
-        {exceedsSanity && (
-          <Alert severity="info" sx={{ mt: 2 }}>
-            {fmt(expected.ultimatePerSecond, 2)} ult/s is above the practical sustained ceiling (~
-            {sanityMax}/s, roughly the best a Warden achieves). Double-check the enabled sources and
-            uptimes — this may be optimistic.
-          </Alert>
-        )}
-      </Paper>
-
-      <Box sx={{ display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2.5 }}>
-        {/* ============================ INPUTS ============================ */}
-        <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
-          <SectionHeader icon={<TuneOutlined />} title="Your build" accent={accent} />
-
-          {/* Quick-start presets — flip context/role + boolean source toggles only. */}
-          <Box sx={{ mb: 2 }}>
-            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-              <AutoFixHighOutlined sx={{ fontSize: 15, color: accent }} />
-              <Typography
-                variant="caption"
-                sx={{
-                  color: 'text.secondary',
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.6,
-                  fontWeight: 700,
-                }}
-              >
-                Quick start
-              </Typography>
-            </Stack>
-            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
-              {BUILD_PRESETS.map((p) => {
-                const active = activePresetId === p.id;
-                return (
-                  <Chip
-                    key={p.id}
-                    label={p.label}
-                    clickable
-                    onClick={() => applyPreset(p)}
-                    aria-pressed={active}
-                    sx={{
-                      height: 30,
-                      borderRadius: 2,
-                      fontWeight: 600,
-                      px: 0.25,
-                      border: `1px solid ${active ? accent : theme.palette.divider}`,
-                      color: active ? accentText : 'text.secondary',
-                      background: active
-                        ? theme.palette.mode === 'dark'
-                          ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                          : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
-                        : theme.palette.mode === 'dark'
-                          ? 'rgba(148,163,184,0.06)'
-                          : 'rgba(255,255,255,0.6)',
-                      boxShadow: active
-                        ? theme.palette.mode === 'dark'
-                          ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 14px rgba(56,189,248,0.12)'
-                          : 'inset 0 0 0 1px rgba(40,145,200,0.35)'
-                        : 'none',
-                      transition: 'background-color 0.18s ease, border-color 0.18s ease',
-                      '&:hover': {
-                        borderColor: accent,
-                        background: active
-                          ? theme.palette.mode === 'dark'
-                            ? 'linear-gradient(135deg, rgba(56,189,248,0.26), rgba(0,225,255,0.1))'
-                            : 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                          : theme.palette.mode === 'dark'
-                            ? 'rgba(56,189,248,0.08)'
-                            : 'rgba(40,145,200,0.06)',
-                      },
-                    }}
-                  />
-                );
-              })}
-            </Stack>
-          </Box>
-
-          {/* Context / class / role */}
-          <Stack spacing={2}>
-            <Box>
-              <Typography
-                id="ult-context-label"
-                variant="caption"
-                sx={{
-                  color: 'text.secondary',
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.5,
-                  fontWeight: 600,
-                }}
-              >
-                Context
-              </Typography>
-              <ToggleButtonGroup
-                exclusive
-                fullWidth
-                value={state.context}
-                onChange={(_, v) => v && calc.setContext(v as CombatContext)}
-                aria-labelledby="ult-context-label"
-                sx={{
-                  mt: 0.75,
-                  gap: 0.5,
-                  p: 0.5,
-                  borderRadius: 2.5,
-                  border: `1px solid ${theme.palette.divider}`,
-                  background:
-                    theme.palette.mode === 'dark'
-                      ? 'rgba(148,163,184,0.05)'
-                      : 'rgba(255,255,255,0.55)',
-                  // Segmented-control styling that mirrors the top Stats/Ultimate
-                  // switcher: filled accent pill behind the active option.
-                  '& .MuiToggleButtonGroup-grouped': {
-                    border: 0,
-                    borderRadius: '8px !important',
-                    flexDirection: 'column',
-                    gap: 0,
-                    py: 0.85,
-                    minHeight: 48,
-                    color: 'text.secondary',
-                    transition:
-                      'background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease',
-                    '&:hover': {
-                      backgroundColor:
-                        theme.palette.mode === 'dark'
-                          ? 'rgba(56,189,248,0.06)'
-                          : 'rgba(15,23,42,0.04)',
-                    },
-                    '&.Mui-selected': {
-                      color: accentText,
-                      background:
-                        theme.palette.mode === 'dark'
-                          ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
-                          : 'linear-gradient(135deg, rgba(56,189,248,0.16), rgba(0,225,255,0.05))',
-                      boxShadow:
-                        theme.palette.mode === 'dark'
-                          ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 16px rgba(56,189,248,0.12)'
-                          : 'inset 0 0 0 1px rgba(40,145,200,0.4)',
-                      '&:hover': {
-                        background:
-                          theme.palette.mode === 'dark'
-                            ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
-                            : 'linear-gradient(135deg, rgba(56,189,248,0.2), rgba(0,225,255,0.07))',
-                      },
-                    },
-                  },
-                }}
-              >
-                {CONTEXT_OPTIONS.map((c) => (
-                  <ToggleButton key={c} value={c} sx={{ textTransform: 'none' }}>
-                    <Typography
-                      component="span"
-                      sx={{ fontWeight: 700, fontSize: '0.875rem', lineHeight: 1.15 }}
-                    >
-                      {CONTEXT_META[c].label}
-                    </Typography>
-                    <Typography
-                      component="span"
-                      sx={{ fontSize: 10, opacity: 0.85, lineHeight: 1.2, mt: 0.25 }}
-                    >
-                      {CONTEXT_META[c].hint}
-                    </Typography>
-                  </ToggleButton>
-                ))}
-              </ToggleButtonGroup>
-            </Box>
-
-            <Stack direction="row" spacing={2}>
-              <FormControl size="small" fullWidth>
-                <InputLabel id="ult-class-label">Class</InputLabel>
-                <Select
-                  labelId="ult-class-label"
-                  label="Class"
-                  value={state.esoClass}
-                  onChange={(e) => calc.setClass(e.target.value as EsoClass)}
-                  renderValue={(v) => (
-                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                      <Swatch color={CLASS_COLORS[v as EsoClass]} size={9} />
-                      <span>{ESO_CLASS_LABELS[v as EsoClass]}</span>
-                    </Stack>
-                  )}
-                >
-                  {ESO_CLASSES.map((c) => (
-                    <MenuItem key={c} value={c}>
-                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                        <Swatch color={CLASS_COLORS[c]} glow />
-                        <span>{ESO_CLASS_LABELS[c]}</span>
-                      </Stack>
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-              <FormControl size="small" fullWidth>
-                <InputLabel id="ult-role-label">Role</InputLabel>
-                <Select
-                  labelId="ult-role-label"
-                  label="Role"
-                  value={state.role}
-                  onChange={(e) => calc.setRole(e.target.value as CombatRole)}
-                >
-                  {ROLE_OPTIONS.map((r) => (
-                    <MenuItem key={r.value} value={r.value}>
-                      {r.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Stack>
-
-            <TextField
-              label="Fight duration"
-              type="number"
-              size="small"
-              value={state.fightDurationSeconds}
-              onChange={(e) => calc.setFightDuration(Number(e.target.value))}
-              slotProps={{
-                htmlInput: { min: 1, step: 5 },
-                input: {
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                        sec
-                      </Typography>
-                    </InputAdornment>
-                  ),
-                },
-              }}
-            />
-
-            {/* Decisive */}
-            <Box>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={state.decisiveEnabled}
-                    onChange={(e) => calc.setDecisiveEnabled(e.target.checked)}
-                  />
-                }
-                label={
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    Decisive weapon trait
-                  </Typography>
-                }
-              />
-              {state.decisiveEnabled && (
-                <Stack
-                  spacing={1.5}
+              {/* Gauge: this rate against the practical sustained ceiling. */}
+              <Box sx={{ mt: 1.25 }}>
+                <LinearProgress
+                  variant="determinate"
+                  value={Math.min(100, (expected.ultimatePerSecond / sanityMax) * 100)}
+                  aria-hidden
                   sx={{
-                    mt: 1,
-                    p: 1.5,
-                    borderRadius: 2,
-                    borderLeft: `3px solid ${accent}`,
-                    background:
-                      theme.palette.mode === 'dark'
-                        ? 'rgba(56,189,248,0.05)'
-                        : 'rgba(40,145,200,0.04)',
+                    height: 7,
+                    borderRadius: 4,
+                    backgroundColor: alpha(theme.palette.divider, 0.6),
+                    '& .MuiLinearProgress-bar': {
+                      borderRadius: 4,
+                      background: `linear-gradient(90deg, ${accent}, ${
+                        theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.9)' : accent
+                      })`,
+                    },
                   }}
+                />
+                <Stack
+                  direction="row"
+                  sx={{ justifyContent: 'space-between', alignItems: 'baseline', mt: 0.6 }}
                 >
-                  <FormControl size="small" fullWidth>
-                    <InputLabel id="decisive-quality-label">Weapon quality</InputLabel>
-                    <Select
-                      labelId="decisive-quality-label"
-                      label="Weapon quality"
-                      value={state.decisiveQuality}
-                      onChange={(e) => calc.setDecisiveQuality(e.target.value as DecisiveQuality)}
-                      renderValue={(v) => (
-                        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                          <Swatch color={QUALITY_COLORS[v as DecisiveQuality]} square size={9} />
-                          <span>
-                            {QUALITY_OPTIONS.find((o) => o.value === v)?.label} —{' '}
-                            {(DECISIVE_PROC_CHANCE[v as DecisiveQuality] * 100).toFixed(1)}%
-                          </span>
-                        </Stack>
-                      )}
+                  <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                    <Box
+                      component="span"
+                      className="u-tabular"
+                      sx={{ fontWeight: 700, color: accentText }}
                     >
-                      {QUALITY_OPTIONS.map((opt) => (
-                        <MenuItem key={opt.value} value={opt.value}>
-                          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                            <Swatch color={QUALITY_COLORS[opt.value]} square />
-                            <span>
-                              {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
-                            </span>
-                          </Stack>
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <Tooltip
-                    arrow
-                    title="A two-handed melee weapon (greatsword, battle axe, maul) provides twice the Decisive bonus — it rolls for the extra ultimate twice per gain instead of once."
-                  >
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={state.decisiveTwoHanded}
-                          onChange={(e) => calc.setDecisiveTwoHanded(e.target.checked)}
-                        />
-                      }
-                      label={<Typography variant="body2">Two-handed (rolls twice)</Typography>}
-                    />
-                  </Tooltip>
-                </Stack>
-              )}
-            </Box>
-
-            <Divider textAlign="left" sx={{ '&::before': { width: '0%' }, mt: 0.5 }}>
-              <Typography
-                variant="caption"
-                sx={{
-                  color: accentText,
-                  fontWeight: 700,
-                  textTransform: 'uppercase',
-                  letterSpacing: 0.6,
-                }}
-              >
-                Ultimate sources
-              </Typography>
-            </Divider>
-
-            {/* Source toggles, grouped by category */}
-            {grouped.map(([category, entries]) => (
-              <Box key={category}>
-                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-                  <Box
-                    aria-hidden
-                    sx={{
-                      width: 5,
-                      height: 5,
-                      borderRadius: '50%',
-                      background: accent,
-                      flexShrink: 0,
-                    }}
-                  />
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: 'text.secondary',
-                      fontWeight: 700,
-                      textTransform: 'uppercase',
-                      letterSpacing: 0.6,
-                    }}
-                  >
-                    {SOURCE_CATEGORY_LABELS[category]}
+                      {fmt(expected.totalUltimate, 0)}
+                    </Box>{' '}
+                    ult over {state.fightDurationSeconds}s
                   </Typography>
-                </Stack>
-                <Stack spacing={1}>
-                  {entries.map((s) => {
-                    const enabled = calc.isEnabled(s.id, s.defaultEnabled);
-                    return (
-                      <Box
-                        key={s.id}
-                        sx={{
-                          borderRadius: 2.5,
-                          px: 1.5,
-                          py: enabled ? 1.25 : 0.5,
-                          pl: 1.75,
-                          position: 'relative',
-                          overflow: 'hidden',
-                          transition:
-                            'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
-                          border: `1px solid ${
-                            enabled
-                              ? theme.palette.mode === 'dark'
-                                ? 'rgba(56,189,248,0.32)'
-                                : 'rgba(40,145,200,0.28)'
-                              : theme.palette.divider
-                          }`,
-                          background: enabled
-                            ? theme.palette.mode === 'dark'
-                              ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
-                              : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
-                            : 'transparent',
-                          // Raised + glowing when active, flush when off.
-                          boxShadow: enabled
-                            ? theme.palette.mode === 'dark'
-                              ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
-                              : '0 2px 8px rgba(15,23,42,0.05)'
-                            : 'none',
-                          // Accent rail on the left edge marks an active source.
-                          '&::before': enabled
-                            ? {
-                                content: '""',
-                                position: 'absolute',
-                                left: 0,
-                                top: 0,
-                                bottom: 0,
-                                width: 3,
-                                background: `linear-gradient(180deg, ${accent}, ${
-                                  theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.8)' : accent
-                                })`,
-                                boxShadow:
-                                  theme.palette.mode === 'dark'
-                                    ? '0 0 10px rgba(0,225,255,0.5)'
-                                    : 'none',
-                              }
-                            : undefined,
-                          '&:hover': {
-                            borderColor: enabled
-                              ? theme.palette.mode === 'dark'
-                                ? 'rgba(56,189,248,0.5)'
-                                : 'rgba(40,145,200,0.45)'
-                              : theme.palette.mode === 'dark'
-                                ? 'rgba(148,163,184,0.4)'
-                                : 'rgba(15,23,42,0.18)',
-                          },
-                        }}
-                      >
-                        <Stack
-                          direction="row"
-                          spacing={1}
-                          sx={{
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                            minHeight: 44,
-                          }}
-                        >
-                          <FormControlLabel
-                            sx={{ mr: 0, flex: 1, minWidth: 0, gap: 0.75 }}
-                            control={
-                              <Switch
-                                checked={enabled}
-                                onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
-                              />
-                            }
-                            label={
-                              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                                <Typography
-                                  variant="body2"
-                                  sx={{ fontWeight: enabled ? 600 : 500, lineHeight: 1.3 }}
-                                >
-                                  {s.label}
-                                </Typography>
-                                {s.confidence !== 'high' && (
-                                  <Chip
-                                    label={s.confidence}
-                                    size="small"
-                                    sx={{
-                                      height: 17,
-                                      fontSize: 10,
-                                      textTransform: 'capitalize',
-                                    }}
-                                  />
-                                )}
-                              </Stack>
-                            }
-                          />
-                          {s.provenance && (
-                            <Link
-                              href={s.provenance}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              variant="caption"
-                              sx={{ flexShrink: 0, fontWeight: 600 }}
-                            >
-                              source
-                            </Link>
-                          )}
-                        </Stack>
-                        {enabled && (
-                          <Box
-                            sx={{
-                              mt: 0.75,
-                              pt: 1,
-                              borderTop: `1px solid ${alpha(theme.palette.divider, 0.7)}`,
-                            }}
-                          >
-                            <Stack
-                              direction="row"
-                              sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
-                            >
-                              <Typography
-                                variant="caption"
-                                sx={{
-                                  color: 'text.secondary',
-                                  textTransform: 'uppercase',
-                                  letterSpacing: 0.5,
-                                  fontSize: 10,
-                                  fontWeight: 700,
-                                }}
-                              >
-                                Uptime
-                              </Typography>
-                              <Typography
-                                className="u-tabular"
-                                variant="body2"
-                                sx={{ color: accentText, fontWeight: 700 }}
-                              >
-                                {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
-                              </Typography>
-                            </Stack>
-                            <Slider
-                              size="small"
-                              value={Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}
-                              onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
-                              min={0}
-                              max={100}
-                              aria-label={`${s.label} uptime`}
-                              sx={{ py: 0.5 }}
-                            />
-                            {s.description && (
-                              <Typography
-                                variant="caption"
-                                sx={{
-                                  color: 'text.secondary',
-                                  display: 'block',
-                                  mt: -0.25,
-                                  lineHeight: 1.45,
-                                }}
-                              >
-                                {s.description}
-                              </Typography>
-                            )}
-                            {/* Pillager's per-cast amount scales with the cost of the
-                                ULTIMATE OF WHOEVER WEARS THE SET (usually your healer) —
-                                a different player's ult, NOT your own. You receive 10% of
-                                their ult's cost. Deliberately decoupled from the main
-                                "Which ultimate?" cost above to avoid implying it tracks
-                                your own ultimate. */}
-                            {s.id === 'pillagers-profit-external' && (
-                              <Stack spacing={0.5} sx={{ mt: 1 }}>
-                                <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                                  <TextField
-                                    label="Wearer's ult cost"
-                                    type="number"
-                                    size="small"
-                                    value={state.pillagerHealerUltCost}
-                                    onChange={(e) =>
-                                      calc.setPillagerHealerUltCost(Number(e.target.value))
-                                    }
-                                    slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
-                                    sx={{ width: 160 }}
-                                  />
-                                  <Tooltip
-                                    arrow
-                                    title="The cost of the ULTIMATE CAST BY THE PILLAGER'S WEARER — usually your healer, not you. You receive 10% of their ult's cost (once per 45s). This is separate from the 'Which ultimate?' cost above, which is your own ult."
-                                  >
-                                    <InfoOutlined
-                                      role="img"
-                                      aria-label="About the wearer's ult cost: the cost of the ultimate cast by the Pillager's wearer (usually your healer), not your own. You receive 10% of it, once per 45 seconds."
-                                      tabIndex={0}
-                                      sx={{
-                                        fontSize: 16,
-                                        color: 'text.secondary',
-                                        cursor: 'help',
-                                        borderRadius: '50%',
-                                        '&:focus-visible': {
-                                          outline: `2px solid ${accent}`,
-                                          outlineOffset: 2,
-                                        },
-                                      }}
-                                    />
-                                  </Tooltip>
-                                  <Typography
-                                    variant="caption"
-                                    className="u-tabular"
-                                    sx={{ color: 'text.secondary' }}
-                                  >
-                                    → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
-                                  </Typography>
-                                </Stack>
-                                <Typography
-                                  variant="caption"
-                                  sx={{ color: 'text.secondary', display: 'block' }}
-                                >
-                                  Whoever wears Pillager&apos;s (usually your healer) — not your own
-                                  ultimate.
-                                </Typography>
-                              </Stack>
-                            )}
-                          </Box>
-                        )}
-                      </Box>
-                    );
-                  })}
+                  <Typography variant="caption" sx={{ color: 'text.secondary', opacity: 0.8 }}>
+                    ceiling ~{sanityMax}/s
+                  </Typography>
                 </Stack>
               </Box>
-            ))}
+            </Box>
 
-            <Button
-              onClick={calc.reset}
-              size="small"
-              variant="text"
-              startIcon={<RestartAltOutlined sx={{ fontSize: 16 }} />}
-              sx={{ alignSelf: 'flex-start', color: 'text.secondary', mt: 0.5 }}
+            {/* SECONDARY — supporting stats, 3-up across every breakpoint. */}
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: 'grid',
+                gap: { xs: 1, sm: 1.25 },
+                gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              }}
             >
-              Reset to defaults
-            </Button>
-          </Stack>
+              <StatBlock
+                label="Time to first ult"
+                value={fmtSeconds(timeToUlt.secondsToFirstCast)}
+                sub={`${effectiveCost} ult cost`}
+                accent={accent}
+                info={`How long until you can first fire the selected ultimate (effective cost ${effectiveCost}), counting any banked ultimate at fight start.`}
+              />
+              <StatBlock
+                label="Casts / fight"
+                value={
+                  Number.isFinite(timeToUlt.castsPerFight) ? String(timeToUlt.castsPerFight) : '∞'
+                }
+                sub={`every ${fmtSeconds(timeToUlt.secondsPerCast)}`}
+                accent={accent}
+                info={`How many times you can fire it in a ${state.fightDurationSeconds}s fight — total generation divided by its effective cost.`}
+              />
+              <StatBlock
+                label="By 60s"
+                value={fmt(expected.ultimatePerSecond * 60, 0)}
+                sub={`ult · cap ${maxPool}`}
+                accent={accent}
+                info={`Ultimate built in the first minute at this rate. The pool itself can only hold ${maxPool} at once.`}
+              />
+            </Box>
+          </Box>
+          {exceedsSanity && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              {fmt(expected.ultimatePerSecond, 2)} ult/s is above the practical sustained ceiling (~
+              {sanityMax}/s, roughly the best a Warden achieves). Double-check the enabled sources
+              and uptimes — this may be optimistic.
+            </Alert>
+          )}
         </Paper>
 
-        {/* ============================ RESULTS ============================ */}
-        <Stack spacing={2.5} sx={{ flex: '1 1 480px', minWidth: 0 }}>
-          {/* Ultimate picker / cost */}
-          <Paper elevation={0} sx={panelSx(theme)}>
-            <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />
-            <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
-              <FormControl size="small" sx={{ flex: '1 1 100%' }}>
-                <InputLabel id="ult-ability-label">Ultimate</InputLabel>
-                <Select
-                  labelId="ult-ability-label"
-                  label="Ultimate"
-                  value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
-                  renderValue={renderSelectedUltimate}
-                  MenuProps={{ slotProps: { paper: { sx: { maxHeight: 420 } } } }}
-                  onChange={(e) => {
-                    // Seed custom cost with the current EFFECTIVE cost (after any
-                    // reductions), since a custom cost is treated as already
-                    // effective — seeding with the unreduced base would make the
-                    // number jump the moment you switch to Custom.
-                    if (e.target.value === 'custom') calc.setCustomUltimateCost(effectiveCost);
-                    else calc.setUltimateAbility(e.target.value);
+        <Box sx={{ display: 'flex', flexDirection: { xs: 'column', lg: 'row' }, gap: 2.5 }}>
+          {/* ============================ INPUTS ============================ */}
+          <Paper elevation={0} sx={{ ...panelSx(theme), flex: '1 1 420px', minWidth: 0 }}>
+            <SectionHeader icon={<TuneOutlined />} title="Your build" accent={accent} />
+
+            {/* Quick-start presets — flip context/role + boolean source toggles only. */}
+            <Box sx={{ mb: 2 }}>
+              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+                <AutoFixHighOutlined sx={{ fontSize: 15, color: accent }} />
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.6,
+                    fontWeight: 700,
                   }}
                 >
-                  {/* Grouped by owner. Children are emitted as ONE flat array
-                      (ListSubheader + MenuItems per group) — wrapping a group in
-                      a Fragment/Box would break MUI Select's direct-child value
-                      scan and blank the closed control. */}
-                  {ultimateGroups.flatMap((g) => [
-                    <ListSubheader
-                      key={`sub-${g.key}`}
-                      disableSticky
+                  Quick start
+                </Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+                {BUILD_PRESETS.map((p) => {
+                  const active = activePresetId === p.id;
+                  return (
+                    <Chip
+                      key={p.id}
+                      label={p.label}
+                      clickable
+                      onClick={() => applyPreset(p)}
+                      aria-pressed={active}
                       sx={{
-                        lineHeight: 2.2,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        letterSpacing: 0.5,
-                        textTransform: 'uppercase',
-                        color: 'text.secondary',
-                        background: 'transparent',
+                        height: 30,
+                        borderRadius: 2,
+                        fontWeight: 600,
+                        px: 0.25,
+                        border: `1px solid ${active ? accent : theme.palette.divider}`,
+                        color: active ? accentText : 'text.secondary',
+                        background: active
+                          ? theme.palette.mode === 'dark'
+                            ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                            : 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                          : theme.palette.mode === 'dark'
+                            ? 'rgba(148,163,184,0.06)'
+                            : 'rgba(255,255,255,0.6)',
+                        boxShadow: active
+                          ? theme.palette.mode === 'dark'
+                            ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 14px rgba(56,189,248,0.12)'
+                            : 'inset 0 0 0 1px rgba(40,145,200,0.35)'
+                          : 'none',
+                        transition: 'background-color 0.18s ease, border-color 0.18s ease',
+                        '&:hover': {
+                          borderColor: accent,
+                          background: active
+                            ? theme.palette.mode === 'dark'
+                              ? 'linear-gradient(135deg, rgba(56,189,248,0.26), rgba(0,225,255,0.1))'
+                              : 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                            : theme.palette.mode === 'dark'
+                              ? 'rgba(56,189,248,0.08)'
+                              : 'rgba(40,145,200,0.06)',
+                        },
                       }}
-                    >
-                      {g.label}
-                    </ListSubheader>,
-                    ...g.items.map((a) => (
-                      <MenuItem
-                        key={a.id}
-                        value={a.id}
-                        // Fold the approximate-cost note into the item's accessible
-                        // name rather than a hover Tooltip — focus inside a Select
-                        // menu doesn't reliably surface tooltips for keyboard/SR users.
-                        aria-label={
-                          a.confidence !== 'high'
-                            ? `${a.label}, ${a.baseCost} ultimate (cost approximate — not fully confirmed for Update 50)`
-                            : `${a.label}, ${a.baseCost} ultimate`
-                        }
-                      >
-                        <Stack
-                          direction="row"
-                          spacing={1}
-                          sx={{ alignItems: 'center', width: '100%' }}
-                        >
-                          <Swatch color={ownerColor(a.owner, accent)} size={8} />
-                          <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
-                            {a.label}
-                          </Typography>
-                          <Typography
-                            aria-hidden
-                            variant="caption"
-                            className="u-tabular"
-                            sx={{ color: 'text.secondary', fontWeight: 600 }}
-                          >
-                            {a.baseCost}
-                            {a.confidence !== 'high' ? (
-                              <Box component="span" sx={{ color: accentText, ml: 0.25 }}>
-                                *
-                              </Box>
-                            ) : null}
-                          </Typography>
-                        </Stack>
-                      </MenuItem>
-                    )),
-                  ])}
-                  <MenuItem value="custom">
-                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                      <Swatch color={theme.palette.text.disabled} size={8} />
-                      <span>Custom cost…</span>
-                    </Stack>
-                  </MenuItem>
-                </Select>
-              </FormControl>
-              {state.customUltimateCost != null && (
-                <TextField
-                  label="Custom cost"
-                  type="number"
-                  size="small"
-                  value={state.customUltimateCost}
-                  onChange={(e) => calc.setCustomUltimateCost(Number(e.target.value))}
-                  slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
-                  sx={{ width: 140 }}
-                />
-              )}
-              <TextField
-                label="Starting ultimate"
-                type="number"
-                size="small"
-                value={state.startingUltimate}
-                onChange={(e) => calc.setStartingUltimate(Number(e.target.value))}
-                slotProps={{
-                  htmlInput: { min: 0, max: 500, step: 5 },
-                  input: {
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                          ult
-                        </Typography>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-                sx={{ width: 190 }}
-                helperText="Banked at start"
-              />
-            </Stack>
-            {state.customUltimateCost == null && (
-              <Typography
-                variant="caption"
-                sx={{ color: 'text.secondary', display: 'block', mt: 1 }}
-              >
-                <Box component="span" sx={{ color: accentText, fontWeight: 700 }}>
-                  *
-                </Box>{' '}
-                marks a cost not fully confirmed for Update 50 — treat it as approximate.
-              </Typography>
-            )}
-            {/* Cost-reduction toggles — only meaningful for a catalog ability; a
-                custom cost is taken as already-effective so reductions don't apply. */}
-            {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
-              <Stack spacing={0.5} sx={{ mt: 2 }}>
+                    />
+                  );
+                })}
+              </Stack>
+            </Box>
+
+            {/* Context / class / role */}
+            <Stack spacing={2}>
+              <Box>
                 <Typography
+                  id="ult-context-label"
                   variant="caption"
                   sx={{
                     color: 'text.secondary',
@@ -1488,382 +952,1064 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     fontWeight: 600,
                   }}
                 >
-                  Cost reductions
+                  Context
                 </Typography>
-                {availableReductionEntries.map((r) => (
-                  <FormControlLabel
-                    key={r.id}
-                    control={
-                      <Switch
-                        size="small"
-                        checked={calc.isEnabled(r.id, r.defaultEnabled)}
-                        onChange={(e) => calc.toggleSource(r.id, e.target.checked)}
-                      />
-                    }
-                    label={
-                      <Typography variant="body2">
-                        {r.label} (−{Math.round(r.fraction * 100)}%)
-                      </Typography>
-                    }
-                  />
-                ))}
-              </Stack>
-            )}
-            {state.customUltimateCost == null && reductionFraction > 0 && (
-              <Box
-                sx={{
-                  mt: 1.5,
-                  px: 1.5,
-                  py: 1,
-                  borderRadius: 2,
-                  background:
-                    theme.palette.mode === 'dark' ? 'rgba(34,197,94,0.08)' : 'rgba(5,150,105,0.06)',
-                  border: `1px solid ${
-                    theme.palette.mode === 'dark' ? 'rgba(34,197,94,0.25)' : 'rgba(5,150,105,0.2)'
-                  }`,
-                }}
-              >
-                <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
-                  Cost reduced{' '}
-                  <Box component="span" sx={{ color: theme.palette.success.main, fontWeight: 700 }}>
-                    {Math.round(reductionFraction * 100)}%
-                  </Box>{' '}
-                  <Box component="span" className="u-tabular">
-                    ({baseCost} → {effectiveCost})
-                  </Box>{' '}
-                  by{' '}
-                  {appliedReductions
-                    .filter((r) => r.enabled)
-                    .map((r) => r.label)
-                    .join(', ')}
-                  .
-                </Typography>
-              </Box>
-            )}
-          </Paper>
-
-          {/* Per-source breakdown */}
-          <Paper elevation={0} sx={panelSx(theme)}>
-            <SectionHeader
-              icon={<InsightsOutlined />}
-              title="Where it comes from"
-              accent={accent}
-              action={
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<QueryStatsOutlined sx={{ fontSize: 16 }} />}
-                  onClick={calc.computeDistribution}
-                  sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
-                >
-                  {distribution ? 'Recompute spread' : 'Show spread'}
-                </Button>
-              }
-            />
-            <Box sx={{ overflowX: 'auto', mx: -0.5 }}>
-              <Table
-                size="small"
-                aria-label="per-source ultimate breakdown"
-                sx={{
-                  '& td, & th': { borderColor: theme.palette.divider },
-                  '& .MuiTableCell-root': { fontVariantNumeric: 'tabular-nums' },
-                  '& tbody tr:nth-of-type(odd) td': {
-                    backgroundColor:
+                <ToggleButtonGroup
+                  exclusive
+                  fullWidth
+                  value={state.context}
+                  onChange={(_, v) => v && calc.setContext(v as CombatContext)}
+                  aria-labelledby="ult-context-label"
+                  sx={{
+                    mt: 0.75,
+                    gap: 0.5,
+                    p: 0.5,
+                    borderRadius: 2.5,
+                    border: `1px solid ${theme.palette.divider}`,
+                    background:
                       theme.palette.mode === 'dark'
-                        ? 'rgba(148,163,184,0.03)'
-                        : 'rgba(15,23,42,0.015)',
-                  },
-                  '& tbody tr:hover td': {
-                    backgroundColor:
-                      theme.palette.mode === 'dark'
-                        ? 'rgba(56,189,248,0.06)'
-                        : 'rgba(40,145,200,0.05)',
-                  },
-                }}
-              >
-                <TableHead>
-                  <TableRow>
-                    <TableCell
-                      sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        color: 'text.secondary',
-                      }}
-                    >
-                      Source
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        color: 'text.secondary',
-                        display: { xs: 'none', sm: 'table-cell' },
-                      }}
-                    >
-                      Base
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        color: 'text.secondary',
-                        display: { xs: 'none', sm: 'table-cell' },
-                      }}
-                    >
-                      Decisive
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        color: 'text.secondary',
-                      }}
-                    >
-                      Total
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {expected.contributions.map((c) => {
-                    const tot = c.baseUltimate + c.decisiveUltimate;
-                    // Presentation-only share of the grand total, shown as a
-                    // mini bar so the dominant source reads at a glance.
-                    const share = expected.totalUltimate > 0 ? tot / expected.totalUltimate : 0;
-                    return (
-                      <TableRow key={c.sourceId}>
-                        <TableCell sx={{ minWidth: 150 }}>
-                          <Typography variant="body2">{c.label}</Typography>
-                          <Stack
-                            direction="row"
-                            spacing={0.75}
-                            sx={{ alignItems: 'center', mt: 0.5 }}
-                          >
-                            <LinearProgress
-                              variant="determinate"
-                              value={Math.min(100, share * 100)}
-                              aria-hidden
-                              sx={{
-                                flex: 1,
-                                height: 5,
-                                borderRadius: 3,
-                                backgroundColor: alpha(theme.palette.divider, 0.5),
-                                '& .MuiLinearProgress-bar': {
-                                  borderRadius: 3,
-                                  background: `linear-gradient(90deg, ${accent}, ${
-                                    theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.85)' : accent
-                                  })`,
-                                },
-                              }}
-                            />
-                            <Typography
-                              variant="caption"
-                              className="u-tabular"
-                              sx={{ minWidth: 32, textAlign: 'right', color: 'text.secondary' }}
-                            >
-                              {Math.round(share * 100)}%
-                            </Typography>
-                          </Stack>
-                        </TableCell>
-                        <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
-                          {fmt(c.baseUltimate, 0)}
-                        </TableCell>
-                        <TableCell align="right" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
-                          {fmt(c.decisiveUltimate, 1)}
-                        </TableCell>
-                        <TableCell align="right">{fmt(tot, 1)}</TableCell>
-                      </TableRow>
-                    );
-                  })}
-                  <TableRow
-                    sx={{
-                      '& td': {
-                        borderTop: `2px solid ${accent}55`,
+                        ? 'rgba(148,163,184,0.05)'
+                        : 'rgba(255,255,255,0.55)',
+                    // Segmented-control styling that mirrors the top Stats/Ultimate
+                    // switcher: filled accent pill behind the active option.
+                    '& .MuiToggleButtonGroup-grouped': {
+                      border: 0,
+                      borderRadius: '8px !important',
+                      flexDirection: 'column',
+                      gap: 0,
+                      py: 0.85,
+                      minHeight: 48,
+                      color: 'text.secondary',
+                      transition:
+                        'background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease',
+                      '&:hover': {
+                        backgroundColor:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(56,189,248,0.06)'
+                            : 'rgba(15,23,42,0.04)',
+                      },
+                      '&.Mui-selected': {
+                        color: accentText,
                         background:
                           theme.palette.mode === 'dark'
-                            ? 'rgba(56,189,248,0.08) !important'
-                            : 'rgba(40,145,200,0.06) !important',
+                            ? 'linear-gradient(135deg, rgba(56,189,248,0.18), rgba(0,225,255,0.06))'
+                            : 'linear-gradient(135deg, rgba(56,189,248,0.16), rgba(0,225,255,0.05))',
+                        boxShadow:
+                          theme.palette.mode === 'dark'
+                            ? 'inset 0 0 0 1px rgba(56,189,248,0.4), 0 0 16px rgba(56,189,248,0.12)'
+                            : 'inset 0 0 0 1px rgba(40,145,200,0.4)',
+                        '&:hover': {
+                          background:
+                            theme.palette.mode === 'dark'
+                              ? 'linear-gradient(135deg, rgba(56,189,248,0.22), rgba(0,225,255,0.08))'
+                              : 'linear-gradient(135deg, rgba(56,189,248,0.2), rgba(0,225,255,0.07))',
+                        },
                       },
+                    },
+                  }}
+                >
+                  {CONTEXT_OPTIONS.map((c) => (
+                    <ToggleButton key={c} value={c} sx={{ textTransform: 'none' }}>
+                      <Typography
+                        component="span"
+                        sx={{ fontWeight: 700, fontSize: '0.875rem', lineHeight: 1.15 }}
+                      >
+                        {CONTEXT_META[c].label}
+                      </Typography>
+                      <Typography
+                        component="span"
+                        sx={{ fontSize: 10, opacity: 0.85, lineHeight: 1.2, mt: 0.25 }}
+                      >
+                        {CONTEXT_META[c].hint}
+                      </Typography>
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </Box>
+
+              <Stack direction="row" spacing={2}>
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="ult-class-label">Class</InputLabel>
+                  <Select
+                    labelId="ult-class-label"
+                    label="Class"
+                    value={state.esoClass}
+                    onChange={(e) => calc.setClass(e.target.value as EsoClass)}
+                    renderValue={(v) => (
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                        <Swatch color={CLASS_COLORS[v as EsoClass]} size={9} />
+                        <span>{ESO_CLASS_LABELS[v as EsoClass]}</span>
+                      </Stack>
+                    )}
+                  >
+                    {ESO_CLASSES.map((c) => (
+                      <MenuItem key={c} value={c}>
+                        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                          <Swatch color={CLASS_COLORS[c]} glow />
+                          <span>{ESO_CLASS_LABELS[c]}</span>
+                        </Stack>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="ult-role-label">Role</InputLabel>
+                  <Select
+                    labelId="ult-role-label"
+                    label="Role"
+                    value={state.role}
+                    onChange={(e) => calc.setRole(e.target.value as CombatRole)}
+                  >
+                    {ROLE_OPTIONS.map((r) => (
+                      <MenuItem key={r.value} value={r.value}>
+                        {r.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
+
+              <TextField
+                label="Fight duration"
+                type="number"
+                size="small"
+                value={state.fightDurationSeconds}
+                onChange={(e) => calc.setFightDuration(Number(e.target.value))}
+                slotProps={{
+                  htmlInput: { min: 1, step: 5 },
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          sec
+                        </Typography>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+
+              {/* Decisive */}
+              <Box>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={state.decisiveEnabled}
+                      onChange={(e) => calc.setDecisiveEnabled(e.target.checked)}
+                    />
+                  }
+                  label={
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      Decisive weapon trait
+                    </Typography>
+                  }
+                />
+                {state.decisiveEnabled && (
+                  <Stack
+                    spacing={1.5}
+                    sx={{
+                      mt: 1,
+                      p: 1.5,
+                      borderRadius: 2,
+                      borderLeft: `3px solid ${accent}`,
+                      background:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.05)'
+                          : 'rgba(40,145,200,0.04)',
                     }}
                   >
-                    <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
+                    <FormControl size="small" fullWidth>
+                      <InputLabel id="decisive-quality-label">Weapon quality</InputLabel>
+                      <Select
+                        labelId="decisive-quality-label"
+                        label="Weapon quality"
+                        value={state.decisiveQuality}
+                        onChange={(e) => calc.setDecisiveQuality(e.target.value as DecisiveQuality)}
+                        renderValue={(v) => (
+                          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                            <Swatch color={QUALITY_COLORS[v as DecisiveQuality]} square size={9} />
+                            <span>
+                              {QUALITY_OPTIONS.find((o) => o.value === v)?.label} —{' '}
+                              {(DECISIVE_PROC_CHANCE[v as DecisiveQuality] * 100).toFixed(1)}%
+                            </span>
+                          </Stack>
+                        )}
+                      >
+                        {QUALITY_OPTIONS.map((opt) => (
+                          <MenuItem key={opt.value} value={opt.value}>
+                            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                              <Swatch color={QUALITY_COLORS[opt.value]} square />
+                              <span>
+                                {opt.label} — {(DECISIVE_PROC_CHANCE[opt.value] * 100).toFixed(1)}%
+                              </span>
+                            </Stack>
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <Tooltip
+                      arrow
+                      title="A two-handed melee weapon (greatsword, battle axe, maul) provides twice the Decisive bonus — it rolls for the extra ultimate twice per gain instead of once."
                     >
-                      {fmt(expected.baseUltimate, 0)}
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
-                    >
-                      {fmt(expected.decisiveUltimate, 1)}
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      sx={{ fontWeight: 700, color: accentText }}
-                      data-testid="ult-grand-total"
-                    >
-                      {fmt(expected.totalUltimate, 1)}
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </Box>
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={state.decisiveTwoHanded}
+                            onChange={(e) => calc.setDecisiveTwoHanded(e.target.checked)}
+                          />
+                        }
+                        label={<Typography variant="body2">Two-handed (rolls twice)</Typography>}
+                      />
+                    </Tooltip>
+                  </Stack>
+                )}
+              </Box>
 
-            {distribution && (
-              <Box
-                className="u-fade-in"
-                sx={{
-                  mt: 2,
-                  p: 1.75,
-                  borderRadius: 2.5,
-                  background:
-                    theme.palette.mode === 'dark'
-                      ? 'rgba(148,163,184,0.05)'
-                      : 'rgba(15,23,42,0.02)',
-                  border: `1px solid ${theme.palette.divider}`,
-                }}
-              >
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                  Per-fight spread (Monte Carlo, {distribution.runs.toLocaleString()} runs) —
-                  Decisive is random, so a single fight varies around the mean:
+              <Divider textAlign="left" sx={{ '&::before': { width: '0%' }, mt: 0.5 }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: accentText,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.6,
+                  }}
+                >
+                  Ultimate sources
                 </Typography>
-                <Stack direction="row" spacing={3} sx={{ mt: 1.25, flexWrap: 'wrap', rowGap: 1.5 }}>
-                  <Box>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color: 'text.secondary',
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 10,
-                        display: 'block',
-                      }}
-                    >
-                      Mean (95% CI)
-                    </Typography>
-                    <Typography
-                      className="u-tabular"
-                      variant="body2"
-                      sx={{ fontWeight: 700, color: accentText }}
-                    >
-                      {fmt(distribution.meanTotal, 1)} ± {fmt(distribution.ci95HalfWidth, 2)}
-                    </Typography>
-                  </Box>
-                  <Box>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color: 'text.secondary',
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 10,
-                        display: 'block',
-                      }}
-                    >
-                      Range
-                    </Typography>
-                    <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
-                      {fmt(distribution.minTotal, 0)}–{fmt(distribution.maxTotal, 0)}
-                    </Typography>
-                  </Box>
-                  <Box>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color: 'text.secondary',
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.4,
-                        fontSize: 10,
-                        display: 'block',
-                      }}
-                    >
-                      Std dev
-                    </Typography>
-                    <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
-                      {fmt(distribution.stdDevTotal, 1)}
-                    </Typography>
-                  </Box>
-                </Stack>
+              </Divider>
 
-                {/* Min–mean–max range bar: the whole track spans the observed
-                    min→max, with the mean marked so the spread reads visually. */}
-                {distribution.maxTotal > distribution.minTotal && (
-                  <Box sx={{ mt: 1.75 }}>
+              {/* Source toggles, grouped by category */}
+              {grouped.map(([category, entries]) => (
+                <Box key={category}>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
                     <Box
                       aria-hidden
                       sx={{
-                        position: 'relative',
-                        height: 8,
-                        borderRadius: 4,
-                        background: `linear-gradient(90deg, ${alpha(accent, 0.18)}, ${alpha(
-                          accent,
-                          0.5,
-                        )})`,
-                        border: `1px solid ${alpha(theme.palette.divider, 0.8)}`,
+                        width: 5,
+                        height: 5,
+                        borderRadius: '50%',
+                        background: accent,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.6,
                       }}
                     >
-                      <Box
-                        sx={{
-                          position: 'absolute',
-                          top: -3,
-                          bottom: -3,
-                          left: `${Math.min(
-                            100,
-                            Math.max(
-                              0,
-                              ((distribution.meanTotal - distribution.minTotal) /
-                                (distribution.maxTotal - distribution.minTotal)) *
-                                100,
-                            ),
-                          )}%`,
-                          width: 2,
-                          transform: 'translateX(-1px)',
-                          background: theme.palette.mode === 'dark' ? '#fff' : accentText,
-                          borderRadius: 2,
-                          boxShadow: `0 0 6px ${accent}`,
-                        }}
-                      />
-                    </Box>
-                    <Stack
-                      direction="row"
-                      sx={{ justifyContent: 'space-between', mt: 0.5 }}
-                      className="u-tabular"
-                    >
-                      <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 10 }}>
-                        {fmt(distribution.minTotal, 0)}
-                      </Typography>
-                      <Typography
-                        variant="caption"
-                        sx={{ color: accentText, fontWeight: 700, fontSize: 10 }}
-                      >
-                        mean {fmt(distribution.meanTotal, 0)}
-                      </Typography>
-                      <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 10 }}>
-                        {fmt(distribution.maxTotal, 0)}
-                      </Typography>
-                    </Stack>
-                  </Box>
-                )}
-              </Box>
-            )}
+                      {SOURCE_CATEGORY_LABELS[category]}
+                    </Typography>
+                  </Stack>
+                  <Stack spacing={1}>
+                    {entries.map((s) => {
+                      const enabled = calc.isEnabled(s.id, s.defaultEnabled);
+                      return (
+                        <Box
+                          key={s.id}
+                          sx={{
+                            borderRadius: 2.5,
+                            px: 1.5,
+                            py: enabled ? 1.25 : 0.5,
+                            pl: 1.75,
+                            position: 'relative',
+                            overflow: 'hidden',
+                            transition:
+                              'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
+                            border: `1px solid ${
+                              enabled
+                                ? theme.palette.mode === 'dark'
+                                  ? 'rgba(56,189,248,0.32)'
+                                  : 'rgba(40,145,200,0.28)'
+                                : theme.palette.divider
+                            }`,
+                            background: enabled
+                              ? theme.palette.mode === 'dark'
+                                ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
+                                : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
+                              : 'transparent',
+                            // Raised + glowing when active, flush when off.
+                            boxShadow: enabled
+                              ? theme.palette.mode === 'dark'
+                                ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
+                                : '0 2px 8px rgba(15,23,42,0.05)'
+                              : 'none',
+                            // Accent rail on the left edge marks an active source.
+                            '&::before': enabled
+                              ? {
+                                  content: '""',
+                                  position: 'absolute',
+                                  left: 0,
+                                  top: 0,
+                                  bottom: 0,
+                                  width: 3,
+                                  background: `linear-gradient(180deg, ${accent}, ${
+                                    theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.8)' : accent
+                                  })`,
+                                  boxShadow:
+                                    theme.palette.mode === 'dark'
+                                      ? '0 0 10px rgba(0,225,255,0.5)'
+                                      : 'none',
+                                }
+                              : undefined,
+                            '&:hover': {
+                              borderColor: enabled
+                                ? theme.palette.mode === 'dark'
+                                  ? 'rgba(56,189,248,0.5)'
+                                  : 'rgba(40,145,200,0.45)'
+                                : theme.palette.mode === 'dark'
+                                  ? 'rgba(148,163,184,0.4)'
+                                  : 'rgba(15,23,42,0.18)',
+                            },
+                          }}
+                        >
+                          <Stack
+                            direction="row"
+                            spacing={1}
+                            sx={{
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              minHeight: 44,
+                            }}
+                          >
+                            <FormControlLabel
+                              sx={{ mr: 0, flex: 1, minWidth: 0, gap: 0.75 }}
+                              control={
+                                <Switch
+                                  checked={enabled}
+                                  onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
+                                />
+                              }
+                              label={
+                                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                                  <Typography
+                                    variant="body2"
+                                    sx={{ fontWeight: enabled ? 600 : 500, lineHeight: 1.3 }}
+                                  >
+                                    {s.label}
+                                  </Typography>
+                                  {s.confidence !== 'high' && (
+                                    <Chip
+                                      label={s.confidence}
+                                      size="small"
+                                      sx={{
+                                        height: 17,
+                                        fontSize: 10,
+                                        textTransform: 'capitalize',
+                                      }}
+                                    />
+                                  )}
+                                </Stack>
+                              }
+                            />
+                            {s.provenance && (
+                              <Link
+                                href={s.provenance}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant="caption"
+                                sx={{ flexShrink: 0, fontWeight: 600 }}
+                              >
+                                source
+                              </Link>
+                            )}
+                          </Stack>
+                          {enabled && (
+                            <Box
+                              sx={{
+                                mt: 0.75,
+                                pt: 1,
+                                borderTop: `1px solid ${alpha(theme.palette.divider, 0.7)}`,
+                              }}
+                            >
+                              <Stack
+                                direction="row"
+                                sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+                              >
+                                <Typography
+                                  variant="caption"
+                                  sx={{
+                                    color: 'text.secondary',
+                                    textTransform: 'uppercase',
+                                    letterSpacing: 0.5,
+                                    fontSize: 10,
+                                    fontWeight: 700,
+                                  }}
+                                >
+                                  Uptime
+                                </Typography>
+                                <Typography
+                                  className="u-tabular"
+                                  variant="body2"
+                                  sx={{ color: accentText, fontWeight: 700 }}
+                                >
+                                  {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
+                                </Typography>
+                              </Stack>
+                              <Slider
+                                size="small"
+                                value={Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}
+                                onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
+                                min={0}
+                                max={100}
+                                aria-label={`${s.label} uptime`}
+                                sx={{ py: 0.5 }}
+                              />
+                              {s.description && (
+                                <Typography
+                                  variant="caption"
+                                  sx={{
+                                    color: 'text.secondary',
+                                    display: 'block',
+                                    mt: -0.25,
+                                    lineHeight: 1.45,
+                                  }}
+                                >
+                                  {s.description}
+                                </Typography>
+                              )}
+                              {/* Pillager's per-cast amount scales with the cost of the
+                                ULTIMATE OF WHOEVER WEARS THE SET (usually your healer) —
+                                a different player's ult, NOT your own. You receive 10% of
+                                their ult's cost. Deliberately decoupled from the main
+                                "Which ultimate?" cost above to avoid implying it tracks
+                                your own ultimate. */}
+                              {s.id === 'pillagers-profit-external' && (
+                                <Stack spacing={0.5} sx={{ mt: 1 }}>
+                                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                                    <TextField
+                                      label="Wearer's ult cost"
+                                      type="number"
+                                      size="small"
+                                      value={state.pillagerHealerUltCost}
+                                      onChange={(e) =>
+                                        calc.setPillagerHealerUltCost(Number(e.target.value))
+                                      }
+                                      slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
+                                      sx={{ width: 160 }}
+                                    />
+                                    <Tooltip
+                                      arrow
+                                      title="The cost of the ULTIMATE CAST BY THE PILLAGER'S WEARER — usually your healer, not you. You receive 10% of their ult's cost (once per 45s). This is separate from the 'Which ultimate?' cost above, which is your own ult."
+                                    >
+                                      <InfoOutlined
+                                        role="img"
+                                        aria-label="About the wearer's ult cost: the cost of the ultimate cast by the Pillager's wearer (usually your healer), not your own. You receive 10% of it, once per 45 seconds."
+                                        tabIndex={0}
+                                        sx={{
+                                          fontSize: 16,
+                                          color: 'text.secondary',
+                                          cursor: 'help',
+                                          borderRadius: '50%',
+                                          '&:focus-visible': {
+                                            outline: `2px solid ${accent}`,
+                                            outlineOffset: 2,
+                                          },
+                                        }}
+                                      />
+                                    </Tooltip>
+                                    <Typography
+                                      variant="caption"
+                                      className="u-tabular"
+                                      sx={{ color: 'text.secondary' }}
+                                    >
+                                      → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
+                                    </Typography>
+                                  </Stack>
+                                  <Typography
+                                    variant="caption"
+                                    sx={{ color: 'text.secondary', display: 'block' }}
+                                  >
+                                    Whoever wears Pillager&apos;s (usually your healer) — not your
+                                    own ultimate.
+                                  </Typography>
+                                </Stack>
+                              )}
+                            </Box>
+                          )}
+                        </Box>
+                      );
+                    })}
+                  </Stack>
+                </Box>
+              ))}
+
+              <Button
+                onClick={calc.reset}
+                size="small"
+                variant="text"
+                startIcon={<RestartAltOutlined sx={{ fontSize: 16 }} />}
+                sx={{ alignSelf: 'flex-start', color: 'text.secondary', mt: 0.5 }}
+              >
+                Reset to defaults
+              </Button>
+            </Stack>
           </Paper>
 
-          {/* Verify against your own ESO Logs report */}
-          <LogCalibrationPanel modeledPerSecond={expected.ultimatePerSecond} />
-        </Stack>
+          {/* ============================ RESULTS ============================ */}
+          <Stack spacing={2.5} sx={{ flex: '1 1 480px', minWidth: 0 }}>
+            {/* Ultimate picker / cost */}
+            <Paper elevation={0} sx={panelSx(theme)}>
+              <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />
+              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
+                <FormControl size="small" sx={{ flex: '1 1 100%' }}>
+                  <InputLabel id="ult-ability-label">Ultimate</InputLabel>
+                  <Select
+                    labelId="ult-ability-label"
+                    label="Ultimate"
+                    value={state.customUltimateCost != null ? 'custom' : state.ultimateAbilityId}
+                    renderValue={renderSelectedUltimate}
+                    MenuProps={{ slotProps: { paper: { sx: { maxHeight: 420 } } } }}
+                    onChange={(e) => {
+                      // Seed custom cost with the current EFFECTIVE cost (after any
+                      // reductions), since a custom cost is treated as already
+                      // effective — seeding with the unreduced base would make the
+                      // number jump the moment you switch to Custom.
+                      if (e.target.value === 'custom') calc.setCustomUltimateCost(effectiveCost);
+                      else calc.setUltimateAbility(e.target.value);
+                    }}
+                  >
+                    {/* Grouped by owner. Children are emitted as ONE flat array
+                      (ListSubheader + MenuItems per group) — wrapping a group in
+                      a Fragment/Box would break MUI Select's direct-child value
+                      scan and blank the closed control. */}
+                    {ultimateGroups.flatMap((g) => [
+                      <ListSubheader
+                        key={`sub-${g.key}`}
+                        disableSticky
+                        sx={{
+                          lineHeight: 2.2,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          letterSpacing: 0.5,
+                          textTransform: 'uppercase',
+                          color: 'text.secondary',
+                          background: 'transparent',
+                        }}
+                      >
+                        {g.label}
+                      </ListSubheader>,
+                      ...g.items.map((a) => (
+                        <MenuItem
+                          key={a.id}
+                          value={a.id}
+                          // Fold the approximate-cost note into the item's accessible
+                          // name rather than a hover Tooltip — focus inside a Select
+                          // menu doesn't reliably surface tooltips for keyboard/SR users.
+                          aria-label={
+                            a.confidence !== 'high'
+                              ? `${a.label}, ${a.baseCost} ultimate (cost approximate — not fully confirmed for Update 50)`
+                              : `${a.label}, ${a.baseCost} ultimate`
+                          }
+                        >
+                          <Stack
+                            direction="row"
+                            spacing={1}
+                            sx={{ alignItems: 'center', width: '100%' }}
+                          >
+                            <Swatch color={ownerColor(a.owner, accent)} size={8} />
+                            <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                              {a.label}
+                            </Typography>
+                            <Typography
+                              aria-hidden
+                              variant="caption"
+                              className="u-tabular"
+                              sx={{ color: 'text.secondary', fontWeight: 600 }}
+                            >
+                              {a.baseCost}
+                              {a.confidence !== 'high' ? (
+                                <Box component="span" sx={{ color: accentText, ml: 0.25 }}>
+                                  *
+                                </Box>
+                              ) : null}
+                            </Typography>
+                          </Stack>
+                        </MenuItem>
+                      )),
+                    ])}
+                    <MenuItem value="custom">
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                        <Swatch color={theme.palette.text.disabled} size={8} />
+                        <span>Custom cost…</span>
+                      </Stack>
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+                {state.customUltimateCost != null && (
+                  <TextField
+                    label="Custom cost"
+                    type="number"
+                    size="small"
+                    value={state.customUltimateCost}
+                    onChange={(e) => calc.setCustomUltimateCost(Number(e.target.value))}
+                    slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
+                    sx={{ width: 140 }}
+                  />
+                )}
+                <TextField
+                  label="Starting ultimate"
+                  type="number"
+                  size="small"
+                  value={state.startingUltimate}
+                  onChange={(e) => calc.setStartingUltimate(Number(e.target.value))}
+                  slotProps={{
+                    htmlInput: { min: 0, max: 500, step: 5 },
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                            ult
+                          </Typography>
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                  sx={{ width: 190 }}
+                  helperText="Banked at start"
+                />
+              </Stack>
+              {state.customUltimateCost == null && (
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'text.secondary', display: 'block', mt: 1 }}
+                >
+                  <Box component="span" sx={{ color: accentText, fontWeight: 700 }}>
+                    *
+                  </Box>{' '}
+                  marks a cost not fully confirmed for Update 50 — treat it as approximate.
+                </Typography>
+              )}
+              {/* Cost-reduction toggles — only meaningful for a catalog ability; a
+                custom cost is taken as already-effective so reductions don't apply. */}
+              {state.customUltimateCost == null && availableReductionEntries.length > 0 && (
+                <Stack spacing={0.5} sx={{ mt: 2 }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: 'text.secondary',
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.5,
+                      fontWeight: 600,
+                    }}
+                  >
+                    Cost reductions
+                  </Typography>
+                  {availableReductionEntries.map((r) => (
+                    <FormControlLabel
+                      key={r.id}
+                      control={
+                        <Switch
+                          size="small"
+                          checked={calc.isEnabled(r.id, r.defaultEnabled)}
+                          onChange={(e) => calc.toggleSource(r.id, e.target.checked)}
+                        />
+                      }
+                      label={
+                        <Typography variant="body2">
+                          {r.label} (−{Math.round(r.fraction * 100)}%)
+                        </Typography>
+                      }
+                    />
+                  ))}
+                </Stack>
+              )}
+              {state.customUltimateCost == null && reductionFraction > 0 && (
+                <Box
+                  sx={{
+                    mt: 1.5,
+                    px: 1.5,
+                    py: 1,
+                    borderRadius: 2,
+                    background:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(34,197,94,0.08)'
+                        : 'rgba(5,150,105,0.06)',
+                    border: `1px solid ${
+                      theme.palette.mode === 'dark' ? 'rgba(34,197,94,0.25)' : 'rgba(5,150,105,0.2)'
+                    }`,
+                  }}
+                >
+                  <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
+                    Cost reduced{' '}
+                    <Box
+                      component="span"
+                      sx={{ color: theme.palette.success.main, fontWeight: 700 }}
+                    >
+                      {Math.round(reductionFraction * 100)}%
+                    </Box>{' '}
+                    <Box component="span" className="u-tabular">
+                      ({baseCost} → {effectiveCost})
+                    </Box>{' '}
+                    by{' '}
+                    {appliedReductions
+                      .filter((r) => r.enabled)
+                      .map((r) => r.label)
+                      .join(', ')}
+                    .
+                  </Typography>
+                </Box>
+              )}
+            </Paper>
+
+            {/* Per-source breakdown */}
+            <Paper elevation={0} sx={panelSx(theme)}>
+              <SectionHeader
+                icon={<InsightsOutlined />}
+                title="Where it comes from"
+                accent={accent}
+                action={
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<QueryStatsOutlined sx={{ fontSize: 16 }} />}
+                    onClick={calc.computeDistribution}
+                    sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                  >
+                    {distribution ? 'Recompute spread' : 'Show spread'}
+                  </Button>
+                }
+              />
+              <Box
+                sx={{
+                  overflowX: 'auto',
+                  // Rounded glass container that clips the table's square corners.
+                  borderRadius: '12px',
+                  overflowY: 'hidden',
+                  border: `1px solid ${
+                    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.14)' : theme.palette.divider
+                  }`,
+                }}
+              >
+                <Table
+                  size="small"
+                  aria-label="per-source ultimate breakdown"
+                  sx={{
+                    '& td, & th': { borderColor: theme.palette.divider },
+                    // Drop the bottom border on the final row so it doesn't draw a
+                    // line against the rounded container's clipped bottom edge.
+                    '& tbody tr:last-of-type td': { borderBottom: 'none' },
+                    '& .MuiTableCell-root': { fontVariantNumeric: 'tabular-nums' },
+                    '& tbody tr:nth-of-type(odd) td': {
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(148,163,184,0.03)'
+                          : 'rgba(15,23,42,0.015)',
+                    },
+                    '& tbody tr:hover td': {
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.06)'
+                          : 'rgba(40,145,200,0.05)',
+                    },
+                  }}
+                >
+                  <TableHead>
+                    <TableRow>
+                      <TableCell
+                        sx={{
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: 'text.secondary',
+                        }}
+                      >
+                        Source
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: 'text.secondary',
+                          display: { xs: 'none', sm: 'table-cell' },
+                        }}
+                      >
+                        Base
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: 'text.secondary',
+                          display: { xs: 'none', sm: 'table-cell' },
+                        }}
+                      >
+                        Decisive
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: 'text.secondary',
+                        }}
+                      >
+                        Total
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {expected.contributions.map((c) => {
+                      const tot = c.baseUltimate + c.decisiveUltimate;
+                      // Presentation-only share of the grand total, shown as a
+                      // mini bar so the dominant source reads at a glance.
+                      const share = expected.totalUltimate > 0 ? tot / expected.totalUltimate : 0;
+                      return (
+                        <TableRow key={c.sourceId}>
+                          <TableCell sx={{ minWidth: 150 }}>
+                            <Typography variant="body2">{c.label}</Typography>
+                            <Stack
+                              direction="row"
+                              spacing={0.75}
+                              sx={{ alignItems: 'center', mt: 0.5 }}
+                            >
+                              <LinearProgress
+                                variant="determinate"
+                                value={Math.min(100, share * 100)}
+                                aria-hidden
+                                sx={{
+                                  flex: 1,
+                                  height: 5,
+                                  borderRadius: 3,
+                                  backgroundColor: alpha(theme.palette.divider, 0.5),
+                                  '& .MuiLinearProgress-bar': {
+                                    borderRadius: 3,
+                                    background: `linear-gradient(90deg, ${accent}, ${
+                                      theme.palette.mode === 'dark'
+                                        ? 'rgba(0,225,255,0.85)'
+                                        : accent
+                                    })`,
+                                  },
+                                }}
+                              />
+                              <Typography
+                                variant="caption"
+                                className="u-tabular"
+                                sx={{ minWidth: 32, textAlign: 'right', color: 'text.secondary' }}
+                              >
+                                {Math.round(share * 100)}%
+                              </Typography>
+                            </Stack>
+                          </TableCell>
+                          <TableCell
+                            align="right"
+                            sx={{ display: { xs: 'none', sm: 'table-cell' } }}
+                          >
+                            {fmt(c.baseUltimate, 0)}
+                          </TableCell>
+                          <TableCell
+                            align="right"
+                            sx={{ display: { xs: 'none', sm: 'table-cell' } }}
+                          >
+                            {fmt(c.decisiveUltimate, 1)}
+                          </TableCell>
+                          <TableCell align="right">{fmt(tot, 1)}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                    <TableRow
+                      sx={{
+                        '& td': {
+                          borderTop: `2px solid ${accent}55`,
+                          background:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(56,189,248,0.08) !important'
+                              : 'rgba(40,145,200,0.06) !important',
+                        },
+                      }}
+                    >
+                      <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
+                      >
+                        {fmt(expected.baseUltimate, 0)}
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{ fontWeight: 700, display: { xs: 'none', sm: 'table-cell' } }}
+                      >
+                        {fmt(expected.decisiveUltimate, 1)}
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{ fontWeight: 700, color: accentText }}
+                        data-testid="ult-grand-total"
+                      >
+                        {fmt(expected.totalUltimate, 1)}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Box>
+
+              {distribution && (
+                <Box
+                  className="u-fade-in"
+                  sx={{
+                    mt: 2,
+                    p: 1.75,
+                    borderRadius: 2.5,
+                    background:
+                      theme.palette.mode === 'dark'
+                        ? 'rgba(148,163,184,0.05)'
+                        : 'rgba(15,23,42,0.02)',
+                    border: `1px solid ${theme.palette.divider}`,
+                  }}
+                >
+                  <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                    Per-fight spread (Monte Carlo, {distribution.runs.toLocaleString()} runs) —
+                    Decisive is random, so a single fight varies around the mean:
+                  </Typography>
+                  <Stack
+                    direction="row"
+                    spacing={3}
+                    sx={{ mt: 1.25, flexWrap: 'wrap', rowGap: 1.5 }}
+                  >
+                    <Box>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 10,
+                          display: 'block',
+                        }}
+                      >
+                        Mean (95% CI)
+                      </Typography>
+                      <Typography
+                        className="u-tabular"
+                        variant="body2"
+                        sx={{ fontWeight: 700, color: accentText }}
+                      >
+                        {fmt(distribution.meanTotal, 1)} ± {fmt(distribution.ci95HalfWidth, 2)}
+                      </Typography>
+                    </Box>
+                    <Box>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 10,
+                          display: 'block',
+                        }}
+                      >
+                        Range
+                      </Typography>
+                      <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
+                        {fmt(distribution.minTotal, 0)}–{fmt(distribution.maxTotal, 0)}
+                      </Typography>
+                    </Box>
+                    <Box>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 10,
+                          display: 'block',
+                        }}
+                      >
+                        Std dev
+                      </Typography>
+                      <Typography className="u-tabular" variant="body2" sx={{ fontWeight: 600 }}>
+                        {fmt(distribution.stdDevTotal, 1)}
+                      </Typography>
+                    </Box>
+                  </Stack>
+
+                  {/* Min–mean–max range bar: the whole track spans the observed
+                    min→max, with the mean marked so the spread reads visually. */}
+                  {distribution.maxTotal > distribution.minTotal && (
+                    <Box sx={{ mt: 1.75 }}>
+                      <Box
+                        aria-hidden
+                        sx={{
+                          position: 'relative',
+                          height: 8,
+                          borderRadius: 4,
+                          background: `linear-gradient(90deg, ${alpha(accent, 0.18)}, ${alpha(
+                            accent,
+                            0.5,
+                          )})`,
+                          border: `1px solid ${alpha(theme.palette.divider, 0.8)}`,
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            top: -3,
+                            bottom: -3,
+                            left: `${Math.min(
+                              100,
+                              Math.max(
+                                0,
+                                ((distribution.meanTotal - distribution.minTotal) /
+                                  (distribution.maxTotal - distribution.minTotal)) *
+                                  100,
+                              ),
+                            )}%`,
+                            width: 2,
+                            transform: 'translateX(-1px)',
+                            background: theme.palette.mode === 'dark' ? '#fff' : accentText,
+                            borderRadius: 2,
+                            boxShadow: `0 0 6px ${accent}`,
+                          }}
+                        />
+                      </Box>
+                      <Stack
+                        direction="row"
+                        sx={{ justifyContent: 'space-between', mt: 0.5 }}
+                        className="u-tabular"
+                      >
+                        <Typography
+                          variant="caption"
+                          sx={{ color: 'text.secondary', fontSize: 10 }}
+                        >
+                          {fmt(distribution.minTotal, 0)}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          sx={{ color: accentText, fontWeight: 700, fontSize: 10 }}
+                        >
+                          mean {fmt(distribution.meanTotal, 0)}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          sx={{ color: 'text.secondary', fontSize: 10 }}
+                        >
+                          {fmt(distribution.maxTotal, 0)}
+                        </Typography>
+                      </Stack>
+                    </Box>
+                  )}
+                </Box>
+              )}
+            </Paper>
+
+            {/* Verify against your own ESO Logs report */}
+            <LogCalibrationPanel modeledPerSecond={expected.ultimatePerSecond} />
+          </Stack>
+        </Box>
       </Box>
-    </Box>
+    </ThemeProvider>
   );
 };

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -210,22 +210,24 @@ const fmtSeconds = (n: number): string => {
 };
 
 /**
- * Shared surface style for the redesigned panels — opts into the app's
- * signature glass-gradient card look (the same gradient MuiPaper uses) instead
- * of the flat `variant="outlined"` surface, so the Ultimate tab reads as a
- * sibling of the rest of the toolkit rather than a bare MUI form.
+ * Shared surface style for the redesigned panels. Dark mode leans into a
+ * layered, cyan-tinted depth system: panels are a recessed mid-layer (deeper
+ * gradient, faint cyan border, a glossy top inset highlight, and a soft drop
+ * shadow) so the raised cards inside them read as sitting above the surface.
  */
 const panelSx = (theme: Theme): SxProps<Theme> => ({
   p: { xs: 2, sm: 2.5 },
   borderRadius: 3.5,
-  border: `1px solid ${theme.palette.divider}`,
+  border: `1px solid ${
+    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
+  }`,
   background:
     theme.palette.mode === 'dark'
-      ? 'linear-gradient(180deg, rgba(15,23,42,0.66) 0%, rgba(3,7,18,0.66) 100%)'
+      ? 'linear-gradient(180deg, rgba(14,22,42,0.74) 0%, rgba(3,9,20,0.82) 100%)'
       : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
   boxShadow:
     theme.palette.mode === 'dark'
-      ? '0 8px 30px rgba(0, 0, 0, 0.25)'
+      ? '0 14px 36px rgba(0,0,0,0.44), inset 0 1px 0 rgba(255,255,255,0.05)'
       : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
 });
 
@@ -287,17 +289,27 @@ const StatBlock: React.FC<{
         borderRadius: 2.5,
         position: 'relative',
         height: '100%',
+        // Raised card: a cyan-tinted gradient that lifts off the recessed panel,
+        // with a glossy top inset highlight and a soft drop shadow for depth.
         background:
-          theme.palette.mode === 'dark' ? 'rgba(148,163,184,0.05)' : 'rgba(255,255,255,0.5)',
-        border: `1px solid ${theme.palette.divider}`,
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(180deg, rgba(56,189,248,0.09) 0%, rgba(56,189,248,0.02) 100%)'
+            : 'rgba(255,255,255,0.6)',
+        border: `1px solid ${
+          theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.16)' : theme.palette.divider
+        }`,
+        boxShadow:
+          theme.palette.mode === 'dark'
+            ? 'inset 0 1px 0 rgba(255,255,255,0.07), 0 6px 16px rgba(0,0,0,0.34)'
+            : '0 2px 8px rgba(15,23,42,0.05)',
         // Motion-safe hover: border + shadow only (no transform), so the tiles
         // feel responsive without violating prefers-reduced-motion.
         transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
         '&:hover': {
-          borderColor: `${tileAccent}55`,
+          borderColor: `${tileAccent}66`,
           boxShadow:
             theme.palette.mode === 'dark'
-              ? `0 6px 22px rgba(0,0,0,0.28), 0 0 0 1px ${tileAccent}22`
+              ? `inset 0 1px 0 rgba(255,255,255,0.09), 0 8px 24px rgba(0,0,0,0.4), 0 0 18px ${tileAccent}1f`
               : '0 6px 18px rgba(15,23,42,0.08)',
         },
       }}
@@ -520,28 +532,45 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           borderRadius: 4,
           position: 'relative',
           overflow: 'hidden',
-          border: `1px solid ${theme.palette.divider}`,
+          border: `1px solid ${
+            theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.18)' : theme.palette.divider
+          }`,
           background:
             theme.palette.mode === 'dark'
-              ? 'linear-gradient(135deg, rgba(56,189,248,0.10) 0%, rgba(15,23,42,0.55) 55%, rgba(3,7,18,0.6) 100%)'
+              ? 'linear-gradient(135deg, rgba(56,189,248,0.16) 0%, rgba(13,22,42,0.6) 50%, rgba(3,8,18,0.72) 100%)'
               : 'linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(248,250,252,0.85) 60%, rgba(255,255,255,0.95) 100%)',
           boxShadow:
             theme.palette.mode === 'dark'
-              ? '0 10px 40px rgba(0,0,0,0.3), 0 0 60px rgba(56,189,248,0.06)'
+              ? '0 18px 50px rgba(0,0,0,0.46), 0 0 80px rgba(56,189,248,0.10), inset 0 1px 0 rgba(255,255,255,0.06)'
               : '0 6px 20px rgba(15,23,42,0.07)',
-          // Soft accent glow bleeding from the top-left, behind the stats.
+          // Two soft cyan glows (top-left + bottom-right) bleeding behind the
+          // stats to give the panel atmospheric depth.
           '&::before': {
             content: '""',
             position: 'absolute',
-            top: -80,
-            left: -60,
-            width: 260,
-            height: 260,
+            top: -90,
+            left: -70,
+            width: 300,
+            height: 300,
             borderRadius: '50%',
             background:
               theme.palette.mode === 'dark'
-                ? 'radial-gradient(circle, rgba(56,189,248,0.18), transparent 70%)'
+                ? 'radial-gradient(circle, rgba(0,225,255,0.22), transparent 70%)'
                 : 'radial-gradient(circle, rgba(56,189,248,0.16), transparent 70%)',
+            pointerEvents: 'none',
+          },
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            bottom: -120,
+            right: -80,
+            width: 320,
+            height: 320,
+            borderRadius: '50%',
+            background:
+              theme.palette.mode === 'dark'
+                ? 'radial-gradient(circle, rgba(56,189,248,0.12), transparent 70%)'
+                : 'radial-gradient(circle, rgba(56,189,248,0.08), transparent 70%)',
             pointerEvents: 'none',
           },
         }}
@@ -549,6 +578,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
         <Box
           sx={{
             position: 'relative',
+            zIndex: 1,
             display: 'flex',
             flexDirection: { xs: 'column', md: 'row' },
             gap: { xs: 2, md: 3 },
@@ -1069,9 +1099,15 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                           }`,
                           background: enabled
                             ? theme.palette.mode === 'dark'
-                              ? 'linear-gradient(135deg, rgba(56,189,248,0.10) 0%, rgba(56,189,248,0.02) 100%)'
+                              ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
                               : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
                             : 'transparent',
+                          // Raised + glowing when active, flush when off.
+                          boxShadow: enabled
+                            ? theme.palette.mode === 'dark'
+                              ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
+                              : '0 2px 8px rgba(15,23,42,0.05)'
+                            : 'none',
                           // Accent rail on the left edge marks an active source.
                           '&::before': enabled
                             ? {
@@ -1082,8 +1118,12 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                 bottom: 0,
                                 width: 3,
                                 background: `linear-gradient(180deg, ${accent}, ${
-                                  theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.7)' : accent
+                                  theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.8)' : accent
                                 })`,
+                                boxShadow:
+                                  theme.palette.mode === 'dark'
+                                    ? '0 0 10px rgba(0,225,255,0.5)'
+                                    : 'none',
                               }
                             : undefined,
                           '&:hover': {

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -177,7 +177,7 @@ const fmtSeconds = (n: number): string => {
  */
 const panelSx = (theme: Theme): SxProps<Theme> => ({
   p: { xs: 2, sm: 2.5 },
-  borderRadius: 2, // 20px — top-level panel tier (radius scale: panel 20 / card 14 / control 10)
+  borderRadius: 2.8, // 28px — top-level panel tier (rounded; scale: panel 28 / card 14 / control 10)
   border: `1px solid ${
     theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
   }`,
@@ -375,10 +375,15 @@ const buildCalcTheme = (base: Theme): Theme => {
     ? `linear-gradient(90deg, ${cyan}, ${cyanBright})`
     : `linear-gradient(90deg, ${cyan}, rgb(56,189,248))`;
   // Translucent glass fill for inputs.
-  const inputFill = dark ? 'rgba(56,189,248,0.05)' : 'rgba(56,189,248,0.04)';
-  const inputFillHover = dark ? 'rgba(56,189,248,0.09)' : 'rgba(56,189,248,0.06)';
-  const inputBorder = dark ? 'rgba(56,189,248,0.18)' : 'rgba(40,145,200,0.28)';
-  const inputBorderHover = dark ? 'rgba(56,189,248,0.55)' : 'rgba(40,145,200,0.6)';
+  // Inputs read as recessed wells (darker than the panel + an inset shadow) so
+  // they're clearly distinct rather than blending into the surface.
+  const inputFill = dark ? 'rgba(3,8,20,0.66)' : 'rgba(255,255,255,0.92)';
+  const inputFillHover = dark ? 'rgba(3,8,20,0.82)' : 'rgba(255,255,255,1)';
+  const inputBorder = dark ? 'rgba(56,189,248,0.32)' : 'rgba(40,145,200,0.34)';
+  const inputBorderHover = dark ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.65)';
+  const inputInset = dark
+    ? 'inset 0 2px 5px rgba(0,0,0,0.5)'
+    : 'inset 0 1px 2px rgba(15,23,42,0.08)';
   const railColor = dark ? 'rgba(148,163,184,0.28)' : 'rgba(15,23,42,0.16)';
 
   return createTheme(base, {
@@ -428,6 +433,7 @@ const buildCalcTheme = (base: Theme): Theme => {
           root: {
             borderRadius: 10,
             backgroundColor: inputFill,
+            boxShadow: inputInset,
             transition: 'background-color 0.2s ease, box-shadow 0.2s ease',
             '& .MuiOutlinedInput-notchedOutline': {
               borderColor: inputBorder,
@@ -444,7 +450,7 @@ const buildCalcTheme = (base: Theme): Theme => {
               borderWidth: 1,
             },
             '&.Mui-focused': {
-              boxShadow: focusRing,
+              boxShadow: `${inputInset}, ${focusRing}`,
             },
           },
         },
@@ -724,7 +730,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           sx={{
             p: { xs: 2, sm: 2.75 },
             mb: 2.5,
-            borderRadius: 2, // 20px — panel tier (was 40, matched nothing else)
+            borderRadius: 2.8, // 28px — panel tier (unified with result panels)
             position: 'relative',
             overflow: 'hidden',
             border: `1px solid ${
@@ -1112,10 +1118,19 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       mt: 1,
                       p: 1.5,
                       borderRadius: 1.4, // 14px — card tier
-                      borderLeft: `3px solid ${accent}`,
+                      // Full border (was a left rail that read like a slider).
+                      border: `1px solid ${
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.28)'
+                          : 'rgba(40,145,200,0.3)'
+                      }`,
+                      boxShadow:
+                        theme.palette.mode === 'dark'
+                          ? 'inset 0 1px 0 rgba(255,255,255,0.05), 0 4px 14px rgba(0,0,0,0.3)'
+                          : '0 2px 8px rgba(15,23,42,0.05)',
                       background:
                         theme.palette.mode === 'dark'
-                          ? 'rgba(56,189,248,0.05)'
+                          ? 'linear-gradient(135deg, rgba(56,189,248,0.08), rgba(56,189,248,0.02))'
                           : 'rgba(40,145,200,0.04)',
                     }}
                   >
@@ -1287,44 +1302,31 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                 overflow: 'hidden',
                                 transition:
                                   'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
+                                // Enabled = a full cyan border + tint + glow (no
+                                // left rail — it read like a vertical slider next
+                                // to the real uptime slider). Disabled cards sit
+                                // recessed/flush so active ones clearly stand out.
                                 border: `1px solid ${
                                   enabled
                                     ? theme.palette.mode === 'dark'
-                                      ? 'rgba(56,189,248,0.32)'
-                                      : 'rgba(40,145,200,0.28)'
+                                      ? 'rgba(56,189,248,0.5)'
+                                      : 'rgba(40,145,200,0.45)'
                                     : theme.palette.divider
                                 }`,
                                 background: enabled
                                   ? theme.palette.mode === 'dark'
-                                    ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
-                                    : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
-                                  : 'transparent',
-                                // Raised + glowing when active, flush when off.
+                                    ? 'linear-gradient(135deg, rgba(56,189,248,0.15) 0%, rgba(56,189,248,0.04) 100%)'
+                                    : 'linear-gradient(135deg, rgba(40,145,200,0.08) 0%, rgba(40,145,200,0.02) 100%)'
+                                  : theme.palette.mode === 'dark'
+                                    ? 'rgba(2,6,16,0.35)'
+                                    : 'rgba(15,23,42,0.015)',
                                 boxShadow: enabled
                                   ? theme.palette.mode === 'dark'
-                                    ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
-                                    : '0 2px 8px rgba(15,23,42,0.05)'
-                                  : 'none',
-                                // Accent rail on the left edge marks an active source.
-                                '&::before': enabled
-                                  ? {
-                                      content: '""',
-                                      position: 'absolute',
-                                      left: 0,
-                                      top: 0,
-                                      bottom: 0,
-                                      width: 3,
-                                      background: `linear-gradient(180deg, ${accent}, ${
-                                        theme.palette.mode === 'dark'
-                                          ? 'rgba(0,225,255,0.8)'
-                                          : accent
-                                      })`,
-                                      boxShadow:
-                                        theme.palette.mode === 'dark'
-                                          ? '0 0 10px rgba(0,225,255,0.5)'
-                                          : 'none',
-                                    }
-                                  : undefined,
+                                    ? 'inset 0 1px 0 rgba(255,255,255,0.07), 0 6px 18px rgba(0,0,0,0.35), 0 0 18px rgba(56,189,248,0.12)'
+                                    : '0 4px 12px rgba(15,23,42,0.07)'
+                                  : theme.palette.mode === 'dark'
+                                    ? 'inset 0 1px 2px rgba(0,0,0,0.3)'
+                                    : 'none',
                                 '&:hover': {
                                   borderColor: enabled
                                     ? theme.palette.mode === 'dark'

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -177,7 +177,7 @@ const fmtSeconds = (n: number): string => {
  */
 const panelSx = (theme: Theme): SxProps<Theme> => ({
   p: { xs: 2, sm: 2.5 },
-  borderRadius: 3.5,
+  borderRadius: 2, // 20px — top-level panel tier (radius scale: panel 20 / card 14 / control 10)
   border: `1px solid ${
     theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
   }`,
@@ -246,7 +246,7 @@ const StatBlock: React.FC<{
         minWidth: 0,
         px: { xs: 1.25, sm: 1.75 },
         py: { xs: 1.25, sm: 1.5 },
-        borderRadius: 2.5,
+        borderRadius: 1.4, // 14px — card tier (nested inside 20px panels)
         position: 'relative',
         height: '100%',
         // Raised card: a cyan-tinted gradient that lifts off the recessed panel,
@@ -502,7 +502,7 @@ const buildCalcTheme = (base: Theme): Theme => {
       MuiMenuItem: {
         styleOverrides: {
           root: {
-            borderRadius: 9,
+            borderRadius: 10,
             marginLeft: 7,
             marginRight: 7,
             paddingTop: 9,
@@ -539,6 +539,13 @@ const buildCalcTheme = (base: Theme): Theme => {
               },
             },
           },
+        },
+      },
+      // Control tier: buttons share the inputs' 10px radius (global default is
+      // 8px, which read as inconsistent next to the 10px fields).
+      MuiButton: {
+        styleOverrides: {
+          root: { borderRadius: 10 },
         },
       },
     },
@@ -717,7 +724,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
           sx={{
             p: { xs: 2, sm: 2.75 },
             mb: 2.5,
-            borderRadius: 4,
+            borderRadius: 2, // 20px — panel tier (was 40, matched nothing else)
             position: 'relative',
             overflow: 'hidden',
             border: `1px solid ${
@@ -958,7 +965,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     mt: 0.75,
                     gap: 0.5,
                     p: 0.5,
-                    borderRadius: 2.5,
+                    borderRadius: 1.4, // 14px — card tier
                     border: `1px solid ${theme.palette.divider}`,
                     background:
                       theme.palette.mode === 'dark'
@@ -968,7 +975,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     // switcher: filled accent pill behind the active option.
                     '& .MuiToggleButtonGroup-grouped': {
                       border: 0,
-                      borderRadius: '8px !important',
+                      borderRadius: '10px !important', // control tier (was 8, matches fields now)
                       flexDirection: 'column',
                       gap: 0,
                       py: 0.85,
@@ -1104,7 +1111,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     sx={{
                       mt: 1,
                       p: 1.5,
-                      borderRadius: 2,
+                      borderRadius: 1.4, // 14px — card tier
                       borderLeft: `3px solid ${accent}`,
                       background:
                         theme.palette.mode === 'dark'
@@ -1272,7 +1279,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                             <Box
                               key={s.id}
                               sx={{
-                                borderRadius: 2.5,
+                                borderRadius: 1.4, // 14px — card tier
                                 px: 1.5,
                                 py: enabled ? 1.25 : 0.5,
                                 pl: 1.75,
@@ -1699,7 +1706,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     mt: 1.5,
                     px: 1.5,
                     py: 1,
-                    borderRadius: 2,
+                    borderRadius: 1.4, // 14px — card tier (cost-reduction note)
                     background:
                       theme.palette.mode === 'dark'
                         ? 'rgba(34,197,94,0.08)'
@@ -1937,7 +1944,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   sx={{
                     mt: 2,
                     p: 1.75,
-                    borderRadius: 2.5,
+                    borderRadius: 1.4, // 14px — card tier (Monte Carlo spread box)
                     background:
                       theme.palette.mode === 'dark'
                         ? 'rgba(148,163,184,0.05)'
@@ -2118,7 +2125,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                 gap: 1.25,
                 px: 1.75,
                 py: 1,
-                borderRadius: 3,
+                borderRadius: 1.4, // 14px — card tier
                 cursor: 'pointer',
                 border: `1px solid ${
                   theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.45)'

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -461,15 +461,18 @@ const buildCalcTheme = (base: Theme): Theme => {
             marginTop: 6,
             overflow: 'hidden',
             backgroundImage: 'none',
+            // Lighter, more transparent frosted glass so the popover floats
+            // clearly ABOVE the dark panels instead of merging with them; the
+            // heavy blur keeps items readable over whatever's behind.
             background: dark
-              ? 'linear-gradient(180deg, rgba(18,34,58,0.94) 0%, rgba(6,13,28,0.96) 100%)'
-              : 'linear-gradient(180deg, rgba(244,251,255,0.98) 0%, rgba(255,255,255,0.98) 100%)',
-            backdropFilter: 'blur(18px) saturate(1.4)',
-            WebkitBackdropFilter: 'blur(18px) saturate(1.4)',
-            border: `1px solid ${dark ? 'rgba(56,189,248,0.30)' : 'rgba(40,145,200,0.28)'}`,
+              ? 'linear-gradient(180deg, rgba(34,54,86,0.85) 0%, rgba(20,37,66,0.88) 100%)'
+              : 'linear-gradient(180deg, rgba(240,250,255,0.9) 0%, rgba(252,254,255,0.92) 100%)',
+            backdropFilter: 'blur(22px) saturate(1.6)',
+            WebkitBackdropFilter: 'blur(22px) saturate(1.6)',
+            border: `1px solid ${dark ? 'rgba(56,189,248,0.5)' : 'rgba(40,145,200,0.35)'}`,
             boxShadow: dark
-              ? '0 24px 60px rgba(0,0,0,0.62), 0 0 26px rgba(56,189,248,0.16), inset 0 1px 0 rgba(255,255,255,0.07)'
-              : '0 20px 48px rgba(15,23,42,0.18), 0 0 18px rgba(40,145,200,0.10), inset 0 1px 0 rgba(255,255,255,0.9)',
+              ? '0 24px 60px rgba(0,0,0,0.6), 0 0 36px rgba(56,189,248,0.28), inset 0 1px 0 rgba(255,255,255,0.1)'
+              : '0 20px 48px rgba(15,23,42,0.2), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9)',
             // A thin cyan sheen across the very top edge of the popover.
             '&::before': {
               content: '""',

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -1465,7 +1465,10 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                       valueLabelDisplay="auto"
                                       valueLabelFormat={(v) => `${v}%`}
                                       aria-label={`${s.label} uptime`}
-                                      sx={{ py: 0.5, display: 'block' }}
+                                      // Keep the theme's 10px touch-padding (don't
+                                      // override with py) so the 18px thumb + glow
+                                      // has room and never overlaps the text below.
+                                      sx={{ display: 'block' }}
                                     />
                                   </Box>
                                   {s.description && (
@@ -1474,7 +1477,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                       sx={{
                                         color: 'text.secondary',
                                         display: 'block',
-                                        mt: -0.25,
+                                        mt: 0.5,
                                         lineHeight: 1.45,
                                       }}
                                     >

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -460,19 +460,23 @@ const buildCalcTheme = (base: Theme): Theme => {
             borderRadius: 14,
             marginTop: 6,
             overflow: 'hidden',
-            backgroundImage: 'none',
-            // Near-opaque, distinctly lighter slate surface. (A transparent menu
-            // let the dark panels bleed through and read as the same color, so it
-            // "blended in" — opacity + a clearly lighter tone fixes that.)
-            background: dark
-              ? 'linear-gradient(180deg, rgba(46,66,102,0.985) 0%, rgba(32,50,82,0.985) 100%)'
-              : 'linear-gradient(180deg, rgba(248,252,255,0.99) 0%, rgba(255,255,255,0.99) 100%)',
             backdropFilter: 'blur(20px) saturate(1.5)',
             WebkitBackdropFilter: 'blur(20px) saturate(1.5)',
-            border: `1px solid ${dark ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.4)'}`,
             boxShadow: dark
               ? '0 24px 60px rgba(0,0,0,0.65), 0 0 36px rgba(56,189,248,0.3), inset 0 1px 0 rgba(255,255,255,0.12)'
               : '0 20px 48px rgba(15,23,42,0.22), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9)',
+            // The global theme forces `.MuiMenu-paper { background:#0f172a
+            // !important }`, which a normal scoped override can't beat — so the
+            // dropdown kept rendering the same dark navy and blending in. Win it
+            // locally with higher specificity (&&) + !important: a distinctly
+            // lighter, solid slate surface, scoped to this tab's menus only.
+            '&&': {
+              backgroundColor: `${dark ? 'rgb(45,64,99)' : 'rgb(250,253,255)'} !important`,
+              backgroundImage: 'none !important',
+              border: `1px solid ${
+                dark ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.4)'
+              } !important`,
+            },
             // A thin cyan sheen across the very top edge of the popover.
             '&::before': {
               content: '""',
@@ -485,6 +489,7 @@ const buildCalcTheme = (base: Theme): Theme => {
                 ? 'linear-gradient(90deg, transparent, rgba(0,225,255,0.7), transparent)'
                 : 'linear-gradient(90deg, transparent, rgba(40,145,200,0.6), transparent)',
               pointerEvents: 'none',
+              zIndex: 1,
             },
           },
           list: { paddingTop: 7, paddingBottom: 7 },

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -11,8 +11,10 @@
 
 import {
   BoltOutlined,
+  ExpandMore,
   InfoOutlined,
   InsightsOutlined,
+  KeyboardArrowUp,
   QueryStatsOutlined,
   RestartAltOutlined,
   TuneOutlined,
@@ -22,6 +24,7 @@ import {
   Box,
   Button,
   Chip,
+  Collapse,
   Divider,
   FormControl,
   FormControlLabel,
@@ -32,6 +35,7 @@ import {
   ListSubheader,
   MenuItem,
   Paper,
+  Portal,
   Select,
   Slider,
   Stack,
@@ -575,7 +579,47 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
 
   const reductionFraction = totalReductionFraction(appliedReductions);
 
-  // Order the ultimate picker so the current class's ults (and global/weapon
+  const prefersReducedMotion = React.useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+
+  // --- Mobile sticky results bar -------------------------------------------
+  // On phones the hero scrolls far out of view while editing the build below,
+  // so the headline number is invisible right when you're tweaking it. An
+  // IntersectionObserver on the hero toggles a slim fixed bar that keeps ult/s
+  // (and time-to-ult) live in view; tapping it jumps back to the results.
+  const heroRef = React.useRef<HTMLDivElement>(null);
+  const [showStickyResults, setShowStickyResults] = React.useState(false);
+  React.useEffect(() => {
+    const el = heroRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const obs = new IntersectionObserver(([entry]) => setShowStickyResults(!entry.isIntersecting), {
+      threshold: 0,
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+  const jumpToResults = React.useCallback(() => {
+    heroRef.current?.scrollIntoView({
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      block: 'start',
+    });
+  }, [prefersReducedMotion]);
+
+  // --- Collapsible source groups -------------------------------------------
+  // Each category defaults open when it has an enabled source and folded away
+  // when it's all-off, so the build form isn't one giant scroll; an explicit
+  // user toggle overrides the default.
+  const [groupOpen, setGroupOpen] = React.useState<Record<string, boolean>>({});
+  const toggleGroup = React.useCallback(
+    (key: string, currentlyOpen: boolean) => setGroupOpen((m) => ({ ...m, [key]: !currentlyOpen })),
+    [],
+  );
+
   // ones, usable by everyone) surface first; other classes' ults follow.
   const orderedUltimates = React.useMemo(() => {
     const rank = (owner: string): number => {
@@ -656,6 +700,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
 
         {/* ===================== HEADLINE (full width, results-first) ===================== */}
         <Paper
+          ref={heroRef}
           elevation={0}
           sx={{
             p: { xs: 2, sm: 2.75 },
@@ -1117,263 +1162,344 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               </Divider>
 
               {/* Source toggles, grouped by category */}
-              {grouped.map(([category, entries]) => (
-                <Box key={category}>
-                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-                    <Box
-                      aria-hidden
-                      sx={{
-                        width: 5,
-                        height: 5,
-                        borderRadius: '50%',
-                        background: accent,
-                        flexShrink: 0,
+              {grouped.map(([category, entries]) => {
+                const onCount = entries.reduce(
+                  (n, s) => n + (calc.isEnabled(s.id, s.defaultEnabled) ? 1 : 0),
+                  0,
+                );
+                // Default: open when something's enabled, folded when all-off;
+                // an explicit user toggle (groupOpen) wins.
+                const open = category in groupOpen ? groupOpen[category] : onCount > 0;
+                return (
+                  <Box key={category}>
+                    <Stack
+                      direction="row"
+                      spacing={0.75}
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={open}
+                      onClick={() => toggleGroup(category, open)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          toggleGroup(category, open);
+                        }
                       }}
-                    />
-                    <Typography
-                      variant="caption"
                       sx={{
-                        color: 'text.secondary',
-                        fontWeight: 700,
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.6,
+                        alignItems: 'center',
+                        mb: 0.75,
+                        py: 0.25,
+                        borderRadius: 1.5,
+                        cursor: 'pointer',
+                        userSelect: 'none',
+                        '&:hover .cat-label': { color: 'text.primary' },
+                        '&:focus-visible': { outline: `2px solid ${accent}`, outlineOffset: 2 },
                       }}
                     >
-                      {SOURCE_CATEGORY_LABELS[category]}
-                    </Typography>
-                  </Stack>
-                  <Stack spacing={1}>
-                    {entries.map((s) => {
-                      const enabled = calc.isEnabled(s.id, s.defaultEnabled);
-                      return (
+                      <Box
+                        aria-hidden
+                        sx={{
+                          width: 5,
+                          height: 5,
+                          borderRadius: '50%',
+                          background: accent,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <Typography
+                        className="cat-label"
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.6,
+                          transition: 'color 0.15s ease',
+                        }}
+                      >
+                        {SOURCE_CATEGORY_LABELS[category]}
+                      </Typography>
+                      {onCount > 0 && (
                         <Box
-                          key={s.id}
+                          component="span"
+                          aria-hidden
                           sx={{
-                            borderRadius: 2.5,
-                            px: 1.5,
-                            py: enabled ? 1.25 : 0.5,
-                            pl: 1.75,
-                            position: 'relative',
-                            overflow: 'hidden',
-                            transition:
-                              'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
-                            border: `1px solid ${
-                              enabled
-                                ? theme.palette.mode === 'dark'
-                                  ? 'rgba(56,189,248,0.32)'
-                                  : 'rgba(40,145,200,0.28)'
-                                : theme.palette.divider
-                            }`,
-                            background: enabled
-                              ? theme.palette.mode === 'dark'
-                                ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
-                                : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
-                              : 'transparent',
-                            // Raised + glowing when active, flush when off.
-                            boxShadow: enabled
-                              ? theme.palette.mode === 'dark'
-                                ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
-                                : '0 2px 8px rgba(15,23,42,0.05)'
-                              : 'none',
-                            // Accent rail on the left edge marks an active source.
-                            '&::before': enabled
-                              ? {
-                                  content: '""',
-                                  position: 'absolute',
-                                  left: 0,
-                                  top: 0,
-                                  bottom: 0,
-                                  width: 3,
-                                  background: `linear-gradient(180deg, ${accent}, ${
-                                    theme.palette.mode === 'dark' ? 'rgba(0,225,255,0.8)' : accent
-                                  })`,
-                                  boxShadow:
-                                    theme.palette.mode === 'dark'
-                                      ? '0 0 10px rgba(0,225,255,0.5)'
-                                      : 'none',
-                                }
-                              : undefined,
-                            '&:hover': {
-                              borderColor: enabled
-                                ? theme.palette.mode === 'dark'
-                                  ? 'rgba(56,189,248,0.5)'
-                                  : 'rgba(40,145,200,0.45)'
-                                : theme.palette.mode === 'dark'
-                                  ? 'rgba(148,163,184,0.4)'
-                                  : 'rgba(15,23,42,0.18)',
-                            },
+                            ml: 0.25,
+                            px: 0.6,
+                            borderRadius: 1,
+                            fontSize: 9.5,
+                            fontWeight: 700,
+                            lineHeight: 1.7,
+                            color: accentText,
+                            border: `1px solid ${accent}55`,
+                            background:
+                              theme.palette.mode === 'dark'
+                                ? 'rgba(56,189,248,0.10)'
+                                : 'rgba(40,145,200,0.08)',
                           }}
                         >
-                          <Stack
-                            direction="row"
-                            spacing={1}
-                            sx={{
-                              justifyContent: 'space-between',
-                              alignItems: 'center',
-                              minHeight: 44,
-                            }}
-                          >
-                            <FormControlLabel
-                              sx={{ mr: 0, flex: 1, minWidth: 0, gap: 0.75 }}
-                              control={
-                                <Switch
-                                  checked={enabled}
-                                  onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
-                                />
-                              }
-                              label={
-                                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                                  <Typography
-                                    variant="body2"
-                                    sx={{ fontWeight: enabled ? 600 : 500, lineHeight: 1.3 }}
-                                  >
-                                    {s.label}
-                                  </Typography>
-                                  {s.confidence !== 'high' && (
-                                    <Chip
-                                      label={s.confidence}
-                                      size="small"
-                                      sx={{
-                                        height: 17,
-                                        fontSize: 10,
-                                        textTransform: 'capitalize',
-                                      }}
-                                    />
-                                  )}
-                                </Stack>
-                              }
-                            />
-                            {s.provenance && (
-                              <Link
-                                href={s.provenance}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                variant="caption"
-                                sx={{ flexShrink: 0, fontWeight: 600 }}
-                              >
-                                source
-                              </Link>
-                            )}
-                          </Stack>
-                          {enabled && (
+                          {onCount} on
+                        </Box>
+                      )}
+                      <Box sx={{ flex: 1 }} />
+                      <ExpandMore
+                        aria-hidden
+                        sx={{
+                          fontSize: 18,
+                          color: 'text.secondary',
+                          transition: prefersReducedMotion ? 'none' : 'transform 0.2s ease',
+                          transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+                        }}
+                      />
+                    </Stack>
+                    <Collapse in={open} timeout={prefersReducedMotion ? 0 : 'auto'}>
+                      <Stack spacing={1}>
+                        {entries.map((s) => {
+                          const enabled = calc.isEnabled(s.id, s.defaultEnabled);
+                          return (
                             <Box
+                              key={s.id}
                               sx={{
-                                mt: 0.75,
-                                pt: 1,
-                                borderTop: `1px solid ${alpha(theme.palette.divider, 0.7)}`,
+                                borderRadius: 2.5,
+                                px: 1.5,
+                                py: enabled ? 1.25 : 0.5,
+                                pl: 1.75,
+                                position: 'relative',
+                                overflow: 'hidden',
+                                transition:
+                                  'background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
+                                border: `1px solid ${
+                                  enabled
+                                    ? theme.palette.mode === 'dark'
+                                      ? 'rgba(56,189,248,0.32)'
+                                      : 'rgba(40,145,200,0.28)'
+                                    : theme.palette.divider
+                                }`,
+                                background: enabled
+                                  ? theme.palette.mode === 'dark'
+                                    ? 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.03) 100%)'
+                                    : 'linear-gradient(135deg, rgba(40,145,200,0.07) 0%, rgba(40,145,200,0.01) 100%)'
+                                  : 'transparent',
+                                // Raised + glowing when active, flush when off.
+                                boxShadow: enabled
+                                  ? theme.palette.mode === 'dark'
+                                    ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 14px rgba(0,0,0,0.3), 0 0 16px rgba(56,189,248,0.07)'
+                                    : '0 2px 8px rgba(15,23,42,0.05)'
+                                  : 'none',
+                                // Accent rail on the left edge marks an active source.
+                                '&::before': enabled
+                                  ? {
+                                      content: '""',
+                                      position: 'absolute',
+                                      left: 0,
+                                      top: 0,
+                                      bottom: 0,
+                                      width: 3,
+                                      background: `linear-gradient(180deg, ${accent}, ${
+                                        theme.palette.mode === 'dark'
+                                          ? 'rgba(0,225,255,0.8)'
+                                          : accent
+                                      })`,
+                                      boxShadow:
+                                        theme.palette.mode === 'dark'
+                                          ? '0 0 10px rgba(0,225,255,0.5)'
+                                          : 'none',
+                                    }
+                                  : undefined,
+                                '&:hover': {
+                                  borderColor: enabled
+                                    ? theme.palette.mode === 'dark'
+                                      ? 'rgba(56,189,248,0.5)'
+                                      : 'rgba(40,145,200,0.45)'
+                                    : theme.palette.mode === 'dark'
+                                      ? 'rgba(148,163,184,0.4)'
+                                      : 'rgba(15,23,42,0.18)',
+                                },
                               }}
                             >
                               <Stack
                                 direction="row"
-                                sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+                                spacing={1}
+                                sx={{
+                                  justifyContent: 'space-between',
+                                  alignItems: 'center',
+                                  minHeight: 44,
+                                }}
                               >
-                                <Typography
-                                  variant="caption"
-                                  sx={{
-                                    color: 'text.secondary',
-                                    textTransform: 'uppercase',
-                                    letterSpacing: 0.5,
-                                    fontSize: 10,
-                                    fontWeight: 700,
-                                  }}
-                                >
-                                  Uptime
-                                </Typography>
-                                <Typography
-                                  className="u-tabular"
-                                  variant="body2"
-                                  sx={{ color: accentText, fontWeight: 700 }}
-                                >
-                                  {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
-                                </Typography>
+                                <FormControlLabel
+                                  sx={{ mr: 0, flex: 1, minWidth: 0, gap: 0.75 }}
+                                  control={
+                                    <Switch
+                                      checked={enabled}
+                                      onChange={(e) => calc.toggleSource(s.id, e.target.checked)}
+                                    />
+                                  }
+                                  label={
+                                    <Stack
+                                      direction="row"
+                                      spacing={0.75}
+                                      sx={{ alignItems: 'center' }}
+                                    >
+                                      <Typography
+                                        variant="body2"
+                                        sx={{ fontWeight: enabled ? 600 : 500, lineHeight: 1.3 }}
+                                      >
+                                        {s.label}
+                                      </Typography>
+                                      {s.confidence !== 'high' && (
+                                        <Chip
+                                          label={s.confidence}
+                                          size="small"
+                                          sx={{
+                                            height: 17,
+                                            fontSize: 10,
+                                            textTransform: 'capitalize',
+                                          }}
+                                        />
+                                      )}
+                                    </Stack>
+                                  }
+                                />
+                                {s.provenance && (
+                                  <Link
+                                    href={s.provenance}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    variant="caption"
+                                    sx={{ flexShrink: 0, fontWeight: 600 }}
+                                  >
+                                    source
+                                  </Link>
+                                )}
                               </Stack>
-                              <Slider
-                                size="small"
-                                value={Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}
-                                onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
-                                min={0}
-                                max={100}
-                                aria-label={`${s.label} uptime`}
-                                sx={{ py: 0.5 }}
-                              />
-                              {s.description && (
-                                <Typography
-                                  variant="caption"
+                              {enabled && (
+                                <Box
                                   sx={{
-                                    color: 'text.secondary',
-                                    display: 'block',
-                                    mt: -0.25,
-                                    lineHeight: 1.45,
+                                    mt: 0.75,
+                                    pt: 1,
+                                    borderTop: `1px solid ${alpha(theme.palette.divider, 0.7)}`,
                                   }}
                                 >
-                                  {s.description}
-                                </Typography>
-                              )}
-                              {/* Pillager's per-cast amount scales with the cost of the
+                                  <Stack
+                                    direction="row"
+                                    sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+                                  >
+                                    <Typography
+                                      variant="caption"
+                                      sx={{
+                                        color: 'text.secondary',
+                                        textTransform: 'uppercase',
+                                        letterSpacing: 0.5,
+                                        fontSize: 10,
+                                        fontWeight: 700,
+                                      }}
+                                    >
+                                      Uptime
+                                    </Typography>
+                                    <Typography
+                                      className="u-tabular"
+                                      variant="body2"
+                                      sx={{ color: accentText, fontWeight: 700 }}
+                                    >
+                                      {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
+                                    </Typography>
+                                  </Stack>
+                                  <Slider
+                                    size="small"
+                                    value={Math.round(
+                                      (state.uptimeOverrides[s.id] ?? s.uptime) * 100,
+                                    )}
+                                    onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
+                                    min={0}
+                                    max={100}
+                                    aria-label={`${s.label} uptime`}
+                                    sx={{ py: 0.5 }}
+                                  />
+                                  {s.description && (
+                                    <Typography
+                                      variant="caption"
+                                      sx={{
+                                        color: 'text.secondary',
+                                        display: 'block',
+                                        mt: -0.25,
+                                        lineHeight: 1.45,
+                                      }}
+                                    >
+                                      {s.description}
+                                    </Typography>
+                                  )}
+                                  {/* Pillager's per-cast amount scales with the cost of the
                                 ULTIMATE OF WHOEVER WEARS THE SET (usually your healer) —
                                 a different player's ult, NOT your own. You receive 10% of
                                 their ult's cost. Deliberately decoupled from the main
                                 "Which ultimate?" cost above to avoid implying it tracks
                                 your own ultimate. */}
-                              {s.id === 'pillagers-profit-external' && (
-                                <Stack spacing={0.5} sx={{ mt: 1 }}>
-                                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                                    <TextField
-                                      label="Wearer's ult cost"
-                                      type="number"
-                                      size="small"
-                                      value={state.pillagerHealerUltCost}
-                                      onChange={(e) =>
-                                        calc.setPillagerHealerUltCost(Number(e.target.value))
-                                      }
-                                      slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
-                                      sx={{ width: 160 }}
-                                    />
-                                    <Tooltip
-                                      arrow
-                                      title="The cost of the ULTIMATE CAST BY THE PILLAGER'S WEARER — usually your healer, not you. You receive 10% of their ult's cost (once per 45s). This is separate from the 'Which ultimate?' cost above, which is your own ult."
-                                    >
-                                      <InfoOutlined
-                                        role="img"
-                                        aria-label="About the wearer's ult cost: the cost of the ultimate cast by the Pillager's wearer (usually your healer), not your own. You receive 10% of it, once per 45 seconds."
-                                        tabIndex={0}
-                                        sx={{
-                                          fontSize: 16,
-                                          color: 'text.secondary',
-                                          cursor: 'help',
-                                          borderRadius: '50%',
-                                          '&:focus-visible': {
-                                            outline: `2px solid ${accent}`,
-                                            outlineOffset: 2,
-                                          },
-                                        }}
-                                      />
-                                    </Tooltip>
-                                    <Typography
-                                      variant="caption"
-                                      className="u-tabular"
-                                      sx={{ color: 'text.secondary' }}
-                                    >
-                                      → {Math.round(state.pillagerHealerUltCost * 0.1)} ult / cast
-                                    </Typography>
-                                  </Stack>
-                                  <Typography
-                                    variant="caption"
-                                    sx={{ color: 'text.secondary', display: 'block' }}
-                                  >
-                                    Whoever wears Pillager&apos;s (usually your healer) — not your
-                                    own ultimate.
-                                  </Typography>
-                                </Stack>
+                                  {s.id === 'pillagers-profit-external' && (
+                                    <Stack spacing={0.5} sx={{ mt: 1 }}>
+                                      <Stack
+                                        direction="row"
+                                        spacing={1}
+                                        sx={{ alignItems: 'center' }}
+                                      >
+                                        <TextField
+                                          label="Wearer's ult cost"
+                                          type="number"
+                                          size="small"
+                                          value={state.pillagerHealerUltCost}
+                                          onChange={(e) =>
+                                            calc.setPillagerHealerUltCost(Number(e.target.value))
+                                          }
+                                          slotProps={{ htmlInput: { min: 70, max: 500, step: 5 } }}
+                                          sx={{ width: 160 }}
+                                        />
+                                        <Tooltip
+                                          arrow
+                                          title="The cost of the ULTIMATE CAST BY THE PILLAGER'S WEARER — usually your healer, not you. You receive 10% of their ult's cost (once per 45s). This is separate from the 'Which ultimate?' cost above, which is your own ult."
+                                        >
+                                          <InfoOutlined
+                                            role="img"
+                                            aria-label="About the wearer's ult cost: the cost of the ultimate cast by the Pillager's wearer (usually your healer), not your own. You receive 10% of it, once per 45 seconds."
+                                            tabIndex={0}
+                                            sx={{
+                                              fontSize: 16,
+                                              color: 'text.secondary',
+                                              cursor: 'help',
+                                              borderRadius: '50%',
+                                              '&:focus-visible': {
+                                                outline: `2px solid ${accent}`,
+                                                outlineOffset: 2,
+                                              },
+                                            }}
+                                          />
+                                        </Tooltip>
+                                        <Typography
+                                          variant="caption"
+                                          className="u-tabular"
+                                          sx={{ color: 'text.secondary' }}
+                                        >
+                                          → {Math.round(state.pillagerHealerUltCost * 0.1)} ult /
+                                          cast
+                                        </Typography>
+                                      </Stack>
+                                      <Typography
+                                        variant="caption"
+                                        sx={{ color: 'text.secondary', display: 'block' }}
+                                      >
+                                        Whoever wears Pillager&apos;s (usually your healer) — not
+                                        your own ultimate.
+                                      </Typography>
+                                    </Stack>
+                                  )}
+                                </Box>
                               )}
                             </Box>
-                          )}
-                        </Box>
-                      );
-                    })}
-                  </Stack>
-                </Box>
-              ))}
+                          );
+                        })}
+                      </Stack>
+                    </Collapse>
+                  </Box>
+                );
+              })}
 
               <Button
                 onClick={calc.reset}
@@ -1946,6 +2072,100 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             <LogCalibrationPanel modeledPerSecond={expected.ultimatePerSecond} />
           </Stack>
         </Box>
+
+        {/* Mobile sticky results bar — keeps the headline live while you edit the
+            build below; tap to jump back to the results. Phones only (desktop
+            shows the results column alongside the inputs). Portalled to <body>
+            because the calculator root carries an (identity) transform from its
+            fade-in animation, which would otherwise be the fixed-positioning
+            containing block and pin the bar to the panel instead of the screen. */}
+        {showStickyResults && (
+          <Portal>
+            <Box
+              role="button"
+              tabIndex={0}
+              aria-label={`Live result ${fmt(expected.ultimatePerSecond, 2)} ultimate per second, first ultimate in ${fmtSeconds(
+                timeToUlt.secondsToFirstCast,
+              )}. Jump back to results.`}
+              onClick={jumpToResults}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  jumpToResults();
+                }
+              }}
+              className="u-fade-in-up"
+              sx={{
+                display: { xs: 'flex', md: 'none' },
+                position: 'fixed',
+                left: 10,
+                right: 10,
+                bottom: 10,
+                zIndex: (t) => t.zIndex.appBar + 2,
+                alignItems: 'center',
+                gap: 1.25,
+                px: 1.75,
+                py: 1,
+                borderRadius: 3,
+                cursor: 'pointer',
+                border: `1px solid ${
+                  theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.38)' : 'rgba(40,145,200,0.3)'
+                }`,
+                background:
+                  theme.palette.mode === 'dark'
+                    ? 'linear-gradient(180deg, rgba(14,24,44,0.92), rgba(7,14,28,0.95))'
+                    : 'rgba(255,255,255,0.96)',
+                backdropFilter: 'blur(16px) saturate(1.3)',
+                WebkitBackdropFilter: 'blur(16px) saturate(1.3)',
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0 14px 38px rgba(0,0,0,0.55), 0 0 24px rgba(56,189,248,0.18)'
+                    : '0 12px 30px rgba(15,23,42,0.18)',
+                '&:focus-visible': { outline: `2px solid ${accent}`, outlineOffset: 2 },
+              }}
+            >
+              <BoltOutlined sx={{ fontSize: 20, color: accent, flexShrink: 0 }} />
+              <Box sx={{ display: 'flex', alignItems: 'baseline', minWidth: 0 }}>
+                <Typography
+                  component="span"
+                  className="u-tabular"
+                  sx={{
+                    fontFamily: 'Space Grotesk, Inter, system-ui',
+                    fontWeight: 700,
+                    fontSize: '1.3rem',
+                    letterSpacing: '-0.02em',
+                    color: accent,
+                    lineHeight: 1,
+                  }}
+                >
+                  {fmt(expected.ultimatePerSecond, 2)}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.72rem', ml: 0.5 }}
+                >
+                  ult/s
+                </Typography>
+              </Box>
+              <Divider orientation="vertical" flexItem sx={{ borderColor: 'divider', my: 0.25 }} />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'text.secondary', display: 'block', fontSize: 9.5, lineHeight: 1.2 }}
+                >
+                  to 1st ult
+                </Typography>
+                <Typography
+                  className="u-tabular"
+                  sx={{ fontWeight: 700, fontSize: '0.9rem', lineHeight: 1.2 }}
+                >
+                  {fmtSeconds(timeToUlt.secondsToFirstCast)}
+                </Typography>
+              </Box>
+              <KeyboardArrowUp sx={{ fontSize: 22, color: 'text.secondary', flexShrink: 0 }} />
+            </Box>
+          </Portal>
+        )}
       </Box>
     </ThemeProvider>
   );

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -461,18 +461,18 @@ const buildCalcTheme = (base: Theme): Theme => {
             marginTop: 6,
             overflow: 'hidden',
             backgroundImage: 'none',
-            // Lighter, more transparent frosted glass so the popover floats
-            // clearly ABOVE the dark panels instead of merging with them; the
-            // heavy blur keeps items readable over whatever's behind.
+            // Near-opaque, distinctly lighter slate surface. (A transparent menu
+            // let the dark panels bleed through and read as the same color, so it
+            // "blended in" — opacity + a clearly lighter tone fixes that.)
             background: dark
-              ? 'linear-gradient(180deg, rgba(34,54,86,0.85) 0%, rgba(20,37,66,0.88) 100%)'
-              : 'linear-gradient(180deg, rgba(240,250,255,0.9) 0%, rgba(252,254,255,0.92) 100%)',
-            backdropFilter: 'blur(22px) saturate(1.6)',
-            WebkitBackdropFilter: 'blur(22px) saturate(1.6)',
-            border: `1px solid ${dark ? 'rgba(56,189,248,0.5)' : 'rgba(40,145,200,0.35)'}`,
+              ? 'linear-gradient(180deg, rgba(46,66,102,0.985) 0%, rgba(32,50,82,0.985) 100%)'
+              : 'linear-gradient(180deg, rgba(248,252,255,0.99) 0%, rgba(255,255,255,0.99) 100%)',
+            backdropFilter: 'blur(20px) saturate(1.5)',
+            WebkitBackdropFilter: 'blur(20px) saturate(1.5)',
+            border: `1px solid ${dark ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.4)'}`,
             boxShadow: dark
-              ? '0 24px 60px rgba(0,0,0,0.6), 0 0 36px rgba(56,189,248,0.28), inset 0 1px 0 rgba(255,255,255,0.1)'
-              : '0 20px 48px rgba(15,23,42,0.2), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9)',
+              ? '0 24px 60px rgba(0,0,0,0.65), 0 0 36px rgba(56,189,248,0.3), inset 0 1px 0 rgba(255,255,255,0.12)'
+              : '0 20px 48px rgba(15,23,42,0.22), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9)',
             // A thin cyan sheen across the very top edge of the popover.
             '&::before': {
               content: '""',

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -459,7 +459,11 @@ const buildCalcTheme = (base: Theme): Theme => {
             position: 'relative',
             borderRadius: 14,
             marginTop: 6,
-            overflow: 'hidden',
+            // Clip the rounded corners horizontally, but allow vertical scroll —
+            // `overflow: hidden` here previously broke scrolling in tall menus
+            // (e.g. the Ultimate picker). border-radius still clips with auto.
+            overflowX: 'hidden',
+            overflowY: 'auto',
             backdropFilter: 'blur(20px) saturate(1.5)',
             WebkitBackdropFilter: 'blur(20px) saturate(1.5)',
             boxShadow: dark

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -397,34 +397,60 @@ const buildCalcTheme = (base: Theme): Theme => {
             color: cyan,
           },
           rail: {
-            height: 5,
-            borderRadius: 4,
+            height: 6,
+            borderRadius: 3,
             opacity: 1,
             backgroundColor: railColor,
+            // Recessed groove so the filled track reads as raised + glowing.
+            boxShadow: dark
+              ? 'inset 0 1px 2px rgba(0,0,0,0.55)'
+              : 'inset 0 1px 2px rgba(15,23,42,0.12)',
           },
           track: {
-            height: 5,
-            borderRadius: 4,
+            height: 6,
+            borderRadius: 3,
             border: 'none',
             backgroundImage: trackGradient,
-            boxShadow: dark ? `0 0 8px rgba(0,225,255,0.35)` : 'none',
+            // Glowing, slightly glossy fill.
+            boxShadow: dark
+              ? '0 0 10px rgba(0,225,255,0.45), inset 0 1px 0 rgba(255,255,255,0.3)'
+              : '0 1px 3px rgba(40,145,200,0.3), inset 0 1px 0 rgba(255,255,255,0.4)',
           },
           thumb: {
-            width: 16,
-            height: 16,
-            backgroundColor: dark ? '#eaf9ff' : '#ffffff',
+            width: 18,
+            height: 18,
+            // Glossy domed thumb (radial highlight) instead of a flat dot.
+            backgroundImage: dark
+              ? 'radial-gradient(circle at 35% 30%, #ffffff 0%, #d6f6ff 45%, #8fe6ff 100%)'
+              : 'radial-gradient(circle at 35% 30%, #ffffff 0%, #eaf9ff 60%, #d6f1ff 100%)',
             border: `2px solid ${cyan}`,
             boxShadow: dark
-              ? '0 1px 4px rgba(0,0,0,0.5), 0 0 0 1px rgba(0,225,255,0.25)'
-              : '0 1px 3px rgba(15,23,42,0.25)',
-            // Color/shadow-only transition (reduced-motion safe).
+              ? '0 2px 6px rgba(0,0,0,0.55), 0 0 0 1px rgba(0,225,255,0.35), 0 0 12px rgba(0,225,255,0.4)'
+              : '0 2px 5px rgba(15,23,42,0.28), 0 0 0 1px rgba(40,145,200,0.25)',
+            // Shadow-only transitions (reduced-motion safe — no scale/move).
             transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
             '&:hover, &.Mui-focusVisible': {
-              boxShadow: focusRing,
+              boxShadow: dark
+                ? '0 2px 8px rgba(0,0,0,0.6), 0 0 0 6px rgba(56,189,248,0.18), 0 0 16px rgba(0,225,255,0.55)'
+                : '0 2px 8px rgba(15,23,42,0.3), 0 0 0 6px rgba(56,189,248,0.16)',
             },
             '&.Mui-active': {
-              boxShadow: '0 0 0 5px rgba(56,189,248,0.3)',
+              boxShadow: dark
+                ? '0 2px 10px rgba(0,0,0,0.6), 0 0 0 9px rgba(56,189,248,0.22), 0 0 22px rgba(0,225,255,0.6)'
+                : '0 2px 10px rgba(15,23,42,0.32), 0 0 0 9px rgba(56,189,248,0.2)',
             },
+          },
+          valueLabel: {
+            // Cyan-glass bubble shown while dragging.
+            backgroundColor: dark ? 'rgba(8,22,40,0.96)' : 'rgba(15,23,42,0.94)',
+            border: `1px solid ${cyan}`,
+            borderRadius: 8,
+            fontWeight: 700,
+            fontSize: 11,
+            lineHeight: 1.4,
+            padding: '1px 7px',
+            boxShadow: dark ? '0 0 14px rgba(0,225,255,0.45)' : '0 2px 8px rgba(15,23,42,0.25)',
+            '&::before': { color: dark ? 'rgba(8,22,40,0.96)' : 'rgba(15,23,42,0.94)' },
           },
         },
       },
@@ -1425,17 +1451,23 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                                       {Math.round((state.uptimeOverrides[s.id] ?? s.uptime) * 100)}%
                                     </Typography>
                                   </Stack>
-                                  <Slider
-                                    size="small"
-                                    value={Math.round(
-                                      (state.uptimeOverrides[s.id] ?? s.uptime) * 100,
-                                    )}
-                                    onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
-                                    min={0}
-                                    max={100}
-                                    aria-label={`${s.label} uptime`}
-                                    sx={{ py: 0.5 }}
-                                  />
+                                  {/* Horizontal padding keeps the 18px thumb from
+                                      colliding with the card edge at 0%/100%. */}
+                                  <Box sx={{ px: '12px' }}>
+                                    <Slider
+                                      size="small"
+                                      value={Math.round(
+                                        (state.uptimeOverrides[s.id] ?? s.uptime) * 100,
+                                      )}
+                                      onChange={(_, v) => calc.setUptime(s.id, (v as number) / 100)}
+                                      min={0}
+                                      max={100}
+                                      valueLabelDisplay="auto"
+                                      valueLabelFormat={(v) => `${v}%`}
+                                      aria-label={`${s.label} uptime`}
+                                      sx={{ py: 0.5, display: 'block' }}
+                                    />
+                                  </Box>
                                   {s.description && (
                                     <Typography
                                       variant="caption"

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -1574,8 +1574,100 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
             {/* Ultimate picker / cost */}
             <Paper elevation={0} sx={panelSx(theme)}>
               <SectionHeader icon={<BoltOutlined />} title="Which ultimate?" accent={accent} />
-              <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', rowGap: 2 }}>
-                <FormControl size="small" sx={{ flex: '1 1 100%' }}>
+              {/* Focal cost readout — the card's answer, and live feedback as the
+                  cost-reduction toggles below change it. */}
+              <Box
+                sx={{
+                  mb: 2,
+                  px: 2,
+                  py: 1.5,
+                  borderRadius: 1.4, // 14px — card tier
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  border: `1px solid ${
+                    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.28)' : 'rgba(40,145,200,0.3)'
+                  }`,
+                  background:
+                    theme.palette.mode === 'dark'
+                      ? 'linear-gradient(135deg, rgba(56,189,248,0.1), rgba(56,189,248,0.02))'
+                      : 'linear-gradient(135deg, rgba(40,145,200,0.06), rgba(40,145,200,0.01))',
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? 'inset 0 1px 0 rgba(255,255,255,0.05), 0 4px 14px rgba(0,0,0,0.25)'
+                      : '0 2px 8px rgba(15,23,42,0.05)',
+                }}
+              >
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      display: 'block',
+                      color: 'text.secondary',
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.6,
+                      fontWeight: 700,
+                      fontSize: 10,
+                    }}
+                  >
+                    Ultimate cost
+                  </Typography>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'baseline' }}>
+                    <Typography
+                      className="u-tabular"
+                      sx={{
+                        fontSize: 34,
+                        fontWeight: 800,
+                        lineHeight: 1.05,
+                        color: accentText,
+                      }}
+                    >
+                      {effectiveCost}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                      ult
+                    </Typography>
+                  </Stack>
+                </Box>
+                {state.customUltimateCost == null && reductionFraction > 0 && (
+                  <Stack spacing={0.5} sx={{ alignItems: 'flex-end', flexShrink: 0 }}>
+                    <Box
+                      sx={{
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: theme.palette.success.main,
+                        background:
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(34,197,94,0.14)'
+                            : 'rgba(5,150,105,0.1)',
+                        border: `1px solid ${
+                          theme.palette.mode === 'dark'
+                            ? 'rgba(34,197,94,0.35)'
+                            : 'rgba(5,150,105,0.25)'
+                        }`,
+                      }}
+                    >
+                      −{Math.round(reductionFraction * 100)}%
+                    </Box>
+                    <Typography
+                      variant="caption"
+                      className="u-tabular"
+                      sx={{ color: 'text.secondary' }}
+                    >
+                      base{' '}
+                      <Box component="span" sx={{ textDecoration: 'line-through' }}>
+                        {baseCost}
+                      </Box>
+                    </Typography>
+                  </Stack>
+                )}
+              </Box>
+              <Stack spacing={2}>
+                <FormControl size="small" fullWidth>
                   <InputLabel id="ult-ability-label">Ultimate</InputLabel>
                   <Select
                     labelId="ult-ability-label"
@@ -1667,7 +1759,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                     value={state.customUltimateCost}
                     onChange={(e) => calc.setCustomUltimateCost(Number(e.target.value))}
                     slotProps={{ htmlInput: { min: 0, max: 500, step: 5 } }}
-                    sx={{ width: 140 }}
+                    fullWidth
                   />
                 )}
                 <TextField
@@ -1688,7 +1780,7 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                       ),
                     },
                   }}
-                  sx={{ width: 190 }}
+                  fullWidth
                   helperText="Banked at start"
                 />
               </Stack>

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -445,6 +445,52 @@ const buildCalcTheme = (base: Theme): Theme => {
           },
         },
       },
+      // The open dropdown popover + its items — was stock MUI; now a cyan-glass
+      // panel with rounded, inset-highlighted items to match the inputs.
+      MuiMenu: {
+        styleOverrides: {
+          paper: {
+            borderRadius: 12,
+            marginTop: 6,
+            backgroundImage: 'none',
+            backgroundColor: dark ? 'rgba(10,17,33,0.92)' : 'rgba(255,255,255,0.97)',
+            backdropFilter: 'blur(14px) saturate(1.3)',
+            WebkitBackdropFilter: 'blur(14px) saturate(1.3)',
+            border: `1px solid ${dark ? 'rgba(56,189,248,0.16)' : 'rgba(40,145,200,0.18)'}`,
+            boxShadow: dark
+              ? '0 16px 40px rgba(0,0,0,0.55), 0 0 0 1px rgba(56,189,248,0.08), inset 0 1px 0 rgba(255,255,255,0.05)'
+              : '0 16px 40px rgba(15,23,42,0.16), 0 0 0 1px rgba(40,145,200,0.08)',
+          },
+          list: { paddingTop: 6, paddingBottom: 6 },
+        },
+      },
+      MuiMenuItem: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+            marginLeft: 6,
+            marginRight: 6,
+            paddingTop: 7,
+            paddingBottom: 7,
+            transition: 'background-color 0.15s ease, color 0.15s ease',
+            '&:hover': {
+              backgroundColor: dark ? 'rgba(56,189,248,0.10)' : 'rgba(40,145,200,0.08)',
+            },
+            '&.Mui-focusVisible': {
+              backgroundColor: dark ? 'rgba(56,189,248,0.14)' : 'rgba(40,145,200,0.10)',
+            },
+            '&.Mui-selected': {
+              backgroundColor: dark ? 'rgba(56,189,248,0.16)' : 'rgba(40,145,200,0.12)',
+              '&:hover': {
+                backgroundColor: dark ? 'rgba(56,189,248,0.22)' : 'rgba(40,145,200,0.16)',
+              },
+              '&.Mui-focusVisible': {
+                backgroundColor: dark ? 'rgba(56,189,248,0.2)' : 'rgba(40,145,200,0.15)',
+              },
+            },
+          },
+        },
+      },
     },
   });
 };

--- a/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
@@ -35,6 +35,7 @@ import { DECISIVE_PROC_CHANCE, DecisiveQuality } from '../../shared/constants';
 import { useUltimateSimulator } from '../useUltimateSimulator';
 
 const QUALITY_OPTIONS: { value: DecisiveQuality; label: string }[] = [
+  { value: 'normal', label: 'Normal (white)' },
   { value: 'fine', label: 'Fine (green)' },
   { value: 'superior', label: 'Superior (blue)' },
   { value: 'epic', label: 'Epic (purple)' },

--- a/src/features/ultimate-simulator/presentation/useLogCalibration.ts
+++ b/src/features/ultimate-simulator/presentation/useLogCalibration.ts
@@ -9,7 +9,7 @@
  * Redux flow.
  */
 
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import { EsoLogsClientContext } from '../../../EsoLogsClientContext';
 import {
@@ -70,6 +70,19 @@ export function parseReportCode(input: string): string {
   return codeMatch ? codeMatch[0] : trimmed;
 }
 
+/** Hard cap on resource-event pages per hostility scope (loop-runaway guard). */
+const MAX_EVENT_PAGES = 100;
+
+/**
+ * Whether a paginator cursor is making forward progress. The events query pages
+ * by `nextPageTimestamp`; a valid next cursor must be a finite number strictly
+ * greater than where this page started. A repeated/equal/backwards cursor (a
+ * malformed paginator) would loop forever, so we treat it as "stop".
+ */
+export function isCursorAdvancing(prevStart: number, next: number | null | undefined): boolean {
+  return typeof next === 'number' && Number.isFinite(next) && next > prevStart;
+}
+
 export function useLogCalibration(): UseLogCalibration {
   // Read the context non-throwingly: the calculator must work even if it ever
   // renders outside the EsoLogsClientProvider (e.g. tests, isolated previews).
@@ -94,6 +107,10 @@ export function useLogCalibration(): UseLogCalibration {
   const [fightWindows, setFightWindows] = useState<Map<number, { start: number; end: number }>>(
     new Map(),
   );
+  // Monotonic id for the latest measure() call — lets a slow measurement detect
+  // that a newer one (or a selection change) has superseded it and bail before
+  // writing a stale result.
+  const measureReqId = useRef(0);
 
   const setReportCode = useCallback(
     (code: string) => {
@@ -210,10 +227,13 @@ export function useLogCalibration(): UseLogCalibration {
   }, [client, isReady, reportCode]);
 
   const setFight = useCallback((fightId: number) => {
+    // Invalidate any in-flight measurement so its (now stale) result is dropped.
+    measureReqId.current += 1;
     setSelectedFightId(fightId);
     setMeasurement(null);
   }, []);
   const setPlayer = useCallback((playerId: number) => {
+    measureReqId.current += 1;
     setSelectedPlayerId(playerId);
     setMeasurement(null);
   }, []);
@@ -228,6 +248,9 @@ export function useLogCalibration(): UseLogCalibration {
     if (!window) return;
     const fight = fights.find((f) => f.id === selectedFightId);
     const player = players.find((p) => p.id === selectedPlayerId);
+    // Claim this measurement; a later measure()/setFight()/setPlayer() bumps the
+    // id so this run knows it has been superseded and must not write its result.
+    const reqId = (measureReqId.current += 1);
     setPhase('measuring');
     setError(null);
     try {
@@ -243,24 +266,41 @@ export function useLogCalibration(): UseLogCalibration {
       };
       for (const hostilityType of [HostilityType.Friendlies, HostilityType.Enemies]) {
         let next: number | null = null;
+        let pages = 0;
         do {
+          const startTime = next ?? window.start;
           const res: EventsPage = await client.query({
             query: GetResourceEventsDocument,
             variables: {
               code,
               fightIds: [selectedFightId],
-              startTime: next ?? window.start,
+              startTime,
               endTime: window.end,
               hostilityType,
               limit: 100000,
             },
+            // Match the existing resource-event fetcher: never cache these large
+            // pages in the Apollo singleton.
+            fetchPolicy: 'no-cache',
           });
+          // Bail if a newer measurement/selection has superseded this one.
+          if (reqId !== measureReqId.current) return;
           const page = res.reportData?.report?.events;
           if (page?.data) all.push(...(page.data as ResourceChangeEvent[]));
-          next = page?.nextPageTimestamp ?? null;
+          const nextCursor = page?.nextPageTimestamp ?? null;
+          // Stop on a non-advancing cursor (repeated/backwards/malformed) or when
+          // the page cap is hit — either would otherwise spin forever.
+          if (!isCursorAdvancing(startTime, nextCursor)) break;
+          next = nextCursor;
+          pages += 1;
+          if (pages >= MAX_EVENT_PAGES) {
+            throw new Error('Fight has too many resource events to measure reliably.');
+          }
         } while (next);
       }
 
+      // Final staleness check before committing the result.
+      if (reqId !== measureReqId.current) return;
       const result = calibrateFromEvents({
         events: all,
         fightDurationSeconds: fight?.durationSeconds ?? 0,
@@ -274,6 +314,8 @@ export function useLogCalibration(): UseLogCalibration {
       });
       setPhase('measured');
     } catch (e) {
+      // A superseded run that happened to throw must not surface an error either.
+      if (reqId !== measureReqId.current) return;
       setError(
         e instanceof Error
           ? `Could not measure that fight: ${e.message}`

--- a/src/features/ultimate-simulator/presentation/useLogCalibration.ts
+++ b/src/features/ultimate-simulator/presentation/useLogCalibration.ts
@@ -1,0 +1,319 @@
+/**
+ * Live-log calibration hook for the Ultimate Calculator.
+ *
+ * Lets the user paste an ESO Logs report code, pick a fight + player, and measure
+ * that player's real ultimate generation (via the conservation/snapshot method in
+ * calibration.ts) to compare against the model. Self-contained: it queries the
+ * EsoLogsClient directly (the Worker proxy injects tokens for public client
+ * queries, so no sign-in is needed) rather than going through the report-viewer
+ * Redux flow.
+ */
+
+import { useCallback, useContext, useMemo, useState } from 'react';
+
+import { EsoLogsClientContext } from '../../../EsoLogsClientContext';
+import {
+  GetReportByCodeDocument,
+  GetReportMasterDataDocument,
+  GetResourceEventsDocument,
+  HostilityType,
+} from '../../../graphql/gql/graphql';
+import type { ResourceChangeEvent } from '../../../types/combatlogEvents';
+import { calibrateFromEvents, type CalibrationResult } from '../application/calibration';
+
+export interface LogFight {
+  readonly id: number;
+  readonly name: string;
+  readonly durationSeconds: number;
+  readonly kill: boolean;
+}
+
+export interface LogPlayer {
+  readonly id: number;
+  readonly name: string;
+  readonly subType: string; // class
+}
+
+export interface CalibrationMeasurement extends CalibrationResult {
+  readonly fightName: string;
+  readonly playerName: string;
+  readonly playerClass: string;
+}
+
+type Phase = 'idle' | 'loadingReport' | 'reportLoaded' | 'measuring' | 'measured' | 'error';
+
+export interface UseLogCalibration {
+  phase: Phase;
+  error: string | null;
+  reportCode: string;
+  fights: readonly LogFight[];
+  players: readonly LogPlayer[];
+  selectedFightId: number | null;
+  selectedPlayerId: number | null;
+  measurement: CalibrationMeasurement | null;
+  /** Are we able to talk to the API yet? */
+  ready: boolean;
+  setReportCode: (code: string) => void;
+  loadReport: () => Promise<void>;
+  setFight: (fightId: number) => void;
+  setPlayer: (playerId: number) => void;
+  measure: () => Promise<void>;
+  clear: () => void;
+}
+
+/** Extract a bare report code from a pasted code or a full esologs URL. */
+export function parseReportCode(input: string): string {
+  const trimmed = input.trim();
+  const urlMatch = trimmed.match(/reports\/([A-Za-z0-9]{16})/);
+  if (urlMatch) return urlMatch[1];
+  const codeMatch = trimmed.match(/[A-Za-z0-9]{16}/);
+  return codeMatch ? codeMatch[0] : trimmed;
+}
+
+export function useLogCalibration(): UseLogCalibration {
+  // Read the context non-throwingly: the calculator must work even if it ever
+  // renders outside the EsoLogsClientProvider (e.g. tests, isolated previews).
+  // If absent, the panel simply shows as not-ready.
+  const context = useContext(EsoLogsClientContext);
+  const client = context?.client ?? null;
+  const isReady = context?.isReady ?? false;
+
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [reportCode, setReportCodeState] = useState('');
+  const [fights, setFights] = useState<readonly LogFight[]>([]);
+  const [players, setPlayers] = useState<readonly LogPlayer[]>([]);
+  const [selectedFightId, setSelectedFightId] = useState<number | null>(null);
+  const [selectedPlayerId, setSelectedPlayerId] = useState<number | null>(null);
+  const [measurement, setMeasurement] = useState<CalibrationMeasurement | null>(null);
+  // Absolute fight windows, needed to scope the resource-events query.
+  const [fightWindows, setFightWindows] = useState<Map<number, { start: number; end: number }>>(
+    new Map(),
+  );
+
+  const setReportCode = useCallback((code: string) => {
+    setReportCodeState(code);
+    setError(null);
+  }, []);
+
+  const loadReport = useCallback(async () => {
+    if (!client || !isReady) {
+      setError('The ESO Logs connection is not ready yet — try again in a moment.');
+      return;
+    }
+    const code = parseReportCode(reportCode);
+    if (!code || code.length < 16) {
+      setError('Enter a valid ESO Logs report code (16 characters) or report URL.');
+      return;
+    }
+    setPhase('loadingReport');
+    setError(null);
+    setMeasurement(null);
+    try {
+      const [reportRes, masterRes] = await Promise.all([
+        client.query({ query: GetReportByCodeDocument, variables: { code } }),
+        client.query({ query: GetReportMasterDataDocument, variables: { code } }),
+      ]);
+      const report = (reportRes as { reportData?: { report?: unknown } }).reportData?.report as
+        | {
+            fights?: Array<{
+              id: number;
+              name?: string | null;
+              kill?: boolean | null;
+              startTime: number;
+              endTime: number;
+            } | null> | null;
+          }
+        | undefined;
+      const master = (masterRes as { reportData?: { report?: unknown } }).reportData?.report as
+        | {
+            masterData?: {
+              actors?: Array<{
+                id: number;
+                name?: string | null;
+                subType?: string | null;
+                type?: string | null;
+              } | null> | null;
+            } | null;
+          }
+        | undefined;
+
+      const windows = new Map<number, { start: number; end: number }>();
+      const fightList: LogFight[] = [];
+      for (const f of report?.fights ?? []) {
+        if (!f) continue;
+        windows.set(f.id, { start: f.startTime, end: f.endTime });
+        const durationSeconds = Math.max(0, Math.round((f.endTime - f.startTime) / 1000));
+        // Skip trash/very short segments — boss fights are what people calibrate against.
+        if (durationSeconds < 10) continue;
+        fightList.push({
+          id: f.id,
+          name: f.name ?? `Fight ${f.id}`,
+          durationSeconds,
+          kill: Boolean(f.kill),
+        });
+      }
+      fightList.sort((a, b) => b.durationSeconds - a.durationSeconds);
+
+      const playerList: LogPlayer[] = [];
+      for (const a of master?.masterData?.actors ?? []) {
+        if (!a || a.type !== 'Player') continue;
+        playerList.push({
+          id: a.id,
+          name: a.name ?? `Player ${a.id}`,
+          subType: a.subType ?? 'Unknown',
+        });
+      }
+      playerList.sort((a, b) => a.name.localeCompare(b.name));
+
+      if (fightList.length === 0) {
+        setError('No fights found in that report (is the code correct and the report public?).');
+        setPhase('error');
+        return;
+      }
+
+      setFights(fightList);
+      setPlayers(playerList);
+      setFightWindows(windows);
+      setSelectedFightId(fightList[0].id);
+      setSelectedPlayerId(playerList[0]?.id ?? null);
+      setPhase('reportLoaded');
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? `Could not load that report: ${e.message}`
+          : 'Could not load that report.',
+      );
+      setPhase('error');
+    }
+  }, [client, isReady, reportCode]);
+
+  const setFight = useCallback((fightId: number) => {
+    setSelectedFightId(fightId);
+    setMeasurement(null);
+  }, []);
+  const setPlayer = useCallback((playerId: number) => {
+    setSelectedPlayerId(playerId);
+    setMeasurement(null);
+  }, []);
+
+  const measure = useCallback(async () => {
+    if (!client || !isReady) return;
+    if (selectedFightId == null || selectedPlayerId == null) return;
+    const window = fightWindows.get(selectedFightId);
+    if (!window) return;
+    const fight = fights.find((f) => f.id === selectedFightId);
+    const player = players.find((p) => p.id === selectedPlayerId);
+    setPhase('measuring');
+    setError(null);
+    try {
+      // Page through the fight's resource events for both hostility scopes.
+      const code = parseReportCode(reportCode);
+      const all: ResourceChangeEvent[] = [];
+      type EventsPage = {
+        reportData?: {
+          report?: {
+            events?: { data?: unknown[]; nextPageTimestamp?: number | null } | null;
+          } | null;
+        } | null;
+      };
+      for (const hostilityType of [HostilityType.Friendlies, HostilityType.Enemies]) {
+        let next: number | null = null;
+        do {
+          const res: EventsPage = await client.query({
+            query: GetResourceEventsDocument,
+            variables: {
+              code,
+              fightIds: [selectedFightId],
+              startTime: next ?? window.start,
+              endTime: window.end,
+              hostilityType,
+              limit: 100000,
+            },
+          });
+          const page = res.reportData?.report?.events;
+          if (page?.data) all.push(...(page.data as ResourceChangeEvent[]));
+          next = page?.nextPageTimestamp ?? null;
+        } while (next);
+      }
+
+      const result = calibrateFromEvents({
+        events: all,
+        fightDurationSeconds: fight?.durationSeconds ?? 0,
+        targetActorID: selectedPlayerId,
+      });
+      setMeasurement({
+        ...result,
+        fightName: fight?.name ?? '',
+        playerName: player?.name ?? '',
+        playerClass: player?.subType ?? '',
+      });
+      setPhase('measured');
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? `Could not measure that fight: ${e.message}`
+          : 'Could not measure that fight.',
+      );
+      setPhase('error');
+    }
+  }, [
+    client,
+    isReady,
+    selectedFightId,
+    selectedPlayerId,
+    fightWindows,
+    fights,
+    players,
+    reportCode,
+  ]);
+
+  const clear = useCallback(() => {
+    setPhase('idle');
+    setError(null);
+    setReportCodeState('');
+    setFights([]);
+    setPlayers([]);
+    setSelectedFightId(null);
+    setSelectedPlayerId(null);
+    setMeasurement(null);
+    setFightWindows(new Map());
+  }, []);
+
+  return useMemo(
+    () => ({
+      phase,
+      error,
+      reportCode,
+      fights,
+      players,
+      selectedFightId,
+      selectedPlayerId,
+      measurement,
+      ready: isReady,
+      setReportCode,
+      loadReport,
+      setFight,
+      setPlayer,
+      measure,
+      clear,
+    }),
+    [
+      phase,
+      error,
+      reportCode,
+      fights,
+      players,
+      selectedFightId,
+      selectedPlayerId,
+      measurement,
+      isReady,
+      setReportCode,
+      loadReport,
+      setFight,
+      setPlayer,
+      measure,
+      clear,
+    ],
+  );
+}

--- a/src/features/ultimate-simulator/presentation/useLogCalibration.ts
+++ b/src/features/ultimate-simulator/presentation/useLogCalibration.ts
@@ -81,6 +81,10 @@ export function useLogCalibration(): UseLogCalibration {
   const [phase, setPhase] = useState<Phase>('idle');
   const [error, setError] = useState<string | null>(null);
   const [reportCode, setReportCodeState] = useState('');
+  // The report code that was actually LOADED (fights/players/windows belong to
+  // it). Measurement must use this, never the live text field — otherwise editing
+  // the input after loading would query a new report with the old fight/player.
+  const [loadedReportCode, setLoadedReportCode] = useState<string | null>(null);
   const [fights, setFights] = useState<readonly LogFight[]>([]);
   const [players, setPlayers] = useState<readonly LogPlayer[]>([]);
   const [selectedFightId, setSelectedFightId] = useState<number | null>(null);
@@ -91,10 +95,26 @@ export function useLogCalibration(): UseLogCalibration {
     new Map(),
   );
 
-  const setReportCode = useCallback((code: string) => {
-    setReportCodeState(code);
-    setError(null);
-  }, []);
+  const setReportCode = useCallback(
+    (code: string) => {
+      setReportCodeState(code);
+      setError(null);
+      // If the entered code no longer matches what was loaded, the loaded
+      // fights/players/windows are stale — drop them so Measure can't run against
+      // a mismatched report. The user must re-load the new code first.
+      if (loadedReportCode != null && parseReportCode(code) !== loadedReportCode) {
+        setLoadedReportCode(null);
+        setFights([]);
+        setPlayers([]);
+        setFightWindows(new Map());
+        setSelectedFightId(null);
+        setSelectedPlayerId(null);
+        setMeasurement(null);
+        setPhase('idle');
+      }
+    },
+    [loadedReportCode],
+  );
 
   const loadReport = useCallback(async () => {
     if (!client || !isReady) {
@@ -177,6 +197,7 @@ export function useLogCalibration(): UseLogCalibration {
       setFightWindows(windows);
       setSelectedFightId(fightList[0].id);
       setSelectedPlayerId(playerList[0]?.id ?? null);
+      setLoadedReportCode(code);
       setPhase('reportLoaded');
     } catch (e) {
       setError(
@@ -200,6 +221,9 @@ export function useLogCalibration(): UseLogCalibration {
   const measure = useCallback(async () => {
     if (!client || !isReady) return;
     if (selectedFightId == null || selectedPlayerId == null) return;
+    // Always measure the LOADED report — never the live text field — so the
+    // fight window/player below refer to the same report being queried.
+    if (loadedReportCode == null) return;
     const window = fightWindows.get(selectedFightId);
     if (!window) return;
     const fight = fights.find((f) => f.id === selectedFightId);
@@ -208,7 +232,7 @@ export function useLogCalibration(): UseLogCalibration {
     setError(null);
     try {
       // Page through the fight's resource events for both hostility scopes.
-      const code = parseReportCode(reportCode);
+      const code = loadedReportCode;
       const all: ResourceChangeEvent[] = [];
       type EventsPage = {
         reportData?: {
@@ -265,13 +289,14 @@ export function useLogCalibration(): UseLogCalibration {
     fightWindows,
     fights,
     players,
-    reportCode,
+    loadedReportCode,
   ]);
 
   const clear = useCallback(() => {
     setPhase('idle');
     setError(null);
     setReportCodeState('');
+    setLoadedReportCode(null);
     setFights([]);
     setPlayers([]);
     setSelectedFightId(null);

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -1,0 +1,314 @@
+/**
+ * Presenter hook for the all-class Ultimate Calculator.
+ *
+ * Holds the editable selection (context / class / role, per-source toggles &
+ * uptimes, Decisive weapon, fight length, chosen ultimate & extra cost
+ * reduction) and derives every result with the closed-form engine — exact and
+ * instant, recomputed synchronously on each change.
+ *
+ * The optional Monte Carlo distribution is computed lazily (only when the user
+ * opens the distribution view) so the headline path stays cheap.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+import {
+  availableReductions,
+  availableSources,
+  compileReductions,
+  compileSources,
+  isEntryEnabled,
+  type CatalogSelection,
+} from '../application/compileCatalog';
+import { applyCostReduction, type CostReduction } from '../core/cost';
+import { expectedValue, timeToUltimate } from '../core/expectedValue';
+import { runMonteCarlo } from '../core/monteCarlo';
+import {
+  DEFAULT_DECISIVE_QUALITY,
+  DEFAULT_FIGHT_DURATION_SECONDS,
+  makeDecisiveConfig,
+  type DecisiveQuality,
+} from '../shared/constants';
+import {
+  COST_REDUCTION_CATALOG,
+  MAX_ULTIMATE_POOL,
+  SANITY_MAX_ULT_PER_SECOND,
+  ULTIMATE_ABILITIES,
+  ULTIMATE_SOURCE_CATALOG,
+} from '../shared/constants/catalog';
+import type { ExpectedValueResult, MonteCarloResult, TimeToUltimateResult } from '../shared/types';
+import type {
+  CatalogCostReduction,
+  CatalogSource,
+  CombatContext,
+  CombatRole,
+  EsoClass,
+} from '../shared/types/catalog';
+
+const DEFAULT_MC_RUNS = 20000;
+const MC_BASE_SEED = 1;
+
+export interface UltimateCalculatorState {
+  context: CombatContext;
+  esoClass: EsoClass;
+  role: CombatRole;
+  fightDurationSeconds: number;
+  decisiveEnabled: boolean;
+  decisiveQuality: DecisiveQuality;
+  decisiveTwoHanded: boolean;
+  enabledOverrides: Record<string, boolean>;
+  uptimeOverrides: Record<string, number>;
+  /** Chosen ultimate ability id (drives time-to-ult), or a custom cost. */
+  ultimateAbilityId: string;
+  customUltimateCost: number | null;
+  startingUltimate: number;
+}
+
+const INITIAL_STATE: UltimateCalculatorState = {
+  context: 'groupPve',
+  esoClass: 'arcanist',
+  role: 'dps',
+  fightDurationSeconds: DEFAULT_FIGHT_DURATION_SECONDS,
+  decisiveEnabled: true,
+  decisiveQuality: DEFAULT_DECISIVE_QUALITY,
+  decisiveTwoHanded: false,
+  enabledOverrides: {},
+  uptimeOverrides: {},
+  ultimateAbilityId: 'generic-250',
+  customUltimateCost: null,
+  startingUltimate: 0,
+};
+
+export interface UltimateCalculatorResult {
+  state: UltimateCalculatorState;
+  selection: CatalogSelection;
+  /** Sources available for the current selection (for the toggle list). */
+  availableSourceEntries: readonly CatalogSource[];
+  /** Cost reductions available for the current selection. */
+  availableReductionEntries: readonly CatalogCostReduction[];
+  /** Resolved enabled state per entry id (default merged with override). */
+  isEnabled: (id: string, defaultEnabled: boolean) => boolean;
+  /** Closed-form expected generation. */
+  expected: ExpectedValueResult;
+  /** Effective ultimate cost after reductions. */
+  effectiveCost: number;
+  baseCost: number;
+  appliedReductions: readonly CostReduction[];
+  /** Time-to-ultimate output. */
+  timeToUlt: TimeToUltimateResult;
+  /** Whether the generation rate looks unrealistically high. */
+  exceedsSanity: boolean;
+  sanityMax: number;
+  maxPool: number;
+  /** Lazily-computed Monte Carlo distribution (null until requested). */
+  distribution: MonteCarloResult | null;
+  computeDistribution: () => void;
+  // setters
+  setContext: (c: CombatContext) => void;
+  setClass: (c: EsoClass) => void;
+  setRole: (r: CombatRole) => void;
+  setFightDuration: (s: number) => void;
+  setDecisiveEnabled: (b: boolean) => void;
+  setDecisiveQuality: (q: DecisiveQuality) => void;
+  setDecisiveTwoHanded: (b: boolean) => void;
+  toggleSource: (id: string, enabled: boolean) => void;
+  setUptime: (id: string, uptime: number) => void;
+  setUltimateAbility: (id: string) => void;
+  setCustomUltimateCost: (cost: number | null) => void;
+  setStartingUltimate: (n: number) => void;
+  reset: () => void;
+}
+
+export function useUltimateCalculator(): UltimateCalculatorResult {
+  const [state, setState] = useState<UltimateCalculatorState>(INITIAL_STATE);
+  const [distribution, setDistribution] = useState<MonteCarloResult | null>(null);
+
+  const selection = useMemo<CatalogSelection>(
+    () => ({
+      context: state.context,
+      esoClass: state.esoClass,
+      role: state.role,
+      enabledOverrides: state.enabledOverrides,
+      uptimeOverrides: state.uptimeOverrides,
+    }),
+    [state.context, state.esoClass, state.role, state.enabledOverrides, state.uptimeOverrides],
+  );
+
+  const availableSourceEntries = useMemo(
+    () => availableSources(ULTIMATE_SOURCE_CATALOG, selection),
+    [selection],
+  );
+  const availableReductionEntries = useMemo(
+    () => availableReductions(COST_REDUCTION_CATALOG, selection),
+    [selection],
+  );
+
+  const decisive = useMemo(
+    () =>
+      state.decisiveEnabled
+        ? makeDecisiveConfig(state.decisiveQuality, state.decisiveTwoHanded)
+        : null,
+    [state.decisiveEnabled, state.decisiveQuality, state.decisiveTwoHanded],
+  );
+
+  const compiledSources = useMemo(
+    () => compileSources(ULTIMATE_SOURCE_CATALOG, selection),
+    [selection],
+  );
+
+  const expected = useMemo<ExpectedValueResult>(
+    () =>
+      expectedValue({
+        fightDurationSeconds: state.fightDurationSeconds,
+        sources: compiledSources,
+        decisive,
+      }),
+    [compiledSources, decisive, state.fightDurationSeconds],
+  );
+
+  const appliedReductions = useMemo(
+    () => compileReductions(COST_REDUCTION_CATALOG, selection),
+    [selection],
+  );
+
+  const baseCost = useMemo(() => {
+    if (state.customUltimateCost != null) return state.customUltimateCost;
+    const ability = ULTIMATE_ABILITIES.find((a) => a.id === state.ultimateAbilityId);
+    return ability?.baseCost ?? 250;
+  }, [state.customUltimateCost, state.ultimateAbilityId]);
+
+  const effectiveCost = useMemo(
+    () => applyCostReduction(baseCost, appliedReductions),
+    [baseCost, appliedReductions],
+  );
+
+  const timeToUlt = useMemo<TimeToUltimateResult>(
+    () =>
+      timeToUltimate({
+        effectiveCost,
+        ultimatePerSecond: expected.ultimatePerSecond,
+        fightDurationSeconds: state.fightDurationSeconds,
+        startingUltimate: state.startingUltimate,
+      }),
+    [effectiveCost, expected.ultimatePerSecond, state.fightDurationSeconds, state.startingUltimate],
+  );
+
+  const exceedsSanity = expected.ultimatePerSecond > SANITY_MAX_ULT_PER_SECOND;
+
+  // Recompute the distribution on demand (and clear it when inputs change so a
+  // stale chart never lingers — the headline EV always stays live).
+  const computeDistribution = useCallback(() => {
+    setDistribution(
+      runMonteCarlo(
+        { fightDurationSeconds: state.fightDurationSeconds, sources: compiledSources, decisive },
+        { runs: DEFAULT_MC_RUNS, baseSeed: MC_BASE_SEED },
+      ),
+    );
+  }, [state.fightDurationSeconds, compiledSources, decisive]);
+
+  const isEnabled = useCallback(
+    (id: string, defaultEnabled: boolean) =>
+      isEntryEnabled(id, defaultEnabled, state.enabledOverrides),
+    [state.enabledOverrides],
+  );
+
+  // --- setters (each clears any stale distribution) -------------------------
+  const patch = useCallback((updater: (s: UltimateCalculatorState) => UltimateCalculatorState) => {
+    setState(updater);
+    setDistribution(null);
+  }, []);
+
+  const setContext = useCallback(
+    (context: CombatContext) => patch((s) => ({ ...s, context })),
+    [patch],
+  );
+  const setClass = useCallback((esoClass: EsoClass) => patch((s) => ({ ...s, esoClass })), [patch]);
+  const setRole = useCallback((role: CombatRole) => patch((s) => ({ ...s, role })), [patch]);
+  const setFightDuration = useCallback(
+    (seconds: number) =>
+      patch((s) => ({ ...s, fightDurationSeconds: Math.max(1, Math.round(seconds)) })),
+    [patch],
+  );
+  const setDecisiveEnabled = useCallback(
+    (decisiveEnabled: boolean) => patch((s) => ({ ...s, decisiveEnabled })),
+    [patch],
+  );
+  const setDecisiveQuality = useCallback(
+    (decisiveQuality: DecisiveQuality) => patch((s) => ({ ...s, decisiveQuality })),
+    [patch],
+  );
+  const setDecisiveTwoHanded = useCallback(
+    (decisiveTwoHanded: boolean) => patch((s) => ({ ...s, decisiveTwoHanded })),
+    [patch],
+  );
+  const toggleSource = useCallback(
+    (id: string, enabled: boolean) =>
+      patch((s) => ({ ...s, enabledOverrides: { ...s.enabledOverrides, [id]: enabled } })),
+    [patch],
+  );
+  const setUptime = useCallback(
+    (id: string, uptime: number) =>
+      patch((s) => ({
+        ...s,
+        uptimeOverrides: { ...s.uptimeOverrides, [id]: Math.min(1, Math.max(0, uptime)) },
+      })),
+    [patch],
+  );
+  const setUltimateAbility = useCallback(
+    (ultimateAbilityId: string) =>
+      patch((s) => ({ ...s, ultimateAbilityId, customUltimateCost: null })),
+    [patch],
+  );
+  const setCustomUltimateCost = useCallback(
+    (customUltimateCost: number | null) =>
+      patch((s) => ({
+        ...s,
+        customUltimateCost:
+          customUltimateCost == null ? null : Math.max(0, Math.round(customUltimateCost)),
+      })),
+    [patch],
+  );
+  const setStartingUltimate = useCallback(
+    (startingUltimate: number) =>
+      patch((s) => ({
+        ...s,
+        startingUltimate: Math.min(MAX_ULTIMATE_POOL, Math.max(0, Math.round(startingUltimate))),
+      })),
+    [patch],
+  );
+  const reset = useCallback(() => {
+    setState(INITIAL_STATE);
+    setDistribution(null);
+  }, []);
+
+  return {
+    state,
+    selection,
+    availableSourceEntries,
+    availableReductionEntries,
+    isEnabled,
+    expected,
+    effectiveCost,
+    baseCost,
+    appliedReductions,
+    timeToUlt,
+    exceedsSanity,
+    sanityMax: SANITY_MAX_ULT_PER_SECOND,
+    maxPool: MAX_ULTIMATE_POOL,
+    distribution,
+    computeDistribution,
+    setContext,
+    setClass,
+    setRole,
+    setFightDuration,
+    setDecisiveEnabled,
+    setDecisiveQuality,
+    setDecisiveTwoHanded,
+    toggleSource,
+    setUptime,
+    setUltimateAbility,
+    setCustomUltimateCost,
+    setStartingUltimate,
+    reset,
+  };
+}

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -177,9 +177,16 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     return ability?.baseCost ?? 250;
   }, [state.customUltimateCost, state.ultimateAbilityId]);
 
+  // A custom cost is the user's own EFFECTIVE number — applying class reductions
+  // on top would double-count, so reductions only apply to a catalog ability's
+  // base cost.
+  const isCustomCost = state.customUltimateCost != null;
   const effectiveCost = useMemo(
-    () => applyCostReduction(baseCost, appliedReductions),
-    [baseCost, appliedReductions],
+    () =>
+      isCustomCost
+        ? Math.max(0, Math.round(baseCost))
+        : applyCostReduction(baseCost, appliedReductions),
+    [isCustomCost, baseCost, appliedReductions],
   );
 
   const timeToUlt = useMemo<TimeToUltimateResult>(

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -62,6 +62,8 @@ export interface UltimateCalculatorState {
   ultimateAbilityId: string;
   customUltimateCost: number | null;
   startingUltimate: number;
+  /** Healer's ultimate cost for the Pillager's Profit external source (10% of it per cast). */
+  pillagerHealerUltCost: number;
 }
 
 const INITIAL_STATE: UltimateCalculatorState = {
@@ -77,6 +79,8 @@ const INITIAL_STATE: UltimateCalculatorState = {
   ultimateAbilityId: 'generic-250',
   customUltimateCost: null,
   startingUltimate: 0,
+  // A typical healer ultimate (e.g. ~250 cost) → 25 ult per affecting cast.
+  pillagerHealerUltCost: 250,
 };
 
 export interface UltimateCalculatorResult {
@@ -116,6 +120,7 @@ export interface UltimateCalculatorResult {
   setUltimateAbility: (id: string) => void;
   setCustomUltimateCost: (cost: number | null) => void;
   setStartingUltimate: (n: number) => void;
+  setPillagerHealerUltCost: (n: number) => void;
   reset: () => void;
 }
 
@@ -130,8 +135,16 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
       role: state.role,
       enabledOverrides: state.enabledOverrides,
       uptimeOverrides: state.uptimeOverrides,
+      pillagerHealerUltCost: state.pillagerHealerUltCost,
     }),
-    [state.context, state.esoClass, state.role, state.enabledOverrides, state.uptimeOverrides],
+    [
+      state.context,
+      state.esoClass,
+      state.role,
+      state.enabledOverrides,
+      state.uptimeOverrides,
+      state.pillagerHealerUltCost,
+    ],
   );
 
   const availableSourceEntries = useMemo(
@@ -283,6 +296,17 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
       })),
     [patch],
   );
+  const setPillagerHealerUltCost = useCallback(
+    (pillagerHealerUltCost: number) =>
+      patch((s) => ({
+        ...s,
+        pillagerHealerUltCost: Math.min(
+          MAX_ULTIMATE_POOL,
+          Math.max(0, Math.round(pillagerHealerUltCost)),
+        ),
+      })),
+    [patch],
+  );
   const reset = useCallback(() => {
     setState(INITIAL_STATE);
     setDistribution(null);
@@ -316,6 +340,7 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     setUltimateAbility,
     setCustomUltimateCost,
     setStartingUltimate,
+    setPillagerHealerUltCost,
     reset,
   };
 }

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -79,6 +79,9 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     // if your build actually provides it. (Validated against a real trial log: a
     // baseline Arcanist measured ~3.4 ult/s, matching base income + Decisive.)
     defaultEnabled: false,
+    // Same named buff as the Cryptcanon source — Minor Heroism does not stack
+    // across providers, so enabling both must not double-count.
+    nonStackingGroup: 'minor-heroism',
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
@@ -149,6 +152,8 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     rollsDecisive: true,
     availableIn: ['soloPve', 'groupPve', 'pvp'],
     defaultEnabled: false,
+    // Grants the SAME Minor Heroism buff as the generic source — do not stack.
+    nonStackingGroup: 'minor-heroism',
     provenance: SRC_CRYPTCANON,
     confidence: 'high',
     description:

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -31,7 +31,6 @@ const SRC_IMPLACABLE = 'https://eso-skillbook.com/skill/implacable-outcome';
 const SRC_CORPSE = 'https://eso-skillbook.com/skill/corpse-consumption';
 const SRC_POWERSTONE = 'https://eso-skillbook.com/skill/power-stone';
 const SRC_RESTORING_SPIRIT = 'https://eso-skillbook.com/skill/restoring-spirit';
-const SRC_CRYPTCANON = 'https://en.uesp.net/wiki/Online:Cryptcanon_Vestments';
 const SRC_PILLAGERS = "https://en.uesp.net/wiki/Online:Pillager's_Profit";
 const SRC_MINOR_HEROISM_POTION = 'https://en.uesp.net/wiki/Online:Heroism';
 
@@ -79,9 +78,6 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     // if your build actually provides it. (Validated against a real trial log: a
     // baseline Arcanist measured ~3.4 ult/s, matching base income + Decisive.)
     defaultEnabled: false,
-    // Same named buff as the Cryptcanon source — Minor Heroism does not stack
-    // across providers, so enabling both must not double-count.
-    nonStackingGroup: 'minor-heroism',
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
@@ -140,25 +136,11 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
       'Necromancer Living Death passive: +10 ultimate when you consume a corpse, once every 16 seconds. Uptime depends on corpse availability.',
   },
 
-  // ---- Mythic ---------------------------------------------------------------
-  {
-    id: 'cryptcanon-vestments',
-    label: 'Cryptcanon Vestments (Minor Heroism)',
-    category: 'mythic',
-    kind: 'periodic',
-    amountPerInstance: 1,
-    instancesPerSecond: 1 / 1.5,
-    uptime: 0.98,
-    rollsDecisive: true,
-    availableIn: ['soloPve', 'groupPve', 'pvp'],
-    defaultEnabled: false,
-    // Grants the SAME Minor Heroism buff as the generic source — do not stack.
-    nonStackingGroup: 'minor-heroism',
-    provenance: SRC_CRYPTCANON,
-    confidence: 'high',
-    description:
-      'Mythic that grants Minor Heroism in combat. CAVEAT: while equipped you cannot cast your own ultimate — casting transfers your ult to group members. A support/battery item, not a self-ult enabler.',
-  },
+  // NOTE: Cryptcanon Vestments is intentionally NOT modeled as a self-cast
+  // source. It grants Minor Heroism but PREVENTS you from casting your own
+  // ultimate (casting transfers your ult to group members), so counting it in a
+  // "time to YOUR ultimate / casts per fight" calculation would be misleading.
+  // It belongs in a future group-battery view, not here.
 
   // ---- Group support (external) --------------------------------------------
   {

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -81,7 +81,7 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
     description:
-      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, Cryptcanon Vestments, certain sets, or scribing — enable it if your build provides it.',
+      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, certain sets, or scribing — enable it if your build provides it. (Cryptcanon Vestments also grants it but blocks casting your own ultimate, so it is not modeled here.)',
   },
   {
     id: 'major-heroism',

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -1,0 +1,333 @@
+/**
+ * Ultimate-source CATALOG — the research-sourced data layer.
+ *
+ * Every entry carries a `provenance` URL and `confidence`. Numbers are from
+ * Update 50 / June 2026 research (see .scratch/ult-research-2026.md). Provenance
+ * links point to UESP and ESO-Skillbook (the authoritative community references
+ * this project allows); values were cross-checked across multiple sources.
+ *
+ * Mechanics summary the catalog encodes:
+ *  - There is NO passive ultimate regen. Base income is the light/heavy-attack
+ *    hidden buff: 3 ult/sec while weaving in combat (9s buff, refreshed per LA).
+ *  - Minor Heroism = 1 ult / 1.5s (0.667/s); Major Heroism = 3 ult / 1.5s (2.0/s).
+ *  - Class ult-GENERATION passives are sparse: Arcanist Implacable Outcome
+ *    (+4 ult / Crux consume / 8s ICD) and Necromancer Corpse Consumption
+ *    (+10 ult / corpse / 16s ICD) are the notable ones; most classes have none.
+ *  - Decisive rolls +1 per ult-gain instance on income the wearer generates;
+ *    externally-granted ult (a healer's Pillager's Profit) does not roll it.
+ *  - Sets like Saxhleel Champion / War Machine CONSUME ultimate (Major Force /
+ *    Major Slayer payoff) — they are deliberately NOT in this catalog, because a
+ *    generation calculator must not present them as income.
+ */
+
+import type { CatalogCostReduction, CatalogSource, UltimateAbility } from '../types/catalog';
+
+// Provenance links — UESP (authoritative) and ESO-Skillbook only.
+const UESP_ULTIMATE = 'https://en.uesp.net/wiki/Online:Ultimate';
+const UESP_DECISIVE = 'https://en.uesp.net/wiki/Online:Decisive';
+const SRC_MINOR_HEROISM = 'https://en.uesp.net/wiki/Online:Heroism';
+const SRC_MAJOR_HEROISM = 'https://en.uesp.net/wiki/Online:Heroism';
+const SRC_IMPLACABLE = 'https://eso-skillbook.com/skill/implacable-outcome';
+const SRC_CORPSE = 'https://eso-skillbook.com/skill/corpse-consumption';
+const SRC_POWERSTONE = 'https://eso-skillbook.com/skill/power-stone';
+const SRC_RESTORING_SPIRIT = 'https://eso-skillbook.com/skill/restoring-spirit';
+const SRC_CRYPTCANON = 'https://en.uesp.net/wiki/Online:Cryptcanon_Vestments';
+const SRC_PILLAGERS = "https://en.uesp.net/wiki/Online:Pillager's_Profit";
+const SRC_MINOR_HEROISM_POTION = 'https://en.uesp.net/wiki/Online:Heroism';
+
+/**
+ * The catalog of toggleable ultimate-generation sources.
+ *
+ * `instancesPerSecond` and `amountPerInstance` are chosen so each source's
+ * expected ult/s matches its real in-game rate. `uptime` defaults reflect a
+ * typical optimized build (tune in the UI). `defaultEnabled` marks what a normal
+ * build of that context/class would actually be running.
+ */
+export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
+  // ---- Universal base income ------------------------------------------------
+  {
+    id: 'base-light-attack',
+    label: 'Light/Heavy-attack income',
+    category: 'base',
+    kind: 'periodic',
+    amountPerInstance: 3,
+    instancesPerSecond: 1, // 3 ult/sec while weaving
+    uptime: 0.95,
+    rollsDecisive: true,
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: true,
+    provenance: UESP_ULTIMATE,
+    confidence: 'high',
+    description:
+      'The hidden buff from landing light/heavy attacks on a non-trivial enemy in combat: 3 ultimate/sec for 9s, refreshed each light attack. This is ESO base income — there is no passive ultimate regen.',
+  },
+
+  // ---- Heroism --------------------------------------------------------------
+  {
+    id: 'minor-heroism',
+    label: 'Minor Heroism',
+    category: 'heroism',
+    kind: 'periodic',
+    amountPerInstance: 1,
+    instancesPerSecond: 1 / 1.5, // 1 ult / 1.5s
+    uptime: 0.9,
+    rollsDecisive: true,
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    // Off by default: Minor Heroism is an opt-in build choice (Heroism potions,
+    // Cryptcanon, certain sets, scribing) — not every DPS runs it. Leaving it off
+    // keeps the out-of-box estimate close to a plain weaving build; toggle it on
+    // if your build actually provides it. (Validated against a real trial log: a
+    // baseline Arcanist measured ~3.4 ult/s, matching base income + Decisive.)
+    defaultEnabled: false,
+    provenance: SRC_MINOR_HEROISM,
+    confidence: 'high',
+    description:
+      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, Cryptcanon Vestments, certain sets, or scribing — enable it if your build provides it.',
+  },
+  {
+    id: 'major-heroism',
+    label: 'Major Heroism',
+    category: 'heroism',
+    kind: 'periodic',
+    amountPerInstance: 3,
+    instancesPerSecond: 1 / 1.5, // 3 ult / 1.5s
+    uptime: 0.7,
+    rollsDecisive: true,
+    availableIn: ['groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_MAJOR_HEROISM,
+    confidence: 'high',
+    description:
+      '3 ultimate every 1.5s (2.0/s) in combat — the strongest sustained source. Usually a group buff (Warden U50 class scrip, certain sets) rather than self-applied.',
+  },
+
+  // ---- Class passives -------------------------------------------------------
+  {
+    id: 'arcanist-implacable-outcome',
+    label: 'Implacable Outcome (Crux)',
+    category: 'classPassive',
+    kind: 'triggered',
+    amountPerInstance: 4,
+    instancesPerSecond: 1 / 8, // +4 ult, max once / 8s on Crux consume
+    uptime: 1,
+    rollsDecisive: true,
+    classes: ['arcanist'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: true,
+    provenance: SRC_IMPLACABLE,
+    confidence: 'high',
+    description:
+      'Arcanist Soldier of Apocrypha passive: +4 ultimate when you consume Crux, once every 8 seconds.',
+  },
+  {
+    id: 'necromancer-corpse-consumption',
+    label: 'Corpse Consumption',
+    category: 'classPassive',
+    kind: 'triggered',
+    amountPerInstance: 10,
+    instancesPerSecond: 1 / 16, // +10 ult, once / 16s
+    uptime: 0.6,
+    rollsDecisive: true,
+    classes: ['necromancer'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_CORPSE,
+    confidence: 'high',
+    description:
+      'Necromancer Living Death passive: +10 ultimate when you consume a corpse, once every 16 seconds. Uptime depends on corpse availability.',
+  },
+
+  // ---- Mythic ---------------------------------------------------------------
+  {
+    id: 'cryptcanon-vestments',
+    label: 'Cryptcanon Vestments (Minor Heroism)',
+    category: 'mythic',
+    kind: 'periodic',
+    amountPerInstance: 1,
+    instancesPerSecond: 1 / 1.5,
+    uptime: 0.98,
+    rollsDecisive: true,
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_CRYPTCANON,
+    confidence: 'high',
+    description:
+      'Mythic that grants Minor Heroism in combat. CAVEAT: while equipped you cannot cast your own ultimate — casting transfers your ult to group members. A support/battery item, not a self-ult enabler.',
+  },
+
+  // ---- Group support (external) --------------------------------------------
+  {
+    id: 'pillagers-profit-external',
+    label: "Pillager's Profit (from healer)",
+    category: 'external',
+    kind: 'perCast',
+    amountPerInstance: 50,
+    instancesPerSecond: 1 / 12, // batteried to allies in bursts
+    uptime: 1,
+    rollsDecisive: false, // externally granted — does not roll the wearer's Decisive
+    roles: ['dps'],
+    availableIn: ['groupPve'],
+    defaultEnabled: false,
+    provenance: SRC_PILLAGERS,
+    confidence: 'medium',
+    description:
+      "When a group healer wears Pillager's Profit, 2% of ultimate they spend is granted to nearby group members. Modeled as an external trickle to a DPS; exact rate varies with the healer's ultimate usage.",
+  },
+];
+
+/** Ultimate-cost reductions the user can toggle (multiplicative). */
+export const COST_REDUCTION_CATALOG: readonly CatalogCostReduction[] = [
+  {
+    id: 'sorcerer-power-stone',
+    label: 'Power Stone',
+    category: 'classPassive',
+    fraction: 0.15,
+    enabled: false,
+    classes: ['sorcerer'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: true,
+    provenance: SRC_POWERSTONE,
+    confidence: 'high',
+    description:
+      'Sorcerer Daedric Summoning passive: reduces the cost of your ultimate abilities by 15%.',
+  },
+  {
+    id: 'templar-restoring-spirit',
+    label: 'Restoring Spirit',
+    category: 'classPassive',
+    fraction: 0.05,
+    enabled: false,
+    classes: ['templar'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: true,
+    provenance: SRC_RESTORING_SPIRIT,
+    confidence: 'high',
+    description:
+      "Templar Dawn's Wrath passive: reduces all ability costs, including ultimate, by 5%.",
+  },
+];
+
+/**
+ * Known ultimates and their base costs (max rank), for the time-to-ultimate
+ * picker. A representative set of commonly-run raid/dungeon ultimates across all
+ * classes plus the popular guild/weapon-line ults. Costs are U50-current; morphs
+ * of the same base share a cost, so one representative morph is listed per base.
+ */
+export const ULTIMATE_ABILITIES: readonly UltimateAbility[] = [
+  {
+    id: 'generic-250',
+    label: 'Typical ultimate (250)',
+    baseCost: 250,
+    owner: 'global',
+    provenance: UESP_ULTIMATE,
+    confidence: 'high',
+  },
+  // Guild / weapon lines (available to every class)
+  {
+    id: 'dawnbreaker',
+    label: 'Dawnbreaker / Flawless (Fighters Guild)',
+    baseCost: 125,
+    owner: 'weapon',
+    provenance: 'https://eso-skillbook.com/skill/flawless-dawnbreaker',
+    confidence: 'high',
+  },
+  // Dragonknight
+  {
+    id: 'standard-of-might',
+    label: 'Standard of Might (Dragonknight)',
+    baseCost: 200,
+    owner: 'dragonknight',
+    provenance: 'https://eso-skillbook.com/skill/standard-of-might',
+    confidence: 'high',
+  },
+  {
+    id: 'shifting-standard',
+    label: 'Shifting Standard (Dragonknight)',
+    baseCost: 200,
+    owner: 'dragonknight',
+    provenance: 'https://eso-skillbook.com/skill/shifting-standard',
+    confidence: 'high',
+  },
+  {
+    id: 'corrosive-armor',
+    label: 'Corrosive Armor / Magma Shell (Dragonknight)',
+    baseCost: 200,
+    owner: 'dragonknight',
+    provenance: 'https://eso-skillbook.com/skill/corrosive-armor',
+    confidence: 'high',
+  },
+  // Sorcerer
+  {
+    id: 'storm-atronach',
+    label: 'Greater Storm Atronach (Sorcerer)',
+    baseCost: 200,
+    owner: 'sorcerer',
+    provenance: 'https://eso-skillbook.com/skill/greater-storm-atronach',
+    confidence: 'high',
+  },
+  {
+    id: 'negate-magic',
+    label: 'Negate Magic / Suppression Field (Sorcerer)',
+    baseCost: 225,
+    owner: 'sorcerer',
+    provenance: 'https://eso-skillbook.com/skill/suppression-field',
+    confidence: 'high',
+  },
+  // Nightblade
+  {
+    id: 'incapacitating-strike',
+    label: 'Incapacitating Strike / Soul Harvest (Nightblade)',
+    baseCost: 70,
+    owner: 'nightblade',
+    provenance: 'https://eso-skillbook.com/skill/incapacitating-strike',
+    confidence: 'high',
+  },
+  // Templar
+  {
+    id: 'nova',
+    label: 'Nova / Solar Disturbance (Templar)',
+    baseCost: 225,
+    owner: 'templar',
+    provenance: 'https://eso-skillbook.com/skill/solar-disturbance',
+    confidence: 'high',
+  },
+  // Warden
+  {
+    id: 'permafrost',
+    label: 'Permafrost / Northern Storm (Warden)',
+    baseCost: 200,
+    owner: 'warden',
+    provenance: 'https://eso-skillbook.com/skill/permafrost',
+    confidence: 'high',
+  },
+  // Necromancer
+  {
+    id: 'colossus',
+    label: 'Pestilent / Glacial Colossus (Necromancer)',
+    baseCost: 175,
+    owner: 'necromancer',
+    provenance: 'https://eso-skillbook.com/skill/pestilent-colossus',
+    confidence: 'high',
+  },
+  // Arcanist
+  {
+    id: 'the-unblinking-eye',
+    label: 'The Unblinking Eye (Arcanist)',
+    baseCost: 175,
+    owner: 'arcanist',
+    provenance: 'https://eso-skillbook.com/skill/the-unblinking-eye',
+    confidence: 'high',
+  },
+];
+
+export { SRC_MINOR_HEROISM_POTION, UESP_DECISIVE };
+
+/**
+ * The practical sustainable ultimate-per-second ceiling (≈ Warden's best). Used
+ * only as a sanity flag in the UI — there is no hard per-second cap in game, but
+ * a sustained rate above this almost certainly means the inputs are unrealistic.
+ */
+export const SANITY_MAX_ULT_PER_SECOND = 7;
+
+/** Maximum ultimate that can be banked (hard pool cap). */
+export const MAX_ULTIMATE_POOL = 500;

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -33,6 +33,25 @@ const SRC_POWERSTONE = 'https://eso-skillbook.com/skill/power-stone';
 const SRC_RESTORING_SPIRIT = 'https://eso-skillbook.com/skill/restoring-spirit';
 const SRC_PILLAGERS = "https://en.uesp.net/wiki/Online:Pillager's_Profit";
 const SRC_MINOR_HEROISM_POTION = 'https://en.uesp.net/wiki/Online:Heroism';
+const SRC_BLOODSPAWN = 'https://en.uesp.net/wiki/Online:Bloodspawn_(set)';
+const SRC_MOUNTAINS_BLESSING = "https://en.uesp.net/wiki/Online:Mountain's_Blessing";
+const SRC_CATALYST = 'https://eso-skillbook.com/skill/catalyst';
+const SRC_PRISM = 'https://en.uesp.net/wiki/Online:Prism';
+const SRC_KRAGLENS = "https://en.uesp.net/wiki/Online:Kraglen's_Howl";
+const SRC_ARKASIS = "https://en.uesp.net/wiki/Online:Arkasis's_Genius";
+const SRC_ARKAYS = "https://en.uesp.net/wiki/Online:Arkay's_Charity";
+const SRC_COLOVIAN = 'https://en.uesp.net/wiki/Online:Colovian_Highlands_General';
+
+// SEARCHED-AND-EMPTY (documented so the gaps read as deliberate, not missing):
+//  - MYTHIC items: no mythic generates ultimate via a distinct, not-already-modeled
+//    mechanic. Cryptcanon Vestments grants Minor Heroism but blocks self-casting
+//    ult (excluded above); the Oakensoul Ring's Minor Heroism folds into the
+//    generic `minor-heroism` entry. Adding either would double-count.
+//  - CHAMPION POINTS: no CP star generates flat ultimate via a distinct mechanic
+//    (CP ult interactions are cost-style effects, already covered elsewhere).
+//  - PER-CLASS ULT-COST REDUCTIONS beyond Sorcerer Power Stone (-15%) and Templar
+//    Restoring Spirit (-5%): none exist (UESP's "Reduce Ultimate Cost" taxonomy
+//    lists only item sets). DK/Warden/NB/Necro/Arcanist have no such passive.
 
 /**
  * The catalog of toggleable ultimate-generation sources.
@@ -80,8 +99,13 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     defaultEnabled: false,
     provenance: SRC_MINOR_HEROISM,
     confidence: 'high',
+    // Minor Heroism is a single non-stacking buff, so it is modeled as ONE entry
+    // representing whatever provides it (potions, sets, scribing). Adding a second
+    // toggle per provider would double-count the same buff. Set the uptime to
+    // match your source — e.g. an Essence of Heroism potion is only ~33% uptime
+    // over its 45s cooldown, whereas a set that maintains it can approach 100%.
     description:
-      '1 ultimate every 1.5s (0.67/s) in combat. From Heroism potions, certain sets, or scribing — enable it if your build provides it. (Cryptcanon Vestments also grants it but blocks casting your own ultimate, so it is not modeled here.)',
+      '1 ultimate every 1.5s (0.67/s at full uptime) in combat. From Essence of Heroism potions (~33% uptime on the 45s potion cooldown), Minor-Heroism sets (Champion of the Hist, Daring Corsair, Shalk Exoskeleton, etc.), the Oakensoul Ring mythic, or scribing — enable it and set the uptime to match. (Cryptcanon Vestments also grants it but blocks casting your own ultimate, so it is not modeled here.)',
   },
   {
     id: 'major-heroism',
@@ -92,12 +116,17 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     instancesPerSecond: 1 / 1.5, // 3 ult / 1.5s
     uptime: 0.7,
     rollsDecisive: true,
-    availableIn: ['groupPve', 'pvp'],
+    // Available in every context: in a group it comes from a support's buff
+    // (Warden scrip, Drake's Rush bash set); solo it comes from a self-applied
+    // source like the Dragonknight Basalt-Blooded Warrior class set. Modeled as
+    // ONE entry (Major Heroism is a single non-stacking buff — a separate toggle
+    // per provider would double-count it); set the uptime to match your provider.
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
     defaultEnabled: false,
     provenance: SRC_MAJOR_HEROISM,
     confidence: 'high',
     description:
-      '3 ultimate every 1.5s (2.0/s) in combat — the strongest sustained source. Usually a group buff (Warden U50 class scrip, certain sets) rather than self-applied.',
+      '3 ultimate every 1.5s (2.0/s at full uptime) in combat — the strongest sustained source. From a group buff (Warden U50 class scrip, Drake’s Rush on Bash) or a self-applied source (Dragonknight Basalt-Blooded Warrior set, ~50% front-bar uptime). Set the uptime to match how reliably your build holds it.',
   },
 
   // ---- Class passives -------------------------------------------------------
@@ -135,6 +164,86 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     description:
       'Necromancer Living Death passive: +10 ultimate when you consume a corpse, once every 16 seconds. Uptime depends on corpse availability.',
   },
+  {
+    id: 'dragonknight-mountains-blessing',
+    label: "Mountain's Blessing (Earthen Heart cast)",
+    category: 'classPassive',
+    kind: 'triggered',
+    amountPerInstance: 3,
+    instancesPerSecond: 1 / 6, // +3 ult per Earthen Heart cast, once / 6s ICD
+    uptime: 0.5, // ~one Earthen Heart cast per ~12s rotation
+    rollsDecisive: true,
+    classes: ['dragonknight'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_MOUNTAINS_BLESSING,
+    confidence: 'high',
+    description:
+      'Dragonknight Earthen Heart passive: +3 ultimate when you cast an Earthen Heart ability in combat, at most once every 6s. Uptime reflects how often you actually cast one (~0.25 ult/s at one cast / 12s).',
+  },
+  {
+    id: 'templar-prism',
+    label: "Prism (Dawn's Wrath cast)",
+    category: 'classPassive',
+    kind: 'triggered',
+    amountPerInstance: 3,
+    instancesPerSecond: 1 / 6, // +3 ult per Dawn's Wrath cast, once / 6s ICD
+    uptime: 0.9, // a Dawn's Wrath DPS procs this nearly every 6s window
+    rollsDecisive: true,
+    classes: ['templar'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    // Default-on for Templar: a Templar weaving Dawn's Wrath abilities procs this
+    // almost every window, so it is near-always-on income (like the Arcanist's
+    // Implacable Outcome). The tests assert Arcanist defaults, so this is safe.
+    defaultEnabled: true,
+    provenance: SRC_PRISM,
+    confidence: 'high',
+    description:
+      "Templar Dawn's Wrath passive: +3 ultimate when you cast a Dawn's Wrath ability in combat, once every 6s (~0.45 ult/s for a Dawn's Wrath build).",
+  },
+  {
+    id: 'nightblade-catalyst',
+    label: 'Catalyst (potion drink)',
+    category: 'classPassive',
+    kind: 'triggered',
+    amountPerInstance: 22,
+    instancesPerSecond: 1 / 45, // gated by the 45s base potion cooldown
+    uptime: 1,
+    rollsDecisive: true,
+    classes: ['nightblade'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_CATALYST,
+    confidence: 'high',
+    description:
+      'Nightblade Siphoning passive: +22 ultimate each time you drink a potion, gated by the 45s potion cooldown (~0.49 ult/s drinking on cooldown). Medicinal Use (faster potions) is not baked in.',
+  },
+
+  // ---- Gear sets ------------------------------------------------------------
+  {
+    id: 'bloodspawn',
+    label: 'Bloodspawn (monster set)',
+    category: 'set',
+    kind: 'triggered',
+    // Bloodspawn 2pc: when you take damage, 6% chance to generate up to 13
+    // ultimate and raise resistances for 5s, at most once every 5s. The 6% proc
+    // gate (not the 5s ICD) dominates the cadence at a typical tank hit rate, so
+    // the effective cycle is ~11s → ~0.09 instances/s; uptime scales with how
+    // much of the fight you are actively soaking damage. ~0.7 ult/s. Tank-only in
+    // practice (damage-taken trigger). rollsDecisive=false: a gear proc, not your
+    // own light-attack/ability income.
+    amountPerInstance: 13,
+    instancesPerSecond: 0.09,
+    uptime: 0.6,
+    rollsDecisive: false,
+    roles: ['tank'],
+    availableIn: ['soloPve', 'groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_BLOODSPAWN,
+    confidence: 'medium',
+    description:
+      'Bloodspawn monster set (2pc): when you take damage, 6% chance to generate up to 13 ultimate (5s cooldown). Effective rate depends on how often you are hit — modeled at ~0.7 ult/s for an actively-tanking build.',
+  },
 
   // NOTE: Cryptcanon Vestments is intentionally NOT modeled as a self-cast
   // source. It grants Minor Heroism but PREVENTS you from casting your own
@@ -170,6 +279,89 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     confidence: 'medium',
     description:
       "When a group healer wears Pillager's Profit, casting their ultimate grants you 2% of its cost every 2s for 10s (10% of the cost total) — but only once per 45s. Set your healer's ult cost below; e.g. a 250-cost ult ≈ 25 per cast (~0.55 ult/s), a 500 ult ≈ 50.",
+  },
+  {
+    id: 'arkasis-genius-external',
+    label: "Arkasis's Genius (from ally)",
+    category: 'external',
+    kind: 'triggered',
+    // When an ally wearing Arkasis's Genius (Stone Garden, 5pc) drinks a potion in
+    // combat, up to 3 group members each gain a flat 44 ultimate. The binding gate
+    // is the ally's ~45s potion cooldown (NOT the set's 30s ICD), so ~1/45 → ~0.98
+    // ult/s if the ally pots on cooldown. Each recipient gets the full 44.
+    amountPerInstance: 44,
+    instancesPerSecond: 1 / 45,
+    uptime: 1,
+    rollsDecisive: false,
+    availableIn: ['groupPve'],
+    defaultEnabled: false,
+    provenance: SRC_ARKASIS,
+    confidence: 'medium',
+    description:
+      "When a group member wears Arkasis's Genius (Stone Garden) and drinks a potion in combat, you gain a flat 44 ultimate — gated by their ~45s potion cooldown (~1 ult/s if they pot on cooldown).",
+  },
+  {
+    id: 'arkays-charity-external',
+    label: "Arkay's Charity (ally cleanse)",
+    category: 'external',
+    kind: 'triggered',
+    // When an ally wearing Arkay's Charity cleanses a negative effect from you, you
+    // gain 13 ultimate, once every 9s per target. Highly fight-dependent — only
+    // when you actually have a removable debuff that gets purged. Conservative 25%
+    // realization of the 9s window → ~0.36 ult/s; near-zero with no debuffs.
+    amountPerInstance: 13,
+    instancesPerSecond: 1 / 9,
+    uptime: 0.25,
+    rollsDecisive: false,
+    availableIn: ['groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_ARKAYS,
+    confidence: 'low',
+    description:
+      "When an ally wearing Arkay's Charity cleanses a negative effect from you, you gain 13 ultimate (9s per-target cooldown). Highly situational — only when you have a removable debuff that gets purged; near-zero in fights with no debuffs.",
+  },
+  {
+    id: 'colovian-highlands-general-external',
+    label: 'Colovian Highlands General (from ally)',
+    category: 'external',
+    kind: 'perCast',
+    // PvP Elite set (Cyrodiil, 2pc). When an ally wearing it kills a Player nearby,
+    // you gain a flat 15 ultimate (no ICD — bounded only by kill cadence). Modeled
+    // at ~one shared kill / 72s ≈ 0.21 ult/s averaged; far higher in an active
+    // burst, near-zero during downtime. PvP-only.
+    amountPerInstance: 15,
+    instancesPerSecond: 1 / 72,
+    uptime: 1,
+    rollsDecisive: false,
+    availableIn: ['pvp'],
+    defaultEnabled: false,
+    provenance: SRC_COLOVIAN,
+    confidence: 'low',
+    description:
+      'PvP Cyrodiil Elite set: when an ally wearing it kills a Player near you, you gain a flat 15 ultimate (no cooldown — bounded by kill cadence). Modeled at ~0.2 ult/s over a session; spikes during active fights. Tune the uptime to your engagement.',
+  },
+
+  // ---- Group synergies ------------------------------------------------------
+  {
+    id: 'kraglens-howl-heed-the-call',
+    label: 'Heed the Call (Kraglen’s Howl synergy)',
+    category: 'synergy',
+    kind: 'triggered',
+    // Kraglen's Howl (Stone Garden, 5pc): after a recently-damaged enemy dies, you
+    // grant allies the Heed the Call synergy; activating it gives you and the
+    // activator 12 ultimate, once every 20s. Distinct flat-ult synergy (not
+    // Heroism). Death-gated + depends on an ally pressing it → ~0.3 ult/s in
+    // add-heavy pulls, up to 0.6 at a perfect 20s cadence, near-zero on clean ST.
+    amountPerInstance: 12,
+    instancesPerSecond: 1 / 20,
+    uptime: 0.5,
+    rollsDecisive: false,
+    availableIn: ['groupPve', 'pvp'],
+    defaultEnabled: false,
+    provenance: SRC_KRAGLENS,
+    confidence: 'medium',
+    description:
+      'Kraglen’s Howl set (Stone Garden, 5pc): after a damaged enemy dies you grant allies the Heed the Call synergy; activating it gives you 12 ultimate, once every 20s. Add-death-gated — ~0.3 ult/s in add-heavy pulls, near-zero on a clean single-target boss.',
   },
 ];
 
@@ -315,6 +507,173 @@ export const ULTIMATE_ABILITIES: readonly UltimateAbility[] = [
     owner: 'arcanist',
     provenance: 'https://eso-skillbook.com/skill/the-unblinking-eye',
     confidence: 'high',
+  },
+  {
+    id: 'gibbering-shield',
+    label: 'Gibbering Shield / Sanctum of the Abyssal Sea (Arcanist)',
+    baseCost: 200,
+    owner: 'arcanist',
+    provenance: 'https://eso-skillbook.com/skill/gibbering-shield',
+    confidence: 'high',
+  },
+  {
+    id: 'vitalizing-glyphic',
+    label: 'Vitalizing Glyphic / Glyphic of the Tides (Arcanist)',
+    baseCost: 200,
+    owner: 'arcanist',
+    provenance: 'https://eso-skillbook.com/skill/vitalizing-glyphic',
+    confidence: 'high',
+  },
+  // Dragonknight (additional)
+  {
+    id: 'dragon-leap',
+    label: 'Dragon Leap / Take Flight (Dragonknight)',
+    baseCost: 125,
+    owner: 'dragonknight',
+    provenance: 'https://eso-skillbook.com/skill/dragon-leap',
+    confidence: 'high',
+  },
+  // Nightblade (additional)
+  {
+    id: 'consuming-darkness',
+    label: 'Consuming Darkness / Veil of Blades (Nightblade)',
+    baseCost: 200,
+    owner: 'nightblade',
+    provenance: 'https://eso-skillbook.com/skill/consuming-darkness',
+    confidence: 'high',
+  },
+  {
+    id: 'soul-shred',
+    label: 'Soul Shred / Soul Tether / Soul Siphon (Nightblade)',
+    baseCost: 150,
+    owner: 'nightblade',
+    provenance: 'https://eso-skillbook.com/skill/soul-shred',
+    confidence: 'high',
+  },
+  // Templar (additional)
+  {
+    id: 'radial-sweep',
+    label: 'Radial Sweep / Crescent Sweep (Templar)',
+    baseCost: 75,
+    owner: 'templar',
+    provenance: 'https://eso-skillbook.com/skill/radial-sweep',
+    confidence: 'high',
+  },
+  {
+    id: 'rite-of-passage',
+    label: 'Rite of Passage / Remembrance (Templar)',
+    baseCost: 125,
+    owner: 'templar',
+    provenance: 'https://eso-skillbook.com/skill/rite-of-passage',
+    confidence: 'high',
+  },
+  // Warden (additional)
+  {
+    id: 'feral-guardian',
+    label: "Feral Guardian / Wild Guardian (Warden, Guardian's Wrath)",
+    baseCost: 75,
+    owner: 'warden',
+    provenance: 'https://eso-skillbook.com/skill/feral-guardian',
+    confidence: 'medium',
+  },
+  {
+    id: 'secluded-grove',
+    label: 'Secluded Grove / Healing Thicket (Warden)',
+    baseCost: 90,
+    owner: 'warden',
+    provenance: 'https://eso-skillbook.com/skill/secluded-grove',
+    confidence: 'high',
+  },
+  // Necromancer (additional)
+  {
+    id: 'bone-goliath-transformation',
+    label: 'Bone Goliath / Pummeling Goliath / Ravenous Goliath (Necromancer)',
+    baseCost: 250,
+    owner: 'necromancer',
+    provenance: 'https://eso-skillbook.com/skill/bone-goliath-transformation',
+    confidence: 'high',
+  },
+  {
+    id: 'reanimate',
+    label: 'Reanimate / Animate Blastbones / Renewing Animation (Necromancer)',
+    baseCost: 335,
+    owner: 'necromancer',
+    provenance: 'https://eso-skillbook.com/skill/reanimate',
+    confidence: 'high',
+  },
+  // Weapon lines (available to every class)
+  {
+    id: 'lacerate',
+    label: 'Lacerate / Rend / Thrive in Chaos (Dual Wield)',
+    baseCost: 150,
+    owner: 'weapon',
+    provenance: 'https://eso-skillbook.com/skill/lacerate',
+    confidence: 'high',
+  },
+  {
+    id: 'rapid-fire',
+    label: 'Rapid Fire / Toxic Barrage / Ballista (Bow)',
+    baseCost: 175,
+    owner: 'weapon',
+    provenance: 'https://eso-skillbook.com/skill/rapid-fire',
+    confidence: 'high',
+  },
+  {
+    id: 'elemental-storm',
+    label: 'Elemental Storm / Elemental Rage / Eye of the Storm (Destruction Staff)',
+    baseCost: 250,
+    owner: 'weapon',
+    provenance: 'https://eso-skillbook.com/skill/elemental-storm',
+    confidence: 'high',
+  },
+  {
+    id: 'panacea',
+    label: "Panacea / Life Giver / Light's Champion (Restoration Staff)",
+    baseCost: 125,
+    owner: 'weapon',
+    provenance: 'https://eso-skillbook.com/skill/panacea',
+    confidence: 'high',
+  },
+  // Guild / world / Alliance War lines (available to every class)
+  {
+    id: 'meteor',
+    label: 'Meteor / Shooting Star / Ice Comet (Mages Guild)',
+    baseCost: 200,
+    owner: 'global',
+    provenance: 'https://eso-skillbook.com/skill/meteor',
+    confidence: 'high',
+  },
+  {
+    id: 'soul-strike',
+    label: 'Soul Strike / Soul Assault / Shatter Soul (Soul Magic)',
+    baseCost: 175,
+    owner: 'global',
+    provenance: 'https://eso-skillbook.com/skill/soul-strike',
+    confidence: 'high',
+  },
+  {
+    id: 'undo-psijic',
+    label: 'Precognition / Temporal Guard (Psijic Order)',
+    baseCost: 150,
+    owner: 'global',
+    provenance: 'https://en.uesp.net/wiki/Online:Undo',
+    confidence: 'high',
+  },
+  {
+    id: 'war-horn',
+    label: 'War Horn / Aggressive Horn / Sturdy Horn (Alliance War)',
+    baseCost: 250,
+    owner: 'global',
+    provenance: 'https://eso-skillbook.com/skill/war-horn',
+    confidence: 'high',
+  },
+  {
+    id: 'barrier',
+    label: 'Barrier / Reviving Barrier / Replenishing Barrier (Support)',
+    baseCost: 200,
+    owner: 'global',
+    provenance: 'https://en.uesp.net/wiki/Online:Barrier',
+    confidence: 'medium',
   },
 ];
 

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -483,11 +483,15 @@ export const ULTIMATE_ABILITIES: readonly UltimateAbility[] = [
   },
   // Templar
   {
+    // Nova is one of the rare ults whose morphs DON'T share a cost: base Nova and
+    // the Solar Prison morph are 250, but Solar Disturbance is 225 (verified on
+    // ESO-Skillbook). We list the base/Solar Prison cost (250); pick "Custom cost"
+    // and enter 225 if modeling Solar Disturbance specifically.
     id: 'nova',
-    label: 'Nova / Solar Disturbance (Templar)',
-    baseCost: 225,
+    label: 'Nova / Solar Prison (Templar)',
+    baseCost: 250,
     owner: 'templar',
-    provenance: 'https://eso-skillbook.com/skill/solar-disturbance',
+    provenance: 'https://eso-skillbook.com/skill/nova',
     confidence: 'high',
   },
   // Warden

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -192,10 +192,14 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     rollsDecisive: true,
     classes: ['templar'],
     availableIn: ['soloPve', 'groupPve', 'pvp'],
-    // Default-on for Templar: a Templar weaving Dawn's Wrath abilities procs this
-    // almost every window, so it is near-always-on income (like the Arcanist's
-    // Implacable Outcome). The tests assert Arcanist defaults, so this is safe.
-    defaultEnabled: true,
+    // Default OFF: Prism only procs on a Dawn's Wrath cast — a LOADOUT choice, not
+    // a class-universal mechanic. A Templar tank/healer (Aedric Spear / Restoring
+    // Light) may slot no Dawn's Wrath skills at all, so defaulting it on would
+    // over-estimate their generation. This matches the conservative posture of the
+    // other loadout-dependent class procs (Mountain's Blessing, Corpse Consumption,
+    // both default off). Contrast Arcanist Implacable Outcome, which procs on Crux —
+    // every Arcanist generates and spends Crux, so that one is genuinely default-on.
+    defaultEnabled: false,
     provenance: SRC_PRISM,
     confidence: 'high',
     description:
@@ -254,31 +258,32 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
   // ---- Group support (external) --------------------------------------------
   {
     id: 'pillagers-profit-external',
-    label: "Pillager's Profit (from healer)",
+    label: "Pillager's Profit (from set wearer)",
     category: 'external',
     kind: 'perCast',
-    // Pillager's Profit (Dreadsail Reef, 5pc): when the wearer casts an ultimate
-    // in combat, group members gain 2% of the ultimate SPENT *per tick*, every 2s
-    // over 10s (= 5 ticks → 10% of the cost total), and a member can only be
-    // affected ONCE PER 45s. So one healer-cast grants a DPS 10% of the healer's
-    // ult cost, capped to one bundle / 45s:
+    // Pillager's Profit (Dreadsail Reef, 5pc): when the WEARER (usually your
+    // healer) casts an ultimate in combat, group members gain 2% of the ultimate
+    // SPENT *per tick*, every 2s over 10s (= 5 ticks → 10% of the cost total), and
+    // a member can only be affected ONCE PER 45s. So one wearer-cast grants a group
+    // member 10% of the WEARER'S ult cost, capped to one bundle / 45s:
     //   250-cost ult → 25 ult / 45s ≈ 0.56 ult/s;  500 (max) → 50 ult ≈ 1.1 ult/s.
-    // The per-cast amount scales with the healer's ult cost (set in the UI; see
+    // The per-cast amount scales with the wearer's ult cost (set in the UI; see
     // PILLAGERS_PROFIT_FRACTION_PER_CAST in compileCatalog.ts). amountPerInstance
-    // here is the fallback for a ~250-cost healer ult. The earlier 50/(1/12s)
+    // here is the fallback for a ~250-cost wearer ult. The earlier 50/(1/12s)
     // encoding implied ~4.2 ult/s — ~10× too high — because it ignored the 45s
-    // lockout and applied a flat 50 regardless of the healer's actual ult.
-    amountPerInstance: 25, // 10% of a typical ~250 healer ult (overridden by UI input)
+    // lockout and applied a flat 50 regardless of the wearer's actual ult.
+    amountPerInstance: 25, // 10% of a typical ~250 wearer ult (overridden by UI input)
     instancesPerSecond: 1 / 45, // 45s per-target lockout dominates the cadence
     uptime: 1,
     rollsDecisive: false, // externally granted — does not roll the wearer's Decisive
-    roles: ['dps'],
+    // No role restriction: the Profit bundle is granted to group members in range
+    // regardless of role — a tank or off-healer benefits just as a DPS does.
     availableIn: ['groupPve'],
     defaultEnabled: false,
     provenance: SRC_PILLAGERS,
     confidence: 'medium',
     description:
-      "When a group healer wears Pillager's Profit, casting their ultimate grants you 2% of its cost every 2s for 10s (10% of the cost total) — but only once per 45s. Set your healer's ult cost below; e.g. a 250-cost ult ≈ 25 per cast (~0.55 ult/s), a 500 ult ≈ 50.",
+      "When a group member wears Pillager's Profit (usually your healer), their ultimate cast grants you 2% of ITS cost every 2s for 10s (10% of the cost total) — but only once per 45s. Set the wearer's ult cost below (their ultimate, not yours); e.g. a 250-cost ult ≈ 25 per cast (~0.55 ult/s), a 500 ult ≈ 50.",
   },
   {
     id: 'arkasis-genius-external',
@@ -372,7 +377,6 @@ export const COST_REDUCTION_CATALOG: readonly CatalogCostReduction[] = [
     label: 'Power Stone',
     category: 'classPassive',
     fraction: 0.15,
-    enabled: false,
     classes: ['sorcerer'],
     availableIn: ['soloPve', 'groupPve', 'pvp'],
     defaultEnabled: true,
@@ -386,7 +390,6 @@ export const COST_REDUCTION_CATALOG: readonly CatalogCostReduction[] = [
     label: 'Restoring Spirit',
     category: 'classPassive',
     fraction: 0.05,
-    enabled: false,
     classes: ['templar'],
     availableIn: ['soloPve', 'groupPve', 'pvp'],
     defaultEnabled: true,

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -149,15 +149,17 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     category: 'external',
     kind: 'perCast',
     // Pillager's Profit (Dreadsail Reef, 5pc): when the wearer casts an ultimate
-    // in combat, group members gain 2% of the ultimate SPENT, every 2s over 10s
-    // (= 5 ticks), and a member can only be affected ONCE PER 45s. So one
-    // healer-cast on a ~200 ult ability grants a DPS 2% × 200 × 5 = 20 ultimate,
-    // and the 45s per-target lockout caps it to at most one such bundle / 45s.
-    //   effective ≈ 20 ult / 45s ≈ 0.44 ult/s (healer ulting on cooldown).
-    // Modeled as one 20-ult bundle every 45s. The earlier 50/(1/12s) encoding
-    // implied ~4.2 ult/s — ~10× too high — because it ignored the 45s lockout
-    // and over-stated the per-event amount.
-    amountPerInstance: 20,
+    // in combat, group members gain 2% of the ultimate SPENT *per tick*, every 2s
+    // over 10s (= 5 ticks → 10% of the cost total), and a member can only be
+    // affected ONCE PER 45s. So one healer-cast grants a DPS 10% of the healer's
+    // ult cost, capped to one bundle / 45s:
+    //   250-cost ult → 25 ult / 45s ≈ 0.56 ult/s;  500 (max) → 50 ult ≈ 1.1 ult/s.
+    // The per-cast amount scales with the healer's ult cost (set in the UI; see
+    // PILLAGERS_PROFIT_FRACTION_PER_CAST in compileCatalog.ts). amountPerInstance
+    // here is the fallback for a ~250-cost healer ult. The earlier 50/(1/12s)
+    // encoding implied ~4.2 ult/s — ~10× too high — because it ignored the 45s
+    // lockout and applied a flat 50 regardless of the healer's actual ult.
+    amountPerInstance: 25, // 10% of a typical ~250 healer ult (overridden by UI input)
     instancesPerSecond: 1 / 45, // 45s per-target lockout dominates the cadence
     uptime: 1,
     rollsDecisive: false, // externally granted — does not roll the wearer's Decisive
@@ -167,7 +169,7 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     provenance: SRC_PILLAGERS,
     confidence: 'medium',
     description:
-      "When a group healer wears Pillager's Profit, casting their ultimate grants you 2% of its cost every 2s for 10s — about 20 ultimate from a 200-cost ult — but only once per 45s. Modeled as ~0.4 ult/s; the real rate scales with your healer's ultimate cost and how often they cast it.",
+      "When a group healer wears Pillager's Profit, casting their ultimate grants you 2% of its cost every 2s for 10s (10% of the cost total) — but only once per 45s. Set your healer's ult cost below; e.g. a 250-cost ult ≈ 25 per cast (~0.55 ult/s), a 500 ult ≈ 50.",
   },
 ];
 

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -166,11 +166,17 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
   },
   {
     id: 'dragonknight-mountains-blessing',
-    label: "Mountain's Blessing (Earthen Heart cast)",
+    // U50 name is "Blessing at the Peak" (verified against the repo's curated DK
+    // Earthen Heart skill-line data, src/data/skill-lines/class/earthenHeart.ts —
+    // the project oracle; the old "Mountain's Blessing" name was pre-U50).
+    label: 'Blessing at the Peak (Earthen Heart cast)',
     category: 'classPassive',
     kind: 'triggered',
-    amountPerInstance: 3,
-    instancesPerSecond: 1 / 6, // +3 ult per Earthen Heart cast, once / 6s ICD
+    // Verified value: +1 Ultimate (NOT 3) per Earthen Heart cast/hit, once / 6s.
+    // The earlier "3" was unsourced — the skill-line oracle reads "generate 1
+    // Ultimate ... once every 6 seconds".
+    amountPerInstance: 1,
+    instancesPerSecond: 1 / 6,
     uptime: 0.5, // ~one Earthen Heart cast per ~12s rotation
     rollsDecisive: true,
     classes: ['dragonknight'],
@@ -179,7 +185,7 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     provenance: SRC_MOUNTAINS_BLESSING,
     confidence: 'high',
     description:
-      'Dragonknight Earthen Heart passive: +3 ultimate when you cast an Earthen Heart ability in combat, at most once every 6s. Uptime reflects how often you actually cast one (~0.25 ult/s at one cast / 12s).',
+      'Dragonknight Earthen Heart passive (Blessing at the Peak): +1 ultimate when you cast or deal damage with an Earthen Heart ability in combat, at most once every 6s. Uptime reflects how often you actually use one (~0.08 ult/s at one cast / 12s).',
   },
   {
     id: 'templar-prism',

--- a/src/features/ultimate-simulator/shared/constants/catalog.ts
+++ b/src/features/ultimate-simulator/shared/constants/catalog.ts
@@ -148,8 +148,17 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     label: "Pillager's Profit (from healer)",
     category: 'external',
     kind: 'perCast',
-    amountPerInstance: 50,
-    instancesPerSecond: 1 / 12, // batteried to allies in bursts
+    // Pillager's Profit (Dreadsail Reef, 5pc): when the wearer casts an ultimate
+    // in combat, group members gain 2% of the ultimate SPENT, every 2s over 10s
+    // (= 5 ticks), and a member can only be affected ONCE PER 45s. So one
+    // healer-cast on a ~200 ult ability grants a DPS 2% × 200 × 5 = 20 ultimate,
+    // and the 45s per-target lockout caps it to at most one such bundle / 45s.
+    //   effective ≈ 20 ult / 45s ≈ 0.44 ult/s (healer ulting on cooldown).
+    // Modeled as one 20-ult bundle every 45s. The earlier 50/(1/12s) encoding
+    // implied ~4.2 ult/s — ~10× too high — because it ignored the 45s lockout
+    // and over-stated the per-event amount.
+    amountPerInstance: 20,
+    instancesPerSecond: 1 / 45, // 45s per-target lockout dominates the cadence
     uptime: 1,
     rollsDecisive: false, // externally granted — does not roll the wearer's Decisive
     roles: ['dps'],
@@ -158,7 +167,7 @@ export const ULTIMATE_SOURCE_CATALOG: readonly CatalogSource[] = [
     provenance: SRC_PILLAGERS,
     confidence: 'medium',
     description:
-      "When a group healer wears Pillager's Profit, 2% of ultimate they spend is granted to nearby group members. Modeled as an external trickle to a DPS; exact rate varies with the healer's ultimate usage.",
+      "When a group healer wears Pillager's Profit, casting their ultimate grants you 2% of its cost every 2s for 10s — about 20 ultimate from a 200-cost ult — but only once per 45s. Modeled as ~0.4 ult/s; the real rate scales with your healer's ultimate cost and how often they cast it.",
   },
 ];
 

--- a/src/features/ultimate-simulator/shared/constants/index.ts
+++ b/src/features/ultimate-simulator/shared/constants/index.ts
@@ -1,45 +1,46 @@
 /**
- * Constants and presets for the Arcanist Ultimate Simulator.
+ * Engine-level constants for the Ultimate Calculator.
  *
- * Numbers derive from research (.scratch/ult-sim-research.md) and from decoding
- * the original Google Sheet. The model is a raid-context Arcanist: it RECEIVES
- * group ult support (Major Heroism from a Warden's U50 Class Mastery scrip,
- * Pillager's Profit batteried from the healer) on top of its own base income.
- *
- * Calibration against real ESO Logs data (the source of truth) can later
- * override any of these — they are defaults, not assumptions baked in code.
+ * The all-class source data lives in `./catalog.ts`; this file holds only the
+ * Decisive proc ladder, the default fight length, and the `makeDecisiveConfig`
+ * helper. The `SHEET_VALIDATION_SOURCES` preset (sheetValidation.ts) is kept as a
+ * regression anchor for the engine, reproducing the original ported model's
+ * known outputs.
  */
 
-import type { UltimateSource, DecisiveConfig } from '../types';
+import type { DecisiveConfig, UltimateSource } from '../types';
 
-/** Default fight length used by the sheet. */
+/** Default fight length (3 minutes — a typical raid boss pull). */
 export const DEFAULT_FIGHT_DURATION_SECONDS = 180;
 
-/** Default Monte Carlo run count (10k → standard error ≈ sheet's ÷10). */
-export const DEFAULT_MONTE_CARLO_RUNS = 10000;
-
-/** Default base seed for reproducible aggregates. */
-export const DEFAULT_BASE_SEED = 1;
-
 /**
- * Decisive per-instance proc chance by weapon quality (single roll).
- * The five-tier ladder; the gold value matches the sheet's decoded 27.68%.
- * NOTE: some sources list legendary as .254 — kept .275 to match the sheet's
- * empirical "Half" value pending in-game verification.
+ * Per-instance chance the Decisive trait grants +1 ultimate, by weapon quality.
+ *
+ * The full FIVE-tier ladder, verified against UESP (Online:Decisive):
+ * Normal 19.1% / Fine 21.2% / Superior 23.3% / Epic 25.4% / Legendary 27.5%
+ * (each tier +2.1%). Decisive exists from white quality up. (The historical
+ * "0.254 vs 0.275" disagreement was Epic vs Legendary — two different tiers, not
+ * two competing Legendary values.)
  */
 export const DECISIVE_PROC_CHANCE = {
-  fine: 0.191,
-  superior: 0.212,
-  epic: 0.233,
+  normal: 0.191,
+  fine: 0.212,
+  superior: 0.233,
+  epic: 0.254,
   legendary: 0.275,
 } as const;
 
 export type DecisiveQuality = keyof typeof DECISIVE_PROC_CHANCE;
 
+/** Default weapon quality assumed when Decisive is enabled (an optimized build). */
+export const DEFAULT_DECISIVE_QUALITY: DecisiveQuality = 'legendary';
+
 /**
  * Build a DecisiveConfig from quality + whether the weapon is two-handed.
- * 1H / staff / bow = 1 roll per instance; 2H melee = 2 independent rolls
- * (ESO's "two-handed weapons provide twice the bonus").
+ * 1H / restoration & destruction staff & bow each count as their own weapon for
+ * trait purposes (1 roll); a TWO-HANDED melee weapon (greatsword / battle axe /
+ * maul) occupies both bars' weapon slots and "provides twice the bonus" — modeled
+ * as 2 independent rolls per instance (mean = 2 × procChance).
  */
 export function makeDecisiveConfig(quality: DecisiveQuality, twoHanded: boolean): DecisiveConfig {
   return {
@@ -48,8 +49,14 @@ export function makeDecisiveConfig(quality: DecisiveQuality, twoHanded: boolean)
   };
 }
 
+/** Default Monte Carlo run count (10k → standard error ≈ sheet's ÷10). */
+export const DEFAULT_MONTE_CARLO_RUNS = 10000;
+
+/** Default base seed for reproducible aggregates. */
+export const DEFAULT_BASE_SEED = 1;
+
 /**
- * Raid-context source preset (corrected from the sheet).
+ * Raid-context source preset (used by the standalone Arcanist Ultimate Simulator).
  *
  * Tick cadences: Heroism buffs tick every 1.5s (instancesPerSecond = 1/1.5).
  * The "base" row is the light/heavy-attack buff (3 ult/sec, 1 instance/sec),

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -103,14 +103,6 @@ export interface CatalogSource extends UltimateSource {
   readonly roles?: readonly CombatRole[];
   /** Whether it's enabled by default for its context (typical raid build). */
   readonly defaultEnabled: boolean;
-  /**
-   * Key for a named buff that does NOT stack across providers (e.g. Minor
-   * Heroism from the generic potion/set source AND from Cryptcanon are the same
-   * buff). When more than one enabled source shares this key, only the strongest
-   * single contribution counts — they are not summed. Omit for sources that do
-   * stack independently (base income, class passives, external batteries).
-   */
-  readonly nonStackingGroup?: string;
   /** Source URL the value came from (research provenance — required, no guessing). */
   readonly provenance: string;
   /** Confidence in the encoded numbers. */

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -103,6 +103,14 @@ export interface CatalogSource extends UltimateSource {
   readonly roles?: readonly CombatRole[];
   /** Whether it's enabled by default for its context (typical raid build). */
   readonly defaultEnabled: boolean;
+  /**
+   * Key for a named buff that does NOT stack across providers (e.g. Minor
+   * Heroism from the generic potion/set source AND from Cryptcanon are the same
+   * buff). When more than one enabled source shares this key, only the strongest
+   * single contribution counts — they are not summed. Omit for sources that do
+   * stack independently (base income, class passives, external batteries).
+   */
+  readonly nonStackingGroup?: string;
   /** Source URL the value came from (research provenance — required, no guessing). */
   readonly provenance: string;
   /** Confidence in the encoded numbers. */

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -1,0 +1,135 @@
+/**
+ * Catalog type vocabulary — the schema for the all-class ultimate-source data.
+ *
+ * The engine (core/) is class-agnostic; it only knows generic `UltimateSource`s.
+ * The CATALOG is the data layer that knows ESO specifics: which sources belong
+ * to which class, which sets/mythics/CP/potions exist, what an ultimate costs,
+ * and what reduces that cost. The presentation layer lets the user pick a
+ * class/role/context and toggle catalog entries on/off; enabled entries are
+ * compiled into the engine's `UltimateSource[]` + cost inputs.
+ *
+ * This file defines only the SHAPE. The actual numbers live in catalog data
+ * files and are research-sourced (each entry carries its `source` citation and
+ * `confidence`), so "no guessing" is enforced structurally — an entry without a
+ * citation is visibly incomplete.
+ */
+
+import type { CostReduction } from '../../core/cost';
+
+import type { UltimateSource } from './index';
+
+/** Canonical ESO class keys (matches src/utils/classNameUtils.ts). */
+export type EsoClass =
+  | 'dragonknight'
+  | 'templar'
+  | 'warden'
+  | 'nightblade'
+  | 'sorcerer'
+  | 'necromancer'
+  | 'arcanist';
+
+export const ESO_CLASSES: readonly EsoClass[] = [
+  'arcanist',
+  'dragonknight',
+  'necromancer',
+  'nightblade',
+  'sorcerer',
+  'templar',
+  'warden',
+];
+
+export const ESO_CLASS_LABELS: Record<EsoClass, string> = {
+  arcanist: 'Arcanist',
+  dragonknight: 'Dragonknight',
+  necromancer: 'Necromancer',
+  nightblade: 'Nightblade',
+  sorcerer: 'Sorcerer',
+  templar: 'Templar',
+  warden: 'Warden',
+};
+
+/** Combat role — drives which support sources are realistically available. */
+export type CombatRole = 'dps' | 'healer' | 'tank';
+
+/** Where the build is being played — gates group-only buffs and PvP-only items. */
+export type CombatContext = 'soloPve' | 'groupPve' | 'pvp';
+
+export const COMBAT_CONTEXT_LABELS: Record<CombatContext, string> = {
+  soloPve: 'Solo / parse (PvE)',
+  groupPve: 'Group / trial (PvE)',
+  pvp: 'PvP',
+};
+
+/** What kind of thing a catalog entry is (for grouping in the UI). */
+export type SourceCategory =
+  | 'base' // light/heavy-attack income, damage-dealt/taken income
+  | 'heroism' // Minor/Major Heroism from any provider
+  | 'classPassive' // class skill-line passives that generate ult
+  | 'set' // gear sets
+  | 'mythic' // one-piece mythics
+  | 'championPoint' // CP stars
+  | 'potion' // alchemy potions
+  | 'synergy' // group synergies
+  | 'external'; // ult batteried/granted by an ally (group context)
+
+export const SOURCE_CATEGORY_LABELS: Record<SourceCategory, string> = {
+  base: 'Base income',
+  heroism: 'Heroism',
+  classPassive: 'Class passive',
+  set: 'Gear set',
+  mythic: 'Mythic',
+  championPoint: 'Champion Point',
+  potion: 'Potion',
+  synergy: 'Synergy',
+  external: 'Group support',
+};
+
+export type Confidence = 'high' | 'medium' | 'low';
+
+/**
+ * A single catalog entry: a generation source the user can toggle on/off.
+ *
+ * It extends the engine's `UltimateSource` (so an enabled entry compiles
+ * directly into the engine) with catalog metadata: category, the contexts/roles
+ * /classes it's available in, a default-on flag, and provenance.
+ */
+export interface CatalogSource extends UltimateSource {
+  readonly category: SourceCategory;
+  /** Contexts this source can appear in (e.g. external support is group-only). */
+  readonly availableIn: readonly CombatContext[];
+  /** If set, only these classes can use it (class passives). Omit = all classes. */
+  readonly classes?: readonly EsoClass[];
+  /** If set, only these roles realistically run it. Omit = any role. */
+  readonly roles?: readonly CombatRole[];
+  /** Whether it's enabled by default for its context (typical raid build). */
+  readonly defaultEnabled: boolean;
+  /** Source URL the value came from (research provenance — required, no guessing). */
+  readonly provenance: string;
+  /** Confidence in the encoded numbers. */
+  readonly confidence: Confidence;
+  /** Human-readable note shown in the UI. */
+  readonly description?: string;
+}
+
+/** A catalog entry for an ultimate-cost reduction (compiles into CostReduction). */
+export interface CatalogCostReduction extends CostReduction {
+  readonly category: SourceCategory;
+  readonly availableIn: readonly CombatContext[];
+  readonly classes?: readonly EsoClass[];
+  readonly defaultEnabled: boolean;
+  readonly provenance: string;
+  readonly confidence: Confidence;
+  readonly description?: string;
+}
+
+/** A known ultimate (ability) with its base cost — for the time-to-ult picker. */
+export interface UltimateAbility {
+  readonly id: string;
+  readonly label: string;
+  /** Base ultimate cost before any reduction. */
+  readonly baseCost: number;
+  /** Class that owns it, or 'weapon'/'global' for shared/weapon-line ults. */
+  readonly owner: EsoClass | 'weapon' | 'global';
+  readonly provenance: string;
+  readonly confidence: Confidence;
+}

--- a/src/features/ultimate-simulator/shared/types/catalog.ts
+++ b/src/features/ultimate-simulator/shared/types/catalog.ts
@@ -111,8 +111,15 @@ export interface CatalogSource extends UltimateSource {
   readonly description?: string;
 }
 
-/** A catalog entry for an ultimate-cost reduction (compiles into CostReduction). */
-export interface CatalogCostReduction extends CostReduction {
+/**
+ * A catalog entry for an ultimate-cost reduction (compiles into CostReduction).
+ *
+ * The engine's runtime `enabled` flag is intentionally omitted: the catalog only
+ * declares the DEFAULT (`defaultEnabled`); `compileReductions` synthesizes the
+ * actual `enabled` from the user's toggles. Carrying a literal `enabled` here
+ * would be inert (never read) and could contradict the real default-on behavior.
+ */
+export interface CatalogCostReduction extends Omit<CostReduction, 'enabled'> {
   readonly category: SourceCategory;
   readonly availableIn: readonly CombatContext[];
   readonly classes?: readonly EsoClass[];

--- a/src/features/ultimate-simulator/shared/types/index.ts
+++ b/src/features/ultimate-simulator/shared/types/index.ts
@@ -115,3 +115,45 @@ export interface MonteCarloResult {
   /** Mean per-source contribution across runs. */
   readonly contributions: readonly SourceContribution[];
 }
+
+/**
+ * Exact closed-form expectation of ultimate generation over the fight.
+ *
+ * This is the calculator's headline result — same shape as a single
+ * `SimulationResult`, but every value is the true mean (no sampling noise), so
+ * it never wobbles between recomputes. `contributions` are sorted by total
+ * contribution descending.
+ */
+export interface ExpectedValueResult {
+  readonly totalUltimate: number;
+  readonly baseUltimate: number;
+  readonly decisiveUltimate: number;
+  readonly ultimatePerSecond: number;
+  readonly contributions: readonly SourceContribution[];
+}
+
+/** Inputs to the time-to-ultimate computation. */
+export interface TimeToUltimateInput {
+  /** Ultimate cost AFTER any cost reduction has been applied. */
+  readonly effectiveCost: number;
+  /** Steady-state ultimate generation rate (ult / second). */
+  readonly ultimatePerSecond: number;
+  /** Fight length, for casts-per-fight. */
+  readonly fightDurationSeconds: number;
+  /** Ultimate already banked at the start (0..effectiveCost). Default 0. */
+  readonly startingUltimate?: number;
+}
+
+/** Result of the time-to-ultimate computation. */
+export interface TimeToUltimateResult {
+  readonly effectiveCost: number;
+  readonly ultimatePerSecond: number;
+  /** Seconds until the first cast is affordable (∞ if rate is 0). */
+  readonly secondsToFirstCast: number;
+  /** Steady-state seconds between casts (cost / rate; ∞ if rate is 0). */
+  readonly secondsPerCast: number;
+  /** Number of casts that complete within the fight (∞ if cost is 0). */
+  readonly castsPerFight: number;
+  /** Total ultimate generated over the whole fight (rate × duration). */
+  readonly totalGenerated: number;
+}

--- a/src/features/ultimate-simulator/shared/types/index.ts
+++ b/src/features/ultimate-simulator/shared/types/index.ts
@@ -56,8 +56,9 @@ export interface UltimateSource {
 /** Weapon configuration governing how Decisive rolls. */
 export interface DecisiveConfig {
   /**
-   * Per-instance proc chance for +1 ultimate (0..1). By weapon quality:
-   * Fine .191 / Superior .212 / Epic .233 / Legendary .254 (some sources .275).
+   * Per-instance proc chance for +1 ultimate (0..1). Full five-tier ladder
+   * (see DECISIVE_PROC_CHANCE in shared/constants — verified against UESP):
+   * Normal .191 / Fine .212 / Superior .233 / Epic .254 / Legendary .275.
    */
   readonly procChance: number;
   /**

--- a/tests/utils/skeleton-detector.ts
+++ b/tests/utils/skeleton-detector.ts
@@ -17,7 +17,8 @@ export const SKELETON_SELECTORS = {
   TEXT_EDITOR: '[data-testid="text-editor-skeleton"]',
   CALCULATOR: '[data-testid="calculator-skeleton"]',
   CALCULATOR_LITE: '[data-testid="calculator-skeleton-lite"]',
-  
+  ULTIMATE_CALCULATOR: '[data-testid="ultimate-calculator-skeleton"]',
+
   // These are actual loading skeletons that should disappear
   ACTUAL_LOADING_SKELETONS: [
     '[data-testid="players-skeleton"]',
@@ -31,9 +32,10 @@ export const SKELETON_SELECTORS = {
     '[data-testid="tab-aware-loading-skeleton"]',
     '[data-testid="text-editor-skeleton"]',
     '[data-testid="calculator-skeleton"]',
-    '[data-testid="calculator-skeleton-lite"]'
+    '[data-testid="calculator-skeleton-lite"]',
+    '[data-testid="ultimate-calculator-skeleton"]'
   ].join(', '),
-  
+
   // Loading fallback components - these might be persistent, not reliable for loading detection
   PLAYER_CARD_LOADING: '[data-testid="player-card-loading-fallback"]',
   SKILL_TOOLTIP_LOADING: '[data-testid="skill-tooltip-loading-fallback"]',
@@ -57,7 +59,8 @@ export const SKELETON_SELECTORS = {
     '[data-testid="tab-aware-loading-skeleton"]:not([data-permanent])',
     '[data-testid="text-editor-skeleton"]:not([data-permanent])',
     '[data-testid="calculator-skeleton"]:not([data-permanent])',
-    '[data-testid="calculator-skeleton-lite"]:not([data-permanent])'
+    '[data-testid="calculator-skeleton-lite"]:not([data-permanent])',
+    '[data-testid="ultimate-calculator-skeleton"]:not([data-permanent])'
   ].join(', '),
 } as const;
 


### PR DESCRIPTION
Re-lands the all-class **Ultimate Calculator** (originally #1229, which was accidentally merged then reverted in #1234) as **one clean PR** — the full calculator **plus** all the Codex-review correctness fixes baked in from the start. Supersedes #1233.

## What it adds
A top-level **[ Stats ] [ Ultimate ]** tab on `/calculator`. The existing Pen/Crit/Armor stat calculator is unchanged (Stats tab); the new Ultimate tab gives **ult/second, time to first ult, casts per fight, and ult generated by 60s** for all 7 classes, with context (solo/group/PvP) + role gating, a per-source breakdown, an optional Monte Carlo "spread", and a "verify against your own ESO Logs report" panel. The standalone `/ultimate-simulator` (Arcanist Monte Carlo, #1210) is preserved alongside it. Every catalog number carries a provenance URL (UESP / ESO-Skillbook) + confidence.

## UI/UX modern pass (added 2026-06-14)
A design pass bringing the Ultimate tab in line with the rest of the toolkit's June-2026 look. **No engine, catalog, hook, or logic changes** — sx/markup only, so all the correctness fixes below are untouched (81 tests green). Two commits:

**Visual redesign (e52ddf14):** glass-gradient surfaces, Space Grotesk numerals, icon-badge section headers, results-first hero stat strip (accented primary tile, stacks on mobile), accent-railed source toggle cards, styled breakdown table (uppercase headers, zebra rows, accent total row), success-tinted reduced-cost note, segmented pill tabs.

**Richer dropdowns + detail (f90b614e):**
- **Grouped ultimate picker** — ListSubheader sections by owner (your class / weapon & guild / other classes), each option with a class-color swatch + base cost; the closed control renders clean label text via `renderValue`.
- **Class dropdown** — per-class color swatch (canonical palette); class names stay in their own span so the existing tests still match.
- **Decisive quality dropdown** — tier-color swatches (white/green/blue/purple/gold).
- **Breakdown table** — per-source contribution % mini-bar (derived from the numbers already shown) so the dominant source reads at a glance.
- **Hero stat tiles** — info-icon tooltips explaining each metric.
- **"Quick start" preset chips** (Trial group DPS / Solo parse / PvP) that flip only context/role + boolean source toggles — never an uptime, so no unsourced number is introduced.

Verified live with menus opened in **dark + light + mobile**, including the calibration panel against a real log and a Stats-tab round-trip confirming zero regression on the existing calculator.


## Correctness fixes folded in (from Codex plain + adversarial review, 3 rounds)
- **Banked ultimate:** `timeToUltimate` now banks starting ult up to the 500 pool and counts it via `floor((start + generated) / cost)`; returns **0s** when the bank already covers the cost (was `Infinity` at 0 generation; excess was lost).
- **Cryptcanon Vestments excluded from self-cast generation:** it grants Minor Heroism but *blocks casting your own ultimate* (transfers to group), so it can't feed a "time to YOUR ultimate" calc. Removed as a source; the Minor Heroism copy notes why.
- **Custom cost is treated as already-effective:** class reductions (Sorc Power Stone −15%, Templar Restoring Spirit −5%) no longer double-apply to a user-entered custom cost, and switching to Custom seeds the field with the current *effective* cost (no value jump).
- **Cost-reduction toggles:** Power Stone / Restoring Spirit are default-on for their class but now have an opt-out, so users without the passive aren't silently under-costed.
- **Calibration measures the loaded report, not the live text field:** editing the report code after loading no longer lets "Measure" query a new report with the previous fight/player.
- **Calibration % vs measured:** now divides by the measured rate (the reference) with a measured-zero guard — matches this feature's own validation (3.65 vs 3.37 ult/s = "within 8%").

## Engine / data
Closed-form expected-value engine (exact, instant; matches a 200k-run Monte Carlo mean to ~0.001%). U50 mechanics: 3 ult/s light-attack base income, Minor/Major Heroism, sparse class ult-gen passives, the full 5-tier Decisive ladder (Normal 19.1% → Legendary 27.5%). ESO Logs ultimate is `resourceChangeType` **2** (empirically verified — `maxResourceAmount === maxUltimate`, 16/16 on a live log), measured total-only via snapshot/conservation (logs don't record per-source ult gains). Verified ult costs (Standard of Might 200, The Unblinking Eye 175, etc.).

## Catalog expansion (research-verified, all use cases)
Makes the source/ultimate catalog complete across all 7 classes and every context. Every number is sourced from UESP / ESO-Skillbook and was adversarially rate-checked against the sanity ceiling (the discipline that caught the Pillager's error below). Also fixes a reported Pillager's Profit bug.

**Pillager's Profit fix:** the set was encoded at a flat ~4.2 ult/s (claiming ~88 ult over 21s) — it ignored the set's 45s per-target lockout. Real mechanic (UESP): 2% of the healer's spent ult per tick × 5 ticks = 10% of its cost per cast, once per 45s. Re-encoded, and made **adjustable**: a "Healer's ult cost" input drives the per-cast amount (250 → 25, 500 → 50). Now ~0.4–1.1 ult/s.

**New generators:** Bloodspawn (tank monster set), DK Mountain's Blessing, Templar Prism (default-on for Templar), NB Catalyst, three ally externals (Arkasis's Genius, Arkay's Charity, Colovian Highlands General), and the Kraglen's Howl group synergy — all research-sourced, off-by-default.

**Heroism reconciliation:** Heroism *provider* sets/potions are not added as separate toggles (they'd double-count a non-stacking buff). Instead Major Heroism is now available solo too, and both Heroism entries credit their providers and tell you to set the uptime to match.

**Ultimate picker:** ~20 cost-targets added (every class's remaining ult bases + all weapon/guild/Alliance-War lines) → 36 options grouped by class, with a confidence marker on the few approximate costs.

**Searched-and-empty (documented, not gaps):** no ult-generating mythic (Cryptcanon excluded; Oakensoul folds into Minor Heroism), no Champion Point generator, and no per-class ult-cost reduction beyond Sorcerer Power Stone / Templar Restoring Spirit.

87 tests; the same gates all green.
## Quality
81 tests (engine EV-vs-Monte-Carlo regression incl. 2H Decisive; banked-ult edges; cost-reduction toggles + custom-cost bypass; catalog compiler; calibration conservation + out-of-order robustness; report-code parsing; component + tab-wrapper smoke tests). `tsc`, ESLint, Prettier, no-ESO-Hub + provenance gates, and the production build all green. The Ultimate UI code-splits into its own chunk.
