### PR TITLE
feat(latest-reports): upgrade mobile filter sheet & touch UX

### DIFF
--- a/src/features/latest_reports/components/DateRangeFilter.render.test.tsx
+++ b/src/features/latest_reports/components/DateRangeFilter.render.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DATE_RANGE_PRESETS, dateRangePresetLabel } from '../hooks/rangeToEpochMs';
+
+import { DateRangeFilter, type DateRangeValue } from './DateRangeFilter';
+
+const allTime: DateRangeValue = { range: 'all', customFrom: null, customTo: null };
+
+describe('DateRangeFilter (inline / mobile)', () => {
+  it('renders every preset as a touch target', () => {
+    render(<DateRangeFilter value={allTime} onChange={jest.fn()} inline />);
+    for (const preset of DATE_RANGE_PRESETS) {
+      expect(
+        screen.getByRole('button', { name: dateRangePresetLabel(preset) }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('marks the active preset with aria-pressed', () => {
+    render(
+      <DateRangeFilter
+        value={{ range: '7d', customFrom: null, customTo: null }}
+        onChange={jest.fn()}
+        inline
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Last 7 days' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('emits the selected rolling preset and clears any custom bounds', () => {
+    const onChange = jest.fn();
+    render(
+      <DateRangeFilter
+        value={{ range: 'custom', customFrom: '2026-01-01', customTo: '2026-02-01' }}
+        onChange={onChange}
+        inline
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+    expect(onChange).toHaveBeenCalledWith({ range: '30d', customFrom: null, customTo: null });
+  });
+
+  it('reveals the From/To fields once Custom is active', () => {
+    render(
+      <DateRangeFilter
+        value={{ range: 'custom', customFrom: null, customTo: null }}
+        onChange={jest.fn()}
+        inline
+      />,
+    );
+    expect(screen.getByLabelText('From')).toBeInTheDocument();
+    expect(screen.getByLabelText('To')).toBeInTheDocument();
+  });
+});

--- a/src/features/latest_reports/components/DateRangeFilter.tsx
+++ b/src/features/latest_reports/components/DateRangeFilter.tsx
@@ -26,6 +26,7 @@ import {
   FOCUS_GLOW,
   glassFieldBg,
   glassMenuPaperSx,
+  presetButtonSx,
 } from '../latestReportsStyles';
 
 export interface DateRangeValue {
@@ -54,7 +55,9 @@ interface DateRangeFilterProps {
 const PRESET_BUTTONS: ReadonlyArray<DateRangePreset> = DATE_RANGE_PRESETS;
 
 /** The preset + custom-range picker body, shared by the inline and popover forms. */
-const DateRangeBody: React.FC<DateRangeFilterProps> = ({ value, onChange }) => {
+const DateRangeBody: React.FC<DateRangeFilterProps> = ({ value, onChange, inline = false }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
   const fromId = useId();
   const toId = useId();
   const invalidRange = isInvalidDateRange(value);
@@ -68,27 +71,59 @@ const DateRangeBody: React.FC<DateRangeFilterProps> = ({ value, onChange }) => {
   };
 
   return (
-    <Stack spacing={1.5} sx={{ p: { xs: 0, md: 2 }, minWidth: { md: 260 } }}>
-      <ToggleButtonGroup
-        value={value.range}
-        exclusive
-        size="small"
-        onChange={(_event, next: DateRangePreset | null) => {
-          if (next) handlePreset(next);
-        }}
-        aria-label="Date range preset"
-        sx={{
-          flexWrap: 'wrap',
-          gap: 0.5,
-          '& .MuiToggleButton-root': { borderRadius: '8px !important', border: '1px solid' },
-        }}
-      >
-        {PRESET_BUTTONS.map((preset) => (
-          <ToggleButton key={preset} value={preset} sx={{ textTransform: 'none', px: 1.25 }}>
-            {dateRangePresetLabel(preset)}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
+    <Stack
+      spacing={inline ? 2 : 1.5}
+      sx={{ p: inline ? 0 : { xs: 0, md: 2 }, minWidth: { md: 260 } }}
+    >
+      {inline ? (
+        // Mobile: a touch-first 2-column grid of large pills ("Custom" spans the
+        // full width) instead of the cramped, small-target ToggleButtonGroup.
+        <Box
+          role="group"
+          aria-label="Date range preset"
+          sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1 }}
+        >
+          {PRESET_BUTTONS.map((preset) => {
+            const active = value.range === preset;
+            return (
+              <Box
+                key={preset}
+                component="button"
+                type="button"
+                onClick={() => handlePreset(preset)}
+                aria-pressed={active}
+                sx={{
+                  ...presetButtonSx(isDark, active),
+                  ...(preset === 'custom' ? { gridColumn: '1 / -1' } : null),
+                }}
+              >
+                {dateRangePresetLabel(preset)}
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        <ToggleButtonGroup
+          value={value.range}
+          exclusive
+          size="small"
+          onChange={(_event, next: DateRangePreset | null) => {
+            if (next) handlePreset(next);
+          }}
+          aria-label="Date range preset"
+          sx={{
+            flexWrap: 'wrap',
+            gap: 0.5,
+            '& .MuiToggleButton-root': { borderRadius: '8px !important', border: '1px solid' },
+          }}
+        >
+          {PRESET_BUTTONS.map((preset) => (
+            <ToggleButton key={preset} value={preset} sx={{ textTransform: 'none', px: 1.25 }}>
+              {dateRangePresetLabel(preset)}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      )}
 
       {value.range === 'custom' && (
         <Stack spacing={1.25} sx={{ pt: 0.5 }}>

--- a/src/features/latest_reports/components/MobileFilterSheet.test.tsx
+++ b/src/features/latest_reports/components/MobileFilterSheet.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { LatestReportsFilters } from '../hooks/useLatestReportsUrlState';
+
+import { MobileFilterSheet } from './MobileFilterSheet';
+
+// Avoid the GraphQL client context the real zone hook needs — the sheet's
+// behaviour under test (drafts, reset, apply) is independent of zone loading.
+jest.mock('../hooks/useZoneOptions', () => ({
+  useZoneOptions: () => ({ zones: [], loading: false, error: null }),
+}));
+
+const baseFilters: LatestReportsFilters = {
+  page: 1,
+  q: '',
+  zoneId: null,
+  range: 'all',
+  customFrom: null,
+  customTo: null,
+};
+
+const renderSheet = (over?: Partial<LatestReportsFilters>) => {
+  const onApply = jest.fn();
+  const onClose = jest.fn();
+  render(
+    <MobileFilterSheet
+      open
+      onClose={onClose}
+      filters={{ ...baseFilters, ...over }}
+      onApply={onApply}
+    />,
+  );
+  return { onApply, onClose };
+};
+
+describe('MobileFilterSheet', () => {
+  it('disables Reset and shows a neutral Apply label when nothing is drafted', () => {
+    renderSheet();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeEnabled();
+  });
+
+  it('reflects the active-filter count and commits drafts on Apply', () => {
+    const { onApply, onClose } = renderSheet();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+
+    expect(screen.getByText('1 active')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply 1 filter/ }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      zoneId: null,
+      date: { range: '7d', customFrom: null, customTo: null },
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Reset returns the drafts to the all-time default', () => {
+    renderSheet({ range: '30d' });
+
+    expect(screen.getByText('1 active')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect(screen.queryByText('1 active')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'All time' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+});

--- a/src/features/latest_reports/components/MobileFilterSheet.tsx
+++ b/src/features/latest_reports/components/MobileFilterSheet.tsx
@@ -104,6 +104,12 @@ export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
       onOpen={() => {}}
       disableSwipeToOpen
       disableDiscovery
+      // SwipeableDrawer hardcodes ModalProps.keepMounted=true (so the paper ref
+      // exists for edge swipe-to-open). We disable that gesture, so force the
+      // subtree to UNMOUNT on close — otherwise a still-open Zone autocomplete
+      // listbox (portaled to <body>) would linger, visible and interactive, over
+      // the reports page after the sheet is dismissed.
+      ModalProps={{ keepMounted: false }}
       slotProps={{
         paper: {
           sx: {

--- a/src/features/latest_reports/components/MobileFilterSheet.tsx
+++ b/src/features/latest_reports/components/MobileFilterSheet.tsx
@@ -1,8 +1,21 @@
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import CloseIcon from '@mui/icons-material/Close';
-import { Box, Button, Divider, Drawer, IconButton, Stack, Typography } from '@mui/material';
+import PublicIcon from '@mui/icons-material/Public';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import {
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Stack,
+  SwipeableDrawer,
+  Typography,
+  useTheme,
+} from '@mui/material';
 import React, { useEffect, useState } from 'react';
 
 import type { LatestReportsFilters } from '../hooks/useLatestReportsUrlState';
+import { sheetSectionSx } from '../latestReportsStyles';
 
 import { DateRangeFilter, isInvalidDateRange, type DateRangeValue } from './DateRangeFilter';
 import { ZoneFilterSelect } from './ZoneFilterSelect';
@@ -15,10 +28,29 @@ interface MobileFilterSheetProps {
   onApply: (next: { zoneId: number | null; date: DateRangeValue }) => void;
 }
 
+const SectionLabel: React.FC<{ icon: React.ReactNode; children: React.ReactNode }> = ({
+  icon,
+  children,
+}) => (
+  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 1.25 }}>
+    <Box sx={{ display: 'inline-flex', color: 'text.secondary' }}>{icon}</Box>
+    <Typography
+      variant="subtitle2"
+      sx={{ fontWeight: 700, letterSpacing: '0.02em', color: 'text.primary' }}
+    >
+      {children}
+    </Typography>
+  </Stack>
+);
+
 /**
  * Bottom-sheet filter editor for mobile. Edits are staged as DRAFTS and only
  * committed on "Apply", so the list does not re-query on every tap and the sheet
  * does not disturb the list scroll position until the user is done.
+ *
+ * Uses a SwipeableDrawer so the sheet can be flicked down to dismiss (native
+ * iOS/Android feel), with grouped sections, a live active-filter count, and
+ * touch-first targets (≥ 48px).
  */
 export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
   open,
@@ -26,6 +58,9 @@ export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
   filters,
   onApply,
 }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
   const [draftZoneId, setDraftZoneId] = useState<number | null>(filters.zoneId);
   const [draftDate, setDraftDate] = useState<DateRangeValue>({
     range: filters.range,
@@ -46,6 +81,8 @@ export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
   }, [open, filters.zoneId, filters.range, filters.customFrom, filters.customTo]);
 
   const invalidRange = isInvalidDateRange(draftDate);
+  const activeCount = (draftZoneId !== null ? 1 : 0) + (draftDate.range !== 'all' ? 1 : 0);
+  const nothingActive = activeCount === 0;
 
   const handleApply = (): void => {
     if (invalidRange) return;
@@ -59,19 +96,31 @@ export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
   };
 
   return (
-    <Drawer
+    <SwipeableDrawer
       anchor="bottom"
       open={open}
       onClose={onClose}
+      // Opening is driven by the toolbar trigger, not an edge swipe.
+      onOpen={() => {}}
+      disableSwipeToOpen
+      disableDiscovery
       slotProps={{
         paper: {
           sx: {
-            borderTopLeftRadius: 16,
-            borderTopRightRadius: 16,
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
             px: 2,
             pt: 1,
             pb: 'calc(16px + env(safe-area-inset-bottom))',
-            maxHeight: '85vh',
+            maxHeight: '88vh',
+            background: isDark ? 'rgba(15,21,33,0.96)' : 'rgba(250,251,253,0.98)',
+            backdropFilter: 'blur(20px)',
+            WebkitBackdropFilter: 'blur(20px)',
+            border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+            borderBottom: 'none',
+            boxShadow: isDark
+              ? '0 -16px 48px rgba(0,0,0,0.55)'
+              : '0 -16px 48px rgba(15,23,42,0.18)',
             // Flex column so the controls scroll while the action row stays pinned
             // on short / landscape viewports.
             display: 'flex',
@@ -80,45 +129,92 @@ export const MobileFilterSheet: React.FC<MobileFilterSheetProps> = ({
         },
       }}
     >
+      {/* Grab handle — also the visual swipe-to-dismiss affordance. */}
       <Box
-        sx={{ width: 36, height: 4, borderRadius: 2, bgcolor: 'divider', mx: 'auto', mb: 1 }}
+        sx={{
+          width: 40,
+          height: 5,
+          borderRadius: 3,
+          bgcolor: isDark ? 'rgba(255,255,255,0.22)' : 'rgba(0,0,0,0.18)',
+          mx: 'auto',
+          mt: 0.5,
+          mb: 1.25,
+        }}
         aria-hidden
       />
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-        <Typography variant="h6" component="h2" sx={{ fontWeight: 600 }}>
-          Filters
-        </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <Typography variant="h6" component="h2" sx={{ fontWeight: 700 }}>
+            Filters
+          </Typography>
+          {activeCount > 0 && (
+            <Chip
+              size="small"
+              color="primary"
+              label={`${activeCount} active`}
+              sx={{ fontWeight: 600, height: 22 }}
+            />
+          )}
+        </Stack>
         <IconButton onClick={onClose} aria-label="Close filters" edge="end">
           <CloseIcon />
         </IconButton>
       </Box>
 
-      <Stack spacing={2.5} sx={{ py: 1, overflowY: 'auto', flexGrow: 1, minHeight: 0 }}>
-        <Box>
-          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-            Zone
-          </Typography>
+      <Stack spacing={1.75} sx={{ py: 0.5, overflowY: 'auto', flexGrow: 1, minHeight: 0 }}>
+        <Box sx={sheetSectionSx(isDark)}>
+          <SectionLabel icon={<PublicIcon fontSize="small" />}>Zone</SectionLabel>
           <ZoneFilterSelect value={draftZoneId} onChange={setDraftZoneId} fullWidth />
         </Box>
 
-        <Box>
-          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-            Date range
-          </Typography>
+        <Box sx={sheetSectionSx(isDark)}>
+          <SectionLabel icon={<CalendarMonthIcon fontSize="small" />}>Date range</SectionLabel>
           <DateRangeFilter value={draftDate} onChange={setDraftDate} inline />
         </Box>
       </Stack>
 
-      <Divider sx={{ my: 1.5 }} />
-
-      <Box sx={{ display: 'flex', gap: 1.5, pb: 1, flexShrink: 0 }}>
-        <Button variant="outlined" fullWidth onClick={handleReset}>
+      {/* Pinned action bar with a soft top hairline so it reads as a footer. */}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1.25,
+          pt: 1.5,
+          mt: 0.5,
+          flexShrink: 0,
+          borderTop: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.07)'}`,
+        }}
+      >
+        <Button
+          variant="outlined"
+          onClick={handleReset}
+          disabled={nothingActive}
+          startIcon={<RestartAltIcon />}
+          sx={{
+            minHeight: 48,
+            borderRadius: '12px',
+            textTransform: 'none',
+            fontWeight: 600,
+            px: 2.5,
+          }}
+        >
           Reset
         </Button>
-        <Button variant="contained" fullWidth onClick={handleApply} disabled={invalidRange}>
-          Apply
+        <Button
+          variant="contained"
+          fullWidth
+          onClick={handleApply}
+          disabled={invalidRange}
+          sx={{
+            minHeight: 48,
+            borderRadius: '12px',
+            textTransform: 'none',
+            fontWeight: 700,
+            fontSize: '0.95rem',
+          }}
+        >
+          {activeCount > 0 ? `Apply ${activeCount} filter${activeCount > 1 ? 's' : ''}` : 'Apply'}
         </Button>
       </Box>
-    </Drawer>
+    </SwipeableDrawer>
   );
 };

--- a/src/features/latest_reports/components/ReportCard.tsx
+++ b/src/features/latest_reports/components/ReportCard.tsx
@@ -56,6 +56,10 @@ export const ReportCard: React.FC<ReportCardProps> = ({ report, onSelect, showOw
         flexDirection: 'column',
         gap: 'var(--report-gap, 12px)',
         height: '100%',
+        // Touch ergonomics: suppress the grey tap flash and double-tap zoom so
+        // the card feels like a native, app-like surface on mobile.
+        WebkitTapHighlightColor: 'transparent',
+        touchAction: 'manipulation',
         transition: 'transform 0.2s ease, box-shadow 0.2s ease',
         // Mirror the page container's cyan gradient (135deg) at a lower opacity
         // so cards read as surfaces ON the container rather than detached panels.
@@ -67,7 +71,7 @@ export const ReportCard: React.FC<ReportCardProps> = ({ report, onSelect, showOw
           boxShadow: (theme: Theme) => theme.shadows[4],
           transform: 'translateY(-2px)',
         },
-        '&:active': { transform: 'translateY(0)' },
+        '&:active': { transform: 'scale(0.99)' },
         '&:focus-visible': {
           outline: (theme: Theme) => `2px solid ${theme.palette.primary.main}`,
           outlineOffset: 2,

--- a/src/features/latest_reports/components/ReportsToolbar.tsx
+++ b/src/features/latest_reports/components/ReportsToolbar.tsx
@@ -84,17 +84,28 @@ export const ReportsToolbar: React.FC<ReportsToolbarProps> = ({
           inputRef={searchInputRef}
         />
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Badge badgeContent={activeServerFilterCount} color="primary" overlap="rectangular">
+          <Badge
+            badgeContent={activeServerFilterCount}
+            color="primary"
+            overlap="rectangular"
+            sx={{ flex: 1, '& .MuiBadge-badge': { fontWeight: 700 } }}
+          >
             <Button
+              fullWidth
               variant="outlined"
               startIcon={<TuneIcon />}
               onClick={onOpenMobileFilters}
-              sx={{ textTransform: 'none' }}
+              aria-haspopup="dialog"
+              sx={{
+                textTransform: 'none',
+                minHeight: 44,
+                borderRadius: '10px',
+                fontWeight: 600,
+              }}
             >
               Filters
             </Button>
           </Badge>
-          <Box sx={{ flex: 1 }} />
           <DensityToggle value={density} onChange={onDensityChange} />
         </Box>
         {activeFilters}

--- a/src/features/latest_reports/latestReportsStyles.ts
+++ b/src/features/latest_reports/latestReportsStyles.ts
@@ -96,6 +96,64 @@ export const segmentedTrackSx = (isDark: boolean): SxProps<Theme> => ({
   flexShrink: 0,
 });
 
+/**
+ * Large, full-width date-range preset pill for the MOBILE filter sheet. Uses
+ * the same accent gradient as the segmented controls but with touch-first sizing
+ * (≥ 48px target, WCAG 2.5.8 / iOS HIG) and a tactile press scale.
+ */
+export const presetButtonSx = (isDark: boolean, active: boolean): SxProps<Theme> => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 0.5,
+  width: '100%',
+  minHeight: 48,
+  px: 1.5,
+  borderRadius: '12px',
+  border: '1px solid',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.9rem',
+  fontWeight: 600,
+  letterSpacing: '0.01em',
+  lineHeight: 1.2,
+  textAlign: 'center',
+  transition:
+    'transform 0.15s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease',
+  WebkitTapHighlightColor: 'transparent',
+  touchAction: 'manipulation',
+  ...(active
+    ? {
+        background: accentGradient(isDark),
+        color: '#fff',
+        borderColor: 'transparent',
+        boxShadow: accentGlow(isDark),
+      }
+    : {
+        ...glassFieldBg(isDark),
+        color: isDark ? 'rgba(255,255,255,0.78)' : 'rgba(0,0,0,0.72)',
+        borderColor: fieldBorder(isDark),
+        '&:hover': {
+          borderColor: fieldBorderHover(isDark),
+          background: isDark ? 'rgba(255,255,255,0.09)' : 'rgba(0,0,0,0.05)',
+        },
+      }),
+  '&:active': { transform: 'scale(0.97)' },
+  '&:focus-visible': { outline: `2px solid ${FOCUS_BORDER}`, outlineOffset: '2px' },
+  '@media (prefers-reduced-motion: reduce)': {
+    transition: 'none',
+    '&:active': { transform: 'none' },
+  },
+});
+
+/** Grouped section surface inside the mobile filter sheet (subtle card). */
+export const sheetSectionSx = (isDark: boolean): SxProps<Theme> => ({
+  p: 1.75,
+  borderRadius: '16px',
+  border: `1px solid ${isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)'}`,
+  background: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.015)',
+});
+
 /** A single pill button inside a segmented control. */
 export const segmentedButtonSx = (isDark: boolean, active: boolean): SxProps<Theme> => ({
   display: 'inline-flex',


### PR DESCRIPTION
## Summary

Refines and upgrades the **mobile** experience of the recently-added Latest Reports filtering UI (from #1223). The screenshot that prompted this showed the mobile filter bottom-sheet with cramped, small date-preset toggles and a fairly utilitarian layout — this PR brings it up to a modern, touch-first standard.

## What changed

**`MobileFilterSheet`** — the bottom sheet is the centrepiece:
- Swapped `Drawer` → **`SwipeableDrawer`** so it can be flicked down to dismiss (native iOS/Android feel), with a larger grab handle.
- Filters are now **grouped into subtle section cards** with iconed labels (Zone / Date range).
- Header shows a live **"N active"** count chip; the Apply button reads **"Apply N filters"** contextually.
- **Reset is disabled** until at least one filter is drafted, and the action bar is pinned with safe-area padding + a soft top hairline.
- Glassmorphic paper surface consistent with the rest of the Latest Reports design language.

**`DateRangeFilter` (inline / mobile)** — replaced the cramped, wrapping `ToggleButtonGroup` with a **touch-first 2-column pill grid** (≥ 48px targets per WCAG 2.5.8 / iOS HIG; "Custom" spans full width), using the shared accent-gradient styling. Desktop popover is unchanged.

**`ReportsToolbar` (mobile)** — the "Filters" trigger is now **full-width and taller** (≥ 44px), easier to hit one-handed.

**`ReportCard`** — suppressed the grey tap-highlight, added `touch-action: manipulation` (no double-tap zoom), and a subtle **press-scale** for an app-like, tactile feel.

**Shared styles** — new `presetButtonSx` and `sheetSectionSx` helpers in `latestReportsStyles.ts`, reusing the existing accent gradient / glass vocabulary.

## Tests
- New render tests for the inline preset grid (`DateRangeFilter.render.test.tsx`) and the filter sheet drafts/reset/apply behaviour (`MobileFilterSheet.test.tsx`).
- `npm run validate` (typecheck + lint + format) ✅
- Full `latest_reports` suite: **59/59 passing** ✅

> Note: live in-browser screenshots weren't possible — the remote container has no Chrome executable installed — so verification was done via the unit/render tests above.

https://claude.ai/code/session_015mz5QQeb2K9khRVohhtknr

---
_Generated by [Claude Code](https://claude.ai/code/session_015mz5QQeb2K9khRVohhtknr)_