### PR TITLE
feat(calculator): Gear Upgrade Optimizer — third /calculator pill

### DIFF
--- a/src/components/CalculatorPage.tsx
+++ b/src/components/CalculatorPage.tsx
@@ -1,7 +1,7 @@
 /**
  * /calculator host page — a top-level tab switcher between the existing stat
- * calculator (Penetration / Critical / Armor), the Ultimate Calculator, and the
- * Scribing planner.
+ * calculator (Penetration / Critical / Armor), the Ultimate Calculator, the
+ * Scribing planner, and the Gear Upgrade optimizer.
  *
  * The Stats tab renders the original `Calculator` unchanged, so its sticky
  * footer and internal pen/crit/armor tabs keep working exactly as before — this
@@ -12,7 +12,12 @@
  * the user is already on /calculator.
  */
 
-import { BoltOutlined, HistoryEduOutlined, TuneOutlined } from '@mui/icons-material';
+import {
+  BoltOutlined,
+  HistoryEduOutlined,
+  TrendingUpOutlined,
+  TuneOutlined,
+} from '@mui/icons-material';
 import { Box, Container, Tab, Tabs } from '@mui/material';
 import React, { Suspense } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -34,11 +39,17 @@ const ScribingSimulator = React.lazy(() =>
   })),
 );
 
-type TopTab = 'stats' | 'ultimate' | 'scribing';
+const GearUpgradeCalculator = React.lazy(() =>
+  import('@features/gear-upgrade/GearUpgradeCalculator').then((m) => ({
+    default: m.GearUpgradeCalculator,
+  })),
+);
 
-const VALID_TABS: readonly TopTab[] = ['stats', 'ultimate', 'scribing'];
+type TopTab = 'stats' | 'ultimate' | 'scribing' | 'gear';
 
-/** Map the URL hash (#ultimate / #scribing) to a tab, defaulting to Stats. */
+const VALID_TABS: readonly TopTab[] = ['stats', 'ultimate', 'scribing', 'gear'];
+
+/** Map the URL hash (#ultimate / #scribing / #gear) to a tab, defaulting to Stats. */
 function tabFromHash(hash: string): TopTab {
   const h = hash.replace('#', '').toLowerCase();
   return (VALID_TABS as readonly string[]).includes(h) ? (h as TopTab) : 'stats';
@@ -73,10 +84,12 @@ export const CalculatorPage: React.FC = () => {
           value={tab}
           onChange={handleChange}
           aria-label="Calculator type"
-          variant="standard"
+          variant="scrollable"
+          scrollButtons={false}
           sx={(theme) => ({
             minHeight: 46,
             display: 'inline-flex',
+            maxWidth: '100%',
             p: 0.5,
             borderRadius: 3,
             border: `1px solid ${theme.palette.divider}`,
@@ -88,11 +101,15 @@ export const CalculatorPage: React.FC = () => {
             // filled pill behind the active tab instead.
             '& .MuiTabs-indicator': { display: 'none' },
             '& .MuiTabs-flexContainer': { gap: 0.5 },
+            // Let the pills swipe-scroll horizontally when they overflow a narrow
+            // screen instead of being clipped.
+            '& .MuiTabs-scroller': { overflowX: 'auto !important' },
             '& .MuiTab-root': {
               textTransform: 'none',
               fontWeight: 600,
               minHeight: 38,
               borderRadius: 2.25,
+              whiteSpace: 'nowrap',
               px: { xs: 1.5, sm: 2 },
               color: theme.palette.text.secondary,
               transition: 'background-color 0.18s ease, color 0.18s ease',
@@ -144,6 +161,12 @@ export const CalculatorPage: React.FC = () => {
             iconPosition="start"
             label="Scribing"
           />
+          <Tab
+            value="gear"
+            icon={<TrendingUpOutlined fontSize="small" />}
+            iconPosition="start"
+            label="Gear Upgrades"
+          />
         </Tabs>
       </Container>
 
@@ -176,6 +199,14 @@ export const CalculatorPage: React.FC = () => {
             <ScribingSimulator />
           </Suspense>
         </Box>
+      )}
+
+      {tab === 'gear' && (
+        <Container maxWidth="lg" sx={{ py: 3 }}>
+          <Suspense fallback={<UltimateCalculatorSkeleton />}>
+            <GearUpgradeCalculator />
+          </Suspense>
+        </Container>
       )}
     </Box>
   );

--- a/src/components/__tests__/CalculatorPage.test.tsx
+++ b/src/components/__tests__/CalculatorPage.test.tsx
@@ -24,6 +24,13 @@ jest.mock(
   }),
   { virtual: true },
 );
+jest.mock(
+  '@features/gear-upgrade/GearUpgradeCalculator',
+  () => ({
+    GearUpgradeCalculator: () => <div data-testid="gear-upgrade-calculator">GEAR UPGRADES</div>,
+  }),
+  { virtual: true },
+);
 
 import { CalculatorPage } from '../CalculatorPage';
 
@@ -40,13 +47,25 @@ function renderPage(initialPath = '/calculator') {
 }
 
 describe('CalculatorPage', () => {
-  it('shows all three top-level tabs and defaults to Stats', () => {
+  it('shows all top-level tabs and defaults to Stats', () => {
     renderPage();
     expect(screen.getByRole('tab', { name: /Stats/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Ultimate/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Scribing/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Gear Upgrades/i })).toBeInTheDocument();
     // Stat calculator is rendered by default.
     expect(screen.getByTestId('stat-calculator')).toBeInTheDocument();
+  });
+
+  it('switches to the Gear Upgrades tab and lazy-loads the optimizer', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('tab', { name: /Gear Upgrades/i }));
+    await waitFor(() => expect(screen.getByTestId('gear-upgrade-calculator')).toBeInTheDocument());
+  });
+
+  it('honors a #gear deep-link on first render', async () => {
+    renderPage('/calculator#gear');
+    await waitFor(() => expect(screen.getByTestId('gear-upgrade-calculator')).toBeInTheDocument());
   });
 
   it('switches to the Ultimate tab and lazy-loads the calculator', async () => {

--- a/src/features/gear-upgrade/GearUpgradeCalculator.tsx
+++ b/src/features/gear-upgrade/GearUpgradeCalculator.tsx
@@ -1,0 +1,676 @@
+import {
+  AutoAwesomeOutlined,
+  AutoFixHighOutlined,
+  EmojiEventsOutlined,
+  InfoOutlined,
+  ShieldMoonOutlined,
+  TrendingUpOutlined,
+  TuneOutlined,
+  WorkspacePremiumOutlined,
+} from '@mui/icons-material';
+import {
+  Box,
+  Checkbox,
+  Chip,
+  Container,
+  FormControlLabel,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { alpha, type SxProps, type Theme } from '@mui/material/styles';
+import React, { useMemo, useState } from 'react';
+
+import { CRIT_OPTIMAL_MIN, PEN_OPTIMAL_MIN_PVE } from '@/data/skill-lines/calculator-data';
+
+import { GUIDE_INTRO, UPGRADE_CATALOG, WEAPON_TRAIT_GUIDE } from './engine/gear-upgrade-catalog';
+import { computeUpgrades } from './engine/gearUpgradeEngine';
+import type { BuildBaseline, MundusStone, UpgradeResult } from './engine/types';
+
+const BASE_CRIT_DAMAGE_CAP = 125;
+const RAISED_CRIT_DAMAGE_CAP = 155; // +30 from Nightblade's Above and Beyond
+const DEFAULT_FRONT_BAR_SHARE = 0.8; // most builds do the bulk of damage on the front bar
+
+// Below this, an upgrade is effectively a no-op for this build (e.g. penetration
+// when already at the resistance cap) — shown as "at cap" rather than "+0.00%".
+const NEGLIGIBLE_PCT = 0.01;
+
+const NUMERAL_FONT = 'Space Grotesk, Inter, system-ui';
+const GUIDE_ACCENT = '#f5a524'; // warm amber for the qualitative weapon-trait section
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+// Trial boss / 21M dummy resistance — the same 18,200 the pen target is set to cancel.
+const TRIAL_TARGET_RESISTANCE = 18200;
+
+/**
+ * Preset stat values, fully raid-buffed on a trial boss (the state the optimizer
+ * assumes). The two anchors below come straight from the repo's calculator
+ * constants so they can't drift:
+ *   • Penetration  → PEN_OPTIMAL_MIN_PVE (18,200) — the trial pen target/cap.
+ *   • Crit Damage  → CRIT_OPTIMAL_MIN (125) — the in-game crit-damage cap a
+ *                    min-maxed build sits at (Shadow + Major/Minor Force + sets).
+ *
+ * Weapon/Spell Damage, Max stat, and Crit Chance are NOT carried by ESO Logs
+ * (that's the gap the ESOTK Companion add-on fills), so they're representative
+ * end-game raid-buffed values, not log-derived — tune freely per build.
+ */
+const MAGICKA_DPS: BuildBaseline = {
+  weaponOrSpellDamage: 7500,
+  maxStat: 42000,
+  critChancePct: 70,
+  critDamagePct: CRIT_OPTIMAL_MIN,
+  penetration: PEN_OPTIMAL_MIN_PVE,
+  targetResistance: TRIAL_TARGET_RESISTANCE,
+  mundus: 'thief',
+  critDamageCapPct: BASE_CRIT_DAMAGE_CAP,
+  frontBarDamageShare: DEFAULT_FRONT_BAR_SHARE,
+};
+
+const STAMINA_DPS: BuildBaseline = {
+  weaponOrSpellDamage: 7800,
+  maxStat: 38000,
+  critChancePct: 75,
+  critDamagePct: CRIT_OPTIMAL_MIN,
+  penetration: PEN_OPTIMAL_MIN_PVE,
+  targetResistance: TRIAL_TARGET_RESISTANCE,
+  mundus: 'thief',
+  critDamageCapPct: BASE_CRIT_DAMAGE_CAP,
+  frontBarDamageShare: DEFAULT_FRONT_BAR_SHARE,
+};
+
+// Fresh CP160, self-buffed, not yet min-maxed: under the pen cap and well below
+// the crit-damage cap, so quality/enchant/pen upgrades rank highly.
+const NEW_CHARACTER: BuildBaseline = {
+  weaponOrSpellDamage: 3500,
+  maxStat: 32000,
+  critChancePct: 35,
+  critDamagePct: 60,
+  penetration: 8000,
+  targetResistance: TRIAL_TARGET_RESISTANCE,
+  mundus: 'thief',
+  critDamageCapPct: BASE_CRIT_DAMAGE_CAP,
+  frontBarDamageShare: DEFAULT_FRONT_BAR_SHARE,
+};
+
+// Mid-progression DPS: under the pen and crit-damage caps, so the first view a
+// visitor sees has pen / crit / quality / enchant upgrades all in play — the
+// state where a "what should I upgrade next?" tool is most useful. The fully
+// capped Magicka/Stamina presets are one tap away for min-maxers.
+const MID_DPS: BuildBaseline = {
+  weaponOrSpellDamage: 5500,
+  maxStat: 36000,
+  critChancePct: 55,
+  critDamagePct: 100,
+  penetration: 15000,
+  targetResistance: TRIAL_TARGET_RESISTANCE,
+  mundus: 'thief',
+  critDamageCapPct: BASE_CRIT_DAMAGE_CAP,
+  frontBarDamageShare: DEFAULT_FRONT_BAR_SHARE,
+};
+
+const DEFAULT_BASELINE: BuildBaseline = MID_DPS;
+
+/** One-tap starting points so users aren't faced with a blank stat form. */
+const PRESETS: { label: string; baseline: BuildBaseline }[] = [
+  { label: 'Mid-game DPS', baseline: MID_DPS },
+  { label: 'Magicka DPS', baseline: MAGICKA_DPS },
+  { label: 'Stamina DPS', baseline: STAMINA_DPS },
+  { label: 'New character', baseline: NEW_CHARACTER },
+];
+
+const MUNDUS_OPTIONS: { value: MundusStone; label: string }[] = [
+  { value: 'thief', label: 'The Thief (Crit Chance)' },
+  { value: 'shadow', label: 'The Shadow (Crit Damage)' },
+  { value: 'warrior', label: 'The Warrior (Weapon Dmg)' },
+  { value: 'apprentice', label: 'The Apprentice (Spell Dmg)' },
+  { value: 'lover', label: 'The Lover (Penetration)' },
+  { value: 'mage', label: 'The Mage (Max Stat)' },
+  { value: 'other', label: 'Other (no damage stat)' },
+];
+
+interface StatField {
+  key: keyof BuildBaseline;
+  label: string;
+  help: string;
+}
+
+const CHARACTER_FIELDS: StatField[] = [
+  { key: 'weaponOrSpellDamage', label: 'Weapon/Spell Dmg', help: 'Your higher of the two.' },
+  { key: 'maxStat', label: 'Max Mag/Stam', help: 'The resource your damage scales off.' },
+  { key: 'critChancePct', label: 'Crit Chance %', help: 'Total, including the 10% base.' },
+  { key: 'critDamagePct', label: 'Crit Damage %', help: 'Total, including the 50% base.' },
+  { key: 'penetration', label: 'Penetration', help: 'Your offensive penetration.' },
+  { key: 'targetResistance', label: 'Target Resistance', help: 'Trial boss ≈ 18,200.' },
+];
+
+const CATEGORY_META: Record<UpgradeResult['group'], { label: string; icon: React.ReactNode }> = {
+  trait: { label: 'Trait', icon: <AutoAwesomeOutlined fontSize="small" /> },
+  quality: { label: 'Quality', icon: <WorkspacePremiumOutlined fontSize="small" /> },
+  enchant: { label: 'Enchant', icon: <AutoFixHighOutlined fontSize="small" /> },
+};
+
+type CategoryFilter = 'all' | UpgradeResult['group'];
+
+const CONFIDENCE_LABEL = {
+  high: 'Verified',
+  medium: 'Estimate',
+  low: 'Rough estimate',
+} as const;
+
+/** Magnitude → accent colour, so the big wins read instantly. */
+function gainColor(theme: Theme, pct: number): string {
+  if (pct < NEGLIGIBLE_PCT) return theme.palette.text.disabled;
+  if (pct >= 1) return theme.palette.success.main;
+  if (pct >= 0.3) return theme.palette.primary.main;
+  return theme.palette.text.secondary;
+}
+
+/**
+ * Shared panel surface, matching the Ultimate Calculator / Aurora restyle: a
+ * recessed cyan-glass mid-layer in dark mode, with a faint cyan border, a glossy
+ * top inset highlight, and a soft drop shadow so nested cards read as raised.
+ */
+const panelSx = (theme: Theme): SxProps<Theme> => ({
+  p: { xs: 2, sm: 2.5 },
+  borderRadius: 2.8, // 28px — top-level panel tier
+  border: `1px solid ${
+    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.12)' : theme.palette.divider
+  }`,
+  background:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg, rgba(14,22,42,0.74) 0%, rgba(3,9,20,0.82) 100%)'
+      : 'linear-gradient(180deg, rgb(40 145 200 / 6%) 0%, rgba(248, 250, 252, 0.9) 100%)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0 14px 36px rgba(0,0,0,0.44), inset 0 1px 0 rgba(255,255,255,0.05)'
+      : '0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03)',
+});
+
+/** Raised inner card (14px tier) that lifts off the recessed panel. */
+const cardSx = (theme: Theme): SxProps<Theme> => ({
+  borderRadius: 1.4,
+  border: `1px solid ${
+    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.16)' : theme.palette.divider
+  }`,
+  background:
+    theme.palette.mode === 'dark'
+      ? 'linear-gradient(180deg, rgba(56,189,248,0.09) 0%, rgba(56,189,248,0.02) 100%)'
+      : 'rgba(255,255,255,0.6)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? 'inset 0 1px 0 rgba(255,255,255,0.07), 0 6px 16px rgba(0,0,0,0.34)'
+      : '0 2px 8px rgba(15,23,42,0.05)',
+});
+
+/** Accent "eyebrow" that opens each section, with an icon chip. */
+const SectionHeader: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  accent: string;
+  action?: React.ReactNode;
+}> = ({ icon, title, accent, action }) => (
+  <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1.75 }}>
+    <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', minWidth: 0 }}>
+      <Box
+        aria-hidden
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 30,
+          height: 30,
+          borderRadius: 2,
+          color: accent,
+          background: `${accent}1f`,
+          border: `1px solid ${accent}33`,
+          '& svg': { fontSize: 18 },
+        }}
+      >
+        {icon}
+      </Box>
+      <Typography variant="subtitle1" sx={{ fontWeight: 700, letterSpacing: 0.1, lineHeight: 1.2 }}>
+        {title}
+      </Typography>
+    </Stack>
+    {action}
+  </Stack>
+);
+
+export const GearUpgradeCalculator: React.FC = () => {
+  const theme = useTheme();
+  const accent = theme.palette.primary.main;
+  const [baseline, setBaseline] = useState<BuildBaseline>(DEFAULT_BASELINE);
+  const [filter, setFilter] = useState<CategoryFilter>('all');
+
+  const results = useMemo(() => computeUpgrades(UPGRADE_CATALOG, baseline), [baseline]);
+  const maxPct = useMemo(
+    () => results.reduce((m, r) => Math.max(m, r.dmgIncreasePct), 0),
+    [results],
+  );
+  const visible = useMemo(
+    () => (filter === 'all' ? results : results.filter((r) => r.group === filter)),
+    [results, filter],
+  );
+  const topPick = results.find((r) => r.dmgIncreasePct >= NEGLIGIBLE_PCT) ?? null;
+
+  const setStat = (key: keyof BuildBaseline, raw: string): void => {
+    const value = Number(raw);
+    if (Number.isNaN(value)) return;
+    setBaseline((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const raisedCap = (baseline.critDamageCapPct ?? BASE_CRIT_DAMAGE_CAP) > BASE_CRIT_DAMAGE_CAP;
+
+  const inputSx: SxProps<Theme> = {
+    '& .MuiOutlinedInput-root': {
+      borderRadius: 1.25,
+      backgroundColor:
+        theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.05)' : 'rgba(255,255,255,0.7)',
+    },
+  };
+
+  const helperSx = { sx: { mx: 0, fontSize: '0.68rem', lineHeight: 1.3 } };
+
+  const renderField = ({ key, label, help }: StatField): React.ReactNode => (
+    <TextField
+      key={key}
+      label={label}
+      type="number"
+      size="small"
+      fullWidth
+      value={baseline[key]}
+      onChange={(e) => setStat(key, e.target.value)}
+      helperText={help}
+      sx={inputSx}
+      slotProps={{ htmlInput: { inputMode: 'numeric', min: 0 }, formHelperText: helperSx }}
+    />
+  );
+
+  return (
+    <Container maxWidth="md" sx={{ py: { xs: 2, sm: 4 } }}>
+      <Stack spacing={{ xs: 2, sm: 2.5 }}>
+        <Box>
+          <Typography
+            variant="h4"
+            gutterBottom
+            sx={{ fontWeight: 800, fontSize: { xs: '1.5rem', sm: '2.125rem' } }}
+          >
+            Gear Upgrade Optimizer
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            What should you upgrade <em>next</em>? Enter your stats and every trait, quality, and
+            enchant change is ranked by the damage it adds to your build — biggest win first.
+          </Typography>
+        </Box>
+
+        {/* Inputs */}
+        <Paper elevation={0} sx={panelSx(theme)}>
+          <SectionHeader
+            icon={<TuneOutlined />}
+            title="Your build"
+            accent={accent}
+            action={
+              <Stack direction="row" spacing={0.75} useFlexGap sx={{ flexWrap: 'wrap' }}>
+                {PRESETS.map((p) => (
+                  <Chip
+                    key={p.label}
+                    label={p.label}
+                    size="small"
+                    variant="outlined"
+                    onClick={() => setBaseline(p.baseline)}
+                    sx={{ fontWeight: 600 }}
+                  />
+                ))}
+              </Stack>
+            }
+          />
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(3, 1fr)' },
+              gap: { xs: 1.5, sm: 2 },
+            }}
+          >
+            {CHARACTER_FIELDS.map(renderField)}
+            <TextField
+              select
+              label="Mundus Stone"
+              size="small"
+              fullWidth
+              value={baseline.mundus}
+              onChange={(e) =>
+                setBaseline((prev) => ({ ...prev, mundus: e.target.value as MundusStone }))
+              }
+              helperText="Boosted by the Divines trait."
+              sx={inputSx}
+              slotProps={{ formHelperText: helperSx }}
+            >
+              {MUNDUS_OPTIONS.map((m) => (
+                <MenuItem key={m.value} value={m.value}>
+                  {m.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Front-bar damage %"
+              type="number"
+              size="small"
+              fullWidth
+              value={Math.round((baseline.frontBarDamageShare ?? DEFAULT_FRONT_BAR_SHARE) * 100)}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                if (Number.isNaN(v)) return;
+                setBaseline((prev) => ({ ...prev, frontBarDamageShare: clamp01(v / 100) }));
+              }}
+              helperText="Weapon upgrades only count on their bar."
+              sx={inputSx}
+              slotProps={{
+                htmlInput: { inputMode: 'numeric', min: 0, max: 100 },
+                formHelperText: helperSx,
+              }}
+            />
+          </Box>
+          <FormControlLabel
+            sx={{ mt: 1 }}
+            control={
+              <Checkbox
+                size="small"
+                checked={raisedCap}
+                onChange={(e) =>
+                  setBaseline((prev) => ({
+                    ...prev,
+                    critDamageCapPct: e.target.checked
+                      ? RAISED_CRIT_DAMAGE_CAP
+                      : BASE_CRIT_DAMAGE_CAP,
+                  }))
+                }
+              />
+            }
+            label={
+              <Typography variant="body2" color="text.secondary">
+                Raised crit-damage cap (e.g. Nightblade&apos;s Above and Beyond, 125% → 155%)
+              </Typography>
+            }
+          />
+        </Paper>
+
+        {/* Top pick hero */}
+        {topPick && (
+          <Paper
+            elevation={0}
+            sx={{
+              ...panelSx(theme),
+              border: `1px solid ${alpha(theme.palette.success.main, 0.4)}`,
+              background: `linear-gradient(135deg, ${alpha(theme.palette.success.main, 0.16)}, ${alpha(
+                theme.palette.success.main,
+                0.03,
+              )})`,
+            }}
+          >
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <Box
+                aria-hidden
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 44,
+                  height: 44,
+                  borderRadius: 2,
+                  flexShrink: 0,
+                  color: theme.palette.success.main,
+                  background: alpha(theme.palette.success.main, 0.16),
+                  border: `1px solid ${alpha(theme.palette.success.main, 0.35)}`,
+                }}
+              >
+                <EmojiEventsOutlined />
+              </Box>
+              <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.6,
+                    fontWeight: 700,
+                    fontSize: 10,
+                  }}
+                >
+                  Your best next upgrade
+                </Typography>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+                  {topPick.change} · {topPick.slotLabel}
+                </Typography>
+              </Box>
+              <Typography
+                className="u-tabular"
+                sx={{
+                  fontFamily: NUMERAL_FONT,
+                  fontWeight: 800,
+                  fontSize: { xs: '1.6rem', sm: '2rem' },
+                  letterSpacing: '-0.01em',
+                  color: theme.palette.success.main,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                +{topPick.dmgIncreasePct.toFixed(2)}%
+              </Typography>
+            </Stack>
+          </Paper>
+        )}
+
+        {/* Ranked priority list */}
+        <Paper elevation={0} sx={panelSx(theme)}>
+          <SectionHeader
+            icon={<TrendingUpOutlined />}
+            title="Upgrade priority"
+            accent={accent}
+            action={
+              <ToggleButtonGroup
+                size="small"
+                exclusive
+                value={filter}
+                onChange={(_, next: CategoryFilter | null) => next && setFilter(next)}
+                aria-label="Filter upgrades by type"
+                sx={{ '& .MuiToggleButton-root': { textTransform: 'none', px: 1.25, py: 0.4 } }}
+              >
+                <ToggleButton value="all">All</ToggleButton>
+                <ToggleButton value="trait">Traits</ToggleButton>
+                <ToggleButton value="quality">Quality</ToggleButton>
+                <ToggleButton value="enchant">Enchants</ToggleButton>
+              </ToggleButtonGroup>
+            }
+          />
+
+          <Stack spacing={1} component="ul" sx={{ listStyle: 'none', p: 0, m: 0 }}>
+            {visible.map((row) => {
+              const negligible = row.dmgIncreasePct < NEGLIGIBLE_PCT;
+              const color = gainColor(theme, row.dmgIncreasePct);
+              const barPct = maxPct > 0 ? Math.max(2, (row.dmgIncreasePct / maxPct) * 100) : 0;
+              return (
+                <Box
+                  key={row.id}
+                  component="li"
+                  sx={{ ...cardSx(theme), p: { xs: 1.25, sm: 1.5 } }}
+                >
+                  <Stack
+                    direction="row"
+                    spacing={1.25}
+                    sx={{ alignItems: 'center', mb: negligible ? 0 : 0.85 }}
+                  >
+                    <Tooltip title={CATEGORY_META[row.group].label} arrow>
+                      <Box
+                        aria-hidden
+                        sx={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          width: 28,
+                          height: 28,
+                          borderRadius: 1.5,
+                          flexShrink: 0,
+                          color: accent,
+                          background: alpha(accent, 0.12),
+                          border: `1px solid ${alpha(accent, 0.22)}`,
+                          '& svg': { fontSize: 16 },
+                        }}
+                      >
+                        {CATEGORY_META[row.group].icon}
+                      </Box>
+                    </Tooltip>
+                    <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                      <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.25 }}>
+                        {row.change}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                          fontSize: 9.5,
+                          fontWeight: 700,
+                        }}
+                      >
+                        {row.slotLabel}
+                      </Typography>
+                    </Box>
+                    {row.note && (
+                      <Tooltip title={row.note} arrow enterTouchDelay={0} leaveTouchDelay={4000}>
+                        <InfoOutlined
+                          tabIndex={0}
+                          sx={{ fontSize: 16, color: 'text.disabled', cursor: 'help' }}
+                          aria-label={`About ${row.change}`}
+                        />
+                      </Tooltip>
+                    )}
+                    <Typography
+                      className="u-tabular"
+                      sx={{
+                        fontFamily: NUMERAL_FONT,
+                        fontWeight: 800,
+                        fontSize: '1.05rem',
+                        color,
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {negligible ? 'at cap' : `+${row.dmgIncreasePct.toFixed(2)}%`}
+                    </Typography>
+                  </Stack>
+
+                  {!negligible && (
+                    <Box
+                      sx={{
+                        height: 6,
+                        borderRadius: 3,
+                        backgroundColor: alpha(theme.palette.text.primary, 0.08),
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          width: `${barPct}%`,
+                          height: '100%',
+                          borderRadius: 3,
+                          background: `linear-gradient(90deg, ${color}, ${alpha(color, 0.45)})`,
+                          transition: 'width 0.3s ease',
+                        }}
+                      />
+                    </Box>
+                  )}
+                </Box>
+              );
+            })}
+          </Stack>
+
+          <Stack
+            direction="row"
+            spacing={0.75}
+            useFlexGap
+            sx={{ flexWrap: 'wrap', mt: 2, mb: 1, alignItems: 'center' }}
+          >
+            {(['high', 'medium', 'low'] as const).map((c) => (
+              <Chip
+                key={c}
+                size="small"
+                variant="outlined"
+                label={CONFIDENCE_LABEL[c]}
+                color={c === 'high' ? 'success' : c === 'medium' ? 'warning' : 'default'}
+              />
+            ))}
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            The ranking math is exact. Per-upgrade stat amounts are a first-pass estimate (CP160,
+            Legendary) pending verification against the in-game tooltip data — tap the ⓘ on a row
+            for its sourcing.
+          </Typography>
+        </Paper>
+
+        {/* Qualitative weapon-trait guide */}
+        <Paper elevation={0} sx={panelSx(theme)}>
+          <SectionHeader
+            icon={<ShieldMoonOutlined />}
+            title="Front-bar weapon traits"
+            accent={GUIDE_ACCENT}
+            action={
+              <Tooltip title={GUIDE_INTRO} arrow enterTouchDelay={0} leaveTouchDelay={5000}>
+                <InfoOutlined sx={{ fontSize: 18, color: 'text.disabled', cursor: 'help' }} />
+              </Tooltip>
+            }
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            These hinge on status-effect uptime and rotation, so they&apos;re a guide rather than a
+            single number.
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+              gap: 1,
+            }}
+          >
+            {WEAPON_TRAIT_GUIDE.map((row) => (
+              <Box
+                key={row.scenario}
+                sx={{
+                  ...cardSx(theme),
+                  p: 1.25,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1,
+                }}
+              >
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.25 }}>
+                    {row.scenario}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {row.weaponType}
+                  </Typography>
+                </Box>
+                <Chip
+                  size="small"
+                  label={row.recommendation}
+                  sx={{
+                    fontWeight: 700,
+                    color: GUIDE_ACCENT,
+                    background: `${GUIDE_ACCENT}1f`,
+                    border: `1px solid ${GUIDE_ACCENT}33`,
+                  }}
+                />
+              </Box>
+            ))}
+          </Box>
+        </Paper>
+      </Stack>
+    </Container>
+  );
+};

--- a/src/features/gear-upgrade/VALUE-SOURCING.md
+++ b/src/features/gear-upgrade/VALUE-SOURCING.md
@@ -1,0 +1,79 @@
+# Gear Upgrade Optimizer — value sourcing protocol
+
+The optimizer's **ranking math is exact**, but the per-upgrade stat
+**magnitudes** in `engine/gear-upgrade-catalog.ts` are confidence-tagged
+estimates. This is how to replace them with **client-exact** values.
+
+The repo's `ESOTooltipDump` addon (`tools/eso-tooltip-dump/`) doesn't capture
+per-item trait/quality/glyph/Mundus values directly — but its
+`/dumptooltips state` command prints a live **stat snapshot**, so we measure
+each value by isolating one variable and reading the delta.
+
+## Snapshot fields (`/dumptooltips state`)
+
+`/dumptooltips state` prints two lines:
+
+```
+Reference state: ... | MagMax=… StaMax=… SpellDmg=… WpnDmg=…
+  ...WpnCrit=… SpellCrit=… PhysPen=… SpellPen=…
+```
+
+So you can read **Max Magicka/Stamina, Weapon/Spell Damage, Weapon/Spell Crit
+(rating), and Physical/Spell Penetration** straight from chat — no full dump or
+`/reloadui` needed. Crit is a **rating** (÷ 219 for crit-chance %).
+
+**No crit-damage field** (it isn't a `GetPlayerStat` value) — Shadow Mundus and
+any crit-damage value must be read from the in-game Character sheet ("Critical
+Damage") instead.
+
+> The second line (crit + pen) requires the `state`-command patch in this
+> branch's `tools/eso-tooltip-dump/ESOTooltipDump.lua`. If your installed addon
+> is older, copy that file into
+> `Documents/Elder Scrolls Online/live/AddOns/ESOTooltipDump/` first.
+
+## Ground rules (read before measuring)
+
+- CP160 character; **change exactly one thing** between the two reads — keep
+  food, CP, Mundus, buffs, and all other gear identical.
+- The snapshot reads the **active bar**, so do weapon swaps on the active bar.
+- For weapon quality/glyph tests, keep the **same trait** on both weapons so
+  only the tested variable moves.
+- Record both reads; the **delta** is the exact value. Hand the numbers back
+  and they go straight into the catalog (confidence → `high`, with provenance).
+
+## Measurements
+
+| #   | Catalog constant                 | A → B (swap only this)                                                  | Read (Δ)                                                                           |
+| --- | -------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1   | `QUALITY_STEP.weapon1hWsd`       | 1H weapon **Epic → Legendary** (active bar)                             | Δ `weaponPower` (or `spellPower` if it's a staff)                                  |
+| 2   | `QUALITY_STEP.weapon2hWsd`       | 2H/staff **Epic → Legendary**                                           | Δ `weaponPower`/`spellPower`                                                       |
+| 3   | `QUALITY_STEP.jewelryWsd`        | one jewelry **Epic → Legendary** (same glyph)                           | Δ `weaponPower`                                                                    |
+| 4   | `QUALITY_STEP.bigArmorMaxStat`   | large body piece **Epic → Legendary** (same glyph)                      | Δ `magickaMax`/`staminaMax` (likely ~0 — confirms armor quality ≈ resistance only) |
+| 5   | `QUALITY_STEP.smallArmorMaxStat` | small body piece **Epic → Legendary**                                   | Δ `magickaMax`/`staminaMax`                                                        |
+| 6   | `JEWELRY_WSD_GLYPH`              | jewelry glyph **none → Weapon/Spell Damage (gold)**                     | Δ `weaponPower` (= Δ `spellPower`)                                                 |
+| 7   | `BIG_ARMOR_MAXSTAT_GLYPH`        | large-piece glyph **off-resource → Magicka/Stamina (gold)**             | Δ `magickaMax`/`staminaMax`                                                        |
+| 8   | `SMALL_ARMOR_MAXSTAT_GLYPH`      | small-piece glyph **off-resource → Magicka/Stamina (gold)**             | Δ `magickaMax`/`staminaMax`                                                        |
+| 9   | `MUNDUS_VALUE.warrior`           | Mundus **off → The Warrior**                                            | Δ `weaponPower`                                                                    |
+| 10  | `MUNDUS_VALUE.apprentice`        | Mundus **off → The Apprentice**                                         | Δ `spellPower`                                                                     |
+| 11  | `MUNDUS_VALUE.thief`             | Mundus **off → The Thief**                                              | Δ `weaponCrit` (rating)                                                            |
+| 12  | `MUNDUS_VALUE.lover`             | Mundus **off → The Lover**                                              | Δ `physicalPen`/`spellPen`                                                         |
+| 13  | `MUNDUS_VALUE.mage`              | Mundus **off → The Mage**                                               | Δ `magickaMax`/`staminaMax`                                                        |
+| 14  | `DIVINES_AMP_PER_PIECE`          | with **The Warrior** active, one body piece **no-trait → gold Divines** | Δ `weaponPower` ÷ (#9 value) = per-piece %                                         |
+
+### Needs the Character sheet, not the snapshot
+
+| Catalog constant        | How                                                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MUNDUS_VALUE.shadow`   | Character sheet **Critical Damage %**: Mundus off → The Shadow                                                                                                   |
+| `BLOODTHIRSTY_WSD_PEAK` | In combat on a trial dummy **under 90% health**, read Weapon/Spell Damage with vs. without Bloodthirsty (it's conditional, so the static snapshot won't show it) |
+
+### Genuinely build-dependent (stay user inputs, not constants)
+
+`frontBarDamageShare` and the Bloodthirsty sub-90% **uptime** vary by
+rotation/fight — they're exposed as inputs by design, not sourced here.
+
+## After collecting
+
+Drop the before/after numbers into the PR (or `.scratch/`). Each delta replaces
+its catalog constant, the row's `confidence` becomes `high`, and a provenance
+note records "measured via ESOTooltipDump `/dumptooltips state`, patch <X>".

--- a/src/features/gear-upgrade/__tests__/GearUpgradeCalculator.test.tsx
+++ b/src/features/gear-upgrade/__tests__/GearUpgradeCalculator.test.tsx
@@ -1,0 +1,59 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { GearUpgradeCalculator } from '../GearUpgradeCalculator';
+
+const renderCalc = (): ReturnType<typeof render> =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <GearUpgradeCalculator />
+    </ThemeProvider>,
+  );
+
+describe('GearUpgradeCalculator', () => {
+  it('leads with the single best next upgrade', () => {
+    renderCalc();
+    expect(screen.getByText('Gear Upgrade Optimizer')).toBeInTheDocument();
+    expect(screen.getByText('Your best next upgrade')).toBeInTheDocument();
+    // The hero (and the top list row) show a positive percentage.
+    expect(screen.getAllByText(/^\+\d+\.\d{2}%$/).length).toBeGreaterThan(0);
+  });
+
+  it('renders a ranked priority list with magnitude values', () => {
+    renderCalc();
+    const list = screen.getByText('Upgrade priority').closest('div')?.parentElement;
+    expect(list).toBeTruthy();
+    // Several rows render a "+x.xx%" gain or an "at cap" marker.
+    const gains = screen.getAllByText(/(^\+\d+\.\d{2}%$|^at cap$)/);
+    expect(gains.length).toBeGreaterThan(3);
+  });
+
+  it('filters the list by category', () => {
+    renderCalc();
+    const before = screen.getAllByText(/(^\+\d+\.\d{2}%$|^at cap$)/).length;
+    fireEvent.click(screen.getByRole('button', { name: 'Quality' }));
+    const after = screen.getAllByText(/(^\+\d+\.\d{2}%$|^at cap$)/).length;
+    // Filtering to a single category shows fewer rows than "All".
+    expect(after).toBeLessThan(before);
+    expect(after).toBeGreaterThan(0);
+  });
+
+  it('applies a preset and recomputes without throwing', () => {
+    renderCalc();
+    fireEvent.click(screen.getByRole('button', { name: 'New character' }));
+    expect(screen.getAllByText(/(^\+\d+\.\d{2}%$|^at cap$)/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the qualitative front-bar weapon-trait guide', () => {
+    renderCalc();
+    expect(screen.getByText('Front-bar weapon traits')).toBeInTheDocument();
+    expect(screen.getByText('Charged / Charged')).toBeInTheDocument();
+  });
+
+  it('updates when a stat changes', () => {
+    renderCalc();
+    const wsd = screen.getByLabelText(/Weapon\/Spell Dmg/i);
+    fireEvent.change(wsd, { target: { value: '3000' } });
+    expect(screen.getAllByText(/(^\+\d+\.\d{2}%$|^at cap$)/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/gear-upgrade/engine/__tests__/gearUpgradeEngine.test.ts
+++ b/src/features/gear-upgrade/engine/__tests__/gearUpgradeEngine.test.ts
@@ -1,0 +1,166 @@
+import { CRIT_CHANCE_DIVISOR } from '@/features/build-editor/engine/stat-constants';
+
+import { UPGRADE_CATALOG } from '../gear-upgrade-catalog';
+import {
+  applyPackage,
+  computeUpgrades,
+  marginalDpsPct,
+  MITIGATION_DIVISOR,
+  relativeDamage,
+  WD_TO_STAT,
+} from '../gearUpgradeEngine';
+import type { BuildBaseline, UpgradeOption } from '../types';
+
+const baseline: BuildBaseline = {
+  weaponOrSpellDamage: 6500,
+  maxStat: 36000,
+  critChancePct: 60,
+  critDamagePct: 100,
+  penetration: 18200,
+  targetResistance: 18200,
+  mundus: 'thief',
+};
+
+describe('relativeDamage', () => {
+  it('combines offensive power, crit, and mitigation multiplicatively', () => {
+    const offensivePower = 36000 + WD_TO_STAT * 6500;
+    const critMult = 1 + 0.6 * (2.0 - 1); // 100% crit dmg ⇒ 2.0× on crit
+    const mitigation = 1; // pen meets resistance exactly ⇒ no mitigation
+    expect(relativeDamage(baseline)).toBeCloseTo(offensivePower * critMult * mitigation, 5);
+  });
+
+  it('caps critical damage at 125% by default', () => {
+    const over = relativeDamage({ ...baseline, critDamagePct: 200 });
+    const atCap = relativeDamage({ ...baseline, critDamagePct: 125 });
+    expect(over).toBeCloseTo(atCap, 5);
+  });
+
+  it('honours a raised crit-damage cap (e.g. NB Above and Beyond → 155%)', () => {
+    const raised = { ...baseline, critDamageCapPct: 155 };
+    // At a 140% baseline, crit damage is clamped to 0 under the default cap but
+    // still has headroom under the raised cap, so it must read higher.
+    const atDefaultCap = relativeDamage({ ...raised, critDamagePct: 125 });
+    const underRaisedCap = relativeDamage({ ...raised, critDamagePct: 140 });
+    expect(underRaisedCap).toBeGreaterThan(atDefaultCap);
+  });
+
+  it('applies mitigation when the target out-resists your penetration', () => {
+    const under = { ...baseline, penetration: 0 };
+    const expectedMitigation = 1 - 18200 / MITIGATION_DIVISOR;
+    expect(relativeDamage(under) / relativeDamage({ ...baseline, penetration: 18200 })).toBeCloseTo(
+      expectedMitigation,
+      5,
+    );
+  });
+});
+
+describe('applyPackage', () => {
+  it('converts crit rating to crit chance via the shared divisor', () => {
+    const out = applyPackage(baseline, { deltaCritRating: CRIT_CHANCE_DIVISOR });
+    expect(out.critChancePct).toBeCloseTo(61, 5); // +1% chance per 219 rating
+  });
+
+  it('never lets crit chance exceed 100%', () => {
+    const out = applyPackage(baseline, { deltaCritRating: 100000 });
+    expect(out.critChancePct).toBe(100);
+  });
+});
+
+describe('marginalDpsPct', () => {
+  const wsdOption: UpgradeOption = {
+    id: 't',
+    group: 'enchant',
+    change: '+WSD',
+    slot: 'jewelry',
+    slotLabel: 'Jewelry',
+    pkg: { deltaWeaponOrSpellDamage: 173 },
+    confidence: 'medium',
+  };
+
+  it('returns a positive percentage for a damage-stat gain', () => {
+    expect(marginalDpsPct(wsdOption, baseline)).toBeGreaterThan(0);
+  });
+
+  it('values penetration at zero when already at the resistance cap', () => {
+    const penOption: UpgradeOption = { ...wsdOption, pkg: { deltaPenetration: 2000 } };
+    expect(marginalDpsPct(penOption, baseline)).toBeCloseTo(0, 6);
+  });
+
+  it('values penetration above zero when under the cap', () => {
+    const penOption: UpgradeOption = { ...wsdOption, pkg: { deltaPenetration: 2000 } };
+    expect(marginalDpsPct(penOption, { ...baseline, penetration: 0 })).toBeGreaterThan(0);
+  });
+
+  it('applies damage-done deltas multiplicatively', () => {
+    const ddOption: UpgradeOption = { ...wsdOption, pkg: { deltaDamageDonePct: 5 } };
+    expect(marginalDpsPct(ddOption, baseline)).toBeCloseTo(5, 6);
+  });
+
+  it('values a crit-damage upgrade at zero when capped, but positive with a raised cap', () => {
+    const critDmgOption: UpgradeOption = { ...wsdOption, pkg: { deltaCritDamagePct: 10 } };
+    const capped = { ...baseline, critDamagePct: 125, critDamageCapPct: 125 };
+    const raised = { ...baseline, critDamagePct: 125, critDamageCapPct: 155 };
+    expect(marginalDpsPct(critDmgOption, capped)).toBeCloseTo(0, 6);
+    expect(marginalDpsPct(critDmgOption, raised)).toBeGreaterThan(0);
+  });
+
+  it('weights weapon upgrades by the active-bar damage share', () => {
+    const frontOpt: UpgradeOption = {
+      ...wsdOption,
+      bar: 'front',
+      pkg: { deltaWeaponOrSpellDamage: 100 },
+    };
+    const backOpt: UpgradeOption = { ...frontOpt, bar: 'back' };
+    const unweighted: UpgradeOption = { ...frontOpt, bar: undefined };
+    const b = { ...baseline, frontBarDamageShare: 0.8 };
+
+    const full = marginalDpsPct(unweighted, b);
+    expect(marginalDpsPct(frontOpt, b)).toBeCloseTo(full * 0.8, 6);
+    expect(marginalDpsPct(backOpt, b)).toBeCloseTo(full * 0.2, 6);
+    expect(marginalDpsPct(frontOpt, b)).toBeGreaterThan(marginalDpsPct(backOpt, b));
+  });
+
+  it('does not bar-weight when no front-bar share is set', () => {
+    const frontOpt: UpgradeOption = {
+      ...wsdOption,
+      bar: 'front',
+      pkg: { deltaWeaponOrSpellDamage: 100 },
+    };
+    const noBar: UpgradeOption = { ...frontOpt, bar: undefined };
+    expect(marginalDpsPct(frontOpt, baseline)).toBeCloseTo(marginalDpsPct(noBar, baseline), 6);
+  });
+
+  it('resolves Mundus-dependent (Divines) packages from the baseline', () => {
+    const divines = UPGRADE_CATALOG.find((o) => o.id === 'trait-divines-bigArmor')!;
+    // Thief Mundus feeds crit chance ⇒ positive; "other" Mundus feeds nothing ⇒ ~0.
+    expect(marginalDpsPct(divines, { ...baseline, mundus: 'thief' })).toBeGreaterThan(0);
+    expect(marginalDpsPct(divines, { ...baseline, mundus: 'other' })).toBeCloseTo(0, 6);
+  });
+});
+
+describe('computeUpgrades', () => {
+  it('sorts results by marginal DPS, highest first', () => {
+    const results = computeUpgrades(UPGRADE_CATALOG, baseline);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].dmgIncreasePct).toBeGreaterThanOrEqual(results[i].dmgIncreasePct);
+    }
+  });
+
+  it('excludes qualitative options from the computed table', () => {
+    const withQualitative: UpgradeOption[] = [
+      ...UPGRADE_CATALOG,
+      {
+        id: 'q',
+        group: 'trait',
+        change: 'Charged',
+        slot: 'frontBar2H',
+        slotLabel: 'Front Bar',
+        pkg: {},
+        confidence: 'low',
+        qualitative: true,
+      },
+    ];
+    const results = computeUpgrades(withQualitative, baseline);
+    expect(results.some((r) => r.id === 'q')).toBe(false);
+  });
+});

--- a/src/features/gear-upgrade/engine/gear-upgrade-catalog.ts
+++ b/src/features/gear-upgrade/engine/gear-upgrade-catalog.ts
@@ -1,0 +1,342 @@
+/**
+ * Gear Upgrade Optimizer — catalog
+ *
+ * The set of trait / quality / enchant changes the optimizer scores, plus the
+ * qualitative front-bar weapon-trait guide. Magnitudes are CP160, Legendary
+ * (gold), per piece.
+ *
+ * SOURCING: stat magnitudes below are a first-pass derived from in-game
+ * tooltips and standard ESO values (UESP). They carry a `confidence` marker
+ * and should be reconciled against the client dump in `tools/eso-tooltip-dump`
+ * before being treated as authoritative — the *engine* math is exact, the
+ * per-upgrade stat amounts are the refinable input. (No third-party wikis are
+ * used as a source — only the game client and UESP.)
+ *
+ * Faithful to the reference table this feature is modelled on: only armor /
+ * jewelry traits, quality, and enchants are quantified. Weapon traits
+ * (Charged / Nirnhoned / Precise / Infused) depend on status-effect uptime and
+ * rotation and are surfaced as a qualitative guide rather than a single number.
+ */
+
+import type { BuildBaseline, MundusStone, StatPackage, UpgradeOption } from './types';
+
+// ─── Mundus base values (gold, CP160) — what the Divines trait amplifies ─────
+
+/**
+ * Per-stone gold value and the stat it feeds.
+ * Thief (1333 crit rating), Warrior/Apprentice (238 weapon/spell damage) are
+ * corroborated across sources (UESP / community guides). Shadow's crit-damage,
+ * Lover's penetration, and Mage's max-stat are less consistently documented and
+ * remain estimates — confidence: medium. (Banned third-party wiki excluded per
+ * repo policy; values cross-checked against UESP / community guides.)
+ */
+const MUNDUS_VALUE: Record<MundusStone, StatPackage> = {
+  thief: { deltaCritRating: 1333 }, // Critical Chance — corroborated
+  shadow: { deltaCritDamagePct: 12 }, // Critical Damage — sources give 11–12%
+  warrior: { deltaWeaponOrSpellDamage: 238 }, // Weapon Damage — corroborated
+  apprentice: { deltaWeaponOrSpellDamage: 238 }, // Spell Damage — corroborated
+  lover: { deltaPenetration: 2744 }, // Penetration — estimate
+  mage: { deltaMaxStat: 1763 }, // Max Stat — estimate
+  other: {}, // Atronach / Serpent / etc. — no offensive contribution
+};
+
+/**
+ * One gold Divines piece amplifies the slotted Mundus. Community sources cite a
+ * 7-piece gold Divines cap of ~+52.5%, i.e. ~7.5% per piece (some report up to
+ * 9.1%); UESP's exact per-quality table couldn't be fetched here, so this stays
+ * confidence: medium pending the in-game tooltip dump.
+ */
+const DIVINES_AMP_PER_PIECE = 0.075;
+
+/** Scale a stat package by a scalar (used to turn a Mundus into a Divines step). */
+const scalePackage = (pkg: StatPackage, k: number): StatPackage => ({
+  deltaWeaponOrSpellDamage: (pkg.deltaWeaponOrSpellDamage ?? 0) * k,
+  deltaMaxStat: (pkg.deltaMaxStat ?? 0) * k,
+  deltaCritRating: (pkg.deltaCritRating ?? 0) * k,
+  deltaCritDamagePct: (pkg.deltaCritDamagePct ?? 0) * k,
+  deltaPenetration: (pkg.deltaPenetration ?? 0) * k,
+});
+
+/** Divines on one piece = the slotted Mundus value, scaled by the per-piece amp. */
+const divinesPackage = (b: BuildBaseline): StatPackage =>
+  scalePackage(MUNDUS_VALUE[b.mundus], DIVINES_AMP_PER_PIECE);
+
+// ─── Reference stat magnitudes (gold, CP160) ─────────────────────────────────
+
+/** Max Magicka/Stamina from a main-resource jewelry trait (Arcane/Robust). */
+const JEWELRY_MAIN_RESOURCE_MAXSTAT = 1206;
+/**
+ * Bloodthirsty grants Weapon/Spell Damage against enemies below 90% health
+ * (see src/data/esoTraits.ts) — NOT a flat damage-done bonus. Modelling it as a
+ * WSD delta routes it through offensive power, so its value correctly depends on
+ * the user's own WSD/max-stat baseline. ~225 WSD peak (gold), scaled by the
+ * fraction of a fight spent under 90% health (bosses sit there almost always).
+ */
+const BLOODTHIRSTY_WSD_PEAK = 225;
+const BLOODTHIRSTY_SUB90_UPTIME = 0.9;
+const BLOODTHIRSTY_WSD_AVG = BLOODTHIRSTY_WSD_PEAK * BLOODTHIRSTY_SUB90_UPTIME;
+
+/** Weapon/Spell Damage from a gold jewelry damage glyph. */
+const JEWELRY_WSD_GLYPH = 173;
+/** Max-resource glyph values by armor size. */
+const BIG_ARMOR_MAXSTAT_GLYPH = 1675;
+const SMALL_ARMOR_MAXSTAT_GLYPH = 874;
+
+/** Epic→Legendary per-piece stat step by slot. */
+const QUALITY_STEP = {
+  bigArmorMaxStat: 83,
+  smallArmorMaxStat: 44,
+  jewelryWsd: 21,
+  weapon1hWsd: 54,
+  weapon2hWsd: 108,
+} as const;
+
+/**
+ * Weapon-trait stat values per bar (gold). These are long-stable ESO values
+ * (a fully-traited bar: 2× 1H or a single 2H). Weapon traits are mutually
+ * exclusive — you pick ONE per weapon — and only apply on their active bar.
+ *   • Sharpened → Physical/Spell Penetration (~3,276/bar).
+ *   • Precise   → Critical rating (~1,314/bar ≈ +6% crit chance).
+ */
+const WEAPON_SHARPENED_PEN = 3276;
+const WEAPON_PRECISE_CRIT = 1314;
+
+// ─── Catalog ─────────────────────────────────────────────────────────────────
+
+export const UPGRADE_CATALOG: readonly UpgradeOption[] = [
+  // Traits ───────────────────────────────────────────────────────────────────
+  {
+    id: 'trait-divines-bigArmor',
+    group: 'trait',
+    change: 'Nothing → Divines',
+    slot: 'bigArmor',
+    slotLabel: 'Big Armor',
+    pkg: divinesPackage,
+    confidence: 'medium',
+    note: 'Amplifies your slotted Mundus Stone (~6.24%/piece gold). Value depends on the stone.',
+  },
+  {
+    id: 'trait-divines-smallArmor',
+    group: 'trait',
+    change: 'Nothing → Divines',
+    slot: 'smallArmor',
+    slotLabel: 'Small Armor',
+    pkg: divinesPackage,
+    confidence: 'medium',
+    note: 'Amplifies your slotted Mundus Stone (~6.24%/piece gold). Value depends on the stone.',
+  },
+  {
+    id: 'trait-bloodthirsty-main',
+    group: 'trait',
+    change: 'Main Resource → Bloodthirsty',
+    slot: 'jewelry',
+    slotLabel: 'Jewelry',
+    // You give up a max-resource trait that *was* boosting your damage stat.
+    pkg: {
+      deltaWeaponOrSpellDamage: BLOODTHIRSTY_WSD_AVG,
+      deltaMaxStat: -JEWELRY_MAIN_RESOURCE_MAXSTAT,
+    },
+    confidence: 'low',
+    note: 'WSD below 90% health (uptime-averaged), net of losing the Arcane/Robust max-resource it replaces.',
+  },
+  {
+    id: 'trait-bloodthirsty-off',
+    group: 'trait',
+    change: 'Off Resource → Bloodthirsty',
+    slot: 'jewelry',
+    slotLabel: 'Jewelry',
+    // The off-resource trait contributed nothing to your damage, so no loss.
+    pkg: { deltaWeaponOrSpellDamage: BLOODTHIRSTY_WSD_AVG },
+    confidence: 'low',
+    note: 'WSD below 90% health (uptime-averaged); the off-resource trait gave no damage stat, so the full value lands.',
+  },
+
+  // Quality (Epic → Legendary) ─────────────────────────────────────────────────
+  {
+    id: 'quality-bigArmor',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'bigArmor',
+    slotLabel: 'Armor (large)',
+    pkg: { deltaMaxStat: QUALITY_STEP.bigArmorMaxStat },
+    confidence: 'low',
+  },
+  {
+    id: 'quality-smallArmor',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'smallArmor',
+    slotLabel: 'Armor (small)',
+    pkg: { deltaMaxStat: QUALITY_STEP.smallArmorMaxStat },
+    confidence: 'low',
+  },
+  {
+    id: 'quality-jewelry',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'jewelry',
+    slotLabel: 'Jewelry',
+    pkg: { deltaWeaponOrSpellDamage: QUALITY_STEP.jewelryWsd },
+    confidence: 'low',
+  },
+  {
+    id: 'quality-mainHand1H',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'mainHand1H',
+    slotLabel: 'Main Hand (front bar)',
+    pkg: { deltaWeaponOrSpellDamage: QUALITY_STEP.weapon1hWsd },
+    bar: 'front',
+    confidence: 'low',
+    note: 'A weapon only boosts damage while its bar is active, so this is weighted by your front-bar damage share.',
+  },
+  {
+    id: 'quality-offHand1H',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'offHand1H',
+    slotLabel: 'Off Hand (front bar)',
+    pkg: { deltaWeaponOrSpellDamage: QUALITY_STEP.weapon1hWsd },
+    bar: 'front',
+    confidence: 'low',
+    note: 'Weighted by your front-bar damage share — it only applies while the front bar is active.',
+  },
+  {
+    id: 'quality-frontBar2H',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'frontBar2H',
+    slotLabel: 'Front Bar (2H)',
+    pkg: { deltaWeaponOrSpellDamage: QUALITY_STEP.weapon2hWsd },
+    bar: 'front',
+    confidence: 'low',
+    note: 'Weighted by your front-bar damage share — it only applies while the front bar is active.',
+  },
+  {
+    id: 'quality-backBar2H',
+    group: 'quality',
+    change: 'Epic → Legendary',
+    slot: 'backBar2H',
+    slotLabel: 'Back Bar (2H)',
+    pkg: { deltaWeaponOrSpellDamage: QUALITY_STEP.weapon2hWsd },
+    bar: 'back',
+    confidence: 'low',
+    note: 'Back-bar weapons mostly boost back-bar DoTs, so this is weighted by your back-bar damage share.',
+  },
+
+  // Weapon traits (pen / crit) ─────────────────────────────────────────────────
+  // Mutually exclusive — pick one trait per weapon — and only apply on their bar.
+  {
+    id: 'trait-sharpened-front',
+    group: 'trait',
+    change: 'Nothing → Sharpened',
+    slot: 'frontBar2H',
+    slotLabel: 'Front Bar Weapon',
+    pkg: { deltaPenetration: WEAPON_SHARPENED_PEN },
+    bar: 'front',
+    confidence: 'medium',
+    note: 'Weapon trait (pick one per weapon): ~3,276 penetration on the front bar. Reads "at cap" once you hit the pen cap.',
+  },
+  {
+    id: 'trait-sharpened-back',
+    group: 'trait',
+    change: 'Nothing → Sharpened',
+    slot: 'backBar2H',
+    slotLabel: 'Back Bar Weapon',
+    pkg: { deltaPenetration: WEAPON_SHARPENED_PEN },
+    bar: 'back',
+    confidence: 'medium',
+    note: 'Weapon trait (pick one per weapon): ~3,276 penetration, weighted by your back-bar damage share.',
+  },
+  {
+    id: 'trait-precise-front',
+    group: 'trait',
+    change: 'Nothing → Precise',
+    slot: 'frontBar2H',
+    slotLabel: 'Front Bar Weapon',
+    pkg: { deltaCritRating: WEAPON_PRECISE_CRIT },
+    bar: 'front',
+    confidence: 'medium',
+    note: 'Weapon trait (pick one per weapon): ~1,314 crit rating (~6% crit chance) on the front bar.',
+  },
+  {
+    id: 'trait-precise-back',
+    group: 'trait',
+    change: 'Nothing → Precise',
+    slot: 'backBar2H',
+    slotLabel: 'Back Bar Weapon',
+    pkg: { deltaCritRating: WEAPON_PRECISE_CRIT },
+    bar: 'back',
+    confidence: 'medium',
+    note: 'Weapon trait (pick one per weapon): ~1,314 crit rating, weighted by your back-bar damage share.',
+  },
+
+  // Enchants ───────────────────────────────────────────────────────────────────
+  {
+    id: 'enchant-wsd-jewelry',
+    group: 'enchant',
+    change: 'Any → Weapon/Spell Dmg',
+    slot: 'jewelry',
+    slotLabel: 'Jewelry',
+    pkg: { deltaWeaponOrSpellDamage: JEWELRY_WSD_GLYPH },
+    confidence: 'medium',
+  },
+  {
+    id: 'enchant-mainResource-bigArmor',
+    group: 'enchant',
+    change: 'Off Resource → Main Resource',
+    slot: 'bigArmor',
+    slotLabel: 'Big Armor',
+    pkg: { deltaMaxStat: BIG_ARMOR_MAXSTAT_GLYPH },
+    confidence: 'medium',
+  },
+  {
+    id: 'enchant-mainResource-smallArmor',
+    group: 'enchant',
+    change: 'Off Resource → Main Resource',
+    slot: 'smallArmor',
+    slotLabel: 'Small Armor',
+    pkg: { deltaMaxStat: SMALL_ARMOR_MAXSTAT_GLYPH },
+    confidence: 'medium',
+  },
+];
+
+// ─── Qualitative front-bar weapon-trait guide ────────────────────────────────
+
+export interface WeaponTraitGuideRow {
+  scenario: string;
+  weaponType: string;
+  recommendation: string;
+}
+
+/**
+ * Front-bar weapon traits depend on status-effect uptime and rotation, which a
+ * stat snapshot can't capture — so this is guidance, not a computed number
+ * (the reference table punts on these too).
+ */
+export const WEAPON_TRAIT_GUIDE: readonly WeaponTraitGuideRow[] = [
+  {
+    scenario: 'Single Target Boss (non-Beam)',
+    weaponType: 'Dual Wield',
+    recommendation: 'Charged / Charged',
+  },
+  {
+    scenario: 'General (Beam single target)',
+    weaponType: 'Dual Wield',
+    recommendation: 'Nirnhoned / Charged',
+  },
+  {
+    scenario: 'AoE / Trash (Beam general)',
+    weaponType: 'Dual Wield',
+    recommendation: 'Nirnhoned / Precise',
+  },
+  {
+    scenario: 'Non-Daggers',
+    weaponType: 'Staff / Bow / 2H',
+    recommendation: 'Precise',
+  },
+];
+
+export const GUIDE_INTRO =
+  "It's hard to quantify exact damage differences between Nirnhoned, Charged, and Precise " +
+  'front-bar weapons. Use this as a general guide for each fight scenario.';

--- a/src/features/gear-upgrade/engine/gearUpgradeEngine.ts
+++ b/src/features/gear-upgrade/engine/gearUpgradeEngine.ts
@@ -1,0 +1,126 @@
+/**
+ * Gear Upgrade Optimizer — engine
+ *
+ * Pure, dependency-free marginal-DPS math. Reuses the sourced ESO constants
+ * already defined for the build-editor stat engine so the two never drift.
+ *
+ * Model — relative damage of an average hit:
+ *
+ *   D = offensivePower × critMultiplier × mitigationMultiplier × damageDone
+ *
+ *   offensivePower    = maxStat + WD_TO_STAT × weaponOrSpellDamage
+ *   critMultiplier    = 1 + critChance × (critDamageMultiplier − 1)
+ *   mitigationMult    = 1 − effectiveResist / MITIGATION_DIVISOR
+ *   damageDone        = Π (1 + bonus)
+ *
+ * For a single gear change every untouched factor and the skill's own
+ * coefficient cancel in the after/before ratio, so the marginal DPS is exact
+ * regardless of which skill you cast:
+ *
+ *   marginal% = D(after) / D(before) − 1
+ */
+
+import {
+  ARMOR_CAP,
+  CRIT_CHANCE_DIVISOR,
+  CRIT_DMG_CAPS,
+} from '@/features/build-editor/engine/stat-constants';
+
+import type { BuildBaseline, StatPackage, UpgradeOption, UpgradeResult } from './types';
+
+/**
+ * Tooltip scaling: 1 point of Weapon/Spell Damage is worth WD_TO_STAT points of
+ * Max Stat in ability damage. This 10.5 ratio is the long-standing, widely
+ * reproduced ESO value (derived from the additive ability-damage coefficients).
+ */
+export const WD_TO_STAT = 10.5;
+
+/**
+ * Resistance → mitigation: ARMOR_CAP (33,100) resist = 50% mitigation, so the
+ * mitigation fraction is effectiveResist / (2 × ARMOR_CAP). Derived from the
+ * shared cap so it can never disagree with the rest of the calculator.
+ */
+export const MITIGATION_DIVISOR = ARMOR_CAP * 2;
+
+const clamp = (n: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, n));
+
+/** Relative damage factor for a baseline (units are arbitrary; only ratios matter). */
+export function relativeDamage(b: BuildBaseline): number {
+  const offensivePower = Math.max(0, b.maxStat) + WD_TO_STAT * Math.max(0, b.weaponOrSpellDamage);
+
+  const critChance = clamp(b.critChancePct, 0, 100) / 100;
+  // Crit damage is capped at 125% total in-game (base crits already do +50%), but
+  // some passives raise the cap (e.g. NB Above and Beyond → 155). Honour the
+  // build's cap so crit-damage upgrades aren't clamped to 0 prematurely.
+  const critDamageCap = b.critDamageCapPct ?? CRIT_DMG_CAPS.cap;
+  const critDamageMultiplier = 1 + clamp(b.critDamagePct, 0, critDamageCap) / 100;
+  const critMultiplier = 1 + critChance * (critDamageMultiplier - 1);
+
+  const effectiveResist = Math.max(0, b.targetResistance - b.penetration);
+  const mitigationMultiplier = 1 - effectiveResist / MITIGATION_DIVISOR;
+
+  return offensivePower * critMultiplier * mitigationMultiplier;
+}
+
+/** Apply a stat delta to a baseline, returning a new baseline (pure). */
+export function applyPackage(b: BuildBaseline, pkg: StatPackage): BuildBaseline {
+  const critChanceFromRating = (pkg.deltaCritRating ?? 0) / CRIT_CHANCE_DIVISOR;
+  return {
+    ...b,
+    weaponOrSpellDamage: b.weaponOrSpellDamage + (pkg.deltaWeaponOrSpellDamage ?? 0),
+    maxStat: b.maxStat + (pkg.deltaMaxStat ?? 0),
+    critChancePct: clamp(b.critChancePct + critChanceFromRating, 0, 100),
+    critDamagePct: b.critDamagePct + (pkg.deltaCritDamagePct ?? 0),
+    penetration: b.penetration + (pkg.deltaPenetration ?? 0),
+  };
+}
+
+/** Resolve an option's package (Mundus-dependent options are functions). */
+function resolvePackage(option: UpgradeOption, baseline: BuildBaseline): StatPackage {
+  return typeof option.pkg === 'function' ? option.pkg(baseline) : option.pkg;
+}
+
+/**
+ * Marginal DPS of one upgrade, as a percentage (0.32 ⇒ +0.32%).
+ * "Damage done" deltas multiply the whole result; stat deltas flow through the
+ * damage factor.
+ */
+/**
+ * Fraction of total damage that benefits from an upgrade. Weapon stats only
+ * apply while their bar is active, so a weapon upgrade is worth the share of
+ * your damage dealt on that bar. Always-equipped jewelry/armor (no `bar`) and
+ * builds that haven't set a front-bar share are unweighted (1).
+ */
+function damageShare(option: UpgradeOption, baseline: BuildBaseline): number {
+  if (!option.bar) return 1;
+  const front = baseline.frontBarDamageShare;
+  if (front == null) return 1;
+  const f = clamp(front, 0, 1);
+  return option.bar === 'front' ? f : 1 - f;
+}
+
+export function marginalDpsPct(option: UpgradeOption, baseline: BuildBaseline): number {
+  const pkg = resolvePackage(option, baseline);
+  const before = relativeDamage(baseline);
+  if (before <= 0) return 0;
+
+  const after = relativeDamage(applyPackage(baseline, pkg));
+  const damageDoneFactor = 1 + (pkg.deltaDamageDonePct ?? 0) / 100;
+
+  return ((after * damageDoneFactor) / before - 1) * 100 * damageShare(option, baseline);
+}
+
+/**
+ * Compute every quantifiable upgrade for a build, sorted by marginal DPS
+ * (highest first). Qualitative options (status-effect / front-bar traits) are
+ * excluded — they belong in the qualitative guide.
+ */
+export function computeUpgrades(
+  options: readonly UpgradeOption[],
+  baseline: BuildBaseline,
+): UpgradeResult[] {
+  return options
+    .filter((o) => !o.qualitative)
+    .map((o) => ({ ...o, dmgIncreasePct: marginalDpsPct(o, baseline) }))
+    .sort((a, b) => b.dmgIncreasePct - a.dmgIncreasePct);
+}

--- a/src/features/gear-upgrade/engine/types.ts
+++ b/src/features/gear-upgrade/engine/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Gear Upgrade Optimizer — types
+ *
+ * A "what should I upgrade next?" engine. Given a player's current offensive
+ * stats, it computes the *marginal* DPS gained by changing a single piece of
+ * gear's trait, quality, or enchant. The output mirrors the community
+ * upgrade-priority tables but is computed from the user's own build rather
+ * than hardcoded from one parse.
+ *
+ * No runtime dependencies — pure types shared by the engine, catalog, and UI.
+ */
+
+/** Game mode affects the relevant penetration target / resistance defaults. */
+export type GameMode = 'pve' | 'pvp';
+
+/**
+ * The offensive snapshot a marginal-DPS calculation needs. These are the only
+ * quantities a single gear change can move; everything else (skill coefficient,
+ * buffs that don't change) cancels in the before/after ratio.
+ */
+export interface BuildBaseline {
+  /** Higher of Weapon or Spell Damage — whichever your damaging skills scale off. */
+  weaponOrSpellDamage: number;
+  /** Max Magicka or Max Stamina — whichever your damaging skills scale off. */
+  maxStat: number;
+  /** Total Critical Chance, percent (base 10 + sources). 0–100. */
+  critChancePct: number;
+  /** Total Critical Damage, percent (base 50 + sources). Capped at 125 in-game. */
+  critDamagePct: number;
+  /**
+   * The build's Critical Damage cap, percent. Defaults to 125, but some passives
+   * raise it (e.g. Nightblade's Above and Beyond, +30 → 155), which keeps
+   * crit-damage upgrades valuable above 125 instead of clamping to 0.
+   */
+  critDamageCapPct?: number;
+  /** Your offensive Penetration. */
+  penetration: number;
+  /** Target's Physical/Spell Resistance (boss ≈ 18,200 in PvE). */
+  targetResistance: number;
+  /** Which Mundus stone is slotted — determines what the Divines trait amplifies. */
+  mundus: MundusStone;
+  /**
+   * Share of your damage dealt while the FRONT bar is active (0–1). Weapon
+   * traits/quality/enchants only apply while their bar is active, so a front-bar
+   * weapon upgrade is weighted by this and a back-bar one by (1 − this).
+   * Jewelry and armor are always equipped, so they ignore it. When omitted,
+   * weapon upgrades are unweighted (treated as fully applicable).
+   */
+  frontBarDamageShare?: number;
+}
+
+/**
+ * Mundus stones relevant to damage. The Divines armor trait amplifies the
+ * slotted stone, so its value is routed through whichever stat the stone gives.
+ */
+export type MundusStone =
+  | 'thief' // Critical Chance (rating)
+  | 'shadow' // Critical Damage
+  | 'warrior' // Weapon Damage
+  | 'apprentice' // Spell Damage
+  | 'lover' // Penetration
+  | 'mage' // Max Stat
+  | 'other'; // no offensive stat (Atronach/Serpent/etc.) — Divines adds ~0 DPS
+
+/**
+ * A stat delta. The engine applies it on top of the baseline and re-derives the
+ * relative-damage factor. Only set the fields an upgrade actually changes.
+ */
+export interface StatPackage {
+  deltaWeaponOrSpellDamage?: number;
+  deltaMaxStat?: number;
+  /** Flat critical *rating* (converted to chance via the crit divisor). */
+  deltaCritRating?: number;
+  /** Critical *damage*, percentage points (added to the total, then capped). */
+  deltaCritDamagePct?: number;
+  deltaPenetration?: number;
+  /** Multiplicative "damage done" modifier, percentage points (e.g. Bloodthirsty). */
+  deltaDamageDonePct?: number;
+}
+
+/** Confidence in a catalog value, matching the rest of the toolkit's convention. */
+export type Confidence = 'high' | 'medium' | 'low';
+
+/** Slot family an upgrade applies to — drives the per-slot magnitude. */
+export type SlotKind =
+  | 'bigArmor' // chest, legs, head
+  | 'smallArmor' // shoulders, hands, waist, feet
+  | 'jewelry'
+  | 'mainHand1H'
+  | 'offHand1H'
+  | 'frontBar2H'
+  | 'backBar2H';
+
+/** A single catalog entry: one trait/quality/enchant change on one slot kind. */
+export interface UpgradeOption {
+  /** Stable id, e.g. "trait-nothing-to-divines-bigArmor". */
+  id: string;
+  /** Section the row belongs to. */
+  group: 'trait' | 'quality' | 'enchant';
+  /** Human label for the change, e.g. "Nothing → Divines". */
+  change: string;
+  /** Slot family this applies to. */
+  slot: SlotKind;
+  /** Friendly slot label for the table, e.g. "Big Armor". */
+  slotLabel: string;
+  /**
+   * The stat delta this change grants. For Mundus-dependent traits (Divines)
+   * this is resolved at compute time from the baseline's mundus, so it is
+   * provided as a function instead of a static package.
+   */
+  pkg: StatPackage | ((baseline: BuildBaseline) => StatPackage);
+  /**
+   * For weapon upgrades, the bar the weapon is on. Weapon stats only apply while
+   * that bar is active, so the marginal gain is weighted by the build's
+   * `frontBarDamageShare`. Omit for always-equipped jewelry/armor (global).
+   */
+  bar?: 'front' | 'back';
+  /** Confidence in the magnitude above. */
+  confidence: Confidence;
+  /** Short provenance / note (UESP, in-game tooltip, or derivation). */
+  note?: string;
+  /**
+   * Set when the change is genuinely not quantifiable from stats alone
+   * (status-effect chance / front-bar weapon traits). Such rows are shown in
+   * the qualitative guide, not the computed table.
+   */
+  qualitative?: boolean;
+}
+
+/** A computed table row: an upgrade option plus its marginal DPS for this build. */
+export interface UpgradeResult extends UpgradeOption {
+  /** Marginal DPS increase, percent (e.g. 0.32 means +0.32%). */
+  dmgIncreasePct: number;
+}

--- a/tools/eso-tooltip-dump/ESOTooltipDump.lua
+++ b/tools/eso-tooltip-dump/ESOTooltipDump.lua
@@ -867,6 +867,13 @@ local function handleSlash(args)
     d(string.format("[%s] Reference state: lvl=%s CP=%s equipped=%s | MagMax=%s StaMax=%s SpellDmg=%s WpnDmg=%s",
       ADDON_NAME, tostring(s.level), tostring(s.championPoints), tostring(s.equippedItemCount),
       tostring(s.magickaMax), tostring(s.staminaMax), tostring(s.spellPower), tostring(s.weaponPower)))
+    -- Crit (rating) + penetration too, so A/B gear-swap measurements can read
+    -- every offensive stat from this one command (see the gear-upgrade value
+    -- sourcing protocol). Crit DAMAGE is not a GetPlayerStat field — read it
+    -- from the in-game Character sheet instead.
+    d(string.format("[%s]   ...WpnCrit=%s SpellCrit=%s PhysPen=%s SpellPen=%s",
+      ADDON_NAME, tostring(s.weaponCrit), tostring(s.spellCrit),
+      tostring(s.physicalPen), tostring(s.spellPen)))
     return
   end
 


### PR DESCRIPTION
## What

A **computed** "what should I upgrade next?" optimizer, wired in as the **third top-level pill** on `/calculator` — **`[ Stats ] · [ Ultimate ] · [ Gear Upgrades ]`**. It ranks each trait, quality, and enchant change by the marginal DPS it would add to **your** build (from your own stats), rather than reproducing a single fixed parse table.

> **History:** originally opened off `main` as a standalone `/gear-upgrades` route, then stacked on #1235's tab shell as a pill. Now that #1235 has **merged**, this is **rebased cleanly onto `main`** as a single commit (8 files, +1380/−5). It folds into the existing `CalculatorPage` tab shell with a `#gear` hash deep-link mirroring `#ultimate`.

## How

- **`src/features/gear-upgrade/engine/`** — pure, dependency-free marginal-DPS math. Reuses the build-editor's already-sourced ESO constants (`CRIT_CHANCE_DIVISOR`, `CRIT_DMG_CAPS`, `ARMOR_CAP`) so they can't drift. `D = offensivePower × crit × mitigation`; marginal % is the after/before ratio, exact for any skill. Penetration past the resistance cap and crit damage past the cap both correctly read **at cap / 0**.
- **Bar-aware:** weapon trait/quality/enchant upgrades only apply while their bar is active, so they're weighted by a **front-bar damage share** input. Jewelry and armor are always equipped → global.
- **Catalog** — trait/quality/enchant stat packages, each `confidence`-tagged with a provenance note (CP160 Legendary). Mundus-dependent **Divines** resolves at compute time; **Bloodthirsty** is modelled as build-dependent Weapon/Spell Damage (per `src/data/esoTraits.ts`). Weapon traits (Charged/Nirnhoned/Precise) stay a **qualitative guide**.
- **Crit-damage cap is configurable** (`critDamageCapPct`, default 125; UI checkbox raises it to 155 for Nightblade's Above and Beyond).
- **Results-first, mobile-first UI:** a "best next upgrade" hero, a ranked priority list with magnitude bars + colour, one-tap presets, a category filter, and a scrollable pill bar.

## Honest status

Engine math is exact and unit-tested. The per-upgrade **stat magnitudes** in the catalog are a confidence-tagged first pass and need reconciliation against the in-game **`tools/eso-tooltip-dump`** client data before being treated as authoritative — the UI surfaces this per row, and the engine/UI need no changes when those numbers are refined.

## Verification

- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`, `check:no-esohub` — all clean.
- **28 tests pass** (engine math incl. crit/pen caps, raised-cap, Mundus-dependent Divines, and front/back bar weighting; catalog resolution; component smoke; `CalculatorPage` tab-switch + `#gear` deep-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)