### PR TITLE
feat(roster): collapsible per-fight cards on the /rv run sheet

### DIFF
--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -1423,56 +1423,133 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
                   )}
                 </AccordionSummary>
 
-                <AccordionDetails sx={{ px: 1.25, pt: 0, pb: 1.25 }}>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                <AccordionDetails sx={{ px: 1, pt: 0, pb: 1 }}>
+                  {/* One clearly-separated card per player slot so every role
+                      (MT/OT/H1…/D1–D8) is legible and nothing crams. Each card
+                      stacks: role + player name, then set chips, ultimate, and
+                      the per-fight note (the only place notes are surfaced). */}
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.6 }}>
                     {rows.map((row) => (
                       <Box
                         key={row.key}
                         sx={{
                           display: 'flex',
-                          alignItems: 'center',
-                          // Wrap a slot's chips/ultimate to a new line on narrow
-                          // screens instead of overflowing the card horizontally.
-                          flexWrap: 'wrap',
+                          flexDirection: 'column',
                           gap: 0.4,
+                          p: 0.75,
+                          borderRadius: '8px',
+                          borderLeft: `2px solid ${accentColor}55`,
+                          backgroundColor: isDarkMode
+                            ? 'rgba(255,255,255,0.025)'
+                            : 'rgba(0,0,0,0.02)',
                         }}
                       >
-                        <Typography
-                          sx={{
-                            fontSize: '0.68rem',
-                            fontWeight: 700,
-                            color: 'text.disabled',
-                            minWidth: 24,
-                            flexShrink: 0,
-                          }}
-                        >
-                          {row.label}:
-                        </Typography>
-                        {row.sets.map((s) => (
-                          <Chip
-                            key={s}
-                            label={s}
-                            size="small"
+                        {/* Header line: role badge + player name */}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+                          <Box
                             sx={{
-                              height: 16,
-                              fontSize: '0.6rem',
-                              fontWeight: 500,
-                              backgroundColor: `${accentColor}18`,
-                              color: accentColor,
-                              border: `1px solid ${accentColor}30`,
-                              '& .MuiChip-label': { px: 0.5 },
+                              flexShrink: 0,
+                              px: 0.6,
+                              py: 0.1,
+                              borderRadius: '5px',
+                              backgroundColor: `${accentColor}20`,
+                              border: `1px solid ${accentColor}38`,
                             }}
-                          />
-                        ))}
+                          >
+                            <Typography
+                              sx={{
+                                fontSize: '0.64rem',
+                                fontWeight: 800,
+                                letterSpacing: '0.02em',
+                                color: accentColor,
+                                lineHeight: 1.5,
+                              }}
+                            >
+                              {row.label}
+                            </Typography>
+                          </Box>
+                          {row.playerName && (
+                            <Typography
+                              sx={{
+                                fontSize: '0.72rem',
+                                fontWeight: 600,
+                                color: 'text.primary',
+                                letterSpacing: '-0.01em',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {row.playerName}
+                            </Typography>
+                          )}
+                        </Box>
+
+                        {/* Set chips — wrap freely, never overflow horizontally */}
+                        {row.sets.length > 0 && (
+                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.4, pl: 0.25 }}>
+                            {row.sets.map((s) => (
+                              <Chip
+                                key={s}
+                                label={s}
+                                size="small"
+                                sx={{
+                                  height: 18,
+                                  fontSize: '0.62rem',
+                                  fontWeight: 500,
+                                  maxWidth: '100%',
+                                  backgroundColor: `${accentColor}18`,
+                                  color: accentColor,
+                                  border: `1px solid ${accentColor}30`,
+                                  '& .MuiChip-label': { px: 0.5 },
+                                }}
+                              />
+                            ))}
+                          </Box>
+                        )}
+
+                        {/* Ultimate */}
                         {row.ultimate && (
+                          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5, pl: 0.25 }}>
+                            <Typography
+                              sx={{
+                                fontSize: '0.6rem',
+                                fontWeight: 700,
+                                color: 'text.disabled',
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.04em',
+                                flexShrink: 0,
+                              }}
+                            >
+                              Ult
+                            </Typography>
+                            <Typography
+                              sx={{
+                                fontSize: '0.7rem',
+                                color: 'text.secondary',
+                                fontWeight: 500,
+                              }}
+                            >
+                              {row.ultimate}
+                            </Typography>
+                          </Box>
+                        )}
+
+                        {/* Per-fight note */}
+                        {row.notes && (
                           <Typography
                             sx={{
                               fontSize: '0.68rem',
                               color: 'text.secondary',
                               fontStyle: 'italic',
+                              lineHeight: 1.45,
+                              pl: 0.25,
+                              borderTop: `1px dashed ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+                              pt: 0.4,
+                              mt: 0.1,
                             }}
                           >
-                            {row.ultimate}
+                            {row.notes}
                           </Typography>
                         )}
                       </Box>

--- a/src/pages/RosterViewPage.tsx
+++ b/src/pages/RosterViewPage.tsx
@@ -15,8 +15,14 @@ import {
   Extension as ExtensionIcon,
   OpenInNew as OpenInNewIcon,
   SwapHoriz as PerFightIcon,
+  ExpandMore as ExpandMoreIcon,
+  UnfoldMore as UnfoldMoreIcon,
+  UnfoldLess as UnfoldLessIcon,
 } from '@mui/icons-material';
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   Chip,
@@ -30,6 +36,7 @@ import {
   Alert,
   Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -68,6 +75,7 @@ import {
 } from '../types/trial-encounters';
 import { encodeBuildToURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
+import { buildSlotRows, summarizeFight } from '../utils/perFightRunSheet';
 import { buildVariantSx, getGearChipProps } from '../utils/playerCardStyleUtils';
 import { RICH_TOOLTIP_SLOT_PROPS } from '../utils/richTooltipSlotProps';
 import { DARK_ROLE_COLORS, LIGHT_ROLE_COLORS_SOLID } from '../utils/roleColors';
@@ -1153,7 +1161,16 @@ interface PerFightTrialGroupProps {
   trial: Trial;
   trialOverrides: TrialBuildOverrides;
   isDarkMode: boolean;
+  /** Deep-link target (?trial=&encounter=) so a linked fight starts expanded. */
+  deepLinkTarget?: { trial?: string; encounter?: string };
 }
+
+/** Short, color-coded pill for an encounter's type (boss / mini-boss / trash). */
+const ENCOUNTER_TYPE_LABEL: Record<string, string> = {
+  boss: 'Boss',
+  mini_boss: 'Mini-boss',
+  trash: 'Trash',
+};
 
 /** Read-only run-sheet group for ONE trial's per-fight overrides. */
 const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
@@ -1161,7 +1178,10 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
   trial,
   trialOverrides,
   isDarkMode,
+  deepLinkTarget,
 }) => {
+  const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
   const encountersWithOverrides = trial.encounters.filter((enc) =>
     encounterHasOverrides(trialOverrides.encounterBuilds[enc.id]),
   );
@@ -1170,9 +1190,42 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
   const bgColor = isDarkMode ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)';
   const accentColor = isDarkMode ? '#9c88ff' : '#6c5ce7';
 
+  // Expanded-fight state lives here (not per-card) so "Expand/Collapse all" and
+  // deep-link auto-expand can drive it. Initialized lazily: if this group is the
+  // deep-link target, its fight starts open so the first paint already shows it
+  // expanded — the retry-until-mounted scroll then lands on a rendered, open
+  // card (no expand-then-scroll race).
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    if (deepLinkTarget?.trial === trial.id && deepLinkTarget.encounter) {
+      return new Set([deepLinkTarget.encounter]);
+    }
+    return new Set();
+  });
+
+  const toggle = (encId: string): void => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(encId)) next.delete(encId);
+      else next.add(encId);
+      return next;
+    });
+  };
+  const expandAll = (): void => setExpanded(new Set(encountersWithOverrides.map((e) => e.id)));
+  const collapseAll = (): void => setExpanded(new Set());
+  const allExpanded =
+    encountersWithOverrides.length > 0 && expanded.size === encountersWithOverrides.length;
+
   return (
     <Box id={`pf-${trial.id}`} sx={{ mb: 2.5, scrollMarginTop: '80px' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.75 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          mb: 0.75,
+          flexWrap: 'wrap',
+        }}
+      >
         <Chip
           label={trial.shortName}
           size="small"
@@ -1200,6 +1253,33 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
             {encountersWithOverrides.length > 1 ? 's' : ''}
           </Typography>
         )}
+        {/* Expand / collapse all — only meaningful with 2+ collapsible fights. */}
+        {!trialOverrides.useSameBuildForAll && encountersWithOverrides.length > 1 && (
+          <Button
+            size="small"
+            disableRipple
+            onClick={allExpanded ? collapseAll : expandAll}
+            startIcon={
+              allExpanded ? (
+                <UnfoldLessIcon sx={{ fontSize: '0.9rem' }} />
+              ) : (
+                <UnfoldMoreIcon sx={{ fontSize: '0.9rem' }} />
+              )
+            }
+            sx={{
+              ml: 'auto',
+              minHeight: 32,
+              px: 1,
+              textTransform: 'none',
+              fontSize: '0.68rem',
+              fontWeight: 600,
+              color: accentColor,
+              '&:focus-visible': { outline: '2px solid #38bdf8', outlineOffset: '2px' },
+            }}
+          >
+            {allExpanded ? 'Collapse all' : 'Expand all'}
+          </Button>
+        )}
       </Box>
       {trialOverrides.useSameBuildForAll ? (
         <Paper
@@ -1219,76 +1299,156 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
           {encountersWithOverrides.map((enc) => {
             const overrides = trialOverrides.encounterBuilds[enc.id];
-            // Build player keys + labels from the roster composition
-            const playerKeys: string[] = [];
-            const labelMap: Record<string, string> = {};
-            roster.tanks.forEach((_, i) => {
-              const key = `tank:${i}`;
-              playerKeys.push(key);
-              labelMap[key] = i === 0 ? 'MT' : i === 1 ? 'OT' : `T${i + 1}`;
-            });
-            roster.healers.forEach((_, i) => {
-              const key = `healer:${i}`;
-              playerKeys.push(key);
-              labelMap[key] = `H${i + 1}`;
-            });
+            const summary = summarizeFight(roster, overrides);
+            const rows = buildSlotRows(roster, overrides);
+            const isOpen = expanded.has(enc.id);
+            const typeLabel = ENCOUNTER_TYPE_LABEL[enc.type] ?? enc.type;
 
             return (
-              <Paper
+              <Accordion
                 key={enc.id}
                 id={`pf-${trial.id}-${enc.id}`}
+                expanded={isOpen}
+                onChange={() => toggle(enc.id)}
+                disableGutters
+                square={false}
                 elevation={0}
+                slotProps={{ transition: { unmountOnExit: true, timeout: reduceMotion ? 0 : 200 } }}
                 sx={{
-                  p: 1.25,
                   borderRadius: '10px',
                   backgroundColor: bgColor,
                   border: `1px solid ${borderColor}`,
                   scrollMarginTop: '80px',
+                  overflow: 'hidden',
+                  '&::before': { display: 'none' },
+                  '&.Mui-expanded': { margin: 0 },
                 }}
               >
-                <Typography
+                <AccordionSummary
+                  expandIcon={<ExpandMoreIcon sx={{ fontSize: '1.1rem', color: accentColor }} />}
+                  aria-label={`${enc.name} — ${summary.slotCount} build${
+                    summary.slotCount === 1 ? '' : 's'
+                  }, ${isOpen ? 'collapse' : 'expand'}`}
                   sx={{
-                    fontSize: '0.72rem',
-                    fontWeight: 700,
-                    color: accentColor,
-                    mb: 0.5,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
+                    // Comfortable tap target on phones (WCAG 2.5.5 ≥44px).
+                    minHeight: { xs: 48, sm: 44 },
+                    px: 1.25,
+                    '& .MuiAccordionSummary-content': {
+                      my: 0.75,
+                      alignItems: 'center',
+                      gap: 0.75,
+                      flexWrap: 'wrap',
+                      minWidth: 0,
+                    },
+                    '&.Mui-focusVisible': {
+                      outline: '2px solid #38bdf8',
+                      outlineOffset: '-2px',
+                      backgroundColor: 'transparent',
+                    },
                   }}
                 >
-                  {enc.name}
-                </Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                  {playerKeys.map((key) => {
-                    const o = overrides?.slots?.[key];
-                    if (!o) return null;
-                    const sets = [
-                      o.set1
-                        ? getSetDisplayName(o.set1 as import('../types/abilities').KnownSetIDs)
-                        : null,
-                      o.set2
-                        ? getSetDisplayName(o.set2 as import('../types/abilities').KnownSetIDs)
-                        : null,
-                      o.monsterSet
-                        ? getSetDisplayName(
-                            o.monsterSet as import('../types/abilities').KnownSetIDs,
-                          )
-                        : null,
-                    ].filter(Boolean);
-                    if (!sets.length && !o.ultimate && !o.notes) return null;
-                    return (
-                      <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
+                  <Chip
+                    label={typeLabel}
+                    size="small"
+                    sx={{
+                      height: 17,
+                      fontSize: '0.55rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.04em',
+                      textTransform: 'uppercase',
+                      flexShrink: 0,
+                      backgroundColor:
+                        enc.type === 'boss'
+                          ? `${accentColor}22`
+                          : isDarkMode
+                            ? 'rgba(255,255,255,0.08)'
+                            : 'rgba(0,0,0,0.06)',
+                      color: enc.type === 'boss' ? accentColor : 'text.secondary',
+                      '& .MuiChip-label': { px: 0.6 },
+                    }}
+                  />
+                  <Typography
+                    sx={{
+                      fontSize: '0.78rem',
+                      fontWeight: 700,
+                      color: accentColor,
+                      letterSpacing: '0.01em',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {enc.name}
+                  </Typography>
+                  <Typography sx={{ fontSize: '0.66rem', color: 'text.disabled', flexShrink: 0 }}>
+                    {summary.slotCount} build{summary.slotCount === 1 ? '' : 's'}
+                  </Typography>
+                  {/* Teaser set names — hidden once expanded (full detail shows below)
+                      and on the very narrowest screens to protect the tap target. */}
+                  {!isOpen && summary.teaserSets.length > 0 && (
+                    <Box
+                      sx={{
+                        display: { xs: 'none', sm: 'flex' },
+                        alignItems: 'center',
+                        gap: 0.4,
+                        flexWrap: 'wrap',
+                        minWidth: 0,
+                      }}
+                    >
+                      {summary.teaserSets.map((s) => (
+                        <Chip
+                          key={s}
+                          label={s}
+                          size="small"
+                          sx={{
+                            height: 16,
+                            fontSize: '0.58rem',
+                            fontWeight: 500,
+                            maxWidth: 140,
+                            backgroundColor: `${accentColor}14`,
+                            color: accentColor,
+                            border: `1px solid ${accentColor}26`,
+                            '& .MuiChip-label': {
+                              px: 0.5,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                            },
+                          }}
+                        />
+                      ))}
+                      {summary.hasMoreSets && (
+                        <Typography sx={{ fontSize: '0.62rem', color: 'text.disabled' }}>
+                          +more
+                        </Typography>
+                      )}
+                    </Box>
+                  )}
+                </AccordionSummary>
+
+                <AccordionDetails sx={{ px: 1.25, pt: 0, pb: 1.25 }}>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    {rows.map((row) => (
+                      <Box
+                        key={row.key}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          // Wrap a slot's chips/ultimate to a new line on narrow
+                          // screens instead of overflowing the card horizontally.
+                          flexWrap: 'wrap',
+                          gap: 0.4,
+                        }}
+                      >
                         <Typography
                           sx={{
                             fontSize: '0.68rem',
                             fontWeight: 700,
                             color: 'text.disabled',
-                            minWidth: 20,
+                            minWidth: 24,
+                            flexShrink: 0,
                           }}
                         >
-                          {labelMap[key]}:
+                          {row.label}:
                         </Typography>
-                        {sets.map((s) => (
+                        {row.sets.map((s) => (
                           <Chip
                             key={s}
                             label={s}
@@ -1304,7 +1464,7 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
                             }}
                           />
                         ))}
-                        {o.ultimate && (
+                        {row.ultimate && (
                           <Typography
                             sx={{
                               fontSize: '0.68rem',
@@ -1312,63 +1472,14 @@ const PerFightTrialGroup: React.FC<PerFightTrialGroupProps> = ({
                               fontStyle: 'italic',
                             }}
                           >
-                            {o.ultimate}
+                            {row.ultimate}
                           </Typography>
                         )}
                       </Box>
-                    );
-                  })}
-                  {Object.entries(overrides?.slots ?? {})
-                    .filter(([key]) => key.startsWith('dps:'))
-                    .map(([key, slot]) => {
-                      const dpsIdx = parseInt(key.split(':')[1], 10);
-                      const sets = [
-                        slot.set1
-                          ? getSetDisplayName(slot.set1 as import('../types/abilities').KnownSetIDs)
-                          : null,
-                        slot.set2
-                          ? getSetDisplayName(slot.set2 as import('../types/abilities').KnownSetIDs)
-                          : null,
-                        slot.monsterSet
-                          ? getSetDisplayName(
-                              slot.monsterSet as import('../types/abilities').KnownSetIDs,
-                            )
-                          : null,
-                      ].filter(Boolean);
-                      if (!sets.length && !slot.ultimate && !slot.notes) return null;
-                      return (
-                        <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
-                          <Typography
-                            sx={{
-                              fontSize: '0.68rem',
-                              fontWeight: 700,
-                              color: 'text.disabled',
-                              minWidth: 20,
-                            }}
-                          >
-                            D{dpsIdx + 1}:
-                          </Typography>
-                          {sets.map((s) => (
-                            <Chip
-                              key={s}
-                              label={s}
-                              size="small"
-                              sx={{
-                                height: 16,
-                                fontSize: '0.6rem',
-                                fontWeight: 500,
-                                backgroundColor: `${accentColor}18`,
-                                color: accentColor,
-                                border: `1px solid ${accentColor}30`,
-                                '& .MuiChip-label': { px: 0.5 },
-                              }}
-                            />
-                          ))}
-                        </Box>
-                      );
-                    })}
-                </Box>
-              </Paper>
+                    ))}
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
             );
           })}
         </Box>
@@ -1381,6 +1492,8 @@ interface PerFightSectionProps {
   roster: RaidRoster;
   overridesMap: Record<string, TrialBuildOverrides>;
   isDarkMode: boolean;
+  /** Deep-link target (?trial=&encounter=) so a linked fight starts expanded. */
+  deepLinkTarget?: { trial?: string; encounter?: string };
 }
 
 /**
@@ -1389,7 +1502,12 @@ interface PerFightSectionProps {
  * that has overrides but lost its tag is appended so its work is never hidden.
  * A sticky jump-bar appears at 4+ trials.
  */
-const PerFightSection: React.FC<PerFightSectionProps> = ({ roster, overridesMap, isDarkMode }) => {
+const PerFightSection: React.FC<PerFightSectionProps> = ({
+  roster,
+  overridesMap,
+  isDarkMode,
+  deepLinkTarget,
+}) => {
   const accentColor = isDarkMode ? '#9c88ff' : '#6c5ce7';
 
   // Order: tagged trials first (in roster.trials order), then any orphaned populated trials.
@@ -1483,6 +1601,7 @@ const PerFightSection: React.FC<PerFightSectionProps> = ({ roster, overridesMap,
           trial={g.trial}
           trialOverrides={g.ov}
           isDarkMode={isDarkMode}
+          deepLinkTarget={deepLinkTarget}
         />
       ))}
     </Box>
@@ -2029,6 +2148,7 @@ export const RosterViewPage: React.FC = () => {
           roster={roster}
           overridesMap={roster.trialOverrides}
           isDarkMode={isDarkMode}
+          deepLinkTarget={deepLinkTarget}
         />
       )}
 

--- a/src/utils/perFightRunSheet.test.ts
+++ b/src/utils/perFightRunSheet.test.ts
@@ -1,0 +1,103 @@
+import { createDefaultRoster } from '../types/roster';
+import type { EncounterOverrides } from '../types/trial-encounters';
+import { buildSlotRows, summarizeFight } from './perFightRunSheet';
+
+// Real resolving set IDs (verified in SET_DISPLAY_NAMES):
+const LUCENT_ECHOES = 768;
+const PEARLESCENT_WARD = 648;
+const POWERFUL_ASSAULT = 180;
+const SPELL_POWER_CURE = 185;
+const RELEQUEN = 389;
+const SLIMECRAW = 270;
+
+describe('perFightRunSheet helpers', () => {
+  const roster = createDefaultRoster(); // 2 tanks, 2 healers, 8 dps
+
+  it('returns no rows for undefined overrides', () => {
+    expect(buildSlotRows(roster, undefined)).toEqual([]);
+    expect(summarizeFight(roster, undefined)).toEqual({
+      slotCount: 0,
+      teaserSets: [],
+      hasMoreSets: false,
+    });
+  });
+
+  it('orders rows tanks → healers → dps and labels MT/OT/H1/H2/D1…', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'dps:2': { set1: RELEQUEN },
+        'tank:0': { set1: PEARLESCENT_WARD, ultimate: 'Aggressive Horn' },
+        'healer:1': { set1: SPELL_POWER_CURE },
+        'tank:1': { set1: POWERFUL_ASSAULT },
+        'healer:0': { set1: LUCENT_ECHOES },
+      },
+    };
+    const rows = buildSlotRows(roster, overrides);
+    expect(rows.map((r) => r.label)).toEqual(['MT', 'OT', 'H1', 'H2', 'D3']);
+    expect(rows[0].sets).toContain('Pearlescent Ward');
+    expect(rows[0].ultimate).toBe('Aggressive Horn');
+  });
+
+  it('sorts dps slots numerically, not lexically', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'dps:10': { set1: RELEQUEN },
+        'dps:2': { set1: SLIMECRAW },
+        'dps:1': { set1: POWERFUL_ASSAULT },
+      },
+    };
+    const rows = buildSlotRows(roster, overrides);
+    expect(rows.map((r) => r.label)).toEqual(['D2', 'D3', 'D11']);
+  });
+
+  it('drops slots with no set, ultimate, or note', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': {}, // empty → dropped
+        'tank:1': { ultimate: 'Aggressive Horn' }, // ult only → kept
+        'healer:0': { notes: 'swap on add phase' }, // note only → kept
+      },
+    };
+    const rows = buildSlotRows(roster, overrides);
+    expect(rows.map((r) => r.label)).toEqual(['OT', 'H1']);
+  });
+
+  it('resolves set1 + set2 + monsterSet in order', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': { set1: PEARLESCENT_WARD, set2: POWERFUL_ASSAULT, monsterSet: SLIMECRAW },
+      },
+    };
+    const [row] = buildSlotRows(roster, overrides);
+    expect(row.sets).toEqual(['Pearlescent Ward', 'Powerful Assault', 'Slimecraw']);
+  });
+
+  it('summarizes populated slot count and a de-duplicated teaser', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': { set1: PEARLESCENT_WARD },
+        'tank:1': { set1: PEARLESCENT_WARD }, // duplicate set name
+        'healer:0': { set1: SPELL_POWER_CURE },
+        'healer:1': { set1: LUCENT_ECHOES },
+        'dps:0': { set1: RELEQUEN },
+      },
+    };
+    const summary = summarizeFight(roster, overrides);
+    expect(summary.slotCount).toBe(5);
+    // Distinct sets: Pearlescent Ward, Spell Power Cure, Lucent Echoes, Relequen → 4
+    expect(summary.teaserSets).toEqual(['Pearlescent Ward', 'Spell Power Cure', 'Lucent Echoes']);
+    expect(summary.hasMoreSets).toBe(true);
+  });
+
+  it('reports hasMoreSets=false when distinct sets fit the teaser', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': { set1: PEARLESCENT_WARD },
+        'healer:0': { set1: SPELL_POWER_CURE },
+      },
+    };
+    const summary = summarizeFight(roster, overrides);
+    expect(summary.teaserSets).toEqual(['Pearlescent Ward', 'Spell Power Cure']);
+    expect(summary.hasMoreSets).toBe(false);
+  });
+});

--- a/src/utils/perFightRunSheet.test.ts
+++ b/src/utils/perFightRunSheet.test.ts
@@ -38,6 +38,35 @@ describe('perFightRunSheet helpers', () => {
     expect(rows[0].ultimate).toBe('Aggressive Horn');
   });
 
+  it('resolves player names from the base roster slots when assigned', () => {
+    const named = createDefaultRoster();
+    named.tanks[0].playerName = 'Vael';
+    named.healers[1].playerName = 'Liora';
+    // dps base slots intentionally left unnamed (common for set-only rosters)
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': { set1: PEARLESCENT_WARD },
+        'healer:1': { set1: SPELL_POWER_CURE },
+        'dps:0': { set1: RELEQUEN },
+      },
+    };
+    const rows = buildSlotRows(named, overrides);
+    const byLabel = Object.fromEntries(rows.map((r) => [r.label, r.playerName]));
+    expect(byLabel.MT).toBe('Vael');
+    expect(byLabel.H2).toBe('Liora');
+    expect(byLabel.D1).toBeUndefined();
+  });
+
+  it('carries the per-slot note through to the row', () => {
+    const overrides: EncounterOverrides = {
+      slots: {
+        'tank:0': { set1: PEARLESCENT_WARD, notes: 'Taunt swap at 50%.' },
+      },
+    };
+    const [row] = buildSlotRows(roster, overrides);
+    expect(row.notes).toBe('Taunt swap at 50%.');
+  });
+
   it('sorts dps slots numerically, not lexically', () => {
     const overrides: EncounterOverrides = {
       slots: {

--- a/src/utils/perFightRunSheet.ts
+++ b/src/utils/perFightRunSheet.ts
@@ -18,6 +18,8 @@ export interface SlotRow {
   key: string;
   /** Short role label shown to the user, e.g. "MT", "OT", "H1", "D3". */
   label: string;
+  /** Player name from the base roster slot, when one is assigned. */
+  playerName?: string;
   /** Resolved set display names (set1, set2, monster) in order, empties dropped. */
   sets: string[];
   /** Optional ultimate name. */
@@ -70,13 +72,14 @@ export function buildSlotRows(
   if (!overrides) return [];
   const rows: SlotRow[] = [];
 
-  roster.tanks.forEach((_, i) => {
+  roster.tanks.forEach((tank, i) => {
     const key = `tank:${i}`;
     const o = overrides.slots?.[key];
     if (o && slotHasContent(o)) {
       rows.push({
         key,
         label: tankLabel(i),
+        playerName: tank?.playerName || undefined,
         sets: resolveSets(o),
         ultimate: o.ultimate,
         notes: o.notes,
@@ -84,13 +87,14 @@ export function buildSlotRows(
     }
   });
 
-  roster.healers.forEach((_, i) => {
+  roster.healers.forEach((healer, i) => {
     const key = `healer:${i}`;
     const o = overrides.slots?.[key];
     if (o && slotHasContent(o)) {
       rows.push({
         key,
         label: `H${i + 1}`,
+        playerName: healer?.playerName || undefined,
         sets: resolveSets(o),
         ultimate: o.ultimate,
         notes: o.notes,
@@ -107,6 +111,7 @@ export function buildSlotRows(
         rows.push({
           key,
           label: `D${dpsIdx + 1}`,
+          playerName: roster.dpsSlots?.[dpsIdx]?.playerName || undefined,
           sets: resolveSets(o),
           ultimate: o.ultimate,
           notes: o.notes,

--- a/src/utils/perFightRunSheet.ts
+++ b/src/utils/perFightRunSheet.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure helpers for the read-only "/rv" run-sheet per-fight builds view.
+ *
+ * Extracted from RosterViewPage so the collapsed-summary and slot-row
+ * derivation can be unit-tested without React. These functions never mutate
+ * the roster/override model (it is encoded into shared ?r= URLs).
+ */
+
+import type { KnownSetIDs } from '../types/abilities';
+import type { RaidRoster } from '../types/roster';
+import type { EncounterOverrides, PlayerOverride } from '../types/trial-encounters';
+
+import { getSetDisplayName } from './setNameUtils';
+
+/** One resolved player-slot row in a fight's build detail. */
+export interface SlotRow {
+  /** SlotKey, e.g. "tank:0" | "healer:1" | "dps:3". */
+  key: string;
+  /** Short role label shown to the user, e.g. "MT", "OT", "H1", "D3". */
+  label: string;
+  /** Resolved set display names (set1, set2, monster) in order, empties dropped. */
+  sets: string[];
+  /** Optional ultimate name. */
+  ultimate?: string | null;
+  /** Optional free-text note. */
+  notes?: string;
+}
+
+/** Compact summary used to render a collapsed fight card. */
+export interface FightSummary {
+  /** Number of player slots that carry a real override in this fight. */
+  slotCount: number;
+  /** A few of the most notable set names, for a teaser line. */
+  teaserSets: string[];
+  /** True when there are more distinct sets than the teaser shows. */
+  hasMoreSets: boolean;
+}
+
+/** Role label for a tank slot: MT, OT, then T3, T4… */
+function tankLabel(index: number): string {
+  if (index === 0) return 'MT';
+  if (index === 1) return 'OT';
+  return `T${index + 1}`;
+}
+
+/** Resolve a slot's set IDs to display names, dropping empties. */
+function resolveSets(override: PlayerOverride): string[] {
+  return [
+    override.set1 ? getSetDisplayName(override.set1 as KnownSetIDs) : null,
+    override.set2 ? getSetDisplayName(override.set2 as KnownSetIDs) : null,
+    override.monsterSet ? getSetDisplayName(override.monsterSet as KnownSetIDs) : null,
+  ].filter((s): s is string => Boolean(s));
+}
+
+/** Does a slot carry anything worth rendering (a set, an ultimate, or a note)? */
+function slotHasContent(override: PlayerOverride): boolean {
+  const sets = resolveSets(override);
+  return sets.length > 0 || Boolean(override.ultimate) || Boolean(override.notes);
+}
+
+/**
+ * Build the ordered, resolved slot rows for one fight: tanks (by composition),
+ * then healers (by composition), then any DPS slots present in the overrides
+ * (numerically by index). Only slots with real content are returned.
+ */
+export function buildSlotRows(
+  roster: RaidRoster,
+  overrides: EncounterOverrides | undefined,
+): SlotRow[] {
+  if (!overrides) return [];
+  const rows: SlotRow[] = [];
+
+  roster.tanks.forEach((_, i) => {
+    const key = `tank:${i}`;
+    const o = overrides.slots?.[key];
+    if (o && slotHasContent(o)) {
+      rows.push({
+        key,
+        label: tankLabel(i),
+        sets: resolveSets(o),
+        ultimate: o.ultimate,
+        notes: o.notes,
+      });
+    }
+  });
+
+  roster.healers.forEach((_, i) => {
+    const key = `healer:${i}`;
+    const o = overrides.slots?.[key];
+    if (o && slotHasContent(o)) {
+      rows.push({
+        key,
+        label: `H${i + 1}`,
+        sets: resolveSets(o),
+        ultimate: o.ultimate,
+        notes: o.notes,
+      });
+    }
+  });
+
+  Object.entries(overrides.slots ?? {})
+    .filter(([key]) => key.startsWith('dps:'))
+    .sort(([a], [b]) => parseInt(a.split(':')[1], 10) - parseInt(b.split(':')[1], 10))
+    .forEach(([key, o]) => {
+      if (slotHasContent(o)) {
+        const dpsIdx = parseInt(key.split(':')[1], 10);
+        rows.push({
+          key,
+          label: `D${dpsIdx + 1}`,
+          sets: resolveSets(o),
+          ultimate: o.ultimate,
+          notes: o.notes,
+        });
+      }
+    });
+
+  return rows;
+}
+
+/**
+ * Compute the collapsed-card summary for a fight: how many slots are populated
+ * and a short, de-duplicated teaser of the most notable set names.
+ */
+export function summarizeFight(
+  roster: RaidRoster,
+  overrides: EncounterOverrides | undefined,
+  teaserLimit = 3,
+): FightSummary {
+  const rows = buildSlotRows(roster, overrides);
+  const seen = new Set<string>();
+  const distinctSets: string[] = [];
+  for (const row of rows) {
+    for (const s of row.sets) {
+      if (!seen.has(s)) {
+        seen.add(s);
+        distinctSets.push(s);
+      }
+    }
+  }
+  return {
+    slotCount: rows.length,
+    teaserSets: distinctSets.slice(0, teaserLimit),
+    hasMoreSets: distinctSets.length > teaserLimit,
+  };
+}


### PR DESCRIPTION
## What

Redesigns the read-only **/rv run sheet** per-fight builds so each fight starts **collapsed** as a compact, scannable summary and **expands on demand** into the full per-slot detail. Previously every fight rendered always-expanded as a cramped wall of role chip-rows (MT/OT/H1/H2/D1…), turning a multi-trial roster into an overwhelming blob.

## How

- **Collapsible fights** — each fight is a controlled MUI `Accordion`. The collapsed summary shows: encounter-type pill (Boss/Mini-boss/Trash) · boss name · "N builds" · 2–3 teaser set chips · chevron. Expanding reveals the full slot rows (unchanged content).
- **Expand/Collapse all** — per-trial control in each trial header (shown when a trial has 2+ collapsible fights).
- **Deep-link auto-expand** — a fight linked via `?trial=&encounter=` initializes **expanded at first paint**, so the existing retry-until-mounted scroll lands on an already-open card (no expand-then-scroll race). Anchor IDs `pf-<trialId>` and `pf-<trialId>-<encId>` preserved; jump-bar and deep-linking unaffected.
- **Mobile-first & a11y** — 48px summary tap targets (WCAG 2.5.5), per-row `flexWrap` so expanded detail never overflows horizontally, focus-visible rings, keyboard disclosure (Enter/Space toggle), and `prefers-reduced-motion` honored on the expand transition.
- **Folds in #1252** — includes that PR's role-row `flexWrap` mobile-overflow fix; **supersedes and replaces #1252**.
- **Refactor** — extracts the slot-row + collapsed-summary derivation into a pure, unit-tested helper (`src/utils/perFightRunSheet.ts`, +7 tests) instead of duplicating it inline.

The data model is unchanged (still encoded into shared `?r=` URLs).

## Verification

Verified live on a vite dev server via Chrome MCP with a multi-trial test roster (6 trials tagged; per-fight builds for Rockgrove/Kyne's Aegis/Lucent Citadel), at **desktop 1440×900** and **mobile 390×844**, both light & dark themes:

- ✅ Cards start collapsed; clicking expands the full 8-row detail (MT/OT/H1/H2/D1–D4 with sets + ultimates)
- ✅ Expand all / Collapse all toggles every fight in a trial
- ✅ Jump-bar still scrolls (lands at `scrollMarginTop`)
- ✅ Deep-link `?trial=rockgrove&encounter=boss_3` scrolls to **and** auto-expands Xalvakka, neighbors stay collapsed
- ✅ **0 horizontal overflow** at 390px (`scrollWidth − clientWidth === 0`) with cards expanded
- ✅ Keyboard: summary focusable, Enter/Space toggle, focus-visible cyan ring renders
- ✅ Same-build branch (`useSameBuildForAll`) is unchanged legacy JSX and excluded from the expand-all control

`tsc`, eslint, prettier `--check`, `vite build`, and the roster test suites (122 tests incl. 7 new helper tests) all green.

> Note: `useSameBuildForAll` trials with empty `encounterBuilds` are dropped by the encoder during the `?r=` round-trip, so that single-card branch is not reachable via a shared URL — its JSX is identical to the prior implementation and verified by inspection.