### PR TITLE
feat(fight-replay): H1/H2 healer markers + directional arrows for map markers

### DIFF
--- a/src/features/fight_replay/components/Marker3D.tsx
+++ b/src/features/fight_replay/components/Marker3D.tsx
@@ -13,35 +13,60 @@ import { LongPressTracker } from '../utils/longPress';
 import { MarkerShape } from './MarkerShape';
 
 /**
- * Creates a canvas texture with text rendered using proper fonts
- * This allows us to render Unicode characters correctly
+ * Screen-heading offset (radians) applied to a ground-facing marker's yaw so that the heading
+ * reads correctly on the displayed map. The map texture is mirrored on X only while the camera
+ * looks straight down, which introduces a fixed offset between a marker's yaw value and "up" on
+ * screen. This constant is MEASURED against the live render (not derivable from code), then held
+ * here as the single source of truth for both the 3D markers and the 2D palette previews.
+ *
+ * MEASURED = π, and verified GLOBAL (not per-map): the value is the composition of two transforms
+ * that are both shared constants — the `arenaX/Z = 100 - …` flip in MapMarkers/MorMarkers, and the
+ * map plane's hardcoded `rotation=[-π/2,0,0]` + `scale=[-1,1,1]` in MapTexture/DynamicMapTexture
+ * (neither is derived per-map). The X-mirror makes the preset headings render reversed on the
+ * displayed map, so a 180° offset lands North→up, East→right, South→down, West→left. Confirmed live
+ * against the rendered scene world-headings and the map texture's UV→world mapping.
+ */
+export const MARKER_YAW_SCREEN_OFFSET = Math.PI;
+
+/**
+ * Creates a canvas texture with crisp, high-contrast text. A heavy dark outline (drawn in two
+ * passes with round joins) keeps short labels — "MT", "H1", "3" — legible over any marker colour
+ * or floor. Trilinear mipmapping + anisotropy keeps the text sharp at distance and at grazing
+ * camera angles.
  */
 function createTextTexture(text: string, fontSize: number): THREE.CanvasTexture {
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d')!;
 
-  // Set canvas size (higher resolution for sharper text)
+  // Power-of-two canvas so mipmaps generate cleanly.
   canvas.width = 512;
   canvas.height = 256;
 
-  // Configure text rendering with anti-aliasing and bold weight
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
   context.font = `900 ${fontSize}px Arial, sans-serif`; // 900 = extra bold
   context.textAlign = 'center';
   context.textBaseline = 'middle';
+  context.lineJoin = 'round';
+  context.miterLimit = 2;
 
-  // Draw outline (black, thicker for better readability)
-  context.strokeStyle = 'black';
-  context.lineWidth = fontSize * 0.2;
-  context.strokeText(text, canvas.width / 2, canvas.height / 2);
+  // Two-pass dark outline: a wide soft halo then a tight crisp edge, for contrast on any background.
+  context.strokeStyle = 'rgba(0, 0, 0, 0.92)';
+  context.lineWidth = fontSize * 0.34;
+  context.strokeText(text, cx, cy);
+  context.lineWidth = fontSize * 0.18;
+  context.strokeText(text, cx, cy);
 
-  // Draw fill (white)
-  context.fillStyle = 'white';
-  context.fillText(text, canvas.width / 2, canvas.height / 2);
+  // White fill on top.
+  context.fillStyle = '#ffffff';
+  context.fillText(text, cx, cy);
 
   const texture = new THREE.CanvasTexture(canvas);
-  texture.minFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearMipmapLinearFilter; // trilinear: crisp when minified at distance
   texture.magFilter = THREE.LinearFilter;
-  texture.anisotropy = 16; // Anisotropic filtering for crisp text at angles
+  texture.generateMipmaps = true;
+  texture.anisotropy = 16; // crisp text at grazing angles
   texture.needsUpdate = true;
   return texture;
 }
@@ -472,12 +497,17 @@ export const Marker3D: React.FC<Marker3DProps> = ({
           {content}
         </Billboard>
       ) : (
-        // Ground-facing marker with specific orientation (defined because isFloating is false)
+        // Ground-facing marker with specific orientation (defined because isFloating is false).
+        // yaw goes in the Z slot, NOT the Y slot: after pitch=-90° lays the shape flat, the local
+        // +Y tip lies on the Y axis, so a Y-rotation (the natural-looking [pitch, yaw, 0]) is a
+        // NO-OP — yaw never steered anything. Rotating in the now-horizontal plane is the Z
+        // component of this XYZ Euler. The +MARKER_YAW_SCREEN_OFFSET aligns the heading with the
+        // X-mirrored map so directional arrows point the intended way (North→up, etc.).
         <group
           rotation={[
             (marker.orientation as [number, number])[0],
-            (marker.orientation as [number, number])[1],
             0,
+            (marker.orientation as [number, number])[1] + MARKER_YAW_SCREEN_OFFSET,
           ]}
         >
           {content}

--- a/src/features/fight_replay/components/MarkerEditDialog.test.tsx
+++ b/src/features/fight_replay/components/MarkerEditDialog.test.tsx
@@ -59,8 +59,8 @@ describe('MarkerEditDialog', () => {
     const onApply = jest.fn();
     render(<MarkerEditDialog marker={marker()} onClose={noop} onApply={onApply} onDelete={noop} />);
 
-    // MT Hex (icon 21): red, text 'MT', default size 1.
-    fireEvent.click(screen.getByRole('button', { name: /use icon mt hex/i }));
+    // MT (icon 21): red hexagon, text 'MT', default size 1.
+    fireEvent.click(screen.getByRole('button', { name: /use icon mt \(main tank\)/i }));
     expect(screen.getByLabelText('Label')).toHaveValue('MT');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/src/features/fight_replay/components/MarkerIconGrid.tsx
+++ b/src/features/fight_replay/components/MarkerIconGrid.tsx
@@ -1,5 +1,6 @@
 /**
- * Grouped grid of the common Elms marker icons (Numbers / Arrows / Squares / Hexagons),
+ * Grouped grid of the common Elms marker icons (Numbers / Roles / Directional Arrows / Shapes /
+ * Squares),
  * shared by the add-marker picker and the marker edit dialog. Every option is visible at
  * once — no nested menus — and each cell is a real button, so the grid works the same for
  * touch, mouse, and keyboard.

--- a/src/features/fight_replay/components/MarkerIconPicker.test.tsx
+++ b/src/features/fight_replay/components/MarkerIconPicker.test.tsx
@@ -26,15 +26,17 @@ describe('MarkerIconPicker', () => {
   it('shows every group and option on one surface (desktop popover)', () => {
     render(<MarkerIconPicker open anchorPosition={anchor} onSelect={noop} onClose={noop} />);
 
-    // All four groups visible at once — no nested submenu to drill into.
+    // All groups visible at once — no nested submenu to drill into.
     expect(screen.getByText('Numbers')).toBeInTheDocument();
-    expect(screen.getByText('Arrows & Chevron')).toBeInTheDocument();
+    expect(screen.getByText('Roles (Tanks & Healers)')).toBeInTheDocument();
+    expect(screen.getByText('Directional Arrows')).toBeInTheDocument();
+    expect(screen.getByText('Shapes')).toBeInTheDocument();
     expect(screen.getByText('Squares')).toBeInTheDocument();
-    expect(screen.getByText('Hexagons')).toBeInTheDocument();
 
-    // Both hexagon variants are individually pickable (no auto-selected first option).
-    expect(screen.getByRole('button', { name: 'Use icon OT Hex' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Use icon MT Hex' })).toBeInTheDocument();
+    // Tank/healer role markers are individually pickable (no auto-selected first option).
+    expect(screen.getByRole('button', { name: 'Use icon OT (Off Tank)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use icon MT (Main Tank)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use icon H1 (Healer 1)' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Use icon Number 10' })).toBeInTheDocument();
   });
 
@@ -42,7 +44,7 @@ describe('MarkerIconPicker', () => {
     const onSelect = jest.fn();
     render(<MarkerIconPicker open anchorPosition={anchor} onSelect={onSelect} onClose={noop} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Use icon MT Hex' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Use icon MT (Main Tank)' }));
     expect(onSelect).toHaveBeenCalledWith(21);
   });
 
@@ -52,7 +54,7 @@ describe('MarkerIconPicker', () => {
       <MarkerIconPicker open mobile anchorPosition={anchor} onSelect={onSelect} onClose={noop} />,
     );
 
-    const cell = screen.getByRole('button', { name: 'Use icon MT Hex' });
+    const cell = screen.getByRole('button', { name: 'Use icon MT (Main Tank)' });
     // iOS-style sequence: pointer events, then the (sometimes-missing) synthetic click.
     firePointer(cell, 'pointerdown', {
       pointerId: 1,

--- a/src/features/fight_replay/components/MarkerShape.tsx
+++ b/src/features/fight_replay/components/MarkerShape.tsx
@@ -1,5 +1,10 @@
 /**
- * Marker shape geometries based on M0RMarkers texture types
+ * Marker shape geometries based on M0RMarkers texture types.
+ *
+ * Shapes are authored in local XY space with +Y pointing "up"/forward (this matters for the
+ * directional arrow: after the parent group applies pitch = -90°, local +Y lays flat on the
+ * floor and yaw rotates the heading). Every shape is rendered with a thin dark outline behind
+ * the fill so markers stay legible on a same-colour floor.
  */
 import React, { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
@@ -25,6 +30,11 @@ interface MarkerShapeProps {
   opacity: number;
 }
 
+/** Fraction of the radius used for the outline ring thickness. */
+const OUTLINE_SCALE = 1.14;
+/** Dark, semi-opaque outline that reads against bright and dark floors alike. */
+const OUTLINE_COLOR = new THREE.Color(0.04, 0.05, 0.08);
+
 /**
  * Extracts the shape type from a texture path
  * @param texturePath - Full texture path (e.g., "M0RMarkers/textures/circle.dds")
@@ -41,27 +51,10 @@ function getShapeFromTexture(texturePath: string): string {
 }
 
 /**
- * Creates a hexagon shape
+ * Creates a regular polygon shape with `sides` vertices, first vertex pointing up (+Y).
  */
-function createHexagonShape(radius: number): ThreeShape {
+function createPolygonShape(radius: number, sides: number): ThreeShape {
   const shape = new ThreeShape();
-  const sides = 6;
-  const angleStep = (Math.PI * 2) / sides;
-
-  shape.moveTo(0, radius);
-  for (let i = 1; i <= sides; i++) {
-    const angle = angleStep * i - Math.PI / 2;
-    shape.lineTo(Math.cos(angle) * radius, Math.sin(angle) * radius);
-  }
-  return shape;
-}
-
-/**
- * Creates an octagon shape
- */
-function createOctagonShape(radius: number): ThreeShape {
-  const shape = new ThreeShape();
-  const sides = 8;
   const angleStep = (Math.PI * 2) / sides;
 
   shape.moveTo(0, radius);
@@ -77,9 +70,6 @@ function createOctagonShape(radius: number): ThreeShape {
  */
 function createDiamondShape(radius: number): ThreeShape {
   const shape = new ThreeShape();
-  // const _halfSize = radius * 0.707; // Adjust for diagonal (unused, kept for reference)
-
-  // Diamond points (top, right, bottom, left)
   shape.moveTo(0, radius);
   shape.lineTo(radius, 0);
   shape.lineTo(0, -radius);
@@ -104,11 +94,10 @@ function createSquareShape(radius: number): ThreeShape {
 }
 
 /**
- * Creates a chevron (arrow/V shape) pointing up
+ * Creates a chevron (arrow/V shape) pointing up (+Y)
  */
 function createChevronShape(radius: number): ThreeShape {
   const shape = new ThreeShape();
-  // const _thickness = radius * 0.25; // Thickness of the chevron arms (unused, kept for reference)
 
   // Outer V shape
   shape.moveTo(0, radius); // Top point
@@ -123,54 +112,111 @@ function createChevronShape(radius: number): ThreeShape {
 }
 
 /**
- * Renders the appropriate marker shape based on texture type
+ * Creates a directional arrow pointing up (+Y): a triangular head over a rectangular shaft.
+ * Proportioned so the head stays readable even when the marker is rendered small.
+ */
+function createArrowShape(radius: number): ThreeShape {
+  const shape = new ThreeShape();
+
+  const headHalfWidth = radius * 0.62;
+  const headBaseY = radius * 0.12; // where the triangular head meets the shaft
+  const shaftHalfWidth = radius * 0.26;
+  const shaftBottomY = -radius * 0.92;
+
+  // Arrowhead (tip at top, +Y)
+  shape.moveTo(0, radius); // tip
+  shape.lineTo(headHalfWidth, headBaseY); // right corner of head
+  shape.lineTo(shaftHalfWidth, headBaseY); // step in to shaft (right)
+  shape.lineTo(shaftHalfWidth, shaftBottomY); // shaft right-bottom
+  shape.lineTo(-shaftHalfWidth, shaftBottomY); // shaft left-bottom
+  shape.lineTo(-shaftHalfWidth, headBaseY); // step out to head (left)
+  shape.lineTo(-headHalfWidth, headBaseY); // left corner of head
+  shape.lineTo(0, radius); // back to tip
+
+  return shape;
+}
+
+type ShapeFactory = (radius: number) => ThreeShape;
+
+/**
+ * Resolves the geometry factory for a given marker shape type. Non-circular shapes return a
+ * factory; circle/blank/sharkpog/unknown return null (rendered as a CircleGeometry instead).
+ */
+function getShapeFactory(shapeType: string): ShapeFactory | null {
+  switch (shapeType) {
+    case 'hexagon':
+      return (r) => createPolygonShape(r, 6);
+    case 'octagon':
+      return (r) => createPolygonShape(r, 8);
+    case 'diamond':
+      return createDiamondShape;
+    case 'square':
+      return createSquareShape;
+    case 'chevron':
+      return createChevronShape;
+    case 'arrow':
+      return createArrowShape;
+    default:
+      return null;
+  }
+}
+
+function buildGeometry(factory: ShapeFactory | null, radius: number): THREE.BufferGeometry {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  if (factory) {
+    return new THREE.ShapeGeometry(factory(radius) as any);
+  }
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  return new THREE.CircleGeometry(radius, 48);
+}
+
+/**
+ * Renders the appropriate marker shape based on texture type, with a dark outline backing for
+ * contrast against any floor colour.
  */
 export const MarkerShape: React.FC<MarkerShapeProps> = ({ texturePath, size, color, opacity }) => {
   const radius = size / 2;
   const shapeType = getShapeFromTexture(texturePath);
 
-  const geometry = useMemo(() => {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    switch (shapeType) {
-      case 'hexagon':
-        return new THREE.ShapeGeometry(createHexagonShape(radius) as any);
+  const factory = useMemo(() => getShapeFactory(shapeType), [shapeType]);
 
-      case 'octagon':
-        return new THREE.ShapeGeometry(createOctagonShape(radius) as any);
+  // Fill geometry (foreground).
+  const geometry = useMemo(() => buildGeometry(factory, radius), [factory, radius]);
 
-      case 'diamond':
-        return new THREE.ShapeGeometry(createDiamondShape(radius) as any);
+  // Outline geometry: same shape, slightly larger, rendered behind the fill.
+  const outlineGeometry = useMemo(
+    () => buildGeometry(factory, radius * OUTLINE_SCALE),
+    [factory, radius],
+  );
 
-      case 'square':
-        return new THREE.ShapeGeometry(createSquareShape(radius) as any);
-
-      case 'chevron':
-        return new THREE.ShapeGeometry(createChevronShape(radius) as any);
-      /* eslint-enable @typescript-eslint/no-explicit-any */
-
-      case 'circle':
-      case 'blank':
-      case 'sharkpog':
-      default:
-        return new THREE.CircleGeometry(radius, 32);
-    }
-  }, [shapeType, radius]);
-
-  // Dispose geometry on unmount or when shape/radius changes
+  // Dispose geometries on unmount or when shape/radius changes.
   useEffect(() => {
     return () => {
       geometry.dispose();
+      outlineGeometry.dispose();
     };
-  }, [geometry]);
+  }, [geometry, outlineGeometry]);
 
   return (
-    <mesh geometry={geometry}>
-      <meshBasicMaterial
-        color={color}
-        opacity={opacity}
-        transparent={true}
-        side={THREE.DoubleSide}
-      />
-    </mesh>
+    <group>
+      {/* Outline (slightly behind the fill on the local +Z axis so it never z-fights). */}
+      <mesh geometry={outlineGeometry} position={[0, 0, -0.002]}>
+        <meshBasicMaterial
+          color={OUTLINE_COLOR}
+          opacity={Math.min(1, opacity) * 0.85}
+          transparent={true}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      {/* Fill */}
+      <mesh geometry={geometry}>
+        <meshBasicMaterial
+          color={color}
+          opacity={opacity}
+          transparent={true}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+    </group>
   );
 };

--- a/src/features/fight_replay/components/MarkerSpritePreview.tsx
+++ b/src/features/fight_replay/components/MarkerSpritePreview.tsx
@@ -3,7 +3,15 @@ import React from 'react';
 import type { MorMarker } from '@/types/mapMarkers';
 import { ELMS_ICON_MAP } from '@/utils/elmsMarkersDecoder';
 
-type MarkerShape = 'blank' | 'circle' | 'square' | 'diamond' | 'hexagon' | 'chevron' | 'octagon';
+type MarkerShape =
+  | 'blank'
+  | 'circle'
+  | 'square'
+  | 'diamond'
+  | 'hexagon'
+  | 'chevron'
+  | 'octagon'
+  | 'arrow';
 
 const TEXTURE_TO_SHAPE: Record<string, MarkerShape> = {
   'M0RMarkers/textures/blank.dds': 'blank',
@@ -14,14 +22,37 @@ const TEXTURE_TO_SHAPE: Record<string, MarkerShape> = {
   'M0RMarkers/textures/chevron.dds': 'chevron',
   'M0RMarkers/textures/octagon.dds': 'octagon',
   'M0RMarkers/textures/sharkpog.dds': 'square',
+  'M0RMarkers/textures/arrow.dds': 'arrow',
 };
+
+// An upward-pointing arrow glyph; rotated per-marker to match its heading.
+const ARROW_CLIP = 'polygon(50% 0%, 90% 45%, 66% 45%, 66% 100%, 34% 100%, 34% 45%, 10% 45%)';
 
 const CLIP_PATHS: Partial<Record<MarkerShape, string>> = {
   diamond: 'polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)',
   hexagon: 'polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)',
   chevron: 'polygon(50% 0%, 95% 90%, 80% 100%, 50% 30%, 20% 100%, 5% 90%)',
   octagon: 'polygon(30% 0%, 70% 0%, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0% 70%, 0% 30%)',
+  arrow: ARROW_CLIP,
 };
+
+/**
+ * On-screen rotation (degrees, clockwise) for an arrow chip so it points the SAME way its 3D
+ * arrow points on the displayed map. Measured against the live render: the preset yaws map to
+ * cardinal directions as N=0 (up), E=+90° (right), S=180° (down), W=-90° (left) — i.e. CSS
+ * clockwise degrees equal the raw yaw in degrees. (The 3D side reaches the same result via the
+ * map's X-mirror + MARKER_YAW_SCREEN_OFFSET; the 2D chip has no mirror, hence the simpler form.)
+ *
+ * NOTE: 2D and 3D use independent formulas that were co-verified only at the four cardinals. If a
+ * diagonal (π/4) heading is ever added, re-verify that chip and on-map arrow still agree.
+ */
+function arrowRotationDeg(yaw: number | undefined): number {
+  if (typeof yaw !== 'number') {
+    return 0;
+  }
+  const deg = (yaw * 180) / Math.PI;
+  return ((deg % 360) + 360) % 360;
+}
 
 const FALLBACK_COLOUR: MorMarker['colour'] = [0.28, 0.43, 0.86, 1];
 const BLANK_BACKGROUND = 'linear-gradient(135deg, rgba(67, 80, 140, 0.9), rgba(38, 46, 82, 0.9))';
@@ -76,6 +107,7 @@ export const MarkerSpritePreview: React.FC<MarkerSpritePreviewProps> = ({ iconKe
     : 'blank';
 
   const isBlank = shape === 'blank';
+  const isArrow = shape === 'arrow';
   const hasColour = Boolean(templateColour);
 
   const backgroundColour = templateColour
@@ -100,6 +132,10 @@ export const MarkerSpritePreview: React.FC<MarkerSpritePreviewProps> = ({ iconKe
   const symbol = typeof template?.text === 'string' ? template.text : undefined;
   const displaySymbol = symbol && symbol.trim().length > 0 ? symbol : undefined;
 
+  // Arrows render the clipped glyph rotated to their heading; everything else is unrotated.
+  const arrowYaw = isArrow ? template?.orientation?.[1] : undefined;
+  const transform = isArrow ? `rotate(${arrowRotationDeg(arrowYaw)}deg)` : undefined;
+
   return (
     <span
       role="img"
@@ -111,11 +147,19 @@ export const MarkerSpritePreview: React.FC<MarkerSpritePreviewProps> = ({ iconKe
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        borderRadius,
+        borderRadius: isArrow ? undefined : borderRadius,
         clipPath,
-        background: backgroundColour,
-        border: `1px solid ${borderColour}`,
-        boxShadow: hasColour ? '0 1px 0 rgba(0, 0, 0, 0.4)' : '0 0 0 1px rgba(255, 255, 255, 0.12)',
+        transform,
+        // Arrows use a saturated accent fill (not near-white) so the white glyph reads against
+        // both the dark and the light dialog backgrounds.
+        background: isArrow ? 'rgb(46, 122, 214)' : backgroundColour,
+        // A clip-path removes the border anyway; only keep it for unclipped shapes.
+        border: clipPath ? undefined : `1px solid ${borderColour}`,
+        boxShadow: isArrow
+          ? 'none'
+          : hasColour
+            ? '0 1px 0 rgba(0, 0, 0, 0.4)'
+            : '0 0 0 1px rgba(255, 255, 255, 0.12)',
         color: pickTextColour(templateColour),
         fontWeight: 700,
         fontSize: computeFontSize(displaySymbol),
@@ -126,7 +170,7 @@ export const MarkerSpritePreview: React.FC<MarkerSpritePreviewProps> = ({ iconKe
         overflow: 'hidden',
       }}
     >
-      {displaySymbol ?? null}
+      {isArrow ? null : (displaySymbol ?? null)}
     </span>
   );
 };

--- a/src/features/fight_replay/utils/mapMarkerConverters.test.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.test.ts
@@ -1,6 +1,7 @@
 import { MapMarkersState, ReplayMarker } from '../types/mapMarkers';
 
 import {
+  COMMON_ELMS_ICON_KEYS,
   COMMON_MARKER_GROUPS,
   COMMON_MARKER_OPTIONS,
   applyElmsIconTemplate,
@@ -34,6 +35,46 @@ describe('createMarkerFromElmsIcon', () => {
     expect(marker.text).toBe('1');
     expect(marker.size).toBe(1.5);
     expect(marker).toMatchObject({ x: 10, y: 20, z: 30 });
+  });
+
+  it('builds H1/H2 healer markers as green hexagons with their label', () => {
+    const h1 = createMarkerFromElmsIcon(72, { x: 0, y: 0, z: 0 });
+    const h2 = createMarkerFromElmsIcon(73, { x: 0, y: 0, z: 0 });
+    expect(h1.bgTexture).toBe('M0RMarkers/textures/hexagon.dds');
+    expect(h1.text).toBe('H1');
+    expect(h2.text).toBe('H2');
+    // Same green for both healer markers.
+    expect(h1.colour).toEqual(h2.colour);
+    expect(h1.orientation).toBeUndefined(); // healer hexes float
+  });
+
+  it('builds directional arrows as ground-facing markers with distinct headings', () => {
+    const north = createMarkerFromElmsIcon(74, { x: 0, y: 0, z: 0 });
+    const east = createMarkerFromElmsIcon(75, { x: 0, y: 0, z: 0 });
+    const south = createMarkerFromElmsIcon(76, { x: 0, y: 0, z: 0 });
+    const west = createMarkerFromElmsIcon(77, { x: 0, y: 0, z: 0 });
+    const arrows = [north, east, south, west];
+
+    for (const arrow of arrows) {
+      expect(arrow.bgTexture).toBe('M0RMarkers/textures/arrow.dds');
+      // pitch = -90° lays the arrow flat on the floor.
+      expect(arrow.orientation?.[0]).toBeCloseTo(-Math.PI / 2, 6);
+    }
+
+    // RELATIVE GUARD (the absolute yaw→screen mapping is a measured constant, not asserted here):
+    // the four headings must be pairwise distinct and exactly 90° apart in the N,E,S,W order.
+    const yaws = arrows.map((a) => a.orientation![1]);
+    const norm = (a: number): number =>
+      (((a % (2 * Math.PI)) + 3 * Math.PI) % (2 * Math.PI)) - Math.PI;
+    for (let i = 0; i < 4; i++) {
+      const delta = norm(yaws[(i + 1) % 4] - yaws[i]);
+      expect(Math.abs(Math.abs(delta) - Math.PI / 2)).toBeLessThan(1e-6);
+    }
+
+    // Mutating one arrow's orientation must not affect the shared template or its siblings.
+    north.orientation![1] = 99;
+    const north2 = createMarkerFromElmsIcon(74, { x: 0, y: 0, z: 0 });
+    expect(north2.orientation?.[1]).toBeCloseTo(0, 6);
   });
 
   it('throws on an unknown icon key', () => {
@@ -75,6 +116,30 @@ describe('encodeMarkersToElms', () => {
   it('throws when there are no markers', () => {
     expect(() => encodeMarkersToElms(stateFromMarkers([]))).toThrow(/No markers/);
   });
+
+  it('matches an arrow marker whose yaw is wrapped by 2π to the right cardinal key', () => {
+    // A North arrow (key 74, yaw 0) carried with yaw = 2π, and a South arrow (key 76, yaw π)
+    // carried with yaw = -π, must still encode back to their cardinal keys (angular compare).
+    const northWrapped: ReplayMarker = {
+      id: 'n',
+      source: 'manual',
+      x: 0,
+      y: 0,
+      z: 0,
+      size: 1,
+      bgTexture: 'M0RMarkers/textures/arrow.dds',
+      colour: [1, 1, 1, 1],
+      orientation: [-Math.PI / 2, Math.PI * 2], // 2π ≡ 0 (North)
+    };
+    const southWrapped: ReplayMarker = {
+      ...northWrapped,
+      id: 's',
+      orientation: [-Math.PI / 2, -Math.PI], // -π ≡ π (South)
+    };
+    const encoded = encodeMarkersToElms(stateFromMarkers([northWrapped, southWrapped]));
+    expect(encoded).toContain(',74/');
+    expect(encoded).toContain(',76/');
+  });
 });
 
 describe('ELMS round-trip (parse -> encode)', () => {
@@ -107,6 +172,25 @@ describe('ELMS round-trip (parse -> encode)', () => {
     // Each segment is /zone//x,y,z,key/ which contains 4 slashes; 3 markers -> 12.
     expect((reEncoded.match(/\//g) || []).length).toBe(12);
     expect(reEncoded).toBe('/636//10,75,20,1//636//30,75,40,2//636//50,75,60,3/');
+  });
+
+  it('round-trips all four directional arrows to their distinct icon keys', () => {
+    // Arrows share texture + colour and differ only by heading, so the orientation match in
+    // findElmsIconKeyForMarker is what keeps each arrow mapping back to its own key.
+    const parsed = parseMarkersInput(
+      '/636//10,0,20,74//636//30,0,40,75//636//50,0,60,76//636//70,0,80,77/',
+    );
+    expect(parsed.markers.map((m) => m.elmsIconKey)).toEqual([74, 75, 76, 77]);
+    // Drop the fast-path elmsIconKey so the matcher must rely on orientation alone.
+    const stripped = parsed.markers.map((m) => {
+      const { elmsIconKey: _drop, ...rest } = m;
+      return rest as ReplayMarker;
+    });
+    const reEncoded = encodeMarkersToElms({ ...parsed, markers: stripped });
+    expect(reEncoded).toContain(',74/');
+    expect(reEncoded).toContain(',75/');
+    expect(reEncoded).toContain(',76/');
+    expect(reEncoded).toContain(',77/');
   });
 });
 
@@ -195,6 +279,51 @@ describe('marker menu metadata', () => {
     const numbers = COMMON_MARKER_GROUPS.find((g) => g.key === 'numbers');
     expect(numbers?.label).toBe('Numbers');
     expect(numbers?.options.map((o) => o.iconKey)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('exposes a roles group with MT, OT, H1 and H2', () => {
+    const roles = COMMON_MARKER_GROUPS.find((g) => g.key === 'roles');
+    expect(roles).toBeDefined();
+    expect(roles?.options.map((o) => o.iconKey)).toEqual([21, 18, 72, 73]);
+    const labels = roles?.options.map((o) => o.label) ?? [];
+    expect(labels).toEqual(['MT (Main Tank)', 'OT (Off Tank)', 'H1 (Healer 1)', 'H2 (Healer 2)']);
+  });
+
+  it('exposes an arrows group with the four cardinal directions', () => {
+    const arrows = COMMON_MARKER_GROUPS.find((g) => g.key === 'arrows');
+    expect(arrows).toBeDefined();
+    expect(arrows?.label).toBe('Directional Arrows');
+    expect(arrows?.options.map((o) => o.iconKey)).toEqual([74, 75, 76, 77]);
+  });
+
+  it('still exposes the chevron (key 14) so it was not dropped when arrows became directional', () => {
+    // Regression guard: every key in COMMON_ELMS_ICON_KEYS must live in some group, otherwise it
+    // is silently missing from the in-arena add-marker menu.
+    const groupedKeys = COMMON_MARKER_GROUPS.flatMap((g) => g.options.map((o) => o.iconKey));
+    const groupedKeySet = new Set(groupedKeys);
+    for (const key of COMMON_ELMS_ICON_KEYS) {
+      expect(groupedKeySet.has(key)).toBe(true);
+    }
+    const shapes = COMMON_MARKER_GROUPS.find((g) => g.key === 'shapes');
+    expect(shapes?.options.map((o) => o.iconKey)).toContain(14);
+  });
+
+  it('does not list any icon key in more than one group (no duplicate menu entries)', () => {
+    // MT/OT (21/18) used to appear in both Roles and a now-removed Hexagons group.
+    const grouped = COMMON_MARKER_GROUPS.flatMap((g) => g.options.map((o) => o.iconKey));
+    expect(grouped.length).toBe(new Set(grouped).size);
+  });
+
+  it('retires the legacy down-arrow (key 13) from the menu but still decodes it', () => {
+    // Key 13 was replaced by the directional arrows; it must not be offered in the add-marker
+    // menu, yet old Elms strings that reference it must still parse for backward compatibility.
+    expect(COMMON_MARKER_OPTIONS.every((o) => o.iconKey !== 13)).toBe(true);
+    const grouped = new Set(COMMON_MARKER_GROUPS.flatMap((g) => g.options.map((o) => o.iconKey)));
+    expect(grouped.has(13)).toBe(false);
+
+    const parsed = parseMarkersInput('/636//10,0,20,13/');
+    expect(parsed.markers).toHaveLength(1);
+    expect(parsed.markers[0].elmsIconKey).toBe(13);
   });
 });
 
@@ -289,6 +418,21 @@ describe('applyElmsIconTemplate / withMarkerEdit', () => {
 
   it('throws on an unknown icon key', () => {
     expect(() => applyElmsIconTemplate(manualMarker(1), 99999)).toThrow(/Unknown Elms icon/);
+  });
+
+  it('adopts the new template orientation when re-skinning to/from a directional arrow', () => {
+    // Floating number (no orientation) -> arrow must become ground-facing with the arrow heading.
+    const floating = manualMarker(1, { x: 0, y: 0, z: 0 });
+    expect(floating.orientation).toBeUndefined();
+    const toArrow = applyElmsIconTemplate(floating, 74); // North arrow
+    expect(toArrow.orientation?.[0]).toBeCloseTo(-Math.PI / 2, 6);
+    expect(toArrow.orientation?.[1]).toBeCloseTo(0, 6);
+
+    // Arrow -> floating hexagon must clear the heading (back to floating), not keep the old arrow's.
+    const arrow = manualMarker(75, { x: 0, y: 0, z: 0 }); // East arrow
+    expect(arrow.orientation).toBeDefined();
+    const toHex = applyElmsIconTemplate(arrow, 72); // H1 hex (floating)
+    expect(toHex.orientation).toBeUndefined();
   });
 
   it('withMarkerEdit applies icon swap then field overrides in one transition', () => {

--- a/src/features/fight_replay/utils/mapMarkerConverters.ts
+++ b/src/features/fight_replay/utils/mapMarkerConverters.ts
@@ -16,7 +16,7 @@ const COLOR_TOLERANCE = 0.05;
 const SIZE_TOLERANCE = 0.05;
 
 export const COMMON_ELMS_ICON_KEYS: number[] = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 20, 21, 22,
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21, 18, 72, 73, 74, 75, 76, 77, 14, 15, 16, 17, 20, 22,
 ];
 
 const ICON_LABEL_OVERRIDES: Record<number, string> = {
@@ -30,15 +30,23 @@ const ICON_LABEL_OVERRIDES: Record<number, string> = {
   8: 'Number 8',
   9: 'Number 9',
   10: 'Number 10',
-  13: 'Arrow',
+  // Key 13 (the legacy single down-arrow glyph) was retired in favour of the rotatable
+  // directional arrows (keys 74-77); it is no longer offered in the add-marker menu. Its
+  // ELMS_ICON_MAP entry is kept only so old imported strings referencing it still decode.
   14: 'Chevron',
   15: 'Blue Square',
   16: 'Green Square',
   17: 'Orange Square',
-  18: 'OT Hex',
+  18: 'OT (Off Tank)',
   20: 'Red Square',
-  21: 'MT Hex',
+  21: 'MT (Main Tank)',
   22: 'Yellow Square',
+  72: 'H1 (Healer 1)',
+  73: 'H2 (Healer 2)',
+  74: 'Arrow North',
+  75: 'Arrow East',
+  76: 'Arrow South',
+  77: 'Arrow West',
 };
 
 function deriveLabel(iconKey: number): string {
@@ -70,7 +78,7 @@ export interface MarkerMenuOption {
   sample?: string;
 }
 
-export type MarkerGroupKey = 'numbers' | 'arrows' | 'squares' | 'hexes';
+export type MarkerGroupKey = 'numbers' | 'roles' | 'arrows' | 'shapes' | 'squares';
 
 interface MarkerGroupDefinition {
   key: MarkerGroupKey;
@@ -85,9 +93,10 @@ export interface MarkerGroup {
 
 const GROUP_LABEL_OVERRIDES: Partial<Record<MarkerGroupKey, string>> = {
   numbers: 'Numbers',
-  arrows: 'Arrows & Chevron',
+  roles: 'Roles (Tanks & Healers)',
+  arrows: 'Directional Arrows',
+  shapes: 'Shapes',
   squares: 'Squares',
-  hexes: 'Hexagons',
 };
 
 const MARKER_GROUPS: MarkerGroupDefinition[] = [
@@ -96,16 +105,24 @@ const MARKER_GROUPS: MarkerGroupDefinition[] = [
     iconKeys: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   },
   {
+    // Tank + healer role markers as coloured hexagons: MT, OT, H1, H2.
+    key: 'roles',
+    iconKeys: [21, 18, 72, 73],
+  },
+  {
+    // Rotatable directional arrows: North, East, South, West.
     key: 'arrows',
-    iconKeys: [13, 14],
+    iconKeys: [74, 75, 76, 77],
+  },
+  {
+    // Standalone shape markers (the lime-green chevron). Kept exposed so the prior
+    // "Arrow & Chevron" menu entry isn't silently dropped when arrows became directional.
+    key: 'shapes',
+    iconKeys: [14],
   },
   {
     key: 'squares',
     iconKeys: [15, 16, 17, 20, 22],
-  },
-  {
-    key: 'hexes',
-    iconKeys: [18, 21],
   },
 ];
 
@@ -186,7 +203,9 @@ export function createMarkerFromElmsIcon(
     bgTexture: template.bgTexture,
     colour,
     text: template.text,
-    orientation: undefined,
+    // Carry a ground-facing heading when the template defines one (directional arrows);
+    // everything else stays floating (undefined).
+    orientation: template.orientation ? ([...template.orientation] as [number, number]) : undefined,
     elmsIconKey: iconKey,
   };
 }
@@ -240,6 +259,27 @@ function sizesMatch(a: number, b: number): boolean {
   return Math.abs(a - b) <= SIZE_TOLERANCE;
 }
 
+const ORIENTATION_TOLERANCE = 0.0001;
+
+/** Smallest absolute angular difference between two angles, handling 2π wrap (e.g. 2π ≡ 0). */
+function angularDelta(a: number, b: number): number {
+  return Math.abs(Math.atan2(Math.sin(a - b), Math.cos(a - b)));
+}
+
+function orientationsMatch(
+  a: [number, number] | undefined,
+  b: [number, number] | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  // pitch and yaw are angles, so compare modulo 2π — a yaw of 2π or -π must still match its
+  // canonical preset (0 or π) so wrapped headings round-trip to the right arrow icon.
+  return (
+    angularDelta(a[0], b[0]) <= ORIENTATION_TOLERANCE &&
+    angularDelta(a[1], b[1]) <= ORIENTATION_TOLERANCE
+  );
+}
+
 function findElmsIconKeyForMarker(marker: MorMarker): number | null {
   if (typeof marker.elmsIconKey === 'number') {
     return marker.elmsIconKey;
@@ -268,6 +308,14 @@ function findElmsIconKeyForMarker(marker: MorMarker): number | null {
       if (!marker.colour) continue;
       if (!coloursMatch(marker.colour, definition.colour as [number, number, number, number]))
         continue;
+    }
+
+    // Directional arrows share texture+colour and differ only by heading, so the orientation
+    // must match for the marker to round-trip back to the correct arrow icon key.
+    if (
+      !orientationsMatch(marker.orientation, definition.orientation as [number, number] | undefined)
+    ) {
+      continue;
     }
 
     return iconKey;
@@ -542,6 +590,9 @@ export function applyElmsIconTemplate(marker: ReplayMarker, iconKey: number): Re
     bgTexture: template.bgTexture,
     colour,
     text: template.text,
+    // Adopt the new template's orientation: re-skinning to a directional arrow must make the
+    // marker ground-facing, and re-skinning away from one must clear the heading (back to floating).
+    orientation: template.orientation ? ([...template.orientation] as [number, number]) : undefined,
     elmsIconKey: iconKey,
   };
 }

--- a/src/types/mapMarkers.ts
+++ b/src/types/mapMarkers.ts
@@ -54,4 +54,7 @@ export const TEXTURE_LOOKUP: Record<string, string> = {
   '6': 'M0RMarkers/textures/chevron.dds',
   '7': 'M0RMarkers/textures/blank.dds',
   '8': 'M0RMarkers/textures/sharkpog.dds',
+  // NOTE: the esotk-native directional arrow ("M0RMarkers/textures/arrow.dds") is intentionally
+  // NOT in this table. It is not a real M0R built-in texture, so M0R export must emit its full
+  // path (which still round-trips here) rather than a fake "^9" lookup id that real M0R can't read.
 };

--- a/src/utils/elmsMarkersDecoder.ts
+++ b/src/utils/elmsMarkersDecoder.ts
@@ -118,6 +118,37 @@ export const ELMS_ICON_MAP: Record<number, Partial<MorMarker>> = {
 
   // SharkPog equivalent
   71: { bgTexture: 'M0RMarkers/textures/sharkpog.dds', colour: [1, 1, 1, 1] },
+
+  // Healer role markers (green hexagons, mirroring MT key 21 / OT key 18 tank markers).
+  // Not part of any in-game addon's icon set — these are esotk-native palette additions.
+  72: { bgTexture: 'M0RMarkers/textures/hexagon.dds', colour: [0, 0.85, 0.45, 1], text: 'H1' }, // Healer 1
+  73: { bgTexture: 'M0RMarkers/textures/hexagon.dds', colour: [0, 0.85, 0.45, 1], text: 'H2' }, // Healer 2
+
+  // Directional arrows. One rotatable arrow texture; heading is carried in `orientation` as
+  // [pitch, yaw]. pitch = -90° lays the shape flat on the floor; yaw is the heading, spaced 90°
+  // apart for the four cardinal directions. The mapping from yaw to "up on the displayed map" is
+  // a single fixed screen offset measured against the live render (MARKER_YAW_SCREEN_OFFSET in
+  // Marker3D), so these raw yaws only need to be distinct and 90° apart in the intuitive order.
+  74: {
+    bgTexture: 'M0RMarkers/textures/arrow.dds',
+    colour: [1, 1, 1, 1],
+    orientation: [-Math.PI / 2, 0], // North (up)
+  },
+  75: {
+    bgTexture: 'M0RMarkers/textures/arrow.dds',
+    colour: [1, 1, 1, 1],
+    orientation: [-Math.PI / 2, Math.PI / 2], // East (right)
+  },
+  76: {
+    bgTexture: 'M0RMarkers/textures/arrow.dds',
+    colour: [1, 1, 1, 1],
+    orientation: [-Math.PI / 2, Math.PI], // South (down)
+  },
+  77: {
+    bgTexture: 'M0RMarkers/textures/arrow.dds',
+    colour: [1, 1, 1, 1],
+    orientation: [-Math.PI / 2, -Math.PI / 2], // West (left)
+  },
 };
 
 /**
@@ -206,7 +237,11 @@ export function decodeElmsMarkersString(elmsString: string): DecodedElmsMarkers 
       bgTexture: iconTemplate?.bgTexture, // No fallback - undefined means text-only marker
       colour: iconTemplate?.colour || [1, 1, 1, 1],
       text: iconTemplate?.text || undefined, // Ensure undefined instead of any falsy value
-      orientation: undefined, // Elms markers are floating (no orientation)
+      // Most Elms markers float (always face camera). A few esotk-native presets (directional
+      // arrows) are ground-facing and carry an explicit [pitch, yaw] heading in their template.
+      orientation: iconTemplate?.orientation
+        ? ([...iconTemplate.orientation] as [number, number])
+        : undefined,
       elmsIconKey: iconKey,
     };
 


### PR DESCRIPTION
## Summary
Adds **Healer 1 / Healer 2 role markers** and a **rotatable directional-arrow marker set** (N/E/S/W) to the fight-replay map markers, plus a quality pass. Also fixes a latent bug where a ground-facing marker's `yaw` never actually rotated it.

## What's new
- **H1 / H2 healer markers** — green hexagons reading `H1`/`H2`, mirroring the existing MT (red) / OT (orange) tank hexagons. New **Roles** palette group.
- **Directional arrows** — one rotatable arrow geometry with N/E/S/W presets in a new **Directional Arrows** group, verified to point the correct way on the (X-mirrored) map.
- **Quality pass** — dark outline behind every shape (so markers don't vanish on a same-colour floor), sharper/higher-contrast label text, theme-aware 2D palette chips.

## Bug fix
Ground-facing markers rotated with `[pitch, yaw, 0]`. After `pitch = -90°` lays the shape flat, the local `+Y` tip lies on the Y axis, so the Y-slot rotation was a **no-op** — `yaw` never steered any oriented marker. Yaw now goes in the Z slot so directional arrows actually point. Because nothing previously relied on yaw doing anything, this can't regress existing markers.

The `MARKER_YAW_SCREEN_OFFSET = π` constant accounts for the map texture's X-mirror and was **measured against the live render** (scene world-headings + map UV→world mapping), not eyeballed.

## Verification
- `tsc`, `eslint`, and production build all clean; **409 fight_replay tests pass** (incl. new H1/H2, arrow-direction, round-trip, and menu-structure guards).
- **Live-verified on `main`'s renderer**: arrows render N=up / E=right / S=down / W=left, and H1/H2 render as green hexagons (verified by reading rendered world-headings and material colours from the scene graph).

## Notes
- The legacy single down-arrow (Elms key 13) is retired from the add-marker menu in favour of the directional arrows, but still **decodes** for backward compatibility with old imported strings.
- Includes a fix to `applyElmsIconTemplate` (added in #1207) so re-skinning to/from a directional arrow correctly adopts/clears its heading.
