### PR TITLE
fix(roster-builder): keep Quick Assign popover within the viewport on mobile

### DIFF
--- a/src/components/SetAssignmentManager.tsx
+++ b/src/components/SetAssignmentManager.tsx
@@ -1921,7 +1921,10 @@ export const SetAssignmentManager: React.FC<SetAssignmentManagerProps> = ({
         slotProps={{
           paper: {
             sx: {
-              maxHeight: 560,
+              // Never taller than the visible viewport (dvh accounts for the
+              // mobile browser toolbars), so the popover can't run off-screen and
+              // force the page behind it to scroll to reveal the lower roles.
+              maxHeight: 'min(560px, calc(100dvh - 24px))',
               minWidth: { xs: 'calc(100vw - 32px)', sm: 500 },
               borderRadius: '14px',
               border: isDarkMode
@@ -1933,13 +1936,29 @@ export const SetAssignmentManager: React.FC<SetAssignmentManagerProps> = ({
                 ? '0 24px 64px rgba(0,0,0,0.85), 0 0 0 1px rgba(255,255,255,0.04), inset 0 1px 0 rgba(255,255,255,0.06)'
                 : '0 16px 48px rgba(0,0,0,0.12), 0 4px 12px rgba(0,0,0,0.06)',
               overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column',
+            },
+          },
+          // Lay the menu list out as a flex column so the header can stay pinned
+          // while only the body scrolls. Drop the default MenuList vertical
+          // padding so the header sits flush against the paper edge.
+          list: {
+            sx: {
+              p: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              flex: 1,
+              minHeight: 0,
+              overflow: 'hidden',
             },
           },
         }}
       >
-        {/* Header */}
+        {/* Header — pinned so it stays visible while the body scrolls */}
         <Box
           sx={{
+            flexShrink: 0,
             px: 2,
             py: 1.5,
             background: isDarkMode
@@ -1970,9 +1989,15 @@ export const SetAssignmentManager: React.FC<SetAssignmentManagerProps> = ({
           </Typography>
         </Box>
 
-        {/* Two-column body */}
+        {/* Two-column body — the only scrollable region. overscroll-behavior
+            keeps a touch scroll from chaining to the page behind the popover. */}
         <Box
           sx={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: 'auto',
+            overscrollBehavior: 'contain',
+            WebkitOverflowScrolling: 'touch',
             px: { xs: 1, sm: 1.5 },
             pt: 1.25,
             pb: 1.25,


### PR DESCRIPTION
## Problem

On mobile, the roster builder's **Quick Assign** popover (the `Menu` in `SetAssignmentManager`) runs off the bottom of the screen, and the only way to reach the lower roles is to scroll the page *behind* the popover.

This is a regression surfaced by #1250 ("rebuild All Sets tab"). That PR didn't touch the popover markup, but it made the popover reachable for any assignable 5-piece set (e.g. *Agility*) via the new All Sets browser. A 5-piece set renders **Set 1 + Set 2 for every tank and healer**; on mobile those role cards stack into a single column, so the popover is now taller than a phone screen.

The popover paper was configured with a fixed `maxHeight: 560` + `overflow: 'hidden'` and **no viewport cap**, so the overflowing content was clipped/cut off (visible in the report — H2's "Set 2" jammed against the bottom toolbar) and unreachable except by scrolling the page underneath.

## Fix

- Cap the paper to the visible viewport: `maxHeight: min(560px, calc(100dvh - 24px))` (`dvh` accounts for mobile browser toolbars), so it can never extend past the screen.
- Lay the menu out as a flex column: the **header is pinned** and the **two-column body is the only scroll region**.
- Add `overscroll-behavior: contain` to the body so a touch scroll no longer chains to the page behind the popover.

No functional/behavioral change to assignment logic — purely a layout/scroll-containment fix.

## Verification

- `npm run typecheck` — passes
- `eslint src/components/SetAssignmentManager.tsx` — clean
- `SetAssignmentManager.test.tsx` — passes (2/2)

In-browser visual verification wasn't possible in this environment (no Chromium available and the download is network-blocked), so this was verified via the type/lint/test suite and code review of the MUI `Menu`/`Popover` layout.

https://claude.ai/code/session_01D9Q7QTjCaE4Gq57s9NomWg

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9Q7QTjCaE4Gq57s9NomWg)_