### PR TITLE
fix(calculator): keep mobile gear button a perfect circle

### DIFF
--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -3190,6 +3190,15 @@ const CalculatorComponent: React.FC = () => {
               minWidth: isMobile ? '40px' : '175px',
               width: isMobile ? '40px' : '175px',
               minHeight: isMobile ? '40px' : '24px',
+              // Keep the mobile gear button a perfect circle. The global theme
+              // bumps every Button to a 44px min-height on coarse pointers, which
+              // — combined with the fixed 40px width — would otherwise render this
+              // round button as a vertical oval. Pin the height and neutralise the
+              // coarse-pointer min-height so width and height stay equal.
+              ...(isMobile && {
+                height: '40px',
+                '@media (pointer: coarse)': { minHeight: '40px' },
+              }),
               fontSize: '0.7rem',
               fontWeight: 600,
               py: isMobile ? 0 : 0.4,


### PR DESCRIPTION
## Problem

On the armor (resistance) calculator at `/calculator`, each gear item has a round gear-icon button on mobile that cycles its variant. These were rendering as **vertical ovals** instead of perfect circles.

## Root cause

The button is styled as a fixed **40px-wide** circle (`border-radius: 50%`, `width/min-width: 40px`, `min-height: 40px`) in `Calculator.tsx`.

The global theme (`ReduxThemeProvider.tsx`) applies a touch-target rule to **every** MUI Button:

```js
'@media (pointer: coarse)': { minHeight: 44 }
```

On touch devices that `44px` min-height overrode the button's own `40px` min-height, so the button became **44px tall × 40px wide** — an oval.

## Fix

Pin the mobile gear button's `height` to `40px` and re-assert `min-height: 40px` inside `@media (pointer: coarse)` for this button only, so width and height stay equal and it renders as a true circle. `sx` styles are injected after theme `styleOverrides`, so this reliably wins over the global coarse-pointer rule. Desktop and the 44px touch-target default for all other buttons are unchanged.

## Verification

- `tsc --noEmit` passes (no new errors).
- Visual check in-browser wasn't possible in this environment (no Chrome binary), but the change is a focused, well-understood CSS specificity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wmwv3KbXEVnVqJga6MT8Aw)_