### PR TITLE
feat(roster-builder): multi-trial per-fight builds (rail editor + run-sheet share view)

### DIFF
--- a/discord-bot/src/roster/decoder.ts
+++ b/discord-bot/src/roster/decoder.ts
@@ -12,13 +12,27 @@ import type { DecodedRoster, DecodedRosterSlot, DecodedSkillLines } from './type
 // ── Lookup tables (mirror the frontend's encoding tables) ───────────────────
 
 const CLASS_SKILL_LINES = [
-  'Ardent Flame', 'Draconic Power', 'Earthen Heart',
-  'Dark Magic', 'Daedric Summoning', 'Storm Calling',
-  'Assassination', 'Shadow', 'Siphoning',
-  'Aedric Spear', "Dawn's Wrath", 'Restoring Light',
-  'Animal Companions', 'Green Balance', "Winter's Embrace",
-  'Grave Lord', 'Bone Tyrant', 'Living Death',
-  'Herald of the Tome', 'Apocryphal Soldier', 'Curative Runeforms',
+  'Ardent Flame',
+  'Draconic Power',
+  'Earthen Heart',
+  'Dark Magic',
+  'Daedric Summoning',
+  'Storm Calling',
+  'Assassination',
+  'Shadow',
+  'Siphoning',
+  'Aedric Spear',
+  "Dawn's Wrath",
+  'Restoring Light',
+  'Animal Companions',
+  'Green Balance',
+  "Winter's Embrace",
+  'Grave Lord',
+  'Bone Tyrant',
+  'Living Death',
+  'Herald of the Tome',
+  'Apocryphal Soldier',
+  'Curative Runeforms',
 ] as const;
 
 const ULTIMATE_LIST = [
@@ -86,45 +100,109 @@ async function readAllChunks(readable: ReadableStream<Uint8Array>): Promise<Uint
 
 // ── Compact types (matching CompactRosterV3 shape) ──────────────────────────
 
-interface CompactBuildRef { bi?: string; bn?: string; }
-interface CompactGear { s1?: number; s2?: number; ms?: number; a?: number[]; }
-interface CompactSkills { l1?: number | string; l2?: number | string; l3?: number | string; fl?: 1; }
-interface CompactGroup { g?: string; }
+interface CompactBuildRef {
+  bi?: string;
+  bn?: string;
+}
+interface CompactGear {
+  s1?: number;
+  s2?: number;
+  ms?: number;
+  a?: number[];
+}
+interface CompactSkills {
+  l1?: number | string;
+  l2?: number | string;
+  l3?: number | string;
+  fl?: 1;
+}
+interface CompactGroup {
+  g?: string;
+}
 
 interface CompactTank {
-  pn?: string; rl?: string; pt?: string; pi?: string;
-  lb?: string[]; rn?: string; gs?: CompactGear; sl?: CompactSkills;
-  ul?: number | string; grs?: string[]; gr?: CompactGroup;
-  no?: string; br?: CompactBuildRef;
+  pn?: string;
+  rl?: string;
+  pt?: string;
+  pi?: string;
+  lb?: string[];
+  rn?: string;
+  gs?: CompactGear;
+  sl?: CompactSkills;
+  ul?: number | string;
+  grs?: string[];
+  gr?: CompactGroup;
+  no?: string;
+  br?: CompactBuildRef;
 }
 
 interface CompactHealer {
-  pn?: string; rl?: string; pt?: string; pi?: string;
-  lb?: string[]; rn?: string;
-  s1?: number; s2?: number; ms?: number; a?: number[];
-  sl?: CompactSkills; hb?: number; cp?: number;
-  ul?: number | string; grs?: string[]; gr?: CompactGroup;
-  no?: string; br?: CompactBuildRef;
+  pn?: string;
+  rl?: string;
+  pt?: string;
+  pi?: string;
+  lb?: string[];
+  rn?: string;
+  s1?: number;
+  s2?: number;
+  ms?: number;
+  a?: number[];
+  sl?: CompactSkills;
+  hb?: number;
+  cp?: number;
+  ul?: number | string;
+  grs?: string[];
+  gr?: CompactGroup;
+  no?: string;
+  br?: CompactBuildRef;
 }
 
 interface CompactDPS {
-  sn: number; pn?: string; rl?: string; pt?: string; pi?: string;
-  lb?: string[]; rn?: string;
-  s1?: number; s2?: number; ms?: number; as?: number[]; gs?: number[];
+  sn: number;
+  pn?: string;
+  rl?: string;
+  pt?: string;
+  pi?: string;
+  lb?: string[];
+  rn?: string;
+  s1?: number;
+  s2?: number;
+  ms?: number;
+  as?: number[];
+  gs?: number[];
   sl?: CompactSkills;
-  ul?: number | string; grs?: string[]; gr?: CompactGroup;
-  no?: string; jt?: number; cd?: string; br?: CompactBuildRef;
+  ul?: number | string;
+  grs?: string[];
+  gr?: CompactGroup;
+  no?: string;
+  jt?: number;
+  cd?: string;
+  br?: CompactBuildRef;
 }
 
-interface CompactTrialOverrides { ti: string; }
+interface CompactTrialOverrides {
+  ti: string;
+}
+/** Multi-trial overrides: map keyed by trialId (the value shape is irrelevant here). */
+type CompactTrialOverridesMultiMap = Record<string, unknown>;
 
 interface CompactRoster {
-  v: number; n?: string; no?: string;
+  v: number;
+  n?: string;
+  no?: string;
   /** Composition tuple [tanks, healers, dps] (v3 only). Omitted when default 2/2/8. */
   co?: [number, number, number];
-  ts?: CompactTank[]; hs?: CompactHealer[]; dp?: CompactDPS[];
+  ts?: CompactTank[];
+  hs?: CompactHealer[];
+  dp?: CompactDPS[];
+  /** Legacy single-trial per-fight overrides. */
   to?: CompactTrialOverrides;
-  t1?: CompactTank; t2?: CompactTank; h1?: CompactHealer; h2?: CompactHealer;
+  /** Multi-trial per-fight overrides, keyed by trialId (current form). */
+  tom?: CompactTrialOverridesMultiMap;
+  t1?: CompactTank;
+  t2?: CompactTank;
+  h1?: CompactHealer;
+  h2?: CompactHealer;
 }
 
 // Composition defaults/clamps — mirror the frontend's rosterEncoding.ts so the
@@ -148,13 +226,19 @@ function decodeSkillLines(sl?: CompactSkills): DecodedSkillLines | undefined {
   if (!sl) return undefined;
   const result: DecodedSkillLines = {};
   if (sl.fl) result.isFlex = true;
-  if (sl.l1 !== undefined) result.line1 = typeof sl.l1 === 'number' ? CLASS_SKILL_LINES[sl.l1] : sl.l1;
-  if (sl.l2 !== undefined) result.line2 = typeof sl.l2 === 'number' ? CLASS_SKILL_LINES[sl.l2] : sl.l2;
-  if (sl.l3 !== undefined) result.line3 = typeof sl.l3 === 'number' ? CLASS_SKILL_LINES[sl.l3] : sl.l3;
-  return (result.isFlex || result.line1 || result.line2 || result.line3) ? result : undefined;
+  if (sl.l1 !== undefined)
+    result.line1 = typeof sl.l1 === 'number' ? CLASS_SKILL_LINES[sl.l1] : sl.l1;
+  if (sl.l2 !== undefined)
+    result.line2 = typeof sl.l2 === 'number' ? CLASS_SKILL_LINES[sl.l2] : sl.l2;
+  if (sl.l3 !== undefined)
+    result.line3 = typeof sl.l3 === 'number' ? CLASS_SKILL_LINES[sl.l3] : sl.l3;
+  return result.isFlex || result.line1 || result.line2 || result.line3 ? result : undefined;
 }
 
-function decodeGroupName(grs?: string[], gr?: CompactGroup): { groups?: string[]; groupName?: string } {
+function decodeGroupName(
+  grs?: string[],
+  gr?: CompactGroup,
+): { groups?: string[]; groupName?: string } {
   if (grs?.length) return { groups: grs };
   if (gr?.g) return { groupName: gr.g };
   return {};
@@ -301,9 +385,13 @@ export async function decodeRosterData(rosterData: string): Promise<DecodedRoste
         }
       : { ...DEFAULT_COMPOSITION };
 
+  // Prefer the multi-trial form (first trialId), fall back to legacy single-trial.
+  // Only used for channel naming, so one representative trial is sufficient.
+  const trialId = (compact.tom && Object.keys(compact.tom)[0]) || compact.to?.ti || undefined;
+
   return {
     name: compact.n,
-    trialId: compact.to?.ti || undefined,
+    trialId,
     notes: compact.no,
     composition,
     tanks,

--- a/src/components/EncounterTimeline.tsx
+++ b/src/components/EncounterTimeline.tsx
@@ -48,6 +48,7 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
     const isDark = theme.palette.mode === 'dark';
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+    const optionRefs = React.useRef<Array<HTMLDivElement | null>>([]);
 
     const handleSelect = (id: string, el: HTMLElement | null): void => {
       onSelectEncounter(id);
@@ -59,8 +60,53 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
       });
     };
 
+    // The node that carries tabIndex=0 in the roving-tabindex listbox: the
+    // selected encounter, or the first node when nothing is selected yet.
+    const selectedIndex = encounters.findIndex((e) => e.id === selectedEncounterId);
+    const activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+    const focusOption = (index: number): void => {
+      const clamped = Math.max(0, Math.min(encounters.length - 1, index));
+      const node = optionRefs.current[clamped];
+      node?.focus();
+      handleSelect(encounters[clamped].id, node);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent, index: number, id: string): void => {
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          e.preventDefault();
+          focusOption(index + 1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          e.preventDefault();
+          focusOption(index - 1);
+          break;
+        case 'Home':
+          e.preventDefault();
+          focusOption(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          focusOption(encounters.length - 1);
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          handleSelect(id, e.currentTarget as HTMLElement);
+          break;
+        default:
+          break;
+      }
+    };
+
     return (
       <Box
+        role="listbox"
+        aria-label="Encounter timeline — select a fight to customize"
+        aria-orientation="horizontal"
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -120,7 +166,17 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
                 placement="top"
               >
                 <Box
+                  ref={(el: HTMLDivElement | null) => {
+                    optionRefs.current[index] = el;
+                  }}
+                  role="option"
+                  aria-selected={isSelected}
+                  aria-label={`${encounter.name} — ${ENCOUNTER_LABELS[encounter.type]}${
+                    hasOverride ? ', customized' : ''
+                  }`}
+                  tabIndex={index === activeIndex ? 0 : -1}
                   onClick={(e) => handleSelect(encounter.id, e.currentTarget)}
+                  onKeyDown={(e) => handleKeyDown(e, index, encounter.id)}
                   sx={{
                     position: 'relative',
                     display: 'flex',
@@ -132,11 +188,16 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
                     flexShrink: 0,
                     minWidth: isBoss ? 80 : 64,
                     scrollSnapAlign: 'center',
+                    borderRadius: '12px',
                     // WCAG 2.5.5: ensure a 44px touch target on coarse pointers.
                     '@media (pointer: coarse)': { minHeight: 44 },
-                    transition: 'transform 0.15s ease',
+                    transition: reduceMotion ? 'none' : 'transform 0.15s ease',
                     '&:hover': {
-                      transform: 'translateY(-2px)',
+                      transform: reduceMotion ? 'none' : 'translateY(-2px)',
+                    },
+                    '&:focus-visible': {
+                      outline: '2px solid #38bdf8',
+                      outlineOffset: '2px',
                     },
                   }}
                 >

--- a/src/components/EncounterTimeline.tsx
+++ b/src/components/EncounterTimeline.tsx
@@ -1,4 +1,4 @@
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Tooltip, Typography, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React from 'react';
 
@@ -46,6 +46,18 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
   ({ encounters, selectedEncounterId, onSelectEncounter, overriddenEncounters }) => {
     const theme = useTheme();
     const isDark = theme.palette.mode === 'dark';
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+    const handleSelect = (id: string, el: HTMLElement | null): void => {
+      onSelectEncounter(id);
+      // Center the tapped node so the editor below is comfortably in view.
+      el?.scrollIntoView({
+        behavior: reduceMotion ? 'auto' : 'smooth',
+        inline: 'center',
+        block: 'nearest',
+      });
+    };
 
     return (
       <Box
@@ -55,6 +67,8 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
           gap: 0,
           overflowX: 'auto',
           pb: 1,
+          // Snap nodes into place on mobile for easier fight-to-fight navigation.
+          scrollSnapType: isMobile ? 'x proximity' : 'none',
           // Scrollbar styling
           '&::-webkit-scrollbar': { height: 4 },
           '&::-webkit-scrollbar-track': {
@@ -106,16 +120,20 @@ export const EncounterTimeline: React.FC<EncounterTimelineProps> = React.memo(
                 placement="top"
               >
                 <Box
-                  onClick={() => onSelectEncounter(encounter.id)}
+                  onClick={(e) => handleSelect(encounter.id, e.currentTarget)}
                   sx={{
                     position: 'relative',
                     display: 'flex',
                     flexDirection: 'column',
                     alignItems: 'center',
+                    justifyContent: 'center',
                     gap: 0.5,
                     cursor: 'pointer',
                     flexShrink: 0,
                     minWidth: isBoss ? 80 : 64,
+                    scrollSnapAlign: 'center',
+                    // WCAG 2.5.5: ensure a 44px touch target on coarse pointers.
+                    '@media (pointer: coarse)': { minHeight: 44 },
                     transition: 'transform 0.15s ease',
                     '&:hover': {
                       transform: 'translateY(-2px)',

--- a/src/components/PerFightBuilds.tsx
+++ b/src/components/PerFightBuilds.tsx
@@ -24,7 +24,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 
 import { KnownSetIDs } from '../types/abilities';
 import type { RaidRoster } from '../types/roster';
@@ -38,6 +38,7 @@ import type {
 import {
   TRIAL_ENCOUNTERS,
   getTrialById,
+  resolveTrialId,
   createDefaultTrialOverrides,
   encounterHasOverrides,
   isOverrideEmpty,
@@ -490,6 +491,46 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
       [trialOverrides?.trialId],
     );
 
+    // Trials this roster is tagged "Built for" (top-level picker), resolved to
+    // encounter-data trial ids. Drives which trials the Per-Fight Builds selector
+    // offers, so the two selectors stay in sync.
+    const scopedTrialIds = useMemo<string[]>(() => {
+      const ids = (roster.trials ?? [])
+        .map((tag) => resolveTrialId(tag))
+        .filter((id): id is string => Boolean(id));
+      // Dedupe while preserving order.
+      return Array.from(new Set(ids));
+    }, [roster.trials]);
+
+    // The trials shown in the dropdown: scoped to the "Built for" tags when any
+    // are set, otherwise the full list (backward compatible / untagged rosters).
+    const trialOptions = useMemo<readonly Trial[]>(() => {
+      if (scopedTrialIds.length === 0) return TRIAL_ENCOUNTERS;
+      const scoped = scopedTrialIds
+        .map((id) => getTrialById(id))
+        .filter((t): t is Trial => Boolean(t));
+      // If a per-fight trial is already selected but isn't in the tag set
+      // (e.g. tags changed after customizing), keep it visible so its work isn't hidden.
+      if (selectedTrial && !scoped.some((t) => t.id === selectedTrial.id)) {
+        return [selectedTrial, ...scoped];
+      }
+      return scoped;
+    }, [scopedTrialIds, selectedTrial]);
+
+    // Auto-select the trial when exactly one is tagged and nothing is chosen yet,
+    // so the encounter timeline appears without a redundant second pick. Guarded by
+    // a ref keyed on the scoped-trial set so it fires once per change — otherwise an
+    // explicit "None" pick would be re-selected immediately, making "None" a dead option.
+    const autoSelectedForRef = useRef<string | null>(null);
+    useEffect(() => {
+      const key = scopedTrialIds.join('|');
+      if (autoSelectedForRef.current === key) return; // already handled this set
+      autoSelectedForRef.current = key; // mark as seen regardless of outcome
+      if (scopedTrialIds.length !== 1) return; // only auto-pick the unambiguous case
+      if (trialOverrides?.trialId) return; // user already has a selection
+      onUpdateTrialOverrides(createDefaultTrialOverrides(scopedTrialIds[0]));
+    }, [scopedTrialIds, trialOverrides?.trialId, onUpdateTrialOverrides]);
+
     // Players list derived from roster
     const players = useMemo(() => getPlayersFromRoster(roster), [roster]);
 
@@ -634,7 +675,13 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
 
         <AccordionDetails sx={{ px: 1.5, pt: 1.5, pb: 2 }}>
           <Stack spacing={2}>
-            {/* Trial selector */}
+            {/* Trial selector — scoped to the roster's "Built for" trials when set */}
+            {scopedTrialIds.length > 0 && (
+              <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', mt: -0.5 }}>
+                Showing the {scopedTrialIds.length === 1 ? 'trial' : 'trials'} this roster is{' '}
+                <strong>built for</strong>. Add more in the “Built for (Trials)” picker above.
+              </Typography>
+            )}
             <FormControl fullWidth size="small">
               <InputLabel>Select Trial</InputLabel>
               <Select
@@ -652,7 +699,7 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                 <MenuItem value="">
                   <em>None — No per-fight customization</em>
                 </MenuItem>
-                {TRIAL_ENCOUNTERS.map((trial) => (
+                {trialOptions.map((trial) => (
                   <MenuItem key={trial.id} value={trial.id}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <Chip

--- a/src/components/PerFightBuilds.tsx
+++ b/src/components/PerFightBuilds.tsx
@@ -12,16 +12,14 @@ import {
   Autocomplete,
   Box,
   Chip,
-  FormControl,
+  Dialog,
   IconButton,
-  InputLabel,
-  MenuItem,
   Paper,
-  Select,
   Stack,
   TextField,
   Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
@@ -43,6 +41,8 @@ import {
   encounterHasOverrides,
   isOverrideEmpty,
 } from '../types/trial-encounters';
+import { encodeRosterToURL } from '../utils/rosterEncoding';
+import { copyToClipboard } from '../utils/safeClipboard';
 import { getSetDisplayName, findSetIdByName } from '../utils/setNameUtils';
 import type { SlotKey } from '../utils/slotKey';
 import { makeSlotKey } from '../utils/slotKey';
@@ -186,6 +186,10 @@ const PlayerOverrideEditor: React.FC<PlayerOverrideEditorProps> = React.memo(
         '& fieldset': {
           borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.12)',
         },
+      },
+      // iOS Safari zooms when an input's font-size is below 16px — bump on phones.
+      '@media (max-width: 600px)': {
+        '& .MuiInputBase-input': { fontSize: 16 },
       },
     };
 
@@ -474,128 +478,221 @@ PlayerOverrideEditor.displayName = 'PlayerOverrideEditor';
 
 interface PerFightBuildsProps {
   roster: RaidRoster;
-  onUpdateTrialOverrides: (overrides: TrialBuildOverrides | undefined) => void;
+  /** Update the whole multi-trial overrides map (keyed by trialId). */
+  onUpdateTrialOverrides: (overrides: Record<string, TrialBuildOverrides> | undefined) => void;
 }
 
 export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
   ({ roster, onUpdateTrialOverrides }) => {
     const theme = useTheme();
     const isDark = theme.palette.mode === 'dark';
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-    const trialOverrides = roster.trialOverrides;
-    const [selectedEncounterId, setSelectedEncounterId] = useState<string | null>(null);
+    const overridesMap = roster.trialOverrides;
 
-    // Current trial data
-    const selectedTrial = useMemo<Trial | undefined>(
-      () => (trialOverrides?.trialId ? getTrialById(trialOverrides.trialId) : undefined),
-      [trialOverrides?.trialId],
-    );
-
-    // Trials this roster is tagged "Built for" (top-level picker), resolved to
-    // encounter-data trial ids. Drives which trials the Per-Fight Builds selector
-    // offers, so the two selectors stay in sync.
+    // Trials this roster is tagged "Built for", resolved to encounter-data ids.
+    // This is the EDITABLE set — every tagged trial gets a rail row (incl. empty).
     const scopedTrialIds = useMemo<string[]>(() => {
       const ids = (roster.trials ?? [])
         .map((tag) => resolveTrialId(tag))
         .filter((id): id is string => Boolean(id));
-      // Dedupe while preserving order.
       return Array.from(new Set(ids));
     }, [roster.trials]);
 
-    // The trials shown in the dropdown: scoped to the "Built for" tags when any
-    // are set, otherwise the full list (backward compatible / untagged rosters).
-    const trialOptions = useMemo<readonly Trial[]>(() => {
-      if (scopedTrialIds.length === 0) return TRIAL_ENCOUNTERS;
-      const scoped = scopedTrialIds
-        .map((id) => getTrialById(id))
-        .filter((t): t is Trial => Boolean(t));
-      // If a per-fight trial is already selected but isn't in the tag set
-      // (e.g. tags changed after customizing), keep it visible so its work isn't hidden.
-      if (selectedTrial && !scoped.some((t) => t.id === selectedTrial.id)) {
-        return [selectedTrial, ...scoped];
+    // Rail rows: the tagged trials (or all 15 when untagged), PLUS any trial that
+    // already has overrides but lost its tag (so customized work is never hidden).
+    const railTrials = useMemo<readonly Trial[]>(() => {
+      const base = scopedTrialIds.length === 0 ? TRIAL_ENCOUNTERS.map((t) => t.id) : scopedTrialIds;
+      const ids = [...base];
+      if (overridesMap) {
+        for (const id of Object.keys(overridesMap)) {
+          if (!ids.includes(id)) ids.push(id);
+        }
       }
-      return scoped;
-    }, [scopedTrialIds, selectedTrial]);
+      return ids.map((id) => getTrialById(id)).filter((t): t is Trial => Boolean(t));
+    }, [scopedTrialIds, overridesMap]);
 
-    // Auto-select the trial when exactly one is tagged and nothing is chosen yet,
-    // so the encounter timeline appears without a redundant second pick. Guarded by
-    // a ref keyed on the scoped-trial set so it fires once per change — otherwise an
-    // explicit "None" pick would be re-selected immediately, making "None" a dead option.
-    const autoSelectedForRef = useRef<string | null>(null);
+    // Ephemeral selection — which trial is being edited (NOT persisted).
+    const [selectedTrialId, setSelectedTrialId] = useState<string | null>(null);
+    // Per-trial last-viewed encounter so switching trials restores context.
+    const encounterMemory = useRef<Record<string, string | null>>({});
+    const [selectedEncounterId, setSelectedEncounterId] = useState<string | null>(null);
+
+    // Default the selection to the first rail trial when none is chosen / it vanished.
     useEffect(() => {
-      const key = scopedTrialIds.join('|');
-      if (autoSelectedForRef.current === key) return; // already handled this set
-      autoSelectedForRef.current = key; // mark as seen regardless of outcome
-      if (scopedTrialIds.length !== 1) return; // only auto-pick the unambiguous case
-      if (trialOverrides?.trialId) return; // user already has a selection
-      onUpdateTrialOverrides(createDefaultTrialOverrides(scopedTrialIds[0]));
-    }, [scopedTrialIds, trialOverrides?.trialId, onUpdateTrialOverrides]);
+      if (railTrials.length === 0) {
+        if (selectedTrialId !== null) setSelectedTrialId(null);
+        return;
+      }
+      if (!selectedTrialId || !railTrials.some((t) => t.id === selectedTrialId)) {
+        setSelectedTrialId(railTrials[0].id);
+      }
+    }, [railTrials, selectedTrialId]);
+
+    const selectedTrial = useMemo<Trial | undefined>(
+      () => (selectedTrialId ? getTrialById(selectedTrialId) : undefined),
+      [selectedTrialId],
+    );
+    const selectedTrialOverrides = selectedTrialId ? overridesMap?.[selectedTrialId] : undefined;
 
     // Players list derived from roster
     const players = useMemo(() => getPlayersFromRoster(roster), [roster]);
 
-    // Set of encounter IDs that have overrides
+    // Override-count per trial (for rail badges) + the active trial's overridden encounters.
+    const overrideCountByTrial = useMemo(() => {
+      const counts: Record<string, number> = {};
+      if (overridesMap) {
+        for (const [trialId, t] of Object.entries(overridesMap)) {
+          counts[trialId] = Object.values(t.encounterBuilds).filter((eo) =>
+            encounterHasOverrides(eo),
+          ).length;
+        }
+      }
+      return counts;
+    }, [overridesMap]);
+
     const overriddenEncounterIds = useMemo(() => {
-      if (!trialOverrides?.encounterBuilds) return new Set<string>();
       const ids = new Set<string>();
-      for (const [encId, overrides] of Object.entries(trialOverrides.encounterBuilds)) {
-        if (encounterHasOverrides(overrides)) {
-          ids.add(encId);
+      if (selectedTrialOverrides?.encounterBuilds) {
+        for (const [encId, overrides] of Object.entries(selectedTrialOverrides.encounterBuilds)) {
+          if (encounterHasOverrides(overrides)) ids.add(encId);
         }
       }
       return ids;
-    }, [trialOverrides?.encounterBuilds]);
+    }, [selectedTrialOverrides?.encounterBuilds]);
 
-    // Total override count for the badge
-    const totalOverrideCount = overriddenEncounterIds.size;
-
-    // Handle trial selection
-    const handleTrialChange = useCallback(
-      (trialId: string) => {
-        if (!trialId) {
-          onUpdateTrialOverrides(undefined);
-          setSelectedEncounterId(null);
-          return;
-        }
-        onUpdateTrialOverrides(createDefaultTrialOverrides(trialId));
-        setSelectedEncounterId(null);
-      },
-      [onUpdateTrialOverrides],
+    const totalOverrideCount = useMemo(
+      () => Object.values(overrideCountByTrial).reduce((a, b) => a + b, 0),
+      [overrideCountByTrial],
+    );
+    const trialsWithOverrides = useMemo(
+      () => Object.values(overrideCountByTrial).filter((c) => c > 0).length,
+      [overrideCountByTrial],
     );
 
-    // Handle player override update for selected encounter
+    // ── Map mutation helpers (immutable, prune empties) ──
+    const writeTrial = useCallback(
+      (trialId: string, next: TrialBuildOverrides | undefined) => {
+        const map = { ...(overridesMap ?? {}) };
+        const stillHasData =
+          next && (Object.keys(next.encounterBuilds).length > 0 || next.useSameBuildForAll);
+        if (next && stillHasData) {
+          map[trialId] = next;
+        } else {
+          delete map[trialId];
+        }
+        onUpdateTrialOverrides(Object.keys(map).length > 0 ? map : undefined);
+      },
+      [overridesMap, onUpdateTrialOverrides],
+    );
+
+    // Switch which trial is being edited, restoring its last-viewed encounter.
+    const handleSelectTrial = useCallback((trialId: string) => {
+      setSelectedTrialId(trialId);
+      setSelectedEncounterId(encounterMemory.current[trialId] ?? null);
+    }, []);
+
+    const handleSelectEncounter = useCallback(
+      (encId: string | null) => {
+        setSelectedEncounterId(encId);
+        if (selectedTrialId) encounterMemory.current[selectedTrialId] = encId;
+      },
+      [selectedTrialId],
+    );
+
+    // Toggle "same build for all" for a trial without entering it.
+    const handleToggleSameBuild = useCallback(
+      (trialId: string) => {
+        const existing = overridesMap?.[trialId];
+        const next: TrialBuildOverrides = existing
+          ? { ...existing, useSameBuildForAll: !existing.useSameBuildForAll }
+          : { ...createDefaultTrialOverrides(trialId), useSameBuildForAll: false };
+        // createDefaultTrialOverrides defaults useSameBuildForAll=true; the toggle
+        // intent from an empty trial is "enable per-fight", i.e. sameBuild=false.
+        writeTrial(trialId, next);
+      },
+      [overridesMap, writeTrial],
+    );
+
+    // Handle player override update for selected encounter, within the active trial.
     const handlePlayerOverrideUpdate = useCallback(
       (playerKey: PlayerKey, override: PlayerOverride | undefined) => {
-        if (!trialOverrides || !selectedEncounterId) return;
-        const currentEncounter = trialOverrides.encounterBuilds[selectedEncounterId] ?? {
-          slots: {},
-        };
+        if (!selectedTrialId || !selectedEncounterId) return;
+        const trial =
+          overridesMap?.[selectedTrialId] ?? createDefaultTrialOverrides(selectedTrialId);
+        const currentEncounter = trial.encounterBuilds[selectedEncounterId] ?? { slots: {} };
         const updatedEncounter = setPlayerOverride(currentEncounter, playerKey, override);
-        const updatedBuilds = { ...trialOverrides.encounterBuilds };
-
+        const updatedBuilds = { ...trial.encounterBuilds };
         if (encounterHasOverrides(updatedEncounter)) {
           updatedBuilds[selectedEncounterId] = updatedEncounter;
         } else {
           delete updatedBuilds[selectedEncounterId];
         }
-
-        onUpdateTrialOverrides({
-          ...trialOverrides,
+        // Editing per-fight builds implies per-fight mode.
+        writeTrial(selectedTrialId, {
+          ...trial,
+          useSameBuildForAll: false,
           encounterBuilds: updatedBuilds,
         });
       },
-      [trialOverrides, selectedEncounterId, onUpdateTrialOverrides],
+      [overridesMap, selectedTrialId, selectedEncounterId, writeTrial],
     );
 
-    // Current encounter overrides
     const currentEncounterOverrides = selectedEncounterId
-      ? trialOverrides?.encounterBuilds[selectedEncounterId]
+      ? selectedTrialOverrides?.encounterBuilds[selectedEncounterId]
       : undefined;
-
-    // Selected encounter info
     const selectedEncounterInfo = selectedTrial?.encounters.find(
       (e) => e.id === selectedEncounterId,
     );
+
+    // Roving-tablist keyboard nav for the desktop rail.
+    const railRefs = useRef<(HTMLElement | null)[]>([]);
+    const handleRailKeyDown = useCallback(
+      (e: React.KeyboardEvent, index: number) => {
+        let next = index;
+        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') next = (index + 1) % railTrials.length;
+        else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft')
+          next = (index - 1 + railTrials.length) % railTrials.length;
+        else if (e.key === 'Home') next = 0;
+        else if (e.key === 'End') next = railTrials.length - 1;
+        else return;
+        e.preventDefault();
+        const trial = railTrials[next];
+        if (trial) {
+          handleSelectTrial(trial.id);
+          railRefs.current[next]?.focus();
+        }
+      },
+      [railTrials, handleSelectTrial],
+    );
+
+    // Mobile trial bottom-sheet open state.
+    const [sheetOpen, setSheetOpen] = useState(false);
+
+    // Copy a deep link to the currently-viewed fight on the read-only /rv page.
+    const [copied, setCopied] = useState(false);
+    const handleCopyFightLink = useCallback(() => {
+      void encodeRosterToURL(roster).then(async (encoded) => {
+        if (!encoded) return;
+        const basePath = window.location.pathname.replace(/\/roster-builder(\/.*)?$/, '');
+        let url = `${window.location.origin}${basePath}/rv?r=${encoded}`;
+        if (selectedTrialId) url += `&trial=${encodeURIComponent(selectedTrialId)}`;
+        if (selectedEncounterId) url += `&encounter=${encodeURIComponent(selectedEncounterId)}`;
+        const ok = await copyToClipboard(url);
+        if (ok) {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1800);
+        }
+      });
+    }, [roster, selectedTrialId, selectedEncounterId]);
+
+    const showRail = railTrials.length > 1;
+    const headerBadge =
+      totalOverrideCount > 0
+        ? `${totalOverrideCount} fight${totalOverrideCount > 1 ? 's' : ''}${
+            trialsWithOverrides > 1 ? ` · ${trialsWithOverrides} trials` : ''
+          }`
+        : null;
 
     return (
       <Accordion
@@ -656,9 +753,9 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
               Per-Fight Builds
             </Typography>
           </Box>
-          {totalOverrideCount > 0 && (
+          {headerBadge && (
             <Chip
-              label={`${totalOverrideCount} fight${totalOverrideCount > 1 ? 's' : ''} customized`}
+              label={headerBadge}
               size="small"
               sx={{
                 height: 20,
@@ -674,273 +771,608 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
         </AccordionSummary>
 
         <AccordionDetails sx={{ px: 1.5, pt: 1.5, pb: 2 }}>
-          <Stack spacing={2}>
-            {/* Trial selector — scoped to the roster's "Built for" trials when set */}
-            {scopedTrialIds.length > 0 && (
-              <Typography sx={{ fontSize: '0.7rem', color: 'text.secondary', mt: -0.5 }}>
-                Showing the {scopedTrialIds.length === 1 ? 'trial' : 'trials'} this roster is{' '}
-                <strong>built for</strong>. Add more in the “Built for (Trials)” picker above.
-              </Typography>
-            )}
-            <FormControl fullWidth size="small">
-              <InputLabel>Select Trial</InputLabel>
-              <Select
-                value={trialOverrides?.trialId || ''}
-                onChange={(e) => handleTrialChange(e.target.value)}
-                label="Select Trial"
+          {railTrials.length === 0 ? (
+            <Typography
+              sx={{ fontSize: '0.75rem', color: 'text.disabled', textAlign: 'center', py: 1 }}
+            >
+              Tag this roster with one or more trials in the “Built for (Trials)” picker above to
+              enable per-fight build customization.
+            </Typography>
+          ) : (
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: showRail && !isMobile ? '210px 1fr' : '1fr',
+                gap: 1.5,
+                alignItems: 'start',
+              }}
+            >
+              {/* MASTER — desktop trial rail */}
+              {showRail && !isMobile && (
+                <Box
+                  role="tablist"
+                  aria-label="Trials"
+                  aria-orientation="vertical"
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 0.5,
+                    maxHeight: 360,
+                    overflowY: 'auto',
+                    pr: 0.5,
+                  }}
+                >
+                  {railTrials.map((trial, index) => {
+                    const count = overrideCountByTrial[trial.id] ?? 0;
+                    const sameBuild = overridesMap?.[trial.id]?.useSameBuildForAll ?? false;
+                    const active = trial.id === selectedTrialId;
+                    return (
+                      <Box
+                        key={trial.id}
+                        ref={(el: HTMLElement | null) => {
+                          railRefs.current[index] = el;
+                        }}
+                        role="tab"
+                        aria-selected={active}
+                        aria-controls={`pft-panel-${trial.id}`}
+                        id={`pft-tab-${trial.id}`}
+                        tabIndex={active ? 0 : -1}
+                        onClick={() => handleSelectTrial(trial.id)}
+                        onKeyDown={(e) => handleRailKeyDown(e, index)}
+                        sx={{
+                          cursor: 'pointer',
+                          position: 'relative',
+                          borderRadius: '8px',
+                          px: 1,
+                          py: 0.75,
+                          pl: 1.25,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 0.75,
+                          borderLeft: active ? '3px solid #38bdf8' : '3px solid transparent',
+                          backgroundColor: active
+                            ? isDark
+                              ? 'rgba(56,189,248,0.12)'
+                              : 'rgba(56,189,248,0.10)'
+                            : 'transparent',
+                          transition: 'background-color 0.15s ease',
+                          '&:hover': {
+                            backgroundColor: active
+                              ? isDark
+                                ? 'rgba(56,189,248,0.16)'
+                                : 'rgba(56,189,248,0.14)'
+                              : isDark
+                                ? 'rgba(255,255,255,0.04)'
+                                : 'rgba(0,0,0,0.03)',
+                          },
+                          '&:focus-visible': {
+                            outline: '2px solid #38bdf8',
+                            outlineOffset: '-2px',
+                          },
+                        }}
+                      >
+                        <Chip
+                          label={trial.shortName}
+                          size="small"
+                          sx={{
+                            height: 18,
+                            fontSize: '0.55rem',
+                            fontWeight: 700,
+                            minWidth: 30,
+                            backgroundColor: isDark
+                              ? 'rgba(96,165,250,0.12)'
+                              : 'rgba(37,99,235,0.08)',
+                            color: isDark ? '#bfdbfe' : '#1d4ed8',
+                          }}
+                        />
+                        <Box sx={{ minWidth: 0, flex: 1 }}>
+                          <Typography
+                            sx={{
+                              fontSize: '0.72rem',
+                              fontWeight: active ? 700 : 600,
+                              lineHeight: 1.15,
+                              color: active ? 'text.primary' : 'text.secondary',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {trial.name}
+                          </Typography>
+                          <Typography
+                            sx={{ fontSize: '0.6rem', color: 'text.disabled', lineHeight: 1.1 }}
+                          >
+                            {count > 0
+                              ? `${count} fight${count > 1 ? 's' : ''}`
+                              : sameBuild
+                                ? 'same build'
+                                : 'no edits'}
+                          </Typography>
+                        </Box>
+                        {count > 0 && (
+                          <Box
+                            aria-hidden
+                            sx={{
+                              minWidth: 16,
+                              height: 16,
+                              px: 0.5,
+                              borderRadius: '8px',
+                              fontSize: '0.55rem',
+                              fontWeight: 700,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              backgroundColor: isDark
+                                ? 'rgba(34,197,94,0.18)'
+                                : 'rgba(34,197,94,0.14)',
+                              color: '#22c55e',
+                            }}
+                          >
+                            {count}
+                          </Box>
+                        )}
+                        <Tooltip title="Same build for every fight" arrow>
+                          <IconButton
+                            size="small"
+                            aria-label={`Toggle same build for all fights in ${trial.name}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleToggleSameBuild(trial.id);
+                            }}
+                            sx={{ p: 0.25 }}
+                          >
+                            <Box
+                              component="span"
+                              sx={{
+                                fontSize: '0.7rem',
+                                color: sameBuild ? '#38bdf8' : 'text.disabled',
+                                fontWeight: 700,
+                              }}
+                            >
+                              {sameBuild ? '≣' : '≡'}
+                            </Box>
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              )}
+
+              {/* MASTER — mobile trigger bar */}
+              {showRail && isMobile && selectedTrial && (
+                <Box
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSheetOpen(true)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setSheetOpen(true);
+                    }
+                  }}
+                  sx={{
+                    position: 'sticky',
+                    top: 0,
+                    zIndex: 2,
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    borderRadius: '10px',
+                    px: 1.25,
+                    py: 1,
+                    border: isDark
+                      ? '1px solid rgba(255,255,255,0.1)'
+                      : '1px solid rgba(0,0,0,0.12)',
+                    backgroundColor: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',
+                    '&:focus-visible': { outline: '2px solid #38bdf8', outlineOffset: '2px' },
+                  }}
+                >
+                  <Chip
+                    label={selectedTrial.shortName}
+                    size="small"
+                    sx={{
+                      height: 20,
+                      fontSize: '0.6rem',
+                      fontWeight: 700,
+                      backgroundColor: isDark ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.08)',
+                      color: isDark ? '#bfdbfe' : '#1d4ed8',
+                    }}
+                  />
+                  <Typography sx={{ fontSize: '0.85rem', fontWeight: 600, flex: 1, minWidth: 0 }}>
+                    {selectedTrial.name}
+                  </Typography>
+                  {(overrideCountByTrial[selectedTrial.id] ?? 0) > 0 && (
+                    <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled' }}>
+                      {overrideCountByTrial[selectedTrial.id]} fights
+                    </Typography>
+                  )}
+                  <ExpandMoreIcon sx={{ fontSize: '1.1rem', color: 'text.disabled' }} />
+                </Box>
+              )}
+
+              {/* DETAIL pane */}
+              <Box
+                role="tabpanel"
+                id={selectedTrialId ? `pft-panel-${selectedTrialId}` : undefined}
+                aria-labelledby={selectedTrialId ? `pft-tab-${selectedTrialId}` : undefined}
+              >
+                <Stack spacing={2}>
+                  {/* Encounter timeline (shown immediately when trial is selected) */}
+                  {selectedTrial && (
+                    <>
+                      <Box
+                        sx={{
+                          p: 1.5,
+                          borderRadius: '10px',
+                          backgroundColor: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
+                          border: isDark
+                            ? '1px solid rgba(255,255,255,0.04)'
+                            : '1px solid rgba(0,0,0,0.04)',
+                        }}
+                      >
+                        <Typography
+                          sx={{
+                            fontSize: '0.6rem',
+                            fontWeight: 700,
+                            letterSpacing: '0.08em',
+                            textTransform: 'uppercase',
+                            color: 'text.disabled',
+                            mb: 1,
+                          }}
+                        >
+                          {selectedTrial.name} — Select an encounter to customize
+                        </Typography>
+                        <EncounterTimeline
+                          encounters={selectedTrial.encounters}
+                          selectedEncounterId={selectedEncounterId}
+                          onSelectEncounter={handleSelectEncounter}
+                          overriddenEncounters={overriddenEncounterIds}
+                        />
+                      </Box>
+
+                      {/* Per-fight override editor */}
+                      {selectedEncounterId && selectedEncounterInfo && (
+                        <Paper
+                          elevation={0}
+                          sx={{
+                            p: 1.5,
+                            borderRadius: '10px',
+                            border: isDark
+                              ? '1px solid rgba(255,255,255,0.06)'
+                              : '1px solid rgba(0,0,0,0.06)',
+                            backgroundColor: isDark
+                              ? 'rgba(255,255,255,0.015)'
+                              : 'rgba(0,0,0,0.01)',
+                          }}
+                        >
+                          {/* Encounter header */}
+                          <Box sx={{ mb: 1.5 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                              <Chip
+                                label={
+                                  selectedEncounterInfo.type === 'boss'
+                                    ? 'Boss'
+                                    : selectedEncounterInfo.type === 'mini_boss'
+                                      ? 'Mini-Boss'
+                                      : 'Trash'
+                                }
+                                size="small"
+                                sx={{
+                                  height: 20,
+                                  fontSize: '0.55rem',
+                                  fontWeight: 700,
+                                  backgroundColor:
+                                    selectedEncounterInfo.type === 'boss'
+                                      ? 'rgba(239, 68, 68, 0.12)'
+                                      : selectedEncounterInfo.type === 'mini_boss'
+                                        ? 'rgba(245, 158, 11, 0.12)'
+                                        : 'rgba(59, 130, 246, 0.08)',
+                                  color:
+                                    selectedEncounterInfo.type === 'boss'
+                                      ? '#ef4444'
+                                      : selectedEncounterInfo.type === 'mini_boss'
+                                        ? '#f59e0b'
+                                        : '#3b82f6',
+                                }}
+                              />
+                              <Typography
+                                sx={{
+                                  fontFamily: '"Space Grotesk", sans-serif',
+                                  fontWeight: 700,
+                                  fontSize: '0.9rem',
+                                  letterSpacing: '-0.01em',
+                                }}
+                              >
+                                {selectedEncounterInfo.name}
+                              </Typography>
+                            </Box>
+                            {selectedEncounterInfo.description && (
+                              <Typography
+                                sx={{
+                                  fontSize: '0.7rem',
+                                  color: 'text.secondary',
+                                  ml: 0.5,
+                                }}
+                              >
+                                {selectedEncounterInfo.description}
+                              </Typography>
+                            )}
+                          </Box>
+
+                          {/* Player override list */}
+                          <Stack spacing={0.75}>
+                            {/* Section: Tanks */}
+                            <Typography
+                              sx={{
+                                fontSize: '0.6rem',
+                                fontWeight: 700,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                                color: isDark
+                                  ? 'rgba(59, 130, 246, 0.7)'
+                                  : 'rgba(59, 130, 246, 0.8)',
+                                mt: 0.5,
+                              }}
+                            >
+                              Tanks
+                            </Typography>
+                            {players
+                              .filter((p) => p.role === 'tank')
+                              .map((player) => (
+                                <PlayerOverrideEditor
+                                  key={player.key}
+                                  player={player}
+                                  override={getPlayerOverride(
+                                    currentEncounterOverrides,
+                                    player.key,
+                                  )}
+                                  onUpdate={(override) =>
+                                    handlePlayerOverrideUpdate(player.key, override)
+                                  }
+                                  isDark={isDark}
+                                />
+                              ))}
+
+                            {/* Section: Healers */}
+                            <Typography
+                              sx={{
+                                fontSize: '0.6rem',
+                                fontWeight: 700,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                                color: isDark
+                                  ? 'rgba(168, 85, 247, 0.7)'
+                                  : 'rgba(168, 85, 247, 0.8)',
+                                mt: 1,
+                              }}
+                            >
+                              Healers
+                            </Typography>
+                            {players
+                              .filter((p) => p.role === 'healer')
+                              .map((player) => (
+                                <PlayerOverrideEditor
+                                  key={player.key}
+                                  player={player}
+                                  override={getPlayerOverride(
+                                    currentEncounterOverrides,
+                                    player.key,
+                                  )}
+                                  onUpdate={(override) =>
+                                    handlePlayerOverrideUpdate(player.key, override)
+                                  }
+                                  isDark={isDark}
+                                />
+                              ))}
+
+                            {/* Section: DPS */}
+                            <Typography
+                              sx={{
+                                fontSize: '0.6rem',
+                                fontWeight: 700,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                                color: isDark ? 'rgba(239, 68, 68, 0.7)' : 'rgba(239, 68, 68, 0.8)',
+                                mt: 1,
+                              }}
+                            >
+                              Damage Dealers
+                            </Typography>
+                            {players
+                              .filter((p) => p.role === 'dps')
+                              .map((player) => (
+                                <PlayerOverrideEditor
+                                  key={player.key}
+                                  player={player}
+                                  override={getPlayerOverride(
+                                    currentEncounterOverrides,
+                                    player.key,
+                                  )}
+                                  onUpdate={(override) =>
+                                    handlePlayerOverrideUpdate(player.key, override)
+                                  }
+                                  isDark={isDark}
+                                />
+                              ))}
+                          </Stack>
+                        </Paper>
+                      )}
+
+                      {/* Deep-link to this fight + hint */}
+                      {selectedEncounterId ? (
+                        <Tooltip title="Copy a read-only link that opens this exact fight" arrow>
+                          <Box
+                            role="button"
+                            tabIndex={0}
+                            onClick={handleCopyFightLink}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                handleCopyFightLink();
+                              }
+                            }}
+                            sx={{
+                              alignSelf: 'flex-start',
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              gap: 0.5,
+                              cursor: 'pointer',
+                              fontSize: '0.7rem',
+                              fontWeight: 600,
+                              color: copied ? '#22c55e' : '#38bdf8',
+                              px: 1,
+                              py: 0.5,
+                              borderRadius: '8px',
+                              '&:hover': {
+                                backgroundColor: isDark
+                                  ? 'rgba(56,189,248,0.08)'
+                                  : 'rgba(56,189,248,0.06)',
+                              },
+                              '&:focus-visible': {
+                                outline: '2px solid #38bdf8',
+                                outlineOffset: '2px',
+                              },
+                            }}
+                          >
+                            {copied ? <CheckIcon sx={{ fontSize: '0.85rem' }} /> : null}
+                            {copied ? 'Link copied' : '🔗 Copy link to this fight'}
+                          </Box>
+                        </Tooltip>
+                      ) : (
+                        <Typography
+                          sx={{
+                            fontSize: '0.75rem',
+                            color: 'text.disabled',
+                            textAlign: 'center',
+                            py: 2,
+                            fontStyle: 'italic',
+                          }}
+                        >
+                          Click an encounter in the timeline above to customize builds for that
+                          fight
+                        </Typography>
+                      )}
+                    </>
+                  )}
+                </Stack>
+              </Box>
+            </Box>
+          )}
+
+          {/* MOBILE — trial bottom sheet */}
+          <Dialog
+            open={sheetOpen && isMobile}
+            onClose={() => setSheetOpen(false)}
+            fullScreen
+            slotProps={{
+              paper: {
+                sx: {
+                  background: isDark ? 'rgba(15,23,42,0.98)' : 'rgba(255,255,255,0.98)',
+                  backdropFilter: 'blur(16px)',
+                },
+              },
+            }}
+          >
+            <Box sx={{ p: 2 }}>
+              <Box
                 sx={{
-                  borderRadius: '10px',
-                  backgroundColor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
-                  '& fieldset': {
-                    borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.12)',
-                  },
+                  width: 36,
+                  height: 4,
+                  borderRadius: 2,
+                  mx: 'auto',
+                  mb: 2,
+                  backgroundColor: isDark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)',
+                }}
+              />
+              <Typography
+                sx={{
+                  fontFamily: '"Space Grotesk", sans-serif',
+                  fontWeight: 700,
+                  fontSize: '1rem',
+                  mb: 1.5,
                 }}
               >
-                <MenuItem value="">
-                  <em>None — No per-fight customization</em>
-                </MenuItem>
-                {trialOptions.map((trial) => (
-                  <MenuItem key={trial.id} value={trial.id}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                Choose a trial
+              </Typography>
+              <Stack spacing={0.75}>
+                {railTrials.map((trial) => {
+                  const count = overrideCountByTrial[trial.id] ?? 0;
+                  const sameBuild = overridesMap?.[trial.id]?.useSameBuildForAll ?? false;
+                  const active = trial.id === selectedTrialId;
+                  return (
+                    <Box
+                      key={trial.id}
+                      onClick={() => {
+                        handleSelectTrial(trial.id);
+                        setSheetOpen(false);
+                      }}
+                      sx={{
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        minHeight: 48,
+                        px: 1.25,
+                        borderRadius: '10px',
+                        borderLeft: active ? '3px solid #38bdf8' : '3px solid transparent',
+                        backgroundColor: active
+                          ? isDark
+                            ? 'rgba(56,189,248,0.12)'
+                            : 'rgba(56,189,248,0.10)'
+                          : isDark
+                            ? 'rgba(255,255,255,0.03)'
+                            : 'rgba(0,0,0,0.02)',
+                      }}
+                    >
                       <Chip
                         label={trial.shortName}
                         size="small"
                         sx={{
-                          height: 20,
-                          fontSize: '0.6rem',
+                          height: 22,
+                          fontSize: '0.65rem',
                           fontWeight: 700,
-                          minWidth: 32,
+                          backgroundColor: isDark
+                            ? 'rgba(96,165,250,0.12)'
+                            : 'rgba(37,99,235,0.08)',
+                          color: isDark ? '#bfdbfe' : '#1d4ed8',
                         }}
                       />
-                      <span>{trial.name}</span>
                       <Typography
-                        component="span"
-                        sx={{ fontSize: '0.7rem', color: 'text.disabled', ml: 'auto' }}
+                        sx={{ fontSize: '0.9rem', fontWeight: 600, flex: 1, minWidth: 0 }}
                       >
-                        {trial.encounters.filter((e) => e.type === 'boss').length} bosses
+                        {trial.name}
                       </Typography>
-                    </Box>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-
-            {/* Encounter timeline (shown immediately when trial is selected) */}
-            {selectedTrial && (
-              <>
-                <Box
-                  sx={{
-                    p: 1.5,
-                    borderRadius: '10px',
-                    backgroundColor: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
-                    border: isDark
-                      ? '1px solid rgba(255,255,255,0.04)'
-                      : '1px solid rgba(0,0,0,0.04)',
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      fontSize: '0.6rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.08em',
-                      textTransform: 'uppercase',
-                      color: 'text.disabled',
-                      mb: 1,
-                    }}
-                  >
-                    {selectedTrial.name} — Select an encounter to customize
-                  </Typography>
-                  <EncounterTimeline
-                    encounters={selectedTrial.encounters}
-                    selectedEncounterId={selectedEncounterId}
-                    onSelectEncounter={setSelectedEncounterId}
-                    overriddenEncounters={overriddenEncounterIds}
-                  />
-                </Box>
-
-                {/* Per-fight override editor */}
-                {selectedEncounterId && selectedEncounterInfo && (
-                  <Paper
-                    elevation={0}
-                    sx={{
-                      p: 1.5,
-                      borderRadius: '10px',
-                      border: isDark
-                        ? '1px solid rgba(255,255,255,0.06)'
-                        : '1px solid rgba(0,0,0,0.06)',
-                      backgroundColor: isDark ? 'rgba(255,255,255,0.015)' : 'rgba(0,0,0,0.01)',
-                    }}
-                  >
-                    {/* Encounter header */}
-                    <Box sx={{ mb: 1.5 }}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-                        <Chip
-                          label={
-                            selectedEncounterInfo.type === 'boss'
-                              ? 'Boss'
-                              : selectedEncounterInfo.type === 'mini_boss'
-                                ? 'Mini-Boss'
-                                : 'Trash'
-                          }
-                          size="small"
-                          sx={{
-                            height: 20,
-                            fontSize: '0.55rem',
-                            fontWeight: 700,
-                            backgroundColor:
-                              selectedEncounterInfo.type === 'boss'
-                                ? 'rgba(239, 68, 68, 0.12)'
-                                : selectedEncounterInfo.type === 'mini_boss'
-                                  ? 'rgba(245, 158, 11, 0.12)'
-                                  : 'rgba(59, 130, 246, 0.08)',
-                            color:
-                              selectedEncounterInfo.type === 'boss'
-                                ? '#ef4444'
-                                : selectedEncounterInfo.type === 'mini_boss'
-                                  ? '#f59e0b'
-                                  : '#3b82f6',
-                          }}
-                        />
-                        <Typography
-                          sx={{
-                            fontFamily: '"Space Grotesk", sans-serif',
-                            fontWeight: 700,
-                            fontSize: '0.9rem',
-                            letterSpacing: '-0.01em',
+                      <Typography sx={{ fontSize: '0.7rem', color: 'text.disabled' }}>
+                        {count > 0 ? `${count} fights` : sameBuild ? 'same build' : 'no edits'}
+                      </Typography>
+                      <Tooltip title="Same build for every fight" arrow>
+                        <IconButton
+                          aria-label={`Toggle same build for all fights in ${trial.name}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleToggleSameBuild(trial.id);
                           }}
                         >
-                          {selectedEncounterInfo.name}
-                        </Typography>
-                      </Box>
-                      {selectedEncounterInfo.description && (
-                        <Typography
-                          sx={{
-                            fontSize: '0.7rem',
-                            color: 'text.secondary',
-                            ml: 0.5,
-                          }}
-                        >
-                          {selectedEncounterInfo.description}
-                        </Typography>
-                      )}
+                          <Box
+                            component="span"
+                            sx={{
+                              fontSize: '0.95rem',
+                              color: sameBuild ? '#38bdf8' : 'text.disabled',
+                              fontWeight: 700,
+                            }}
+                          >
+                            {sameBuild ? '≣' : '≡'}
+                          </Box>
+                        </IconButton>
+                      </Tooltip>
                     </Box>
-
-                    {/* Player override list */}
-                    <Stack spacing={0.75}>
-                      {/* Section: Tanks */}
-                      <Typography
-                        sx={{
-                          fontSize: '0.6rem',
-                          fontWeight: 700,
-                          letterSpacing: '0.08em',
-                          textTransform: 'uppercase',
-                          color: isDark ? 'rgba(59, 130, 246, 0.7)' : 'rgba(59, 130, 246, 0.8)',
-                          mt: 0.5,
-                        }}
-                      >
-                        Tanks
-                      </Typography>
-                      {players
-                        .filter((p) => p.role === 'tank')
-                        .map((player) => (
-                          <PlayerOverrideEditor
-                            key={player.key}
-                            player={player}
-                            override={getPlayerOverride(currentEncounterOverrides, player.key)}
-                            onUpdate={(override) =>
-                              handlePlayerOverrideUpdate(player.key, override)
-                            }
-                            isDark={isDark}
-                          />
-                        ))}
-
-                      {/* Section: Healers */}
-                      <Typography
-                        sx={{
-                          fontSize: '0.6rem',
-                          fontWeight: 700,
-                          letterSpacing: '0.08em',
-                          textTransform: 'uppercase',
-                          color: isDark ? 'rgba(168, 85, 247, 0.7)' : 'rgba(168, 85, 247, 0.8)',
-                          mt: 1,
-                        }}
-                      >
-                        Healers
-                      </Typography>
-                      {players
-                        .filter((p) => p.role === 'healer')
-                        .map((player) => (
-                          <PlayerOverrideEditor
-                            key={player.key}
-                            player={player}
-                            override={getPlayerOverride(currentEncounterOverrides, player.key)}
-                            onUpdate={(override) =>
-                              handlePlayerOverrideUpdate(player.key, override)
-                            }
-                            isDark={isDark}
-                          />
-                        ))}
-
-                      {/* Section: DPS */}
-                      <Typography
-                        sx={{
-                          fontSize: '0.6rem',
-                          fontWeight: 700,
-                          letterSpacing: '0.08em',
-                          textTransform: 'uppercase',
-                          color: isDark ? 'rgba(239, 68, 68, 0.7)' : 'rgba(239, 68, 68, 0.8)',
-                          mt: 1,
-                        }}
-                      >
-                        Damage Dealers
-                      </Typography>
-                      {players
-                        .filter((p) => p.role === 'dps')
-                        .map((player) => (
-                          <PlayerOverrideEditor
-                            key={player.key}
-                            player={player}
-                            override={getPlayerOverride(currentEncounterOverrides, player.key)}
-                            onUpdate={(override) =>
-                              handlePlayerOverrideUpdate(player.key, override)
-                            }
-                            isDark={isDark}
-                          />
-                        ))}
-                    </Stack>
-                  </Paper>
-                )}
-
-                {/* Hint when no encounter is selected */}
-                {!selectedEncounterId && (
-                  <Typography
-                    sx={{
-                      fontSize: '0.75rem',
-                      color: 'text.disabled',
-                      textAlign: 'center',
-                      py: 2,
-                      fontStyle: 'italic',
-                    }}
-                  >
-                    Click an encounter in the timeline above to customize builds for that fight
-                  </Typography>
-                )}
-              </>
-            )}
-
-            {!selectedTrial && (
-              <Typography
-                sx={{
-                  fontSize: '0.75rem',
-                  color: 'text.disabled',
-                  textAlign: 'center',
-                  py: 1,
-                }}
-              >
-                Select a trial above to enable per-fight build customization
-              </Typography>
-            )}
-          </Stack>
+                  );
+                })}
+              </Stack>
+            </Box>
+          </Dialog>
         </AccordionDetails>
       </Accordion>
     );

--- a/src/components/PerFightBuilds.tsx
+++ b/src/components/PerFightBuilds.tsx
@@ -4,6 +4,7 @@ import {
   RestartAlt as ResetIcon,
   Edit as EditIcon,
   Check as CheckIcon,
+  Close as CloseIcon,
 } from '@mui/icons-material';
 import {
   Accordion,
@@ -782,7 +783,11 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
             <Box
               sx={{
                 display: 'grid',
-                gridTemplateColumns: showRail && !isMobile ? '210px 1fr' : '1fr',
+                // minmax(0, …) lets the content track shrink below its intrinsic
+                // width so the encounter timeline scrolls internally instead of
+                // blowing the pane out past the viewport on mobile.
+                gridTemplateColumns:
+                  showRail && !isMobile ? '210px minmax(0, 1fr)' : 'minmax(0, 1fr)',
                 gap: 1.5,
                 alignItems: 'start',
               }}
@@ -984,21 +989,25 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                     {selectedTrial.name}
                   </Typography>
                   {(overrideCountByTrial[selectedTrial.id] ?? 0) > 0 && (
-                    <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled' }}>
-                      {overrideCountByTrial[selectedTrial.id]} fights
+                    <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled', flexShrink: 0 }}>
+                      {overrideCountByTrial[selectedTrial.id]} fight
+                      {overrideCountByTrial[selectedTrial.id] > 1 ? 's' : ''}
                     </Typography>
                   )}
-                  <ExpandMoreIcon sx={{ fontSize: '1.1rem', color: 'text.disabled' }} />
+                  <ExpandMoreIcon
+                    sx={{ fontSize: '1.1rem', color: 'text.disabled', flexShrink: 0 }}
+                  />
                 </Box>
               )}
 
-              {/* DETAIL pane */}
+              {/* DETAIL pane — minWidth:0 so it can shrink within the grid track */}
               <Box
                 role="tabpanel"
                 id={selectedTrialId ? `pft-panel-${selectedTrialId}` : undefined}
                 aria-labelledby={selectedTrialId ? `pft-tab-${selectedTrialId}` : undefined}
+                sx={{ minWidth: 0 }}
               >
-                <Stack spacing={2}>
+                <Stack spacing={2} sx={{ minWidth: 0 }}>
                   {/* Encounter timeline (shown immediately when trial is selected) */}
                   {selectedTrial && (
                     <>
@@ -1261,42 +1270,64 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
             </Box>
           )}
 
-          {/* MOBILE — trial bottom sheet */}
+          {/* MOBILE — trial bottom sheet (content-height, anchored to the bottom) */}
           <Dialog
             open={sheetOpen && isMobile}
             onClose={() => setSheetOpen(false)}
-            fullScreen
+            aria-labelledby="pft-sheet-title"
             slotProps={{
               paper: {
                 sx: {
+                  position: 'fixed',
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  m: 0,
+                  width: '100%',
+                  maxWidth: '100%',
+                  maxHeight: '85dvh',
+                  borderRadius: '20px 20px 0 0',
                   background: isDark ? 'rgba(15,23,42,0.98)' : 'rgba(255,255,255,0.98)',
                   backdropFilter: 'blur(16px)',
+                  // Respect the iOS home-indicator safe area.
+                  pb: 'env(safe-area-inset-bottom)',
                 },
               },
             }}
           >
-            <Box sx={{ p: 2 }}>
+            <Box sx={{ px: 2, pt: 1.25, pb: 1.5 }}>
               <Box
                 sx={{
                   width: 36,
                   height: 4,
                   borderRadius: 2,
                   mx: 'auto',
-                  mb: 2,
+                  mb: 1.5,
                   backgroundColor: isDark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)',
                 }}
               />
-              <Typography
-                sx={{
-                  fontFamily: '"Space Grotesk", sans-serif',
-                  fontWeight: 700,
-                  fontSize: '1rem',
-                  mb: 1.5,
-                }}
-              >
-                Choose a trial
-              </Typography>
-              <Stack spacing={0.75}>
+              <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
+                <Typography
+                  id="pft-sheet-title"
+                  sx={{
+                    fontFamily: '"Space Grotesk", sans-serif',
+                    fontWeight: 700,
+                    fontSize: '1rem',
+                    flex: 1,
+                  }}
+                >
+                  Choose a trial
+                </Typography>
+                <IconButton
+                  aria-label="Close trial picker"
+                  onClick={() => setSheetOpen(false)}
+                  size="small"
+                  sx={{ color: 'text.secondary' }}
+                >
+                  <CloseIcon sx={{ fontSize: '1.1rem' }} />
+                </IconButton>
+              </Box>
+              <Stack spacing={0.75} sx={{ overflowY: 'auto' }}>
                 {railTrials.map((trial) => {
                   const count = overrideCountByTrial[trial.id] ?? 0;
                   const sameBuild = overridesMap?.[trial.id]?.useSameBuildForAll ?? false;
@@ -1304,18 +1335,28 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                   return (
                     <Box
                       key={trial.id}
+                      role="button"
+                      tabIndex={0}
+                      aria-pressed={active}
                       onClick={() => {
                         handleSelectTrial(trial.id);
                         setSheetOpen(false);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleSelectTrial(trial.id);
+                          setSheetOpen(false);
+                        }
                       }}
                       sx={{
                         cursor: 'pointer',
                         display: 'flex',
                         alignItems: 'center',
                         gap: 1,
-                        minHeight: 48,
+                        minHeight: 52,
                         px: 1.25,
-                        borderRadius: '10px',
+                        borderRadius: '12px',
                         borderLeft: active ? '3px solid #38bdf8' : '3px solid transparent',
                         backgroundColor: active
                           ? isDark
@@ -1324,6 +1365,7 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                           : isDark
                             ? 'rgba(255,255,255,0.03)'
                             : 'rgba(0,0,0,0.02)',
+                        '&:focus-visible': { outline: '2px solid #38bdf8', outlineOffset: '2px' },
                       }}
                     >
                       <Chip
@@ -1333,6 +1375,7 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                           height: 22,
                           fontSize: '0.65rem',
                           fontWeight: 700,
+                          flexShrink: 0,
                           backgroundColor: isDark
                             ? 'rgba(96,165,250,0.12)'
                             : 'rgba(37,99,235,0.08)',
@@ -1340,12 +1383,26 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                         }}
                       />
                       <Typography
-                        sx={{ fontSize: '0.9rem', fontWeight: 600, flex: 1, minWidth: 0 }}
+                        sx={{
+                          fontSize: '0.9rem',
+                          fontWeight: 600,
+                          flex: 1,
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
                       >
                         {trial.name}
                       </Typography>
-                      <Typography sx={{ fontSize: '0.7rem', color: 'text.disabled' }}>
-                        {count > 0 ? `${count} fights` : sameBuild ? 'same build' : 'no edits'}
+                      <Typography
+                        sx={{ fontSize: '0.7rem', color: 'text.disabled', flexShrink: 0 }}
+                      >
+                        {count > 0
+                          ? `${count} fight${count > 1 ? 's' : ''}`
+                          : sameBuild
+                            ? 'same build'
+                            : 'no edits'}
                       </Typography>
                       <Tooltip title="Same build for every fight" arrow>
                         <IconButton
@@ -1354,6 +1411,7 @@ export const PerFightBuilds: React.FC<PerFightBuildsProps> = React.memo(
                             e.stopPropagation();
                             handleToggleSameBuild(trial.id);
                           }}
+                          sx={{ flexShrink: 0 }}
                         >
                           <Box
                             component="span"

--- a/src/pages/RosterBuilderPage.tsx
+++ b/src/pages/RosterBuilderPage.tsx
@@ -702,12 +702,12 @@ export const RosterBuilderPage: React.FC = () => {
     });
   }, []);
 
-  // Update trial per-fight build overrides
+  // Update trial per-fight build overrides (the whole multi-trial map).
   const handleTrialOverridesChange = useCallback(
-    (overrides: TrialBuildOverrides | undefined): void => {
+    (overrides: Record<string, TrialBuildOverrides> | undefined): void => {
       setRoster((prev) => ({
         ...prev,
-        trialOverrides: overrides,
+        trialOverrides: overrides && Object.keys(overrides).length > 0 ? overrides : undefined,
         updatedAt: new Date().toISOString(),
       }));
     },
@@ -2637,7 +2637,7 @@ export const RosterBuilderPage: React.FC = () => {
       <ServerPickerDialog
         open={discordPublishOpen}
         title={roster.rosterName}
-        trialId={roster.trialOverrides?.trialId ?? ''}
+        trialId={roster.trialOverrides ? (Object.keys(roster.trialOverrides)[0] ?? '') : ''}
         rosterData={discordPublishData}
         onClose={() => setDiscordPublishOpen(false)}
         onSuccess={() => {

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -32,7 +32,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { GearSetTooltip } from '../components/GearSetTooltip';
@@ -58,10 +58,13 @@ import {
   MONSTER_SETS,
   ARENA_WEAPON_SETS,
 } from '../types/roster';
+import type { Trial } from '../types/trial-encounters';
 import {
   TrialBuildOverrides,
   getTrialById,
+  resolveTrialId,
   encounterHasOverrides,
+  trialHasOverrides,
 } from '../types/trial-encounters';
 import { encodeBuildToURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
@@ -1145,20 +1148,20 @@ const SectionLabel: React.FC<{
 // Per-fight builds section
 // ============================================================
 
-interface PerFightSectionProps {
+interface PerFightTrialGroupProps {
   roster: RaidRoster;
+  trial: Trial;
   trialOverrides: TrialBuildOverrides;
   isDarkMode: boolean;
 }
 
-const PerFightSection: React.FC<PerFightSectionProps> = ({
+/** Read-only run-sheet group for ONE trial's per-fight overrides. */
+const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
   roster,
+  trial,
   trialOverrides,
   isDarkMode,
 }) => {
-  const trial = getTrialById(trialOverrides.trialId);
-  if (!trial) return null;
-
   const encountersWithOverrides = trial.encounters.filter((enc) =>
     encounterHasOverrides(trialOverrides.encounterBuilds[enc.id]),
   );
@@ -1168,13 +1171,36 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({
   const accentColor = isDarkMode ? '#9c88ff' : '#6c5ce7';
 
   return (
-    <Box sx={{ mb: 3 }}>
-      <SectionLabel
-        icon={<PerFightIcon sx={{ fontSize: '0.85rem', color: accentColor }} />}
-        label={`Per-Fight Builds — ${trial.name}`}
-        color={accentColor}
-        isDarkMode={isDarkMode}
-      />
+    <Box id={`pf-${trial.id}`} sx={{ mb: 2.5, scrollMarginTop: '80px' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.75 }}>
+        <Chip
+          label={trial.shortName}
+          size="small"
+          sx={{
+            height: 20,
+            fontSize: '0.62rem',
+            fontWeight: 700,
+            backgroundColor: isDarkMode ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.08)',
+            color: isDarkMode ? '#bfdbfe' : '#1d4ed8',
+          }}
+        />
+        <Typography
+          sx={{
+            fontFamily: '"Space Grotesk", sans-serif',
+            fontWeight: 700,
+            fontSize: '0.92rem',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {trial.name}
+        </Typography>
+        {encountersWithOverrides.length > 0 && (
+          <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled', ml: 0.5 }}>
+            {encountersWithOverrides.length} fight
+            {encountersWithOverrides.length > 1 ? 's' : ''}
+          </Typography>
+        )}
+      </Box>
       {trialOverrides.useSameBuildForAll ? (
         <Paper
           elevation={0}
@@ -1187,20 +1213,6 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({
         >
           <Typography sx={{ fontSize: '0.78rem', color: 'text.secondary' }}>
             Same build used for all encounters.
-          </Typography>
-        </Paper>
-      ) : encountersWithOverrides.length === 0 ? (
-        <Paper
-          elevation={0}
-          sx={{
-            p: 1.5,
-            borderRadius: '10px',
-            backgroundColor: bgColor,
-            border: `1px solid ${borderColor}`,
-          }}
-        >
-          <Typography sx={{ fontSize: '0.78rem', color: 'text.secondary' }}>
-            No per-fight overrides configured.
           </Typography>
         </Paper>
       ) : (
@@ -1224,12 +1236,14 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({
             return (
               <Paper
                 key={enc.id}
+                id={`pf-${trial.id}-${enc.id}`}
                 elevation={0}
                 sx={{
                   p: 1.25,
                   borderRadius: '10px',
                   backgroundColor: bgColor,
                   border: `1px solid ${borderColor}`,
+                  scrollMarginTop: '80px',
                 }}
               >
                 <Typography
@@ -1363,6 +1377,113 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({
   );
 };
 
+interface PerFightSectionProps {
+  roster: RaidRoster;
+  overridesMap: Record<string, TrialBuildOverrides>;
+  isDarkMode: boolean;
+}
+
+/**
+ * Read-only "run sheet" of per-fight builds across every populated trial.
+ * Trials are ordered by `roster.trials` (bridged via resolveTrialId); any trial
+ * that has overrides but lost its tag is appended so its work is never hidden.
+ * A sticky jump-bar appears at 4+ trials.
+ */
+const PerFightSection: React.FC<PerFightSectionProps> = ({ roster, overridesMap, isDarkMode }) => {
+  const accentColor = isDarkMode ? '#9c88ff' : '#6c5ce7';
+
+  // Order: tagged trials first (in roster.trials order), then any orphaned populated trials.
+  const orderedTrialIds: string[] = [];
+  for (const tag of roster.trials ?? []) {
+    const id = resolveTrialId(tag);
+    if (id && overridesMap[id] && !orderedTrialIds.includes(id)) orderedTrialIds.push(id);
+  }
+  for (const id of Object.keys(overridesMap)) {
+    if (!orderedTrialIds.includes(id)) orderedTrialIds.push(id);
+  }
+
+  // Only trials with real, displayable content (overrides or same-build flag).
+  const groups = orderedTrialIds
+    .map((id) => ({ id, trial: getTrialById(id), ov: overridesMap[id] }))
+    .filter(
+      (g): g is { id: string; trial: Trial; ov: TrialBuildOverrides } =>
+        Boolean(g.trial) && (g.ov.useSameBuildForAll || trialHasOverrides(g.ov)),
+    );
+
+  if (groups.length === 0) return null;
+
+  const showJumpBar = groups.length >= 4;
+
+  const scrollToTrial = (trialId: string): void => {
+    const el = document.getElementById(`pf-${trialId}`);
+    if (!el) return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+  };
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <SectionLabel
+        icon={<PerFightIcon sx={{ fontSize: '0.85rem', color: accentColor }} />}
+        label="Per-Fight Builds"
+        color={accentColor}
+        isDarkMode={isDarkMode}
+      />
+
+      {showJumpBar && (
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
+            display: 'flex',
+            gap: 0.5,
+            overflowX: 'auto',
+            overscrollBehavior: 'contain',
+            py: 0.75,
+            mb: 1,
+            backdropFilter: 'blur(8px)',
+            WebkitOverflowScrolling: 'touch',
+            '&::-webkit-scrollbar': { display: 'none' },
+            scrollbarWidth: 'none',
+            maskImage: 'linear-gradient(90deg, #000 92%, transparent)',
+          }}
+        >
+          {groups.map((g) => (
+            <Chip
+              key={g.id}
+              label={g.trial.shortName}
+              size="small"
+              onClick={() => scrollToTrial(g.id)}
+              aria-label={`Jump to ${g.trial.name}`}
+              sx={{
+                flexShrink: 0,
+                height: 24,
+                fontSize: '0.62rem',
+                fontWeight: 700,
+                cursor: 'pointer',
+                backgroundColor: isDarkMode ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.08)',
+                color: isDarkMode ? '#bfdbfe' : '#1d4ed8',
+                '&:focus-visible': { outline: '2px solid #38bdf8', outlineOffset: '2px' },
+              }}
+            />
+          ))}
+        </Box>
+      )}
+
+      {groups.map((g) => (
+        <PerFightTrialGroup
+          key={g.id}
+          roster={roster}
+          trial={g.trial}
+          trialOverrides={g.ov}
+          isDarkMode={isDarkMode}
+        />
+      ))}
+    </Box>
+  );
+};
+
 // ============================================================
 // Main page component
 // ============================================================
@@ -1416,6 +1537,43 @@ export const RosterViewPage: React.FC = () => {
 
   // Clean up deep-link fallback on unmount
   useEffect(() => () => cancelDeepLinkRef.current?.(), []);
+
+  // Deep-link target (?trial=&encounter=) read from the URL — preserved so the
+  // page's own Copy button re-shares the same fight, and used to scroll on load.
+  const [deepLinkTarget] = useState<{ trial?: string; encounter?: string }>(() => {
+    const p = new URLSearchParams(window.location.search);
+    return { trial: p.get('trial') ?? undefined, encounter: p.get('encounter') ?? undefined };
+  });
+
+  // After the roster decodes (async), scroll the deep-linked fight into view.
+  // Native hash/scroll no-ops because the target mounts after decode, so we retry
+  // until the node appears (or give up). Honors prefers-reduced-motion. Runs once
+  // per deep-link target via the scrolledForRef guard so settling re-renders
+  // (addons load, etc.) don't re-trigger it.
+  const scrolledForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!roster) return;
+    const { trial, encounter } = deepLinkTarget;
+    if (!trial) return;
+    const anchorId = encounter ? `pf-${trial}-${encounter}` : `pf-${trial}`;
+    if (scrolledForRef.current === anchorId) return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let attempts = 0;
+    let timer: number | undefined;
+    const tryScroll = (): void => {
+      const el = document.getElementById(anchorId);
+      if (el) {
+        scrolledForRef.current = anchorId; // mark done only once we've actually scrolled
+        el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' });
+        return;
+      }
+      if (attempts++ < 20) timer = window.setTimeout(tryScroll, 120);
+    };
+    timer = window.setTimeout(tryScroll, 60);
+    return () => {
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [roster, deepLinkTarget]);
 
   const loadRoster = React.useCallback(() => {
     let cancelled = false;
@@ -1567,11 +1725,15 @@ export const RosterViewPage: React.FC = () => {
     };
   }, [recommendedAddons?.packId]);
 
-  // Copy this shareable link to clipboard
+  // Copy this shareable link to clipboard, preserving any deep-linked fight so a
+  // recipient lands on the same trial+encounter the sharer was viewing.
   const handleCopyLink = (): void => {
-    const url = hubRosterId
+    let url = hubRosterId
       ? `${window.location.origin}${window.location.pathname}?id=${hubRosterId}`
       : `${window.location.origin}${window.location.pathname}?r=${encodedParam}`;
+    if (deepLinkTarget.trial) url += `&trial=${encodeURIComponent(deepLinkTarget.trial)}`;
+    if (deepLinkTarget.encounter)
+      url += `&encounter=${encodeURIComponent(deepLinkTarget.encounter)}`;
     navigator.clipboard
       .writeText(url)
       .then(() => {
@@ -1860,7 +2022,7 @@ export const RosterViewPage: React.FC = () => {
       {roster.trialOverrides && (
         <PerFightSection
           roster={roster}
-          trialOverrides={roster.trialOverrides}
+          overridesMap={roster.trialOverrides}
           isDarkMode={isDarkMode}
         />
       )}

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -1453,17 +1453,22 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({ roster, overridesMap,
             <Chip
               key={g.id}
               label={g.trial.shortName}
-              size="small"
               onClick={() => scrollToTrial(g.id)}
               aria-label={`Jump to ${g.trial.name}`}
               sx={{
                 flexShrink: 0,
-                height: 24,
-                fontSize: '0.62rem',
+                // Comfortable touch target on phones (WCAG 2.5.5), compact on desktop.
+                height: { xs: 36, sm: 28 },
+                borderRadius: '999px',
+                fontSize: '0.68rem',
                 fontWeight: 700,
                 cursor: 'pointer',
                 backgroundColor: isDarkMode ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.08)',
                 color: isDarkMode ? '#bfdbfe' : '#1d4ed8',
+                '& .MuiChip-label': { px: { xs: 1.5, sm: 1.25 } },
+                '&:hover': {
+                  backgroundColor: isDarkMode ? 'rgba(96,165,250,0.2)' : 'rgba(37,99,235,0.14)',
+                },
                 '&:focus-visible': { outline: '2px solid #38bdf8', outlineOffset: '2px' },
               }}
             />

--- a/src/types/roster.ts
+++ b/src/types/roster.ts
@@ -311,8 +311,14 @@ export interface RaidRoster {
   // UI preference for how much detail to show per slot
   rosterDetailLevel?: RosterDetailLevel;
 
-  // Per-fight build overrides (optional, advanced feature)
-  trialOverrides?: TrialBuildOverrides;
+  /**
+   * Per-fight build overrides (optional, advanced feature), keyed by trial id.
+   * A roster can hold per-encounter overrides for each trial it is built for,
+   * independently. Entries are created lazily (only when a trial actually gets
+   * an override), so tagged-but-empty trials cost nothing here or in the URL.
+   * Display order is driven by `trials` iteration, never by map-key order.
+   */
+  trialOverrides?: Record<string, TrialBuildOverrides>;
 
   /**
    * Trials this roster is built for, used to surface it under the right filters

--- a/src/types/trial-encounters.bridge.test.ts
+++ b/src/types/trial-encounters.bridge.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for the trial-id bridge that keeps the Roster Builder's two trial
+ * selectors in sync: the top-level "Built for (Trials)" picker tags rosters
+ * with loadout-manager short codes (e.g. 'RG', 'MOL', 'KA'), while Per-Fight
+ * Builds keys off encounter-data slugs (e.g. 'rockgrove'). `resolveTrialId`
+ * bridges the two, and must stay total/1:1 across all 15 trials.
+ */
+
+import { resolveTrialId, getTrialById, TRIAL_ENCOUNTERS } from './trial-encounters';
+import { TRIALS } from '../features/loadout-manager/data/trialConfigs';
+
+describe('resolveTrialId', () => {
+  it('resolves short codes case-insensitively', () => {
+    expect(resolveTrialId('RG')).toBe('rockgrove');
+    expect(resolveTrialId('rg')).toBe('rockgrove');
+    expect(resolveTrialId('Rg')).toBe('rockgrove');
+  });
+
+  it('resolves codes whose casing differs from trialConfigs (MOL→MoL, HOF→HoF)', () => {
+    // trialConfigs uses 'MOL'/'HOF'; encounter shortNames are 'MoL'/'HoF'.
+    expect(resolveTrialId('MOL')).toBe('maw_of_lorkhaj');
+    expect(resolveTrialId('HOF')).toBe('halls_of_fabrication');
+  });
+
+  it('resolves the apostrophe trials (KA, SE)', () => {
+    expect(resolveTrialId('KA')).toBe('kynes_aegis');
+    expect(resolveTrialId('SE')).toBe('sanitys_edge');
+  });
+
+  it('passes a full encounter-data slug through unchanged', () => {
+    expect(resolveTrialId('rockgrove')).toBe('rockgrove');
+    expect(resolveTrialId('ossein_cage')).toBe('ossein_cage');
+  });
+
+  it('returns undefined for empty or unknown tags', () => {
+    expect(resolveTrialId('')).toBeUndefined();
+    expect(resolveTrialId('NOPE')).toBeUndefined();
+    expect(resolveTrialId('not_a_trial')).toBeUndefined();
+  });
+
+  it('resolves every trialConfigs trial code to a real encounter trial (1:1, no gaps)', () => {
+    const trialCodes = TRIALS.filter((t) => t.type === 'trial').map((t) => t.id);
+    // There are 15 ESO trials; guard against silent loss of one.
+    expect(trialCodes.length).toBe(15);
+    for (const code of trialCodes) {
+      const slug = resolveTrialId(code);
+      expect(slug).toBeDefined();
+      // The resolved slug must point at a real encounter-data trial.
+      expect(getTrialById(slug as string)).toBeDefined();
+    }
+  });
+
+  it('every encounter trial is reachable from exactly one trialConfigs code', () => {
+    const trialCodes = TRIALS.filter((t) => t.type === 'trial').map((t) => t.id);
+    const reached = new Set(trialCodes.map((c) => resolveTrialId(c)).filter(Boolean));
+    expect(reached.size).toBe(TRIAL_ENCOUNTERS.length);
+    for (const t of TRIAL_ENCOUNTERS) {
+      expect(reached.has(t.id)).toBe(true);
+    }
+  });
+});

--- a/src/types/trial-encounters.ts
+++ b/src/types/trial-encounters.ts
@@ -1219,6 +1219,29 @@ export function getTrialById(trialId: string): Trial | undefined {
   return TRIAL_ENCOUNTERS.find((t) => t.id === trialId);
 }
 
+/**
+ * Map of a trial's short code (case-normalized) → its full encounter-data id.
+ * The "Built for (Trials)" picker tags rosters with short codes from
+ * loadout-manager's trialConfigs (e.g. 'RG', 'MOL', 'KA'); this bridges those
+ * to the encounter-data slugs used by Per-Fight Builds (e.g. 'rockgrove').
+ */
+const TRIAL_ID_BY_SHORT_NAME = new Map(
+  TRIAL_ENCOUNTERS.map((t) => [t.shortName.toUpperCase(), t.id] as const),
+);
+
+/**
+ * Resolve a "Built for" trial tag (a trialConfigs short code like 'RG' or a
+ * full encounter slug like 'rockgrove') to the encounter-data trial id.
+ * Returns undefined if it doesn't correspond to a trial with encounter data.
+ */
+export function resolveTrialId(tag: string): string | undefined {
+  if (!tag) return undefined;
+  // Already a full encounter-data id?
+  if (TRIAL_ENCOUNTERS.some((t) => t.id === tag)) return tag;
+  // Otherwise treat as a short code (case-insensitive).
+  return TRIAL_ID_BY_SHORT_NAME.get(tag.toUpperCase());
+}
+
 /** Create a default (empty) TrialBuildOverrides for a given trial */
 export function createDefaultTrialOverrides(trialId: string): TrialBuildOverrides {
   return {

--- a/src/types/trial-encounters.ts
+++ b/src/types/trial-encounters.ts
@@ -77,6 +77,30 @@ export function encounterHasOverrides(overrides: EncounterOverrides | undefined)
   return Object.values(overrides.slots).some((o) => !isOverrideEmpty(o));
 }
 
+/**
+ * Does a single trial's overrides contain any real per-encounter data?
+ * `useSameBuildForAll` alone does NOT count as an override — only populated
+ * encounters do. Used to decide whether a trial shows up on the read-only viewer.
+ */
+export function trialHasOverrides(trial: TrialBuildOverrides | undefined): boolean {
+  if (!trial) return false;
+  return Object.values(trial.encounterBuilds).some((eo) => encounterHasOverrides(eo));
+}
+
+/** Does the multi-trial overrides map have any trial with real per-encounter data? */
+export function hasAnyTrialOverrides(
+  map: Record<string, TrialBuildOverrides> | undefined,
+): boolean {
+  if (!map) return false;
+  return Object.values(map).some((t) => trialHasOverrides(t));
+}
+
+/** Count the encounters in a trial that have real overrides (for badges). */
+export function countTrialOverrides(trial: TrialBuildOverrides | undefined): number {
+  if (!trial) return 0;
+  return Object.values(trial.encounterBuilds).filter((eo) => encounterHasOverrides(eo)).length;
+}
+
 /** Merge a base TankSetup with a sparse override */
 export function applyTankOverride(base: TankSetup, override?: PlayerOverride): TankSetup {
   if (!override || isOverrideEmpty(override)) return base;

--- a/src/utils/rosterEncoding.multitrial.test.ts
+++ b/src/utils/rosterEncoding.multitrial.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the SINGLE-TRIAL → MULTI-TRIAL per-fight overrides migration.
+ *
+ * Covers the load-bearing invariants from the design brief:
+ *  - Multi-trial round-trip: encode (tom) → decode → re-encode preserves every
+ *    trial's encounterBuilds and per-slot data.
+ *  - Backward compat (HARD GATE): a legacy single-trial `?r=` payload (compact
+ *    `to`) decodes to a one-entry map with the right trialId + intact builds,
+ *    and re-encodes to the new `tom` form (never `to`).
+ *  - sa fail-safe: a populated trial decodes with useSameBuildForAll === false
+ *    even if the `sa` flag is missing/stale, so a slip can't silently hide builds.
+ *  - Sparse encoding: same-build-only trials are omitted from the URL.
+ */
+
+/**
+ * @jest-environment node
+ *
+ * rosterEncoding uses CompressionStream/DecompressionStream (Web Streams API),
+ * which jsdom does not ship; the `node` environment provides spec-compatible globals.
+ */
+
+import { createDefaultRoster } from '../types/roster';
+import type { RaidRoster } from '../types/roster';
+import type { TrialBuildOverrides } from '../types/trial-encounters';
+
+import { deflateRawSync, inflateRawSync } from 'zlib';
+
+import {
+  type CompactRoster,
+  type CompactRosterV3,
+  type CompactTrialOverrides,
+  compactifyRoster,
+  expandCompactRoster,
+  toBase64Url,
+  fromBase64Url,
+} from './rosterEncoding';
+
+// Plain numeric set IDs — encoding stores raw numbers, so exact ids are irrelevant
+// to these tests; we only assert they survive the round-trip unchanged.
+const SET_A = 172621; // Pearlescent Ward
+const SET_B = 154716; // a Sul-Xan set
+const SET_C = 185; // Spell Power Cure
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** A trial overrides object with real per-encounter, per-slot data. */
+function trialWithBuilds(trialId: string): TrialBuildOverrides {
+  return {
+    trialId,
+    useSameBuildForAll: false,
+    encounterBuilds: {
+      boss_1: {
+        slots: {
+          'tank:0': { set1: SET_A, ultimate: 'Warhorn', notes: 'shield' },
+          'dps:3': { set1: SET_B },
+        },
+      },
+      boss_2: {
+        slots: {
+          'healer:1': { set1: SET_C, notes: 'group heals' },
+        },
+      },
+    },
+  };
+}
+
+function rosterWithTrials(map: Record<string, TrialBuildOverrides>): RaidRoster {
+  const roster = createDefaultRoster();
+  roster.trials = Object.keys(map);
+  roster.trialOverrides = map;
+  return roster;
+}
+
+/**
+ * URL round-trip via Node zlib — CompressionStream/DecompressionStream are not
+ * available in jest's vm sandbox, so we use the same deflate-raw format that
+ * encodeRosterToURL/decodeRosterFromURL use in the browser. (Mirrors the helper
+ * pattern in rosterEncoding.test.ts.)
+ */
+function encodeViaZlib(roster: RaidRoster): string {
+  const compact = compactifyRoster(roster);
+  const compressed = deflateRawSync(Buffer.from(JSON.stringify(compact), 'utf-8'));
+  return toBase64Url(new Uint8Array(compressed));
+}
+function decodeViaZlib(encoded: string): RaidRoster {
+  const bytes = fromBase64Url(encoded);
+  const json = inflateRawSync(Buffer.from(bytes)).toString('utf-8');
+  const parsed = JSON.parse(json) as CompactRoster;
+  return expandCompactRoster(parsed);
+}
+
+// ── Multi-trial round-trip ─────────────────────────────────────────────────────
+
+describe('multi-trial per-fight overrides — round-trip', () => {
+  it('preserves every trial’s encounterBuilds through encode → decode', () => {
+    const map = {
+      rockgrove: trialWithBuilds('rockgrove'),
+      kynes_aegis: trialWithBuilds('kynes_aegis'),
+    };
+    const roster = rosterWithTrials(map);
+
+    const compact = compactifyRoster(roster) as CompactRosterV3;
+    // New form only: tom present, legacy to absent.
+    expect(compact.tom).toBeDefined();
+    expect(compact.to).toBeUndefined();
+    expect(Object.keys(compact.tom!)).toEqual(['rockgrove', 'kynes_aegis']);
+    // Map key is the trialId — `ti` is dropped inside each entry.
+    expect((compact.tom!.rockgrove as Record<string, unknown>).ti).toBeUndefined();
+
+    const decoded = expandCompactRoster(compact);
+    expect(Object.keys(decoded.trialOverrides ?? {})).toEqual(['rockgrove', 'kynes_aegis']);
+    expect(decoded.trialOverrides?.rockgrove.encounterBuilds.boss_1.slots['tank:0'].set1).toBe(
+      SET_A,
+    );
+    expect(decoded.trialOverrides?.rockgrove.encounterBuilds.boss_1.slots['tank:0'].ultimate).toBe(
+      'Warhorn',
+    );
+    expect(decoded.trialOverrides?.kynes_aegis.encounterBuilds.boss_2.slots['healer:1'].notes).toBe(
+      'group heals',
+    );
+  });
+
+  it('survives a full URL round-trip (deflate-raw + base64url) with no data loss', () => {
+    const map = {
+      rockgrove: trialWithBuilds('rockgrove'),
+      dreadsail_reef: trialWithBuilds('dreadsail_reef'),
+    };
+    const roster = rosterWithTrials(map);
+
+    const encoded = encodeViaZlib(roster);
+    expect(encoded).toBeTruthy();
+    const decoded = decodeViaZlib(encoded);
+    expect(Object.keys(decoded.trialOverrides ?? {}).sort()).toEqual([
+      'dreadsail_reef',
+      'rockgrove',
+    ]);
+    expect(decoded.trialOverrides?.dreadsail_reef.encounterBuilds.boss_1.slots['dps:3'].set1).toBe(
+      SET_B,
+    );
+  });
+});
+
+// ── Backward compatibility (HARD GATE) ─────────────────────────────────────────
+
+describe('legacy single-trial decode (backward compat)', () => {
+  /** Build + encode a legacy `?r=` payload the OLD encoder produced: compact `to` with ti/sa/eb. */
+  function makeLegacyUrl(trialId: string): string {
+    const legacyTo: CompactTrialOverrides = {
+      ti: trialId,
+      sa: false,
+      eb: {
+        boss_1: { sk: { 'tank:0': { s1: SET_A, ul: 'Warhorn' } } },
+        boss_2: { sk: { 'healer:1': { no: 'group heals' } } },
+      },
+    };
+    const legacyCompact = { v: 3, ts: [{}, {}], hs: [{}, {}], dl: 1, to: legacyTo };
+    const compressed = deflateRawSync(Buffer.from(JSON.stringify(legacyCompact), 'utf-8'));
+    return toBase64Url(new Uint8Array(compressed));
+  }
+
+  it('decodes a legacy single-trial URL into a one-entry map with intact builds', () => {
+    const decoded = decodeViaZlib(makeLegacyUrl('rockgrove'));
+    expect(Object.keys(decoded.trialOverrides ?? {})).toEqual(['rockgrove']);
+    const rg = decoded.trialOverrides?.rockgrove;
+    expect(rg?.trialId).toBe('rockgrove');
+    expect(rg?.encounterBuilds.boss_1.slots['tank:0'].set1).toBe(SET_A);
+    expect(rg?.encounterBuilds.boss_1.slots['tank:0'].ultimate).toBe('Warhorn');
+    expect(rg?.encounterBuilds.boss_2.slots['healer:1'].notes).toBe('group heals');
+  });
+
+  it('re-encodes a decoded legacy roster to the new tom form (never to)', () => {
+    const decoded = decodeViaZlib(makeLegacyUrl('kynes_aegis'));
+    const recompact = compactifyRoster(decoded) as CompactRosterV3;
+    expect(recompact.tom).toBeDefined();
+    expect(recompact.to).toBeUndefined();
+    expect(Object.keys(recompact.tom!)).toEqual(['kynes_aegis']);
+  });
+});
+
+// ── sa fail-safe + sparse rules ────────────────────────────────────────────────
+
+describe('sa fail-safe and sparse encoding', () => {
+  it('forces useSameBuildForAll=false when a trial has real builds (even if sa was true)', () => {
+    // Construct a tom entry with a stale sa=true alongside populated eb.
+    const compact: CompactRosterV3 = {
+      v: 3,
+      ts: [{}, {}],
+      hs: [{}, {}],
+      tom: {
+        rockgrove: { sa: true, eb: { boss_1: { sk: { 'tank:0': { s1: 1 } } } } },
+      },
+    };
+    const decoded = expandCompactRoster(compact);
+    expect(decoded.trialOverrides?.rockgrove.useSameBuildForAll).toBe(false);
+    expect(decoded.trialOverrides?.rockgrove.encounterBuilds.boss_1.slots['tank:0'].set1).toBe(1);
+  });
+
+  it('omits a same-build-for-all trial with no real builds from the URL', () => {
+    const roster = rosterWithTrials({
+      rockgrove: { trialId: 'rockgrove', useSameBuildForAll: true, encounterBuilds: {} },
+      kynes_aegis: trialWithBuilds('kynes_aegis'),
+    });
+    const compact = compactifyRoster(roster) as CompactRosterV3;
+    // Empty same-build trial is dropped; only the populated one survives.
+    expect(Object.keys(compact.tom ?? {})).toEqual(['kynes_aegis']);
+  });
+
+  it('produces no tom key when nothing is populated', () => {
+    const roster = rosterWithTrials({
+      rockgrove: { trialId: 'rockgrove', useSameBuildForAll: true, encounterBuilds: {} },
+    });
+    const compact = compactifyRoster(roster) as CompactRosterV3;
+    expect(compact.tom).toBeUndefined();
+  });
+});

--- a/src/utils/rosterEncoding.ts
+++ b/src/utils/rosterEncoding.ts
@@ -40,6 +40,7 @@ import type {
   EncounterOverrides,
   PlayerOverride,
 } from '../types/trial-encounters';
+import { encounterHasOverrides } from '../types/trial-encounters';
 
 import { Logger, LogLevel } from './logger';
 import { makeSlotKey } from './slotKey';
@@ -204,11 +205,26 @@ export interface CompactEncounterOverrides {
   dp?: Array<{ sn: number } & CompactPlayerOverride>; // dpsSlots (sparse)
 }
 
-/** Compact representation of TrialBuildOverrides */
+/**
+ * Compact representation of a single trial's TrialBuildOverrides.
+ * LEGACY single-trial form — decoded for backward compat, never encoded anymore.
+ */
 export interface CompactTrialOverrides {
   ti: string; // trialId
   sa: boolean; // useSameBuildForAll
   eb: Record<string, CompactEncounterOverrides>; // encounterBuilds
+}
+
+/**
+ * Compact representation of ONE trial inside the multi-trial map (`tom`).
+ * The map key IS the trialId, so `ti` is dropped here (×10 byte savings).
+ * `sa` and `eb` are both optional and sparse:
+ *   - omit `eb` when sa===true (viewer never reads per-encounter builds then)
+ *   - a whole trial is omitted from `tom` when sa===true && eb is empty
+ */
+export interface CompactTrialOverridesMulti {
+  sa?: boolean; // useSameBuildForAll
+  eb?: Record<string, CompactEncounterOverrides>; // encounterBuilds
 }
 
 /**
@@ -225,7 +241,10 @@ export interface CompactRosterV2 {
   dp?: CompactDPS[];
   ag?: string[];
   no?: string;
+  /** LEGACY single-trial per-fight overrides (decode only). */
   to?: CompactTrialOverrides;
+  /** Multi-trial per-fight overrides, keyed by trialId. */
+  tom?: Record<string, CompactTrialOverridesMulti>;
   dl?: number;
 }
 
@@ -243,7 +262,10 @@ export interface CompactRosterV3 {
   dp?: CompactDPS[];
   ag?: string[];
   no?: string;
+  /** LEGACY single-trial per-fight overrides (decode only). */
   to?: CompactTrialOverrides;
+  /** Multi-trial per-fight overrides, keyed by trialId (current encode form). */
+  tom?: Record<string, CompactTrialOverridesMulti>;
   dl?: number;
   /** Trials this roster is tagged with (for Hub discovery) */
   tr?: string[];
@@ -763,20 +785,91 @@ function expandEncounterOverrides(c: CompactEncounterOverrides): EncounterOverri
   return { slots };
 }
 
-function compactTrialOverrides(t: TrialBuildOverrides): CompactTrialOverrides {
-  const eb: Record<string, CompactEncounterOverrides> = {};
-  for (const [encId, overrides] of Object.entries(t.encounterBuilds)) {
-    eb[encId] = compactEncounterOverrides(overrides);
-  }
-  return { ti: t.trialId, sa: t.useSameBuildForAll, eb };
-}
+// NOTE: legacy single-trial `compactTrialOverrides` was removed — encoding now
+// always writes the multi-trial `tom` map via `compactTrialOverridesMulti`.
+// `expandTrialOverrides` is kept: it decodes legacy `c.to` URLs for back-compat.
 
 function expandTrialOverrides(c: CompactTrialOverrides): TrialBuildOverrides {
   const encounterBuilds: Record<string, EncounterOverrides> = {};
   for (const [encId, compact] of Object.entries(c.eb)) {
     encounterBuilds[encId] = expandEncounterOverrides(compact);
   }
-  return { trialId: c.ti, useSameBuildForAll: c.sa, encounterBuilds };
+  // sa fail-safe: a populated encounterBuilds can never be "same build for all".
+  const hasBuilds = Object.keys(encounterBuilds).length > 0;
+  return { trialId: c.ti, useSameBuildForAll: hasBuilds ? false : c.sa, encounterBuilds };
+}
+
+// ─── Multi-trial per-fight overrides (current format, key `tom`) ──────────────
+
+/**
+ * Compact the multi-trial overrides map for the URL. Sparse: a trial is OMITTED
+ * entirely when it is `useSameBuildForAll` with no real encounter builds (that
+ * state is recoverable from the `tr` roster-tags + base roster), and `eb` is
+ * omitted whenever `useSameBuildForAll` is true. `sa` is always written
+ * explicitly so decode never has to guess. Returns undefined when nothing to write.
+ */
+function compactTrialOverridesMulti(
+  map: Record<string, TrialBuildOverrides>,
+): Record<string, CompactTrialOverridesMulti> | undefined {
+  const out: Record<string, CompactTrialOverridesMulti> = {};
+  for (const [trialId, t] of Object.entries(map)) {
+    const eb: Record<string, CompactEncounterOverrides> = {};
+    for (const [encId, overrides] of Object.entries(t.encounterBuilds)) {
+      if (encounterHasOverrides(overrides)) {
+        eb[encId] = compactEncounterOverrides(overrides);
+      }
+    }
+    const hasBuilds = Object.keys(eb).length > 0;
+    // Omit a trial that is same-build-for-all with no real per-encounter data.
+    if (!hasBuilds && t.useSameBuildForAll) continue;
+    const entry: CompactTrialOverridesMulti = { sa: hasBuilds ? false : t.useSameBuildForAll };
+    if (hasBuilds) entry.eb = eb;
+    out[trialId] = entry;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Expand a multi-trial overrides map from the URL, capped at MAX_ROSTER_TRIALS. */
+function expandTrialOverridesMulti(
+  c: Record<string, CompactTrialOverridesMulti>,
+): Record<string, TrialBuildOverrides> {
+  const out: Record<string, TrialBuildOverrides> = {};
+  for (const [trialId, ct] of Object.entries(c).slice(0, MAX_ROSTER_TRIALS)) {
+    if (typeof trialId !== 'string' || !trialId) continue;
+    const encounterBuilds: Record<string, EncounterOverrides> = {};
+    for (const [encId, compact] of Object.entries(ct.eb ?? {})) {
+      encounterBuilds[encId] = expandEncounterOverrides(compact);
+    }
+    // sa fail-safe: present encounter builds force useSameBuildForAll=false, so a
+    // missing/stale `sa` flag can never silently hide a populated trial's builds.
+    const hasBuilds = Object.keys(encounterBuilds).length > 0;
+    out[trialId] = {
+      trialId,
+      useSameBuildForAll: hasBuilds ? false : ct.sa !== false,
+      encounterBuilds,
+    };
+  }
+  return out;
+}
+
+/**
+ * Resolve the in-memory multi-trial overrides map from any compact roster form,
+ * applied at every decode site. Precedence:
+ *   1. `tom`  — current multi-trial form
+ *   2. `to`   — legacy single-trial form, wrapped as a one-entry map
+ *   3. undefined
+ */
+function resolveTrialBuilds(c: {
+  tom?: Record<string, CompactTrialOverridesMulti>;
+  to?: CompactTrialOverrides;
+}): Record<string, TrialBuildOverrides> | undefined {
+  if (c.tom && Object.keys(c.tom).length > 0) {
+    return expandTrialOverridesMulti(c.tom);
+  }
+  if (c.to?.ti) {
+    return { [c.to.ti]: expandTrialOverrides(c.to) };
+  }
+  return undefined;
 }
 
 // ============================================================
@@ -834,7 +927,10 @@ export function compactifyRoster(roster: RaidRoster): CompactRosterV3 {
   if (roster.availableGroups?.length) c.ag = roster.availableGroups;
   if (roster.notes) c.no = roster.notes;
   if (roster.trials?.length) c.tr = roster.trials.slice(0, MAX_ROSTER_TRIALS);
-  if (roster.trialOverrides) c.to = compactTrialOverrides(roster.trialOverrides);
+  if (roster.trialOverrides) {
+    const tom = compactTrialOverridesMulti(roster.trialOverrides);
+    if (tom) c.tom = tom;
+  }
   if (roster.rosterDetailLevel) {
     const DL_MAP: Record<RosterDetailLevel, number> = { simple: 0, full: 1 };
     c.dl = DL_MAP[roster.rosterDetailLevel];
@@ -896,7 +992,7 @@ function expandCompactRosterV3(c: CompactRosterV3): RaidRoster {
     availableGroups: c.ag ?? [],
     notes: c.no,
     trials: expandTrials(c.tr),
-    trialOverrides: c.to ? expandTrialOverrides(c.to) : undefined,
+    trialOverrides: resolveTrialBuilds(c),
     rosterDetailLevel: c.dl != null ? DL_LEVELS[c.dl] : undefined,
   };
 }
@@ -935,7 +1031,7 @@ function expandCompactRosterV2(c: CompactRosterV2): RaidRoster {
     dpsSlots,
     availableGroups: c.ag ?? [],
     notes: c.no,
-    trialOverrides: c.to ? expandTrialOverrides(c.to) : undefined,
+    trialOverrides: resolveTrialBuilds(c),
     rosterDetailLevel: c.dl != null ? DL_LEVELS[c.dl] : undefined,
   };
 }
@@ -1126,6 +1222,28 @@ function migrateLegacyRoster(raw: Record<string, unknown>): RaidRoster {
     availableGroups: (raw.availableGroups as string[]) ?? [],
     notes: raw.notes as string | undefined,
     rosterDetailLevel: raw.rosterDetailLevel as RosterDetailLevel | undefined,
-    trialOverrides: raw.trialOverrides as TrialBuildOverrides | undefined,
+    trialOverrides: migrateLegacyTrialOverrides(raw.trialOverrides),
   };
+}
+
+/**
+ * Migrate a legacy v1 `trialOverrides` value (full, uncompacted) into the
+ * multi-trial map. Old data was a single object with a `.trialId`; newer data
+ * is already a map. Returns undefined for anything unrecognized.
+ */
+function migrateLegacyTrialOverrides(
+  raw: unknown,
+): Record<string, TrialBuildOverrides> | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  // Legacy single-trial object → wrap as a one-entry map.
+  const single = raw as Partial<TrialBuildOverrides>;
+  if (typeof single.trialId === 'string' && single.trialId && single.encounterBuilds) {
+    return { [single.trialId]: single as TrialBuildOverrides };
+  }
+  // Already a map keyed by trialId.
+  const map = raw as Record<string, TrialBuildOverrides>;
+  const valid = Object.values(map).every(
+    (t) => t && typeof t === 'object' && 'encounterBuilds' in t,
+  );
+  return valid && Object.keys(map).length > 0 ? map : undefined;
 }

--- a/src/utils/rosterResize.multitrial.test.ts
+++ b/src/utils/rosterResize.multitrial.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests that resizeRoster prunes orphaned per-fight slot overrides across EVERY
+ * trial in the multi-trial map — not just one — when the composition shrinks.
+ */
+
+import { createDefaultRoster } from '../types/roster';
+import type { RaidRoster } from '../types/roster';
+import type { TrialBuildOverrides } from '../types/trial-encounters';
+
+import { resizeRoster } from './rosterResize';
+
+function trialWithDpsSlots(trialId: string): TrialBuildOverrides {
+  return {
+    trialId,
+    useSameBuildForAll: false,
+    encounterBuilds: {
+      boss_1: {
+        slots: {
+          'tank:0': { set1: 1 },
+          'dps:0': { set1: 2 },
+          'dps:7': { set1: 3 }, // will be orphaned when dps shrinks below 8
+        },
+      },
+    },
+  };
+}
+
+describe('resizeRoster — multi-trial override pruning', () => {
+  it('prunes orphaned slot keys in ALL trials when the roster shrinks', () => {
+    const roster: RaidRoster = createDefaultRoster();
+    roster.trials = ['rockgrove', 'kynes_aegis'];
+    roster.trialOverrides = {
+      rockgrove: trialWithDpsSlots('rockgrove'),
+      kynes_aegis: trialWithDpsSlots('kynes_aegis'),
+    };
+
+    // Shrink DPS from 8 to 4 → dps:7 no longer exists.
+    const resized = resizeRoster(roster, { tanks: 2, healers: 2, dps: 4 });
+
+    for (const trialId of ['rockgrove', 'kynes_aegis']) {
+      const slots = resized.trialOverrides?.[trialId]?.encounterBuilds.boss_1?.slots ?? {};
+      expect(slots['dps:7']).toBeUndefined(); // orphaned, pruned
+      expect(slots['dps:0']).toBeDefined(); // still valid
+      expect(slots['tank:0']).toBeDefined(); // still valid
+    }
+  });
+
+  it('keeps every trial in the map (does not drop unrelated trials)', () => {
+    const roster: RaidRoster = createDefaultRoster();
+    roster.trialOverrides = {
+      rockgrove: trialWithDpsSlots('rockgrove'),
+      kynes_aegis: trialWithDpsSlots('kynes_aegis'),
+      sunspire: trialWithDpsSlots('sunspire'),
+    };
+    const resized = resizeRoster(roster, { tanks: 2, healers: 2, dps: 6 });
+    expect(Object.keys(resized.trialOverrides ?? {}).sort()).toEqual([
+      'kynes_aegis',
+      'rockgrove',
+      'sunspire',
+    ]);
+  });
+});

--- a/src/utils/rosterResize.ts
+++ b/src/utils/rosterResize.ts
@@ -8,6 +8,7 @@
 
 import type { RaidRoster, RoleComposition, TankSetup, HealerSetup, DPSSlot } from '../types/roster';
 import { defaultTankSetup, defaultHealerSetup } from '../types/roster';
+import type { TrialBuildOverrides } from '../types/trial-encounters';
 
 import { makeSlotKey } from './slotKey';
 
@@ -53,7 +54,27 @@ function resizeDPS(dpsSlots: DPSSlot[], newCount: number): DPSSlot[] {
 }
 
 /**
- * Clean up trial overrides to remove references to slots that no longer exist.
+ * Clean up one trial's overrides to remove references to slots that no longer exist.
+ */
+function cleanOneTrial(trial: TrialBuildOverrides, validKeys: Set<string>): TrialBuildOverrides {
+  const newEncounterBuilds: TrialBuildOverrides['encounterBuilds'] = {};
+  for (const [encId, overrides] of Object.entries(trial.encounterBuilds)) {
+    const filteredSlots: Record<string, (typeof overrides.slots)[string]> = {};
+    for (const [slotKey, override] of Object.entries(overrides.slots)) {
+      if (validKeys.has(slotKey)) {
+        filteredSlots[slotKey] = override;
+      }
+    }
+    if (Object.keys(filteredSlots).length > 0) {
+      newEncounterBuilds[encId] = { slots: filteredSlots };
+    }
+  }
+  return { ...trial, encounterBuilds: newEncounterBuilds };
+}
+
+/**
+ * Clean up trial overrides across EVERY trial in the map to remove references
+ * to slots that no longer exist after a composition change.
  */
 function cleanTrialOverrides(
   roster: RaidRoster,
@@ -66,23 +87,11 @@ function cleanTrialOverrides(
   for (let i = 0; i < newComp.healers; i++) validKeys.add(makeSlotKey('healer', i));
   for (let i = 0; i < newComp.dps; i++) validKeys.add(makeSlotKey('dps', i));
 
-  const newEncounterBuilds: typeof roster.trialOverrides.encounterBuilds = {};
-  for (const [encId, overrides] of Object.entries(roster.trialOverrides.encounterBuilds)) {
-    const filteredSlots: Record<string, (typeof overrides.slots)[string]> = {};
-    for (const [slotKey, override] of Object.entries(overrides.slots)) {
-      if (validKeys.has(slotKey)) {
-        filteredSlots[slotKey] = override;
-      }
-    }
-    if (Object.keys(filteredSlots).length > 0) {
-      newEncounterBuilds[encId] = { slots: filteredSlots };
-    }
+  const cleaned: Record<string, TrialBuildOverrides> = {};
+  for (const [trialId, trial] of Object.entries(roster.trialOverrides)) {
+    cleaned[trialId] = cleanOneTrial(trial, validKeys);
   }
-
-  return {
-    ...roster.trialOverrides,
-    encounterBuilds: newEncounterBuilds,
-  };
+  return cleaned;
 }
 
 /**


### PR DESCRIPTION
## Multi-trial per-fight builds

> **Supersedes #1231.** This branch contains #1231's commit (`dfcfa512`, scoping Per-Fight Builds to the Built-for trials) as its base, so merging this PR lands both. Rebased onto `main`; #1231 will be closed as superseded once this merges.

### Problem
Per-fight builds were **single-trial only** — `roster.trialOverrides` held one trial's overrides. But a roster can be tagged "Built for" up to **10 trials**, so a roster built for Rockgrove + Kyne's Aegis could only store per-encounter gear/ult/notes for one of them. This makes per-fight builds **multi-trial** end-to-end, with special care for the read-only `/rv` share page (the link the Copy/Share button emits — where everyone a roster is shared *to* lands).

Direction was chosen via a judged design-research pass and confirmed with the requester: **Trial Rail editor + Run Sheet viewer**, shipped as one PR.

### Editor (`/roster-builder`) — Trial Rail
The single "Select Trial" dropdown becomes a **master–detail** layout: a left **trial rail** (one row per tagged trial, **including empty ones** so you can add builds to any) drives the existing encounter timeline + per-encounter editor.
- Rail = ARIA `tablist` with roving tabindex (Arrow/Home/End), per-trial **edit-count badge**, and a per-row **"same build for all" toggle** (bulk-flag without entering).
- Selected trial is **ephemeral UI state** (not persisted); per-trial last-viewed encounter is remembered when switching.
- Single tagged trial → rail hidden (zero regression).
- A **"Copy link to this fight"** action deep-links the `/rv` view.
- **Mobile (390px):** rail collapses to a sticky trigger bar → fullscreen bottom-sheet trial picker (`PickerDialog` pattern). Timeline gets scroll-snap + 44px touch targets; inputs 16px (iOS zoom).

### Shared view (`/rv`) — Run Sheet
The read-only page renders **every populated trial** as a continuous, scannable run sheet (ordered by `roster.trials`), each trial group showing its per-fight override cards.
- Sticky **jump-bar** appears at 4+ trials. **Single populated trial reads exactly as before.**
- **Deep-linking:** Copy preserves the viewed fight; `/rv` reads `?trial=&encounter=` and scrolls to it **after** the async decode (retry-until-mounted, honors `prefers-reduced-motion`).

### Data model + URL (backward-compatible)
- `roster.trialOverrides` → `Record<trialId, TrialBuildOverrides>`; entries created **lazily** (empty tagged trials cost zero URL bytes).
- New compact key `tom` (map keyed by trialId; redundant `ti` dropped). **Encode writes `tom` only**; **decode accepts `tom`, legacy single-trial `to` (wrapped as a one-entry map), and v1 raw** — every existing shared link still decodes.
- **`sa` fail-safe:** a populated trial always decodes `useSameBuildForAll=false`, so a stale/missing flag can never silently hide builds.
- Ported all single→map call sites: `rosterResize` (now prunes orphaned slots across **every** trial), `ServerPickerDialog`, and the **discord-bot decoder**.
- URL size: worst realistic case (~3 fully-overridden + 7 empty trials) ≈ 2–3 KB deflated — far under the 500 KB guard.

### Testing
- **New durable tests:** multi-trial round-trip; **legacy-URL backward-compat** (decode legacy `to` → re-encode to `tom`); `sa`-invariant; sparse encoding; `rosterResize` multi-trial pruning. 147 roster/trial tests green.
- `tsc` + `eslint` + `prettier` + `vite build` clean.
- **Live-verified** (dev server, Chrome): editor rail lists all tagged trials incl. empty ("no edits"); editing two trials persists both independently; viewer run sheet shows both populated trials with correct labels/sets; deep-link scrolls to the right fight from a clean start; **a pre-existing single-trial `/rv?r=` link still renders**.

### Mobile & accessibility follow-ups (this PR)
- **Editor overflow fix:** detail grid track uses `minmax(0, 1fr)` + `minWidth:0` so the encounter timeline scrolls internally instead of blowing the pane past the viewport on phones (verified 0px page overflow at 390px).
- **Bottom sheet redesign:** the mobile trial picker is a content-height sheet anchored to the viewport bottom (rounded top, 85dvh cap with internal scroll, drag handle, titled header + close button, iOS safe-area padding) — not a wasteful full-screen dialog. Sheet rows are keyboard-operable with 52px touch targets; "1 fights" pluralization fixed.
- **Jump-bar touch targets:** `/rv` run-sheet jump chips are 36px on phones (WCAG 2.5.5), 28px on desktop, pill-shaped with hover + focus-visible.
- **Encounter timeline is now a keyboard-accessible ARIA listbox:** `role="listbox"` + `role="option"` nodes with `aria-selected` and descriptive labels, roving tabindex, full keyboard nav (Arrow/Home/End/Enter/Space, selection-follows-focus), visible focus ring, and reduced-motion guards. Previously it was a row of unlabeled clickable divs — unreachable by keyboard and opaque to screen readers.
- All four commits verified live on desktop (1440×900) and mobile (390×740); `tsc`/`eslint`/`prettier`/`build` and the roster test suites green.

### Notes
- The deep-link **highlight pulse** was cut for now (the scroll-to-fight behavior — what matters — works; the pulse is a clean follow-up with a real test). Deep-linking lands you on the correct fight.

