### PR TITLE
fix(roster): wrap per-fight role rows on the /rv run sheet (mobile overflow)

### DIFF
--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -1277,13 +1277,24 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
                     ].filter(Boolean);
                     if (!sets.length && !o.ultimate && !o.notes) return null;
                     return (
-                      <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
+                      <Box
+                        key={key}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          // Wrap a slot's chips/ultimate to a new line on narrow
+                          // screens instead of overflowing the card horizontally.
+                          flexWrap: 'wrap',
+                          gap: 0.4,
+                        }}
+                      >
                         <Typography
                           sx={{
                             fontSize: '0.68rem',
                             fontWeight: 700,
                             color: 'text.disabled',
                             minWidth: 20,
+                            flexShrink: 0,
                           }}
                         >
                           {labelMap[key]}:
@@ -1337,13 +1348,22 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
                       ].filter(Boolean);
                       if (!sets.length && !slot.ultimate && !slot.notes) return null;
                       return (
-                        <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
+                        <Box
+                          key={key}
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            flexWrap: 'wrap',
+                            gap: 0.4,
+                          }}
+                        >
                           <Typography
                             sx={{
                               fontSize: '0.68rem',
                               fontWeight: 700,
                               color: 'text.disabled',
                               minWidth: 20,
+                              flexShrink: 0,
                             }}
                           >
                             D{dpsIdx + 1}:


### PR DESCRIPTION
## Problem

While building an extensively-filled multi-trial example for the `/rv` run sheet (shipped in #1236), a fully-loaded fight card overflowed on narrow phones. Each role row (`MT`/`OT`/`H1`/`D1`…) was a single `nowrap` flex line, so a slot carrying **two 5-piece sets + a monster set + an ultimate** — with long names like "Perfected Pearlescent Ward" + "Pestilent Colossus" — ran ~33px past the 390px viewport and triggered horizontal page scroll.

## Fix

Let each slot row `flexWrap: 'wrap'` so its chips/ultimate flow to a second line, and add `flexShrink: 0` to the role label so it stays put. Applied to both the tank/healer row and the DPS row.

## Verification (live, dev server)

Generated a 6-trial roster with per-fight builds across 4 trials (Rockgrove 3 fights, Kyne's Aegis 2, Lucent Citadel 1, Sanity's Edge 1 — the run-sheet edge case).

- **Before (390px):** `documentElement.scrollWidth - clientWidth = 33`; 4 overflowing role rows in `main`.
- **After (390px):** page overflow `0`; **0** main-content offenders; rows wrap cleanly within the card.
- **Desktop (1440px):** unchanged — rows still render on one line (wrap only engages when the row runs out of width).

`tsc` + `eslint` + `prettier` clean.
