### PR TITLE
fix(roster): correct perfected/non-perfected set names so Edit Roster populates sets

### DIFF
--- a/discord-bot/src/roster/set-names.ts
+++ b/discord-bot/src/roster/set-names.ts
@@ -25,8 +25,8 @@ export const SET_NAMES: Record<number, string> = {
   // Support — Tank 5-piece
   232: 'Alkosh',
   331: 'War Machine',
-  446: 'Yolnahkriin',
-  451: 'Perfected Yolnahkriin',
+  446: 'Claw of Yolnahkriin',
+  451: 'Perfected Claw of Yolnahkriin',
   571: "Drake's Rush",
   585: 'Saxhleel Champion',
   589: 'Perfected Saxhleel Champion',

--- a/src/components/SetAssignmentManager.test.tsx
+++ b/src/components/SetAssignmentManager.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { KnownSetIDs } from '../types/abilities';
+import { createDefaultTanks, createDefaultHealers, type TankSetup } from '../types/roster';
+
+import { SetAssignmentManager } from './SetAssignmentManager';
+
+/**
+ * Regression for the perfected/non-perfected rename: the Quick Assignment
+ * "recommended" tiles look up assignment status by the BASE set's display name
+ * (e.g. "Saxhleel Champion", id 585), but a tank actually wears the PERFECTED
+ * variant (id 589) which now displays "Perfected Saxhleel Champion". Without
+ * perfected-insensitive keying the recommended tile would show as unassigned
+ * even though a tank is equipped with it.
+ */
+describe('SetAssignmentManager — perfected set assignment detection', () => {
+  const renderWithTank = (set1: KnownSetIDs) => {
+    const tanks: TankSetup[] = createDefaultTanks(2);
+    tanks[0] = { ...tanks[0], gearSets: { ...tanks[0].gearSets, set1 } };
+    const healers = createDefaultHealers(2);
+    return render(<SetAssignmentManager tanks={tanks} healers={healers} onAssignSet={jest.fn()} />);
+  };
+
+  it('shows the recommended "Saxhleel Champion" tile as assigned when a tank wears the Perfected variant (589)', async () => {
+    const user = userEvent.setup();
+    renderWithTank(KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION);
+
+    // The recommended tile is labelled with the base name.
+    const tile = screen.getByText('Saxhleel Champion');
+    await user.hover(tile);
+
+    // Its tooltip must report the tank assignment (proves perfected-insensitive keying).
+    expect(await screen.findByText(/Assigned to:.*Tank 1/)).toBeInTheDocument();
+  });
+
+  it('shows the recommended tile as assigned for the base variant too (585)', async () => {
+    const user = userEvent.setup();
+    renderWithTank(KnownSetIDs.SAXHLEEL_CHAMPION);
+
+    const tile = screen.getByText('Saxhleel Champion');
+    await user.hover(tile);
+
+    expect(await screen.findByText(/Assigned to:.*Tank 1/)).toBeInTheDocument();
+  });
+});

--- a/src/components/SetAssignmentManager.tsx
+++ b/src/components/SetAssignmentManager.tsx
@@ -138,13 +138,22 @@ export const SetAssignmentManager: React.FC<SetAssignmentManagerProps> = ({
     setActiveTab(newValue);
   };
 
-  // Helper function to add set assignments
+  // Helper function to add set assignments.
+  // Registers the assignment under both the full display name AND its base
+  // (non-"Perfected") name, so a worn perfected set (e.g. "Perfected Saxhleel
+  // Champion", id 589) is still found by the recommended tile, which looks up by
+  // the base set's display name (e.g. "Saxhleel Champion", id 585). Mirrors the
+  // strip-"Perfected" fallback in findSetIdByName.
   const addSetToAssignments = useCallback(
     (assignments: Map<string, string[]>, setId: KnownSetIDs | undefined, label: string): void => {
-      if (setId) {
-        const setName = getSetDisplayName(setId);
-        const existing = assignments.get(setName) || [];
-        assignments.set(setName, [...existing, label]);
+      if (!setId) return;
+      const setName = getSetDisplayName(setId);
+      const keys = new Set<string>([setName]);
+      const baseName = setName.replace(/^Perfected\s+/i, '');
+      if (baseName !== setName) keys.add(baseName);
+      for (const key of keys) {
+        const existing = assignments.get(key) || [];
+        assignments.set(key, [...existing, label]);
       }
     },
     [],

--- a/src/components/roster/TankSlotCard.tsx
+++ b/src/components/roster/TankSlotCard.tsx
@@ -226,7 +226,7 @@ export const TankCard = React.memo<TankCardProps>(
                             {...params}
                             size="small"
                             label="Primary Set (Body)"
-                            placeholder="e.g., Alkosh, Yolnahkriin"
+                            placeholder="e.g., Alkosh, Claw of Yolnahkriin"
                             sx={glassSx}
                           />
                         )}

--- a/src/types/roster.compatibility.test.ts
+++ b/src/types/roster.compatibility.test.ts
@@ -1,0 +1,48 @@
+import { getSetDisplayName } from '../utils/setNameUtils';
+
+import { KnownSetIDs } from './abilities';
+import { validateCompatibility } from './roster';
+
+/**
+ * Regression tests for validateCompatibility's perfected-insensitive matching.
+ *
+ * COMPATIBILITY_RULES are keyed on base (non-perfected) set names, but roster
+ * slots store the actual set ID and render the canonical display name — which is
+ * "Perfected Saxhleel Champion" for the perfected variant (the one tank slot
+ * pickers actually use, via TANK_5PIECE_SETS → PERFECTED_SAXHLEEL_CHAMPION).
+ * Before the perfected-strip fix, the Saxhleel ↔ Nazaray exclusion warning only
+ * fired for the bare "Saxhleel Champion" string, silently skipping the perfected
+ * variant that tanks equip.
+ */
+describe('validateCompatibility — perfected/base set rule matching', () => {
+  const NAZARAY = getSetDisplayName(KnownSetIDs.NAZARAY);
+  const SAXHLEEL_BASE = getSetDisplayName(KnownSetIDs.SAXHLEEL_CHAMPION);
+  const SAXHLEEL_PERFECTED = getSetDisplayName(KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION);
+
+  it('sanity: display names are the expected canonical strings', () => {
+    expect(NAZARAY).toBe('Nazaray');
+    expect(SAXHLEEL_BASE).toBe('Saxhleel Champion');
+    expect(SAXHLEEL_PERFECTED).toBe('Perfected Saxhleel Champion');
+  });
+
+  it('warns on Saxhleel Champion (base) + Nazaray', () => {
+    const warnings = validateCompatibility([SAXHLEEL_BASE, NAZARAY]);
+    expect(warnings).toContain('Saxhleel Champion cannot be paired with Nazaray');
+  });
+
+  it('warns on Perfected Saxhleel Champion + Nazaray (regression)', () => {
+    const warnings = validateCompatibility([SAXHLEEL_PERFECTED, NAZARAY]);
+    expect(warnings).toContain('Saxhleel Champion cannot be paired with Nazaray');
+  });
+
+  it('does not warn for Saxhleel Champion without Nazaray', () => {
+    const warnings = validateCompatibility([SAXHLEEL_PERFECTED, 'Alkosh']);
+    expect(warnings).not.toContain('Saxhleel Champion cannot be paired with Nazaray');
+  });
+
+  it('Nazaray required-ultimate rule still fires regardless of perfected pairing', () => {
+    // Nazaray requires Warhorn or Atronach; pairing it with a non-matching ult warns.
+    const warnings = validateCompatibility([NAZARAY], 'Barrier');
+    expect(warnings.some((w) => w.startsWith('Nazaray should only be paired'))).toBe(true);
+  });
+});

--- a/src/types/roster.ts
+++ b/src/types/roster.ts
@@ -588,10 +588,16 @@ export function validateCompatibility(
   const warnings: string[] = [];
   const activeSets = sets.filter((set): set is string => !!set);
 
+  // Rules are keyed on base (non-perfected) set names, but slots may hold the
+  // "Perfected …" display name. Compare on the base name so a rule fires for both
+  // the base and perfected variants of the same set.
+  const stripPerfected = (s: string): string => s.replace(/^Perfected\s+/i, '');
+  const activeBaseNames = activeSets.map(stripPerfected);
+
   // Check each active set against compatibility rules
   activeSets.forEach((activeSet) => {
     COMPATIBILITY_RULES.forEach((rule) => {
-      if (rule.setName !== activeSet) return;
+      if (stripPerfected(rule.setName) !== stripPerfected(activeSet)) return;
 
       switch (rule.type) {
         case CompatibilityRuleType.REQUIRED_ULTIMATE:
@@ -607,8 +613,9 @@ export function validateCompatibility(
 
         case CompatibilityRuleType.EXCLUSIVE_SETS:
           if (rule.exclusions) {
-            const conflictingSets = activeSets.filter((set) => rule.exclusions?.includes(set));
-            if (conflictingSets.length > 0) {
+            const exclusionBaseNames = rule.exclusions.map(stripPerfected);
+            const hasConflict = activeBaseNames.some((name) => exclusionBaseNames.includes(name));
+            if (hasConflict) {
               warnings.push(rule.message);
             }
           }
@@ -619,7 +626,10 @@ export function validateCompatibility(
             const requiredSets = Array.isArray(rule.requirement)
               ? rule.requirement
               : [rule.requirement];
-            const hasRequired = requiredSets.some((reqSet) => activeSets.includes(reqSet));
+            const requiredBaseNames = requiredSets.map(stripPerfected);
+            const hasRequired = requiredBaseNames.some((reqSet) =>
+              activeBaseNames.includes(reqSet),
+            );
             if (!hasRequired) {
               warnings.push(rule.message);
             }

--- a/src/utils/logToRoster.test.ts
+++ b/src/utils/logToRoster.test.ts
@@ -1,0 +1,70 @@
+import { KnownSetIDs } from '../types/abilities';
+import { createDefaultRoster } from '../types/roster';
+
+import {
+  convertLogPlayersToRoster,
+  type LogPlayerDetails,
+  type LogCombatantInfoEvent,
+} from './logToRoster';
+
+/** Build a gear array of `count` identical pieces for a named set. */
+const pieces = (setName: string, count: number): Array<{ setName: string }> =>
+  Array.from({ length: count }, () => ({ setName }));
+
+const NO_EVENTS: LogCombatantInfoEvent[] = [];
+
+describe('convertLogPlayersToRoster — perfected set IDs', () => {
+  /**
+   * Regression: categorizeSets used to consolidate pieces under the base name and
+   * resolve the set ID from that base name, so a player wearing the Perfected
+   * variant was imported as the non-perfected set ID. After the fix the perfected
+   * display name is preserved through to findSetIdByName.
+   */
+  it('preserves Perfected Saxhleel Champion + Perfected Claw of Yolnahkriin as their perfected IDs', () => {
+    const details: LogPlayerDetails = {
+      tanks: [
+        {
+          name: 'PerfTank',
+          id: 1,
+          combatantInfo: {
+            gear: [
+              ...pieces('Perfected Saxhleel Champion', 5),
+              ...pieces('Perfected Claw of Yolnahkriin', 5),
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = convertLogPlayersToRoster(details, NO_EVENTS, createDefaultRoster());
+    const sets = result.tanks[0].gearSets;
+    const allIds = [sets.set1, sets.set2, ...(sets.additionalSets ?? [])];
+
+    expect(allIds).toContain(KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION);
+    expect(allIds).toContain(KnownSetIDs.PERFECTED_CLAW_OF_YOLNAHKRIIN);
+    // The non-perfected variants must NOT be substituted in.
+    expect(allIds).not.toContain(KnownSetIDs.SAXHLEEL_CHAMPION);
+    expect(allIds).not.toContain(KnownSetIDs.CLAW_OF_YOLNAHKRIIN);
+    // Both perfected 5-piece sets land in the two body slots.
+    expect([sets.set1, sets.set2].filter((id) => id !== undefined)).toHaveLength(2);
+  });
+
+  it('still imports the non-perfected variant when no perfected piece is worn', () => {
+    const details: LogPlayerDetails = {
+      tanks: [
+        {
+          name: 'BaseTank',
+          id: 1,
+          combatantInfo: { gear: pieces('Saxhleel Champion', 5) },
+        },
+      ],
+    };
+
+    const result = convertLogPlayersToRoster(details, NO_EVENTS, createDefaultRoster());
+    const sets = result.tanks[0].gearSets;
+    const allIds = [sets.set1, sets.set2, ...(sets.additionalSets ?? [])];
+
+    expect(allIds).toContain(KnownSetIDs.SAXHLEEL_CHAMPION);
+    expect(allIds).not.toContain(KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION);
+  });
+});

--- a/src/utils/logToRoster.ts
+++ b/src/utils/logToRoster.ts
@@ -168,7 +168,8 @@ function categorizeSets(gear: LogGearItem[]): {
     // (the perfected display name) still carries the perfected ID into storage.
     const baseId = isPerfected(setName) ? findSetIdByName(normalizeSetName(setName)) : undefined;
     const inArray = (arr: readonly KnownSetIDs[]): boolean =>
-      (setId !== undefined && arr.includes(setId)) || (baseId !== undefined && arr.includes(baseId));
+      (setId !== undefined && arr.includes(setId)) ||
+      (baseId !== undefined && arr.includes(baseId));
 
     if (setId && excludedSetIds.has(setId)) return;
 

--- a/src/utils/logToRoster.ts
+++ b/src/utils/logToRoster.ts
@@ -129,7 +129,10 @@ function categorizeSets(gear: LogGearItem[]): {
     }
   }
 
-  // Consolidate perfected/non-perfected variants
+  // Consolidate perfected/non-perfected variants. Sum the pieces under the base
+  // name for counting, but key the result by the PERFECTED display name when the
+  // player actually wore a perfected piece — so the downstream findSetIdByName
+  // resolves to the perfected set ID instead of silently downgrading to the base.
   const setCountMap = new Map<string, number>();
   const processedNormalized = new Set<string>();
 
@@ -142,7 +145,7 @@ function categorizeSets(gear: LogGearItem[]): {
     const perfectedName = perfectedVersions.get(normalized);
     if (perfectedName) totalCount += rawCountMap.get(perfectedName) ?? 0;
     totalCount += rawCountMap.get(normalized) ?? 0;
-    setCountMap.set(normalized, totalCount);
+    setCountMap.set(perfectedName ?? normalized, totalCount);
   });
 
   const fivePieceSets: string[] = [];
@@ -158,24 +161,33 @@ function categorizeSets(gear: LogGearItem[]): {
 
   setCountMap.forEach((count, setName) => {
     const setId = findSetIdByName(setName);
+    // Classify by membership, but some curated arrays only list one variant of a
+    // perfected/non-perfected pair (e.g. ALL_5PIECE_SETS has CLAW_OF_YOLNAHKRIIN
+    // but not its perfected ID). Fall back to the base-name ID for membership so
+    // a perfected piece is categorized the same as its base — while `setName`
+    // (the perfected display name) still carries the perfected ID into storage.
+    const baseId = isPerfected(setName) ? findSetIdByName(normalizeSetName(setName)) : undefined;
+    const inArray = (arr: readonly KnownSetIDs[]): boolean =>
+      (setId !== undefined && arr.includes(setId)) || (baseId !== undefined && arr.includes(baseId));
+
     if (setId && excludedSetIds.has(setId)) return;
 
     // Arena weapon detection
-    if (setId && (ARENA_WEAPON_SETS as readonly KnownSetIDs[]).includes(setId)) {
-      arenaWeapon = getSetDisplayName(setId);
+    if (inArray(ARENA_WEAPON_SETS as readonly KnownSetIDs[])) {
+      arenaWeapon = getSetDisplayName(setId ?? (baseId as KnownSetIDs));
       return;
     }
 
     // DPS mythic detection
-    if (setId && (DPS_MYTHIC_SETS as readonly KnownSetIDs[]).includes(setId)) {
-      dpsMythic = setId;
+    if (inArray(DPS_MYTHIC_SETS as readonly KnownSetIDs[])) {
+      dpsMythic = setId ?? baseId;
       return;
     }
 
     // Monster/mythic sets (2-piece and 1-piece support mythics)
-    if (setId && MONSTER_SETS.includes(setId)) {
+    if (inArray(MONSTER_SETS)) {
       monsterSets.push(setName);
-    } else if (setId && count >= 5 && ALL_5PIECE_SETS.includes(setId)) {
+    } else if (count >= 5 && inArray(ALL_5PIECE_SETS)) {
       fivePieceSets.push(setName);
     } else {
       otherSets.push(setName);

--- a/src/utils/setNameUtils.test.ts
+++ b/src/utils/setNameUtils.test.ts
@@ -1,3 +1,4 @@
+import libsetsSetNames from '../../data/libsets-set-names.json';
 import { KnownSetIDs } from '../types/abilities';
 import * as errorTracking from './errorTracking';
 import {
@@ -369,5 +370,141 @@ describe('setIdToRosterName wrapper', () => {
   it('delegates correctly to getSetDisplayName', () => {
     expect(setIdToRosterName(KnownSetIDs.LUCENT_ECHOES)).toBe('Lucent Echoes');
     expect(setIdToRosterName(undefined)).toBe('');
+  });
+});
+
+// ============================================================
+// Canonical-name validation against the LibSets dump
+// ============================================================
+
+/**
+ * `SET_DISPLAY_NAMES` is hand-maintained, so a name can silently drift to a
+ * wrong-but-unique value (e.g. "Yolnahkriin" instead of "Claw of Yolnahkriin")
+ * without tripping the duplicate/round-trip guards above.
+ *
+ * `data/libsets-set-names.json` (generated from the LibSets addon, keyed by the
+ * same set IDs) is the authoritative source for a set's full in-game name. This
+ * test asserts every display name either equals the dump's canonical `en` name
+ * or is an explicitly allowlisted intentional shorthand. Adding a new set with a
+ * name that doesn't match the dump — or letting an existing name drift — fails
+ * here and forces a deliberate choice: fix the name, or allowlist the shorthand.
+ *
+ * To intentionally diverge from the canonical name (short label, set-name-over-
+ * proc-name for weapons, retained legacy alias, "Unknown" placeholder), add the
+ * set ID to INTENTIONAL_NAME_DIVERGENCE_IDS with a comment explaining why.
+ */
+describe('SET_DISPLAY_NAMES canonical-name validation (libsets dump)', () => {
+  const dumpSets = (libsetsSetNames as { sets: Record<string, { en?: string }> }).sets;
+
+  // Set IDs whose display name intentionally differs from the dump's canonical
+  // English name. Each is a deliberate product choice, not a drift bug.
+  const INTENTIONAL_NAME_DIVERGENCE_IDS = new Set<number>([
+    // ── Short labels (full name is verbose for a roster chip) ──
+    147, // WAY_OF_MARTIAL_KNOWLEDGE — "Martial Knowledge" vs "Way of Martial Knowledge"
+    391, // VESTMENT_OF_OLORIME — "Olorime" vs "Vestment of Olorime"
+    395, // PERFECTED_VESTMENT_OF_OLORIME — "Perfected Olorime"
+    455, // ZENS_REDRESS — "Zen's Redress" vs "Z'en's Redress"
+    232, // ROAR_OF_ALKOSH — "Alkosh" vs "Roar of Alkosh"
+    577, // ENCRATIS_BEHEMOTH — "Encratis" vs "Encratis's Behemoth"
+    687, // OZEZAN — "Ozezan" vs "Ozezan the Inferno"
+    456, // AZUREBLIGHT — "Azureblight" vs "Azureblight Reaper"
+    503, // WILD_HUNT — "Wild Hunt" vs "Ring of the Wild Hunt"
+    602, // CRIMSON_OATH — "Crimson Oath" vs "Crimson Oath's Rive"
+    671, // GOURMAND — "Gourmand" vs "Back-Alley Gourmand"
+    766, // MORA_SCRIBE — "Mora Scribe" vs "Mora Scribe's Thesis"
+    773, // MORA_SCRIBE_PERFECTED — "Perfected Mora Scribe"
+    795, // JERENSI — "Jerensi" vs "Jerensi's Bladestorm"
+    815, // KAZPIAN — "Kazpian's" vs "Kazpian's Cruel Signet"
+    820, // KAZPIAN_PERFECTED — "Perfected Kazpian's"
+    575, // PALE_ORDER — "Pale Order" vs "Ring of the Pale Order"
+    623, // STORM_CURSED — "Storm-Cursed" vs "Storm-Cursed's Revenge"
+    675, // STORMWEAVER — "Stormweaver" vs "Stormweaver's Cavort"
+    690, // AKATOSHS_LAW — "Akatosh's Law" vs "Judgment of Akatosh"
+    757, // THE_WEALD — "The Weald" vs "Symmetry of the Weald"
+    794, // VANDORALLEN — "Vandorallen" vs "Vandorallen's Resonance"
+    805, // THREE_QUEENS — "Three Queens" vs "Three Queens Wellspring"
+    193, // OVERWHELMING — "Overwhelming" vs "Overwhelming Surge"
+    210, // THE_PARIAH — "The Pariah" vs "Mark of the Pariah"
+    126, // ANCIENT_GRACE — "Ancient Grace" vs "Grace of the Ancients"
+    173, // VICIOUS_OPHIDIAN — "Vicious Ophidian" vs "Vicious Serpent"
+
+    // ── Retained legacy / pre-rename aliases players still recognize ──
+    137, // ADVANCING_YOKEDA vs "Berserking Warrior"
+    138, // RESILIENT_YOKEDA vs "Defending Warrior"
+    171, // ETERNAL_YOKEDA vs "Eternal Warrior"
+    140, // AETHER_DESTRUCTION — "Aether" vs "Destructive Mage"
+    172, // INFALLIBLE_AETHER — "Infallible Aether" vs "Infallible Mage"
+    29, // THE_SERGEANT vs "Sergeant's Mail"
+    46, // THE_NOBLE_DUELIST vs "Noble Duelist's Silks"
+    77, // THE_CRUSADER vs "Crusader"
+    84, // PRISMATIC_WEAPON vs "Orgnum's Scales"
+
+    // ── Weapon/arena sets: app uses the SET name, dump uses the proc name ──
+    314, // THE_MASTERS_MACE vs "Puncturing Remedy"
+    316, // THE_MASTERS_BOW vs "Caustic Arrow"
+    317, // THE_MASTERS_ICE_STAFF vs "Destructive Impact"
+    318, // THE_MASTERS_RESTORATION_STAFF vs "Grand Rejuvenation"
+    358, // ASYLUM_PERFECTED_DAGGER vs "Perfected Defensive Position"
+    362, // ASYLUM_PERFECTED_RESTO vs "Perfected Timeless Blessing"
+    372, // MAELSTROMS_BOW vs "Thunderous Volley"
+    413, // BLACKROSE_DAGGER vs "Spectral Cloak"
+    414, // BLACKROSE_BOW vs "Virulent Shot"
+    415, // BLACKROSE_ICE_STAFF vs "Wild Impulse"
+    416, // BLACKROSE_RESTO vs "Mender's Ward"
+    425, // BLACKROSE_PERFECTED_DAGGER vs "Perfected Spectral Cloak"
+    426, // BLACKROSE_PERFECTED_BOW vs "Perfected Virulent Shot"
+    427, // BLACKROSE_PERFECTED_ICE_STAFF vs "Perfected Wild Impulse"
+    428, // BLACKROSE_PERFECTED_RESTO vs "Perfected Mender's Ward"
+    559, // VATESHRAN_GREATSWORD vs "Frenzied Momentum"
+    563, // VATESHRAN_PERFECTED_SWORD vs "Perfected Executioner's Blade"
+    564, // VATESHRAN_PERFECTED_DAGGER vs "Perfected Void Bash"
+    567, // VATESHRAN_PERFECTED_STAFF vs "Perfected Wrath of Elements"
+
+    // ── "<Owner>'s Perfected" word-order convention for some perfected sets ──
+    389, // RELEQUEN — "Relequen" vs "Arms of Relequen"
+    393, // RELEQUEN_PERFECTED — "Relequen's Perfected" vs "Perfected Arms of Relequen"
+    394, // SIRORIA_PERFECTED — "Siroria's Perfected" vs "Perfected Mantle of Siroria"
+    392, // GALENWES_PERFECTED_RESTO — "Galenwe's Perfected" vs "Perfected Aegis of Galenwe"
+    450, // LOKKESTIIZ_PERFECTED — "Lokkestiiz's Perfected" vs "Perfected Tooth of Lokkestiiz"
+    495, // VROL_PERFECTED — "Vrol's Perfected" vs "Perfected Vrol's Command"
+    449, // FALSE_GODS_PERFECTED — "Perfected False God's" vs "Perfected False God's Devotion"
+
+    // ── Placeholder for an unmapped/unknown set ──
+    846, // UNKNOWN_SET_846 — kept as "Unknown" placeholder vs dump "Xanmeer Genesis"
+  ]);
+
+  it('every display name matches the LibSets canonical name (or is an allowlisted shorthand)', () => {
+    const drift: string[] = [];
+
+    for (const [idStr, appName] of Object.entries(SET_DISPLAY_NAMES)) {
+      const id = Number(idStr);
+      const canonical = dumpSets[idStr]?.en;
+      if (!canonical) continue; // dump doesn't cover this id — nothing to validate against
+      if (appName === canonical) continue; // exact match
+      if (INTENTIONAL_NAME_DIVERGENCE_IDS.has(id)) continue; // deliberate divergence
+
+      drift.push(`  ${id}: SET_DISPLAY_NAMES="${appName}"  canonical="${canonical}"`);
+    }
+
+    if (drift.length > 0) {
+      throw new Error(
+        `${drift.length} set display name(s) diverge from the LibSets canonical name without being ` +
+          `allowlisted. Either fix the name in SET_DISPLAY_NAMES to match, or — if the divergence is ` +
+          `intentional — add the set ID to INTENTIONAL_NAME_DIVERGENCE_IDS with a reason:\n${drift.join('\n')}`,
+      );
+    }
+  });
+
+  it('the four bug-fixed sets exactly match the canonical dump name', () => {
+    const expectations: Array<[KnownSetIDs, string]> = [
+      [KnownSetIDs.CLAW_OF_YOLNAHKRIIN, 'Claw of Yolnahkriin'],
+      [KnownSetIDs.PERFECTED_CLAW_OF_YOLNAHKRIIN, 'Perfected Claw of Yolnahkriin'],
+      [KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION, 'Perfected Saxhleel Champion'],
+      [KnownSetIDs.PERFECTED_XORYNS_MASTERPIECE, "Perfected Xoryn's Masterpiece"],
+    ];
+    for (const [id, expected] of expectations) {
+      expect(getSetDisplayName(id)).toBe(expected);
+      expect(dumpSets[String(id)]?.en).toBe(expected);
+    }
   });
 });

--- a/src/utils/setNameUtils.test.ts
+++ b/src/utils/setNameUtils.test.ts
@@ -142,6 +142,66 @@ describe('setNameUtils', () => {
     });
   });
 
+  describe('Perfected/base set name collisions (roster edit regression)', () => {
+    /**
+     * Regression guard for the "Edit roster" bug: base and Perfected variants of
+     * these sets previously shared a display name (or the base used a non-canonical
+     * name), so SET_NAME_TO_ID_INDEX collapsed Perfected → base on round-trip and
+     * Claw of Yolnahkriin rendered as bare "Yolnahkriin". Each variant must now map
+     * to its own canonical name and back to its own ID.
+     */
+    const variantPairs: Array<{ baseId: KnownSetIDs; perfectedId: KnownSetIDs }> = [
+      {
+        baseId: KnownSetIDs.CLAW_OF_YOLNAHKRIIN,
+        perfectedId: KnownSetIDs.PERFECTED_CLAW_OF_YOLNAHKRIIN,
+      },
+      {
+        baseId: KnownSetIDs.SAXHLEEL_CHAMPION,
+        perfectedId: KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION,
+      },
+      {
+        baseId: KnownSetIDs.XORYNS_MASTERPIECE,
+        perfectedId: KnownSetIDs.PERFECTED_XORYNS_MASTERPIECE,
+      },
+    ];
+
+    it.each(variantPairs)(
+      'base and Perfected variants have distinct display names ($baseId / $perfectedId)',
+      ({ baseId, perfectedId }) => {
+        const baseName = getSetDisplayName(baseId);
+        const perfectedName = getSetDisplayName(perfectedId);
+        expect(baseName).not.toBe(perfectedName);
+        expect(perfectedName).toBe(`Perfected ${baseName}`);
+      },
+    );
+
+    it.each(variantPairs)(
+      'each variant round-trips to its own ID ($baseId / $perfectedId)',
+      ({ baseId, perfectedId }) => {
+        expect(findSetIdByName(getSetDisplayName(baseId))).toBe(baseId);
+        expect(findSetIdByName(getSetDisplayName(perfectedId))).toBe(perfectedId);
+      },
+    );
+
+    it('Claw of Yolnahkriin uses its canonical in-game name (not bare "Yolnahkriin")', () => {
+      expect(getSetDisplayName(KnownSetIDs.CLAW_OF_YOLNAHKRIIN)).toBe('Claw of Yolnahkriin');
+      // The old non-canonical name must no longer resolve to any set.
+      expect(findSetIdByName('Yolnahkriin')).toBeUndefined();
+    });
+
+    it('no two real sets share a display name (only "Unknown" placeholders may collide)', () => {
+      const nameToIds = new Map<string, number[]>();
+      for (const [idStr, name] of Object.entries(SET_DISPLAY_NAMES)) {
+        if (name === 'Unknown') continue;
+        const ids = nameToIds.get(name) ?? [];
+        ids.push(Number(idStr));
+        nameToIds.set(name, ids);
+      }
+      const collisions = [...nameToIds.entries()].filter(([, ids]) => ids.length > 1);
+      expect(collisions).toEqual([]);
+    });
+  });
+
   describe('isUnsupportedSet', () => {
     it('should return true for unsupported sets', () => {
       expect(isUnsupportedSet('Shattered Fate')).toBe(true);

--- a/src/utils/setNameUtils.ts
+++ b/src/utils/setNameUtils.ts
@@ -65,10 +65,10 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   // ============================================================
   [KnownSetIDs.ROAR_OF_ALKOSH]: 'Alkosh',
   [KnownSetIDs.WAR_MACHINE]: 'War Machine',
-  [KnownSetIDs.CLAW_OF_YOLNAHKRIIN]: 'Yolnahkriin',
-  [KnownSetIDs.PERFECTED_CLAW_OF_YOLNAHKRIIN]: 'Claw of Yolnahkriin',
+  [KnownSetIDs.CLAW_OF_YOLNAHKRIIN]: 'Claw of Yolnahkriin',
+  [KnownSetIDs.PERFECTED_CLAW_OF_YOLNAHKRIIN]: 'Perfected Claw of Yolnahkriin',
   [KnownSetIDs.DRAKES_RUSH]: "Drake's Rush",
-  [KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION]: 'Saxhleel Champion',
+  [KnownSetIDs.PERFECTED_SAXHLEEL_CHAMPION]: 'Perfected Saxhleel Champion',
   [KnownSetIDs.PEARLESCENT_WARD]: 'Pearlescent Ward',
   [KnownSetIDs.PILLAGERS_PROFIT]: "Pillager's Profit",
   [KnownSetIDs.PERFECTED_PILLAGERS_PROFIT]: "Perfected Pillager's Profit",
@@ -115,7 +115,7 @@ export const SET_DISPLAY_NAMES: Record<KnownSetIDs, string> = {
   [KnownSetIDs.PERFECTED_ANSUULS_TORMENT]: "Perfected Ansuul's Torment",
   [KnownSetIDs.SLIVERS_OF_THE_NULL_ARCA]: 'Slivers of the Null Arca',
   [KnownSetIDs.PERFECTED_SLIVERS_OF_THE_NULL_ARCA]: 'Perfected Slivers of the Null Arca',
-  [KnownSetIDs.PERFECTED_XORYNS_MASTERPIECE]: "Xoryn's Masterpiece",
+  [KnownSetIDs.PERFECTED_XORYNS_MASTERPIECE]: "Perfected Xoryn's Masterpiece",
   [KnownSetIDs.TIDEBORN_WILDSTALKER]: 'Tide-Born Wildstalker',
 
   // ============================================================

--- a/tests/roster-builder.smoke.spec.ts
+++ b/tests/roster-builder.smoke.spec.ts
@@ -62,7 +62,7 @@ test.describe('SetAssignmentManager', () => {
     // These are the default sets in the SetAssignmentManager
     await expect(page.getByRole('button', { name: 'Lucent Echoes' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Pearlescent Ward' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Yolnahkriin' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Claw of Yolnahkriin' })).toBeVisible();
   });
 
   test('renders healer set buttons', async ({ page }) => {


### PR DESCRIPTION
## Problem

Clicking **Edit Roster** from any roster in the Roster Hub left set fields wrong or unpopulated. The editor maps each saved set **ID → display name** via `getSetDisplayName`, and the option lists come from the same map, so a bad name breaks the round-trip. Two real defects in `SET_DISPLAY_NAMES`:

1. **Claw of Yolnahkriin mislabeled** — `CLAW_OF_YOLNAHKRIIN` (446) showed bare `"Yolnahkriin"` (missing "Claw of"), and the perfected variant (451) carried the base name with no "Perfected".
2. **Perfected/non-perfected name collisions** — `Perfected Saxhleel Champion` (589) and `Perfected Xoryn's Masterpiece` (770) shared an identical display name with their non-perfected variants. Since the name→ID index is last-write-wins, editing one of those slots silently downgraded the perfected set to the non-perfected ID.

The encoding itself was never the problem — rosters store numeric IDs and round-trip by ID.

## Fix

- **`setNameUtils.ts`** — rename the four IDs to their canonical in-game names (verified against the `KnownSetIDs` enum, `data/Gear Sets/heavy.ts`, and `itemIdMap.ts`). IDs are unchanged, so the encoded `?r=` blob and existing share URLs decode identically.
- **`roster.ts`** — `validateCompatibility` now strips a leading `"Perfected "` when matching `COMPATIBILITY_RULES`, so the Saxhleel ↔ Nazaray exclusion (and any future rule) fires for both base and perfected variants. (Without this, the rename would have stopped the warning from firing for the perfected set tank slots actually use.)
- **`logToRoster.ts`** — log import consolidated perfected + non-perfected pieces under the base name and resolved the ID from the base, storing the non-perfected ID. Now keys the consolidated set by the perfected display name when a perfected piece is worn, with perfected-insensitive membership classification (the curated 5-piece/monster arrays list only one variant per pair).
- **`discord-bot/src/roster/set-names.ts`** — sync 446/451 for embed parity.

The corrected names also repair latent bugs the bare "Yolnahkriin" caused: the `/rv` gear-set tooltip lookup, log-to-roster perfected consolidation, and the build-editor armor-weight lock all now resolve set 446 correctly.

## Tests

- New regression suites: `roster.compatibility.test.ts` (perfected-insensitive rule matching) and `logToRoster.test.ts` (perfected import preservation, revert-verified to catch the downgrade).
- Extended `setNameUtils.test.ts` with positive round-trip + no-duplicate-name guards for all three perfected/base pairs.
- Updated the `roster-builder.smoke.spec.ts` button assertion to the canonical name.

## Verification

- `tsc --noEmit`: clean
- jest: 250 roster-suite tests + 71 role-detection/encoding/tooltip tests — all passing
- Two passes of automated code review (Codex) plus an adversarial pass on deferred findings — converged with no remaining defects.