### PR TITLE
fix(discord-bot): harden roster publishing edge cases

### DIFF
--- a/discord-bot/scripts/register-commands.js
+++ b/discord-bot/scripts/register-commands.js
@@ -35,6 +35,7 @@ const commands = [
     name: 'ticket',
     description: 'Manage support tickets',
     default_member_permissions: null, // available to everyone; handlers enforce permissions
+    dm_permission: false, // server-only; handlers assume interaction.member exists
     options: [
       {
         type: 1, // SUB_COMMAND
@@ -86,6 +87,7 @@ const commands = [
     name: 'roster',
     description: 'Manage ESO Toolkit roster → Discord integration',
     default_member_permissions: null,
+    dm_permission: false, // server-only; handlers assume interaction.member/guild exists
     options: [
       {
         type: 1, // SUB_COMMAND
@@ -148,7 +150,8 @@ const commands = [
               {
                 type: 3,
                 name: 'pattern',
-                description: 'Template: {day-short}, {day-full}, {time}, {tag}, {label}',
+                description:
+                  'Template: {day-short}, {day-full}, {day}, {time}, {trial}, {difficulty}',
                 required: true,
               },
             ],
@@ -187,6 +190,24 @@ const commands = [
                 type: 8,
                 name: 'dd-role',
                 description: 'DD role to ping',
+                required: false,
+              },
+              {
+                type: 5, // BOOLEAN
+                name: 'clear-tank',
+                description: 'Stop pinging a tank role',
+                required: false,
+              },
+              {
+                type: 5,
+                name: 'clear-healer',
+                description: 'Stop pinging a healer role',
+                required: false,
+              },
+              {
+                type: 5,
+                name: 'clear-dd',
+                description: 'Stop pinging a DD role',
                 required: false,
               },
             ],
@@ -264,18 +285,11 @@ async function registerCommands() {
   }
 
   console.log('✅ Commands registered successfully!');
-  console.log(
-    'Registered:',
-    data.map((c) => `/${c.name}`).join(', '),
-  );
+  console.log('Registered:', data.map((c) => `/${c.name}`).join(', '));
 
   if (!GUILD_ID) {
-    console.log(
-      '\nNote: Global commands can take up to 1 hour to propagate to all servers.',
-    );
-    console.log(
-      'For instant propagation during development, set DISCORD_GUILD_ID and re-run.',
-    );
+    console.log('\nNote: Global commands can take up to 1 hour to propagate to all servers.');
+    console.log('For instant propagation during development, set DISCORD_GUILD_ID and re-run.');
   }
 }
 

--- a/discord-bot/src/auth.test.ts
+++ b/discord-bot/src/auth.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { verifyHttpCaller } from './auth';
+import type { Env } from './types';
+
+const GUILD = '111111111111111111';
+const USER = '222222222222222222';
+const PUBLISH_ROLE = '333333333333333333';
+
+// Permission bitfields: MANAGE_GUILD = 1 << 5; SEND_MESSAGES = 1 << 11.
+const WITH_MANAGE = (1n << 5n).toString();
+const NO_MANAGE = (1n << 11n).toString();
+
+function makeKv(seed: Record<string, string> = {}): KVNamespace {
+  const store = new Map<string, string>(Object.entries(seed));
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+  } as unknown as KVNamespace;
+}
+
+function makeEnv(config: object): Env {
+  return {
+    ROSTERS: makeKv({ [`guild-config:${GUILD}`]: JSON.stringify(config) }),
+    DISCORD_BOT_TOKEN: 'bot-token',
+  } as unknown as Env;
+}
+
+function mockFetch(opts: { memberRoles?: string[]; guildPerms?: string }) {
+  return vi.fn(async (url: string | URL) => {
+    const u = url.toString();
+    if (u.endsWith('/users/@me')) {
+      return new Response(JSON.stringify({ id: USER }), { status: 200 });
+    }
+    if (u.endsWith('/users/@me/guilds')) {
+      return new Response(
+        JSON.stringify([{ id: GUILD, permissions: opts.guildPerms ?? NO_MANAGE }]),
+        {
+          status: 200,
+        },
+      );
+    }
+    if (u.includes(`/guilds/${GUILD}/members/`)) {
+      return new Response(JSON.stringify({ roles: opts.memberRoles ?? [] }), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('verifyHttpCaller — requireManageGuild gate', () => {
+  it('admins-only actions reject a publish-role holder who lacks MANAGE_GUILD', async () => {
+    const env = makeEnv({ guildId: GUILD, namePattern: 'x', allowedRoleIds: [PUBLISH_ROLE] });
+    vi.stubGlobal('fetch', mockFetch({ memberRoles: [PUBLISH_ROLE], guildPerms: NO_MANAGE }));
+
+    // Publish tier: the configured role grants access via role overlap.
+    const publishTier = await verifyHttpCaller(env, GUILD, 'Bearer tok');
+    expect(publishTier.authorized).toBe(true);
+
+    // Admin tier: the SAME caller must be rejected — the role overlap shortcut
+    // is skipped and MANAGE_GUILD is required. This is the privilege-escalation
+    // guard for config writes.
+    const adminTier = await verifyHttpCaller(env, GUILD, 'Bearer tok', {
+      requireManageGuild: true,
+    });
+    expect(adminTier.authorized).toBe(false);
+  });
+
+  it('admin actions succeed when the caller actually has MANAGE_GUILD', async () => {
+    const env = makeEnv({ guildId: GUILD, namePattern: 'x', allowedRoleIds: [PUBLISH_ROLE] });
+    vi.stubGlobal('fetch', mockFetch({ memberRoles: [PUBLISH_ROLE], guildPerms: WITH_MANAGE }));
+
+    const adminTier = await verifyHttpCaller(env, GUILD, 'Bearer tok', {
+      requireManageGuild: true,
+    });
+    expect(adminTier.authorized).toBe(true);
+    expect(adminTier.userId).toBe(USER);
+  });
+
+  it('rejects a missing/invalid Authorization header', async () => {
+    const env = makeEnv({ guildId: GUILD, namePattern: 'x' });
+    const res = await verifyHttpCaller(env, GUILD, null, { requireManageGuild: true });
+    expect(res.authorized).toBe(false);
+  });
+});

--- a/discord-bot/src/auth.ts
+++ b/discord-bot/src/auth.ts
@@ -140,8 +140,12 @@ export async function verifyHttpCaller(
     return {
       authorized: false,
       userId: me.id,
-      error:
-        'No allowed roles are configured for this server. Only server admins can publish until a role is set up with /roster config set-role.',
+      // Tailor the message to the requested tier: admin-tier callers (e.g. config
+      // writes) get an accurate "Manage Server required" message rather than the
+      // publish-oriented "set up a role" hint.
+      error: opts.requireManageGuild
+        ? 'Manage Server (MANAGE_GUILD) permission is required for this action.'
+        : 'No allowed roles are configured for this server. Only server admins can publish until a role is set up with /roster config set-role.',
     };
   }
 

--- a/discord-bot/src/auth.ts
+++ b/discord-bot/src/auth.ts
@@ -51,20 +51,33 @@ export interface HttpAuthResult {
   error?: string | undefined;
 }
 
+/** Options controlling which permission tier {@link verifyHttpCaller} enforces. */
+export interface VerifyHttpCallerOptions {
+  /**
+   * When true, require MANAGE_GUILD regardless of whether a publish role is
+   * configured. Use this for admin-only actions (e.g. writing guild config) so
+   * a holder of the publish-tier role can never reach admin-tier endpoints. The
+   * publish-role overlap shortcut is skipped entirely.
+   */
+  requireManageGuild?: boolean;
+}
+
 /**
- * Verify that an HTTP caller has permission to publish to the given guild.
+ * Verify that an HTTP caller has permission to act on the given guild.
  *
  * Flow:
  *   1. Extract Bearer token from Authorization header
  *   2. Call Discord /users/@me to get user ID
  *   3. Load guild config to check allowedRoleIds
- *   4. If roles configured: fetch member via bot token, check role overlap
- *   5. If no roles: check MANAGE_GUILD via user's guild list
+ *   4. If roles configured (and not requireManageGuild): fetch member via bot
+ *      token, check role overlap (publish tier)
+ *   5. Otherwise: check MANAGE_GUILD via user's guild list (admin tier)
  */
 export async function verifyHttpCaller(
   env: Env,
   guildId: string,
   authHeader: string | null,
+  opts: VerifyHttpCallerOptions = {},
 ): Promise<HttpAuthResult> {
   if (!authHeader?.startsWith('Bearer ')) {
     return { authorized: false, error: 'Missing or invalid Authorization header.' };
@@ -84,7 +97,10 @@ export async function verifyHttpCaller(
   const config = await getGuildConfig(env, guildId);
   const allowedRoles = config?.allowedRoleIds;
 
-  if (allowedRoles && allowedRoles.length > 0) {
+  // Admin-only actions must NEVER accept the publish-role tier: a publish-role
+  // holder could otherwise rewrite allowedRoleIds and escalate. Skip the
+  // role-overlap shortcut and fall through to the MANAGE_GUILD check.
+  if (!opts.requireManageGuild && allowedRoles && allowedRoles.length > 0) {
     // 3a. Roles are configured — check member's roles via bot token
     try {
       const member = await getGuildMember(env, guildId, me.id);
@@ -102,7 +118,9 @@ export async function verifyHttpCaller(
     }
   }
 
-  // 3b. No roles configured — check MANAGE_GUILD via user's guild list
+  // 3b. Admin tier — require MANAGE_GUILD via the user's guild list. Reached
+  // when no publish role is configured, or when the caller explicitly requested
+  // the admin tier (requireManageGuild).
   const guildsRes = await fetch(`${DISCORD_API}/users/@me/guilds`, {
     headers: { Authorization: `Bearer ${userToken}` },
   });

--- a/discord-bot/src/buttons/roster-refresh.ts
+++ b/discord-bot/src/buttons/roster-refresh.ts
@@ -8,7 +8,7 @@
 import { hasRosterPermission } from '../auth.js';
 import { sendFollowup } from '../discord.js';
 import {
-  getMappingByChannelId,
+  listMappingsForGuild,
   getGuildConfig,
   getDefaultGuildConfig,
   checkRosterRateLimit,
@@ -68,44 +68,57 @@ export async function handleRosterRefreshButton(
   }
 
   // The button encodes its own roster ID (roster_refresh:<rosterId>), so refresh
-  // that exact roster even when several rosters share one channel. Fall back to
-  // the channel→roster lookup for any older buttons without an encoded ID.
+  // that exact roster even when several rosters share one channel. Older buttons
+  // (or those whose ID was too long to fit the custom_id) carry none — for those
+  // we refresh every roster mapped to this channel, which also covers a default
+  // channel hosting several rosters.
   const customId = interaction.data?.custom_id ?? '';
   const prefix = `${RosterButtonId.REFRESH}:`;
   const encodedRosterId = customId.startsWith(prefix) ? customId.slice(prefix.length) : '';
 
   ctx.waitUntil(
     (async () => {
-      let rosterId = encodedRosterId;
-      if (!rosterId) {
-        const mapping = await getMappingByChannelId(env, channelId);
-        if (!mapping) {
+      let rosterIds: string[];
+      if (encodedRosterId) {
+        rosterIds = [encodedRosterId];
+      } else {
+        rosterIds = (await listMappingsForGuild(env, guildId))
+          .filter((m) => m.channelId === channelId)
+          .map((m) => m.rosterId);
+        if (rosterIds.length === 0) {
           await sendFollowup(env, interaction.token, {
             content: '❌ No roster is linked to this channel.',
             flags: MessageFlags.EPHEMERAL,
           });
           return;
         }
-        rosterId = mapping.rosterId;
       }
 
-      const result = await refreshRoster(env, rosterId, guildId);
-      if (result.ok && (result.refreshedCount ?? 0) > 0) {
+      let okCount = 0;
+      let lastError: string | undefined;
+      for (const rid of rosterIds) {
+        const result = await refreshRoster(env, rid, guildId);
+        if (result.ok && (result.refreshedCount ?? 0) > 0) okCount++;
+        else if (!result.ok) lastError = result.error;
+      }
+
+      if (okCount > 0) {
+        const suffix = rosterIds.length > 1 ? ` (${okCount}/${rosterIds.length})` : '';
         await sendFollowup(env, interaction.token, {
-          content: '✅ Roster refreshed!',
+          content: `✅ Roster refreshed!${suffix}`,
           flags: MessageFlags.EPHEMERAL,
         });
-      } else if (result.ok) {
-        // ok but nothing refreshed → this roster has no live post in this server
+      } else if (lastError) {
+        await sendFollowup(env, interaction.token, {
+          content: `❌ Refresh failed: ${lastError}`,
+          flags: MessageFlags.EPHEMERAL,
+        });
+      } else {
+        // ok but nothing refreshed → no live post for this roster in this server
         // (mapping removed/expired). Don't claim success.
         await sendFollowup(env, interaction.token, {
           content:
             "⚠️ Couldn't find this roster's post to refresh — it may have been removed. Try re-publishing it.",
-          flags: MessageFlags.EPHEMERAL,
-        });
-      } else {
-        await sendFollowup(env, interaction.token, {
-          content: `❌ Refresh failed: ${result.error}`,
           flags: MessageFlags.EPHEMERAL,
         });
       }

--- a/discord-bot/src/buttons/roster-signup.ts
+++ b/discord-bot/src/buttons/roster-signup.ts
@@ -8,16 +8,34 @@
  * slots.
  */
 
-import { InteractionResponseType } from '../types.js';
+import { checkRosterRateLimit } from '../roster/kv.js';
+import { InteractionResponseType, MessageFlags } from '../types.js';
 import type { DiscordInteraction, Env, InteractionResponse } from '../types.js';
 
-export function handleRosterSignupButton(
-  _env: Env,
+export async function handleRosterSignupButton(
+  env: Env,
   interaction: DiscordInteraction,
   role: string,
-): InteractionResponse {
+): Promise<InteractionResponse> {
   const username = interaction.member?.user?.username ?? 'Someone';
   const userId = interaction.member?.user?.id;
+
+  // Each click posts a public message, so throttle per user to prevent a
+  // signup-button click loop from flooding the channel. Ephemeral nudge when
+  // exceeded so the spammer (not the channel) sees the limit.
+  const guildId = interaction.guild_id;
+  if (guildId && userId) {
+    const allowed = await checkRosterRateLimit(env, `signup:${guildId}:${userId}`, 5, 60);
+    if (!allowed) {
+      return {
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: "⏳ You're signing up too quickly. Please wait a minute and try again.",
+          flags: MessageFlags.EPHEMERAL,
+        },
+      };
+    }
+  }
 
   const roleEmoji: Record<string, string> = {
     tank: '🛡️',
@@ -32,6 +50,7 @@ export function handleRosterSignupButton(
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
       content: `${emoji} **${username}** is interested in **${roleName}**!${userId ? ` (<@${userId}>)` : ''}\n-# *A raid lead will confirm your slot.*`,
+      allowed_mentions: { parse: [], users: userId ? [userId] : [] },
     },
   };
 }

--- a/discord-bot/src/commands/roster-config.test.ts
+++ b/discord-bot/src/commands/roster-config.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { handleRosterConfig } from './roster-config';
+import type { DiscordInteraction, DiscordInteractionOption, Env } from '../types';
+
+const GUILD = '111111111111111111';
+const USER = '222222222222222222';
+const TANK = '333333333333333333';
+const HEALER = '444444444444444444';
+const DD = '555555555555555555';
+const MANAGE_GUILD = (1n << 5n).toString();
+
+function makeKv(): { kv: KVNamespace; store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+  } as unknown as KVNamespace;
+  return { kv, store };
+}
+
+function configInteraction(options: DiscordInteractionOption[]): DiscordInteraction {
+  return {
+    id: 'i',
+    application_id: 'a',
+    type: 2,
+    token: 't',
+    guild_id: GUILD,
+    member: {
+      user: { id: USER, username: 'admin', discriminator: '0' },
+      roles: [],
+      permissions: MANAGE_GUILD,
+    },
+    data: { name: 'config', options },
+  };
+}
+
+const opt = (name: string, value: string | boolean): DiscordInteractionOption => ({
+  name,
+  type: typeof value === 'boolean' ? 5 : 8,
+  value,
+});
+
+const ctx = {} as unknown as ExecutionContext;
+
+function readPings(store: Map<string, string>): Record<string, string> | undefined {
+  const raw = store.get(`guild-config:${GUILD}`);
+  if (!raw) return undefined;
+  return (JSON.parse(raw) as { rolePingIds?: Record<string, string> }).rolePingIds;
+}
+
+describe('handleRosterConfig — set-role-pings clear flags', () => {
+  it('sets, then clears an individual ping role, then clears all', async () => {
+    const { kv, store } = makeKv();
+    const env = { ROSTERS: kv } as unknown as Env;
+
+    // 1. Set all three ping roles.
+    await handleRosterConfig(
+      env,
+      configInteraction([
+        {
+          name: 'set-role-pings',
+          type: 1,
+          options: [opt('tank-role', TANK), opt('healer-role', HEALER), opt('dd-role', DD)],
+        },
+      ]),
+      ctx,
+    );
+    expect(readPings(store)).toEqual({ tank: TANK, healer: HEALER, dd: DD });
+
+    // 2. Clear just the tank ping — healer/dd survive.
+    await handleRosterConfig(
+      env,
+      configInteraction([{ name: 'set-role-pings', type: 1, options: [opt('clear-tank', true)] }]),
+      ctx,
+    );
+    expect(readPings(store)).toEqual({ healer: HEALER, dd: DD });
+
+    // 3. Clear the rest — rolePingIds is dropped so config reads as unset.
+    await handleRosterConfig(
+      env,
+      configInteraction([
+        {
+          name: 'set-role-pings',
+          type: 1,
+          options: [opt('clear-healer', true), opt('clear-dd', true)],
+        },
+      ]),
+      ctx,
+    );
+    expect(readPings(store)).toBeUndefined();
+  });
+
+  it('a clear flag wins over a same-role value in the same invocation', async () => {
+    const { kv, store } = makeKv();
+    const env = { ROSTERS: kv } as unknown as Env;
+
+    await handleRosterConfig(
+      env,
+      configInteraction([
+        {
+          name: 'set-role-pings',
+          type: 1,
+          options: [opt('tank-role', TANK), opt('clear-tank', true)],
+        },
+      ]),
+      ctx,
+    );
+    expect(readPings(store)).toBeUndefined();
+  });
+
+  it('rejects a non-admin caller', async () => {
+    const { kv, store } = makeKv();
+    const env = { ROSTERS: kv } as unknown as Env;
+    const interaction = configInteraction([
+      { name: 'set-role-pings', type: 1, options: [opt('tank-role', TANK)] },
+    ]);
+    interaction.member!.permissions = '0'; // no MANAGE_GUILD
+    const res = await handleRosterConfig(env, interaction, ctx);
+    expect(res.data?.content).toContain('Manage Server');
+    expect(store.get(`guild-config:${GUILD}`)).toBeUndefined();
+  });
+});

--- a/discord-bot/src/commands/roster-config.ts
+++ b/discord-bot/src/commands/roster-config.ts
@@ -13,6 +13,7 @@
 
 import { isAdmin } from '../discord.js';
 import { getGuildConfig, getDefaultGuildConfig, upsertGuildConfig } from '../roster/kv.js';
+import type { GuildConfig } from '../roster/types.js';
 import { InteractionResponseType, MessageFlags } from '../types.js';
 import type {
   DiscordInteraction,
@@ -21,27 +22,30 @@ import type {
   InteractionResponse,
 } from '../types.js';
 
+/** Discord snowflake (17–20 digits) — reject malformed IDs before storing them. */
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
 export async function handleRosterConfig(
   env: Env,
   interaction: DiscordInteraction,
   _ctx: ExecutionContext,
 ): Promise<InteractionResponse> {
-  if (!isAdmin(interaction)) {
-    return {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-      data: {
-        content: '❌ You need **Manage Server** permission to configure roster settings.',
-        flags: MessageFlags.EPHEMERAL,
-      },
-    };
-  }
-
   const guildId = interaction.guild_id;
   if (!guildId) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content: '❌ This command can only be used in a server.',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
+  if (!isAdmin(interaction)) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '❌ You need **Manage Server** permission to configure roster settings.',
         flags: MessageFlags.EPHEMERAL,
       },
     };
@@ -124,7 +128,7 @@ async function handleSetNamePattern(
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content:
-          '❌ Please provide a pattern. Tokens: `{day-short}`, `{day}`, `{time}`, `{trial}`, `{difficulty}`',
+          '❌ Please provide a pattern. Tokens: `{day-short}`, `{day-full}`, `{day}`, `{time}`, `{trial}`, `{difficulty}`',
         flags: MessageFlags.EPHEMERAL,
       },
     };
@@ -160,11 +164,11 @@ async function handleSetDefaultCategory(
   options: DiscordInteractionOption[],
 ): Promise<InteractionResponse> {
   const categoryId = options.find((o) => o.name === 'category')?.value as string | undefined;
-  if (!categoryId) {
+  if (!categoryId || !SNOWFLAKE_RE.test(categoryId)) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: '❌ Please provide a category channel ID.',
+        content: '❌ Please pick a valid category from the list.',
         flags: MessageFlags.EPHEMERAL,
       },
     };
@@ -192,16 +196,22 @@ async function handleSetRolePings(
   const healer = options.find((o) => o.name === 'healer-role')?.value as string | undefined;
   const dd = options.find((o) => o.name === 'dd-role')?.value as string | undefined;
 
+  // Boolean "clear" flags let an admin REMOVE a configured ping role. ROLE
+  // options can't carry an empty value, so without these there is no slash
+  // path to stop pinging a role once set.
+  const clearTank = options.find((o) => o.name === 'clear-tank')?.value === true;
+  const clearHealer = options.find((o) => o.name === 'clear-healer')?.value === true;
+  const clearDd = options.find((o) => o.name === 'clear-dd')?.value === true;
+
   // Defense-in-depth: option values come from Discord role pickers (already
   // snowflakes), but reject anything malformed so we never store junk that
   // would later be skipped silently at ping time.
-  const snowflake = /^\d{17,20}$/;
   for (const [label, value] of [
     ['tank', tank],
     ['healer', healer],
     ['dd', dd],
   ] as const) {
-    if (value !== undefined && !snowflake.test(value)) {
+    if (value !== undefined && !SNOWFLAKE_RE.test(value)) {
       return {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
@@ -213,18 +223,30 @@ async function handleSetRolePings(
   }
 
   const config = (await getGuildConfig(env, guildId)) ?? getDefaultGuildConfig(guildId);
-  config.rolePingIds = {
-    ...config.rolePingIds,
-    ...(tank !== undefined ? { tank } : {}),
-    ...(healer !== undefined ? { healer } : {}),
-    ...(dd !== undefined ? { dd } : {}),
-  };
+  const next: NonNullable<GuildConfig['rolePingIds']> = { ...config.rolePingIds };
+  // A clear flag wins over a same-role value; otherwise set when provided.
+  if (clearTank) delete next.tank;
+  else if (tank !== undefined) next.tank = tank;
+  if (clearHealer) delete next.healer;
+  else if (healer !== undefined) next.healer = healer;
+  if (clearDd) delete next.dd;
+  else if (dd !== undefined) next.dd = dd;
+
+  // Drop the object entirely when nothing remains, so the config reads as unset.
+  if (!next.tank && !next.healer && !next.dd) {
+    delete config.rolePingIds;
+  } else {
+    config.rolePingIds = next;
+  }
   await upsertGuildConfig(env, config);
 
+  const cleared = clearTank || clearHealer || clearDd;
   return {
     type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
     data: {
-      content: '✅ Role pings updated.',
+      content: cleared
+        ? '✅ Role pings updated (cleared roles removed).'
+        : '✅ Role pings updated.',
       flags: MessageFlags.EPHEMERAL,
     },
   };
@@ -238,11 +260,11 @@ async function handleSetRole(
   options: DiscordInteractionOption[],
 ): Promise<InteractionResponse> {
   const roleId = options.find((o) => o.name === 'role')?.value as string | undefined;
-  if (!roleId) {
+  if (!roleId || !SNOWFLAKE_RE.test(roleId)) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: '❌ Please provide a role.',
+        content: '❌ Please pick a valid role from the list.',
         flags: MessageFlags.EPHEMERAL,
       },
     };
@@ -267,11 +289,11 @@ async function handleAddRole(
   options: DiscordInteractionOption[],
 ): Promise<InteractionResponse> {
   const roleId = options.find((o) => o.name === 'role')?.value as string | undefined;
-  if (!roleId) {
+  if (!roleId || !SNOWFLAKE_RE.test(roleId)) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: '❌ Please provide a role.',
+        content: '❌ Please pick a valid role from the list.',
         flags: MessageFlags.EPHEMERAL,
       },
     };

--- a/discord-bot/src/commands/roster-setup.ts
+++ b/discord-bot/src/commands/roster-setup.ts
@@ -14,22 +14,22 @@ export async function handleRosterSetup(
   env: Env,
   interaction: DiscordInteraction,
 ): Promise<InteractionResponse> {
-  if (!isAdmin(interaction)) {
-    return {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-      data: {
-        content: '❌ You need **Manage Server** permission to view setup instructions.',
-        flags: MessageFlags.EPHEMERAL,
-      },
-    };
-  }
-
   const guildId = interaction.guild_id;
   if (!guildId) {
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: 'This command can only be used in a server.',
+        content: '❌ This command can only be used in a server.',
+        flags: MessageFlags.EPHEMERAL,
+      },
+    };
+  }
+
+  if (!isAdmin(interaction)) {
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '❌ You need **Manage Server** permission to view setup instructions.',
         flags: MessageFlags.EPHEMERAL,
       },
     };
@@ -72,7 +72,7 @@ export async function handleRosterSetup(
     '',
     `${check(hasNamePattern)} **Step 4 — Customize channel names** *(optional)*`,
     'Set a template for auto-generated channel names.',
-    'Tokens: `{day-short}`, `{day}`, `{time}`, `{trial}`, `{difficulty}`',
+    'Tokens: `{day-short}`, `{day-full}`, `{day}`, `{time}`, `{trial}`, `{difficulty}`',
     '```',
     '/roster config set-name-pattern {day-short}-{time}-{trial}',
     '```',

--- a/discord-bot/src/handlers/buttons.ts
+++ b/discord-bot/src/handlers/buttons.ts
@@ -50,8 +50,8 @@ export async function handleButton(
     return handleRosterSignupButton(env, interaction, role);
   }
 
-  // Refresh button: roster_refresh:<rosterId>
-  if (customId.startsWith(`${RosterButtonId.REFRESH}:`)) {
+  // Refresh button: roster_refresh or roster_refresh:<rosterId>
+  if (customId === RosterButtonId.REFRESH || customId.startsWith(`${RosterButtonId.REFRESH}:`)) {
     return handleRosterRefreshButton(env, interaction, ctx);
   }
 

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -598,9 +598,10 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
       guildId,
       ...(typeof body.defaultChannelId === 'string' &&
         /^\d{17,20}$/.test(body.defaultChannelId) && { defaultChannelId: body.defaultChannelId }),
-      ...(typeof body.defaultCategoryId === 'string' && {
-        defaultCategoryId: body.defaultCategoryId,
-      }),
+      ...(typeof body.defaultCategoryId === 'string' &&
+        /^\d{17,20}$/.test(body.defaultCategoryId) && {
+          defaultCategoryId: body.defaultCategoryId,
+        }),
       ...(typeof body.namePattern === 'string' &&
         body.namePattern.length <= 100 && { namePattern: body.namePattern }),
       ...(Array.isArray(body.allowedRoleIds) && {
@@ -629,8 +630,9 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
         })() && { timezone: body.timezone }),
     };
 
-    // An explicit empty string clears the default posting channel.
+    // An explicit empty string clears the default posting channel / category.
     if (body.defaultChannelId === '') delete (updated as GuildConfig).defaultChannelId;
+    if (body.defaultCategoryId === '') delete (updated as GuildConfig).defaultCategoryId;
 
     await upsertGuildConfig(env, updated);
     return jsonResponse({ ok: true, config: updated });

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -13,7 +13,12 @@ import { handleButton } from './handlers/buttons.js';
 import { handleCommand } from './handlers/commands.js';
 import { handleModal } from './handlers/modals.js';
 import { publishRoster, refreshRoster, publishDirect } from './roster/index.js';
-import { getGuildConfig, upsertGuildConfig, getDefaultGuildConfig } from './roster/kv.js';
+import {
+  getGuildConfig,
+  upsertGuildConfig,
+  getDefaultGuildConfig,
+  checkRosterRateLimit,
+} from './roster/kv.js';
 import type { GuildConfig } from './roster/types.js';
 import type { PublishRequest, DirectPublishRequest } from './roster/index.js';
 import { KV_PREFIX } from './roster/kv.js';
@@ -106,7 +111,8 @@ export default {
       return withCors(request, env, await handleOAuthTokenExchange(request, env));
     }
 
-    // ── Guild config API routes (CORS-enabled, admin auth) ────────────
+    // ── Guild config API routes (CORS-enabled; reads = publish tier,
+    //    config writes = admin/MANAGE_GUILD, enforced per-route) ────────
     if (url.pathname.startsWith('/discord/guild/')) {
       return withCors(request, env, await handleGuildApi(request, url, env));
     }
@@ -357,6 +363,18 @@ async function handleRosterApi(request: Request, url: URL, env: Env): Promise<Re
   }
 
   if (path === '/discord/roster/publish') {
+    // Throttle channel creation per publisher. Shares the slash command's
+    // budget (same namespace + key) so the HTTP surface can't be used to
+    // bypass the interaction-side limit.
+    const allowed = await checkRosterRateLimit(
+      env,
+      `publish:${guildId}:${auth.userId ?? 'anon'}`,
+      5,
+      60,
+    );
+    if (!allowed) {
+      return jsonResponse({ error: 'Rate limit exceeded. Try again in a minute.' }, 429);
+    }
     return handlePublish(body, env, auth.userId);
   }
   if (path === '/discord/roster/publish-direct') {
@@ -428,6 +446,17 @@ async function handleRefresh(
     const auth = await verifyHttpCaller(env, guildId, authHeader);
     if (!auth.authorized) {
       return jsonResponse({ error: auth.error ?? 'Forbidden' }, 403);
+    }
+    // Throttle user-initiated refreshes (shares the slash command's budget).
+    // The webhook/server-to-server path above is intentionally left unthrottled.
+    const allowed = await checkRosterRateLimit(
+      env,
+      `refresh:${guildId}:${auth.userId ?? 'anon'}`,
+      10,
+      60,
+    );
+    if (!allowed) {
+      return jsonResponse({ error: 'Rate limit exceeded. Try again in a minute.' }, 429);
     }
     scopeGuildId = guildId;
   }
@@ -502,7 +531,9 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
   const guildId = extractGuildId(url.pathname);
   if (!guildId) return jsonResponse({ error: 'Invalid guild ID.' }, 400);
 
-  // All guild config routes require admin auth
+  // Route-level auth covers the publish tier (read-only channel/role/config
+  // GETs). Config *writes* require MANAGE_GUILD — re-checked in the PUT branch
+  // below so a publish-role holder can't rewrite allowedRoleIds and escalate.
   const auth = await verifyHttpCaller(env, guildId, request.headers.get('Authorization'));
   if (!auth.authorized) {
     return jsonResponse({ error: auth.error ?? 'Unauthorized.' }, 403);
@@ -541,6 +572,19 @@ async function handleGuildApi(request: Request, url: URL, env: Env): Promise<Res
   }
 
   if (subpath === 'config' && request.method === 'PUT') {
+    // Config writes are admin-only — parity with the `/roster config` slash
+    // command (requires Manage Server). The route-level check above only
+    // guarantees the publish tier, so require MANAGE_GUILD here explicitly.
+    const adminAuth = await verifyHttpCaller(env, guildId, request.headers.get('Authorization'), {
+      requireManageGuild: true,
+    });
+    if (!adminAuth.authorized) {
+      return jsonResponse(
+        { error: adminAuth.error ?? 'Manage Server permission is required to change settings.' },
+        403,
+      );
+    }
+
     let body: Record<string, unknown>;
     try {
       body = (await request.json()) as Record<string, unknown>;

--- a/discord-bot/src/roster/decoder.test.ts
+++ b/discord-bot/src/roster/decoder.test.ts
@@ -53,3 +53,33 @@ describe('decodeRosterData — composition', () => {
     await expect(decodeRosterData(data)).rejects.toThrow(/Unsupported roster version/);
   });
 });
+
+describe('decodeRosterData — gear sets', () => {
+  it('keeps a DPS slot whose only gear is in additionalSets (no primary set)', async () => {
+    // 575 = Pale Order, 658 = Oakensoul Ring — a mythic-only DD.
+    const data = await encodeRoster({ v: 3, dp: [{ sn: 1, as: [575, 658] }] });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.dps[0]?.sets).toEqual(['Pale Order', 'Oakensoul Ring']);
+  });
+
+  it('still merges additionalSets after the primary sets when both are present', async () => {
+    const data = await encodeRoster({ v: 3, dp: [{ sn: 1, s1: 80, s2: 292, as: [575] }] });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.dps[0]?.sets).toEqual(["Hunding's Rage", "Mother's Sorrow", 'Pale Order']);
+  });
+});
+
+describe('decodeRosterData — malformed input is tolerated', () => {
+  it('does not throw when array-typed fields arrive as non-arrays', async () => {
+    // Crafted payload: labels/groups/additionalSets are strings, not arrays.
+    const data = await encodeRoster({
+      v: 3,
+      ts: [{ lb: 'evil', grs: 'nope' }],
+      dp: [{ sn: 1, as: 'bad' }],
+    });
+    const decoded = await decodeRosterData(data);
+    expect(decoded.tanks[0]?.labels).toBeUndefined();
+    expect(decoded.tanks[0]?.groups).toBeUndefined();
+    expect(decoded.dps[0]?.sets).toBeUndefined();
+  });
+});

--- a/discord-bot/src/roster/decoder.ts
+++ b/discord-bot/src/roster/decoder.ts
@@ -239,18 +239,26 @@ function decodeGroupName(
   grs?: string[],
   gr?: CompactGroup,
 ): { groups?: string[]; groupName?: string } {
-  if (grs?.length) return { groups: grs };
+  if (Array.isArray(grs) && grs.length) return { groups: grs };
   if (gr?.g) return { groupName: gr.g };
   return {};
+}
+
+/** Pass through a labels array only when it is genuinely an array. */
+function safeLabels(lb: unknown): string[] | undefined {
+  return Array.isArray(lb) ? (lb as string[]) : undefined;
 }
 
 function collectSets(ids: (number | undefined)[], additional?: number[]): string[] | undefined {
   const sets: string[] = [];
   for (const id of ids) {
-    if (id != null) sets.push(getSetName(id));
+    if (typeof id === 'number') sets.push(getSetName(id));
   }
-  if (additional) {
-    for (const id of additional) sets.push(getSetName(id));
+  // Guard against malformed payloads where `additional` is not an array.
+  if (Array.isArray(additional)) {
+    for (const id of additional) {
+      if (typeof id === 'number') sets.push(getSetName(id));
+    }
   }
   return sets.length > 0 ? sets : undefined;
 }
@@ -265,7 +273,7 @@ function decodeTank(t: CompactTank): DecodedRosterSlot {
     buildRefId: t.br?.bi,
     positionTag: t.pt,
     playerNumber: t.pi,
-    labels: t.lb,
+    labels: safeLabels(t.lb),
     roleNotes: t.rn,
     ultimate: decodeUltimate(t.ul),
     skillLines: decodeSkillLines(t.sl),
@@ -284,7 +292,7 @@ function decodeHealer(h: CompactHealer): DecodedRosterSlot {
     buildRefId: h.br?.bi,
     positionTag: h.pt,
     playerNumber: h.pi,
-    labels: h.lb,
+    labels: safeLabels(h.lb),
     roleNotes: h.rn,
     ultimate: decodeUltimate(h.ul),
     skillLines: decodeSkillLines(h.sl),
@@ -297,11 +305,14 @@ function decodeHealer(h: CompactHealer): DecodedRosterSlot {
 
 function decodeDPS(d: CompactDPS): DecodedRosterSlot {
   const grp = decodeGroupName(d.grs, d.gr);
-  // Prefer structured set fields; fall back to legacy gs array
+  // Prefer structured set fields; fall back to legacy gs array.
+  // Include the `as` (additionalSets) array even when no primary set is set —
+  // a DD whose only gear is in additionalSets (e.g. a mythic-only slot) must
+  // still render a GEAR line, matching the web "Copy to Discord" format.
   let sets: string[];
-  if (d.s1 != null || d.s2 != null || d.ms != null) {
+  if (d.s1 != null || d.s2 != null || d.ms != null || (Array.isArray(d.as) && d.as.length > 0)) {
     sets = collectSets([d.s1, d.s2, d.ms], d.as) ?? [];
-  } else if (d.gs?.length) {
+  } else if (Array.isArray(d.gs) && d.gs.length) {
     sets = d.gs.map((id) => getSetName(id)).filter(Boolean);
   } else {
     sets = [];
@@ -318,7 +329,7 @@ function decodeDPS(d: CompactDPS): DecodedRosterSlot {
     buildRefId: d.br?.bi,
     positionTag: d.pt,
     playerNumber: d.pi,
-    labels: d.lb,
+    labels: safeLabels(d.lb),
     roleNotes: d.rn,
     ultimate: decodeUltimate(d.ul),
     skillLines: decodeSkillLines(d.sl),

--- a/discord-bot/src/roster/embed-builder.test.ts
+++ b/discord-bot/src/roster/embed-builder.test.ts
@@ -156,6 +156,22 @@ describe('splitMessages', () => {
     const rejoined = chunks.join('\n');
     expect(rejoined).toBe(text);
   });
+
+  it('hard-wraps a single over-limit line without dropping content', () => {
+    const longLine = 'A'.repeat(4500);
+    const chunks = splitMessages(`before\n${longLine}\nafter`);
+
+    expect(chunks).toEqual([
+      'before',
+      longLine.slice(0, 2000),
+      longLine.slice(2000, 4000),
+      longLine.slice(4000),
+      'after',
+    ]);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+    }
+  });
 });
 
 describe('buildRosterActionRows', () => {
@@ -184,6 +200,23 @@ describe('buildRosterActionRows', () => {
     const rows = buildRosterActionRows('abc-xyz');
     const buttons = rows[0].components ?? [];
     expect(buttons[0].custom_id).toContain('abc-xyz');
+  });
+
+  it('does not truncate over-limit roster IDs in custom_ids', () => {
+    const longRosterId = 'r'.repeat(120);
+    const rows = buildRosterActionRows(longRosterId);
+    const signupButtons = rows[0].components ?? [];
+    const actionButtons = rows[1].components ?? [];
+    const refreshButton = actionButtons.find((button) =>
+      button.custom_id?.startsWith('roster_refresh'),
+    );
+
+    expect(signupButtons.map((button) => button.custom_id)).toEqual([
+      'roster_signup:tank',
+      'roster_signup:healer',
+      'roster_signup:dd',
+    ]);
+    expect(refreshButton?.custom_id).toBe('roster_refresh');
   });
 });
 

--- a/discord-bot/src/roster/embed-builder.ts
+++ b/discord-bot/src/roster/embed-builder.ts
@@ -22,8 +22,9 @@ const SEPARATOR = '▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬';
 /** Wrap a value in brackets as a header token — returns empty string if falsy. */
 const bracket = (val: string | null | undefined): string => (val ? ` [${val}]` : '');
 
-/** Wrap an array of values as bracket tokens. */
-const bracketed = (vals: string[]): string => vals.map((v) => ` [${v}]`).join('');
+/** Wrap an array of values as bracket tokens. Tolerates non-array input. */
+const bracketed = (vals: string[]): string =>
+  Array.isArray(vals) ? vals.map((v) => ` [${v}]`).join('') : '';
 
 /** Derive group arrow from group name: "left" → ⬅️, "right" → ➡️ */
 function groupArrow(slot: DecodedRosterSlot): string {

--- a/discord-bot/src/roster/embed-builder.ts
+++ b/discord-bot/src/roster/embed-builder.ts
@@ -155,7 +155,9 @@ export function buildRosterText(
   sortedDPS.forEach((dd) => {
     const arrow = groupArrow(dd);
     const slotNum = dd.slotNumber ?? 0;
-    const jailType = dd.jailDDType ? ` [${dd.jailDDType === 'Custom' && dd.customDescription ? dd.customDescription : dd.jailDDType}]` : '';
+    const jailType = dd.jailDDType
+      ? ` [${dd.jailDDType === 'Custom' && dd.customDescription ? dd.customDescription : dd.jailDDType}]`
+      : '';
     const pos = formatPosition(dd.positionTag, dd.playerNumber);
     const roleNote = bracket(dd.roleNotes);
     const labelsPart = dd.labels?.length ? bracketed(dd.labels) : '';
@@ -189,7 +191,8 @@ export function buildRosterText(
 
 /**
  * Split text into chunks that each fit within Discord's 2000-char limit.
- * Splits on line boundaries so no line is broken mid-way.
+ * Splits on line boundaries where possible, but hard-wraps individual lines
+ * that exceed Discord's limit so roster content is never silently discarded.
  */
 export function splitMessages(text: string): string[] {
   if (text.length <= MAX_MESSAGE_LENGTH) return [text];
@@ -198,21 +201,39 @@ export function splitMessages(text: string): string[] {
   const chunks: string[] = [];
   let current = '';
 
-  for (const line of lines) {
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      chunks.push(current);
+      current = '';
+    }
+  };
+
+  const appendLine = (line: string) => {
     const addition = current.length === 0 ? line : `\n${line}`;
     if (current.length + addition.length > MAX_MESSAGE_LENGTH) {
-      if (current.length > 0) {
-        chunks.push(current);
-      }
-      current = line.length > MAX_MESSAGE_LENGTH ? line.slice(0, MAX_MESSAGE_LENGTH) : line;
+      pushCurrent();
+      current = line;
     } else {
       current += addition;
     }
+  };
+
+  for (const line of lines) {
+    if (line.length <= MAX_MESSAGE_LENGTH) {
+      appendLine(line);
+      continue;
+    }
+
+    // A single free-text field can exceed 2000 chars (for example pasted
+    // notes). Preserve the entire value by hard-wrapping that line after
+    // flushing any accumulated line-boundary chunk.
+    pushCurrent();
+    for (let start = 0; start < line.length; start += MAX_MESSAGE_LENGTH) {
+      chunks.push(line.slice(start, start + MAX_MESSAGE_LENGTH));
+    }
   }
 
-  if (current.length > 0) {
-    chunks.push(current);
-  }
+  pushCurrent();
 
   return chunks;
 }
@@ -274,8 +295,11 @@ export function buildRolePingLine(
 // ── Action Rows ─────────────────────────────────────────────────────────────
 
 export function buildRosterActionRows(rosterId: string): DiscordComponent[] {
-  // Discord custom_id max is 100 chars. Longest prefix is "roster_signup:healer:" (22 chars).
-  const id = rosterId.slice(0, 75);
+  // Discord custom_id max is 100 chars. Never truncate roster IDs: a truncated
+  // refresh ID cannot be looked up in KV. When an ID is too long, omit it and
+  // let the refresh handler fall back to the channel→roster mapping.
+  const customIdWithOptionalRosterId = (prefix: string): string =>
+    `${prefix}:${rosterId}`.length <= 100 ? `${prefix}:${rosterId}` : prefix;
   return [
     {
       type: ComponentType.ACTION_ROW,
@@ -285,21 +309,21 @@ export function buildRosterActionRows(rosterId: string): DiscordComponent[] {
           style: ButtonStyle.PRIMARY,
           label: 'Tank',
           emoji: { name: '🛡️' },
-          custom_id: `${RosterButtonId.SIGNUP_PREFIX}tank:${id}`,
+          custom_id: customIdWithOptionalRosterId(`${RosterButtonId.SIGNUP_PREFIX}tank`),
         },
         {
           type: ComponentType.BUTTON,
           style: ButtonStyle.PRIMARY,
           label: 'Healer',
           emoji: { name: '💚' },
-          custom_id: `${RosterButtonId.SIGNUP_PREFIX}healer:${id}`,
+          custom_id: customIdWithOptionalRosterId(`${RosterButtonId.SIGNUP_PREFIX}healer`),
         },
         {
           type: ComponentType.BUTTON,
           style: ButtonStyle.PRIMARY,
           label: 'DD',
           emoji: { name: '⚔️' },
-          custom_id: `${RosterButtonId.SIGNUP_PREFIX}dd:${id}`,
+          custom_id: customIdWithOptionalRosterId(`${RosterButtonId.SIGNUP_PREFIX}dd`),
         },
       ],
     },
@@ -317,7 +341,7 @@ export function buildRosterActionRows(rosterId: string): DiscordComponent[] {
           style: ButtonStyle.SECONDARY,
           label: 'Refresh',
           emoji: { name: '🔄' },
-          custom_id: `${RosterButtonId.REFRESH}:${id}`,
+          custom_id: customIdWithOptionalRosterId(RosterButtonId.REFRESH),
         },
       ],
     },

--- a/discord-bot/src/roster/index.ts
+++ b/discord-bot/src/roster/index.ts
@@ -16,7 +16,6 @@ export type {
 
 export {
   getMappingByRosterId,
-  getMappingByChannelId,
   upsertMapping,
   deleteMappingForRoster,
   listMappingsForGuild,
@@ -35,4 +34,9 @@ export { decodeRosterData } from './decoder.js';
 export { fetchRosterSnapshot } from './api.js';
 
 export { publishRoster, refreshRoster, publishDirect } from './publish.js';
-export type { PublishRequest, PublishResult, RefreshResult, DirectPublishRequest } from './publish.js';
+export type {
+  PublishRequest,
+  PublishResult,
+  RefreshResult,
+  DirectPublishRequest,
+} from './publish.js';

--- a/discord-bot/src/roster/kv.ts
+++ b/discord-bot/src/roster/kv.ts
@@ -4,9 +4,12 @@
  * Key schema:
  *   roster-map:{guildId}:{rosterId}  → JSON RosterMapping
  *   guild-config:{guildId}           → JSON GuildConfig
- *   channel-roster:{channelId}       → "{guildId}:{rosterId}" (reverse lookup)
  *   roster-data:{rosterId}           → encoded roster_data (direct-publish only)
  *   roster-meta:{rosterId}           → JSON snapshot metadata (direct-publish only)
+ *
+ * Channel→roster resolution is done by scanning roster-map entries
+ * (listMappingsForGuild) rather than a reverse index: a single default channel
+ * can host many rosters, which a one-value reverse key cannot represent.
  */
 
 import type { Env } from '../types.js';
@@ -16,7 +19,6 @@ import type { GuildConfig, RosterMapping } from './types.js';
 
 export const KV_PREFIX = {
   ROSTER_MAP: 'roster-map',
-  CHANNEL_ROSTER: 'channel-roster',
   GUILD_CONFIG: 'guild-config',
   ROSTER_DATA: 'roster-data',
   ROSTER_META: 'roster-meta',
@@ -26,10 +28,6 @@ export const KV_PREFIX = {
 
 function mappingKey(guildId: string, rosterId: string): string {
   return `${KV_PREFIX.ROSTER_MAP}:${guildId}:${rosterId}`;
-}
-
-function reverseKey(channelId: string): string {
-  return `${KV_PREFIX.CHANNEL_ROSTER}:${channelId}`;
 }
 
 export async function getMappingByRosterId(
@@ -47,20 +45,6 @@ export async function getMappingByRosterId(
   }
 }
 
-export async function getMappingByChannelId(
-  env: Env,
-  channelId: string,
-): Promise<RosterMapping | null> {
-  const ref = await env.ROSTERS.get(reverseKey(channelId));
-  if (!ref) return null;
-  const idx = ref.indexOf(':');
-  if (idx === -1) return null;
-  const guildId = ref.slice(0, idx);
-  const rosterId = ref.slice(idx + 1);
-  if (!guildId || !rosterId) return null;
-  return getMappingByRosterId(env, guildId, rosterId);
-}
-
 export async function upsertMapping(
   env: Env,
   mapping: RosterMapping,
@@ -68,10 +52,7 @@ export async function upsertMapping(
 ): Promise<void> {
   const json = JSON.stringify(mapping);
   const opts = expirationTtl ? { expirationTtl } : undefined;
-  await Promise.all([
-    env.ROSTERS.put(mappingKey(mapping.guildId, mapping.rosterId), json, opts),
-    env.ROSTERS.put(reverseKey(mapping.channelId), `${mapping.guildId}:${mapping.rosterId}`, opts),
-  ]);
+  await env.ROSTERS.put(mappingKey(mapping.guildId, mapping.rosterId), json, opts);
 }
 
 export async function deleteMappingForRoster(
@@ -79,11 +60,7 @@ export async function deleteMappingForRoster(
   guildId: string,
   rosterId: string,
 ): Promise<void> {
-  const existing = await getMappingByRosterId(env, guildId, rosterId);
   await env.ROSTERS.delete(mappingKey(guildId, rosterId));
-  if (existing) {
-    await env.ROSTERS.delete(reverseKey(existing.channelId));
-  }
 }
 
 // ── All Mappings for a Guild (list by prefix) ───────────────────────────────
@@ -149,27 +126,40 @@ const LOCK_TTL_SECONDS = 30;
 
 /**
  * Attempt to acquire a short-lived lock for a roster+guild pair.
- * Returns true if the lock was acquired, false if already held.
- * The lock expires after 30 seconds to prevent deadlocks.
+ * Returns a fencing token (string) if the lock was acquired, or null if it is
+ * already held. The lock expires after 30 seconds to prevent deadlocks.
+ *
+ * Best-effort only: KV has no compare-and-swap, so under a true simultaneous
+ * race both callers can observe an empty key and proceed. This narrows the
+ * common double-submit window but cannot guarantee single-flight.
  */
 export async function acquirePublishLock(
   env: Env,
   guildId: string,
   rosterId: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const key = `${LOCK_PREFIX}:${guildId}:${rosterId}`;
   const existing = await env.ROSTERS.get(key);
-  if (existing) return false;
-  await env.ROSTERS.put(key, Date.now().toString(), { expirationTtl: LOCK_TTL_SECONDS });
-  return true;
+  if (existing) return null;
+  const token = crypto.randomUUID();
+  await env.ROSTERS.put(key, token, { expirationTtl: LOCK_TTL_SECONDS });
+  return token;
 }
 
+/**
+ * Release a previously-acquired lock. Only deletes the key when it still holds
+ * the same fencing token — so a caller whose lock TTL-expired (and was then
+ * re-acquired by someone else) can't delete the new owner's lock.
+ */
 export async function releasePublishLock(
   env: Env,
   guildId: string,
   rosterId: string,
+  token: string,
 ): Promise<void> {
-  await env.ROSTERS.delete(`${LOCK_PREFIX}:${guildId}:${rosterId}`);
+  const key = `${LOCK_PREFIX}:${guildId}:${rosterId}`;
+  const current = await env.ROSTERS.get(key);
+  if (current === token) await env.ROSTERS.delete(key);
 }
 
 // ── Rate limiting ────────────────────────────────────────────────────────────

--- a/discord-bot/src/roster/kv.ts
+++ b/discord-bot/src/roster/kv.ts
@@ -5,6 +5,8 @@
  *   roster-map:{guildId}:{rosterId}  → JSON RosterMapping
  *   guild-config:{guildId}           → JSON GuildConfig
  *   channel-roster:{channelId}       → "{guildId}:{rosterId}" (reverse lookup)
+ *   roster-data:{rosterId}           → encoded roster_data (direct-publish only)
+ *   roster-meta:{rosterId}           → JSON snapshot metadata (direct-publish only)
  */
 
 import type { Env } from '../types.js';
@@ -17,6 +19,7 @@ export const KV_PREFIX = {
   CHANNEL_ROSTER: 'channel-roster',
   GUILD_CONFIG: 'guild-config',
   ROSTER_DATA: 'roster-data',
+  ROSTER_META: 'roster-meta',
 } as const;
 
 // ── Roster Mapping CRUD ─────────────────────────────────────────────────────

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -48,6 +48,13 @@ const SHORT_DAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
 
 const DEFAULT_TIMEZONE = 'America/New_York';
 
+/**
+ * TTL for direct-publish KV entries (mapping, roster-data, roster-meta). A
+ * refresh re-applies it so an actively-used direct roster keeps a sliding
+ * 90-day window and all of its keys expire together.
+ */
+const DIRECT_TTL = 60 * 60 * 24 * 90; // 90 days
+
 /** Get the day-of-week and hour for a Date in a specific IANA timezone. */
 function getDatePartsInTz(date: Date, tz: string): { dayOfWeek: number; hour: number } {
   const dayFmt = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' });
@@ -195,15 +202,15 @@ export interface PublishResult {
 
 export async function publishRoster(env: Env, req: PublishRequest): Promise<PublishResult> {
   // 0. Acquire publish lock to prevent concurrent channel creation
-  const locked = await acquirePublishLock(env, req.guildId, req.rosterId);
-  if (!locked) {
+  const token = await acquirePublishLock(env, req.guildId, req.rosterId);
+  if (!token) {
     return { ok: false, error: 'A publish is already in progress for this roster. Please wait.' };
   }
 
   try {
     return await doPublishRoster(env, req);
   } finally {
-    await releasePublishLock(env, req.guildId, req.rosterId);
+    await releasePublishLock(env, req.guildId, req.rosterId, token);
   }
 }
 
@@ -253,6 +260,8 @@ async function doPublishRoster(env: Env, req: PublishRequest): Promise<PublishRe
       channelName,
       categoryId,
       req.eventTime,
+      true,
+      config.defaultChannelId,
     );
     if (!refreshed.ok) return refreshed;
     channelId = refreshed.channelId!;
@@ -407,6 +416,7 @@ export async function refreshRoster(
       mapping.categoryId,
       undefined,
       allowRecreate,
+      config.defaultChannelId,
     );
 
     if (result.ok) {
@@ -416,7 +426,29 @@ export async function refreshRoster(
         channelId: result.channelId ?? mapping.channelId,
         updatedAt: new Date().toISOString(),
       };
-      await upsertMapping(env, updated);
+      // Direct-publish rosters live only in KV; re-apply the TTL on every
+      // refresh so the mapping, data, and meta keep a sliding 90-day window
+      // and expire together instead of the mapping outliving the data.
+      const isDirect = rosterId.startsWith('direct-');
+      await upsertMapping(env, updated, isDirect ? DIRECT_TTL : undefined);
+      if (isDirect) {
+        await Promise.all([
+          env.ROSTERS.put(`${KV_PREFIX.ROSTER_DATA}:${rosterId}`, snapshot.roster_data, {
+            expirationTtl: DIRECT_TTL,
+          }),
+          env.ROSTERS.put(
+            `${KV_PREFIX.ROSTER_META}:${rosterId}`,
+            JSON.stringify({
+              title: snapshot.title,
+              description: snapshot.description,
+              trial_id: snapshot.trial_id,
+              author_name: snapshot.author_name,
+              tags: snapshot.tags,
+            } satisfies DirectRosterMeta),
+            { expirationTtl: DIRECT_TTL },
+          ),
+        ]);
+      }
       refreshedCount++;
     } else {
       lastError = result.error;
@@ -464,17 +496,19 @@ export async function publishDirect(env: Env, req: DirectPublishRequest): Promis
   // Acquire lock keyed on the *content* (not the random synthetic ID): a rapid
   // double-click sends two identical requests that would each mint a different
   // synthetic ID, so locking on the ID would never collide and both would
-  // create a channel. Hashing the payload makes duplicate submissions contend.
+  // create a channel. Hashing the payload makes duplicate submissions contend
+  // on a best-effort basis (KV has no compare-and-swap, so a true simultaneous
+  // race can still admit two — this only narrows the double-submit window).
   const lockKey = await contentLockKey(req);
-  const locked = await acquirePublishLock(env, req.guildId, lockKey);
-  if (!locked) {
+  const token = await acquirePublishLock(env, req.guildId, lockKey);
+  if (!token) {
     return { ok: false, error: 'A publish is already in progress for this roster. Please wait.' };
   }
 
   try {
     return await doPublishDirect(env, req, syntheticId);
   } finally {
-    await releasePublishLock(env, req.guildId, lockKey);
+    await releasePublishLock(env, req.guildId, lockKey, token);
   }
 }
 
@@ -512,8 +546,6 @@ async function doPublishDirect(
   req: DirectPublishRequest,
   syntheticId: string,
 ): Promise<PublishResult> {
-  const DIRECT_TTL = 60 * 60 * 24 * 90; // 90 days
-
   const snapshot: RosterSnapshot = {
     id: syntheticId,
     title: req.title,
@@ -645,6 +677,7 @@ async function refreshExistingMapping(
   categoryId?: string,
   eventTime?: string,
   allowRecreate = true,
+  defaultChannelId?: string,
 ): Promise<InternalRefreshResult> {
   const text = buildRosterText(snapshot, decoded, eventTime);
   const chunks = splitMessages(text);
@@ -663,24 +696,37 @@ async function refreshExistingMapping(
       }
       return { ok: true, channelId: mapping.channelId, messageId: mapping.messageId };
     } catch (err) {
-      console.warn('[refresh] edit failed, will delete and re-post:', err);
+      console.warn('[refresh] edit failed, will re-post:', err);
     }
   }
 
-  // Delete old messages, then re-post fresh
-  for (const id of oldMessageIds) {
-    try {
-      await deleteMessage(env, mapping.channelId, id);
-    } catch {
-      // Message may already be deleted — ignore
-    }
-  }
-
+  // Re-post path: post the NEW messages first, and only delete the OLD ones
+  // once the new post fully succeeds. This avoids a window where the old
+  // messages are gone but the new ones are incomplete; sendRosterMessages
+  // self-cleans its own partial posts on failure, so nothing is leaked.
   try {
     const messageIds = await sendRosterMessages(env, mapping.channelId, chunks, components);
+    for (const id of oldMessageIds) {
+      try {
+        await deleteMessage(env, mapping.channelId, id);
+      } catch {
+        // Old message may already be deleted — ignore.
+      }
+    }
     return { ok: true, channelId: mapping.channelId, messageId: messageIds };
   } catch (err) {
     console.warn('[refresh] re-post to existing channel failed:', err);
+  }
+
+  // Posting to the existing channel failed. If the roster was consolidated into
+  // the guild's configured default channel, never silently create a new
+  // per-roster channel — that would migrate it out of the default channel on a
+  // transient failure. Leave the mapping intact so it recovers once access does.
+  if (defaultChannelId && mapping.channelId === defaultChannelId) {
+    return {
+      ok: false,
+      error: 'Failed to post into the configured default channel. Check the bot has access to it.',
+    };
   }
 
   // The channel/messages are gone. Only recreate for user-initiated refreshes —
@@ -721,15 +767,28 @@ async function sendRosterMessages(
   components: DiscordComponent[],
 ): Promise<string> {
   const ids: string[] = [];
-  for (let i = 0; i < chunks.length; i++) {
-    const isLast = i === chunks.length - 1;
-    const msg = await sendMessage(env, channelId, {
-      content: chunks[i],
-      ...(isLast ? { components } : {}),
-    });
-    ids.push(msg.id);
+  try {
+    for (let i = 0; i < chunks.length; i++) {
+      const isLast = i === chunks.length - 1;
+      const msg = await sendMessage(env, channelId, {
+        content: chunks[i],
+        ...(isLast ? { components } : {}),
+      });
+      ids.push(msg.id);
+    }
+    return ids.join(',');
+  } catch (err) {
+    // Best-effort cleanup: a mid-sequence failure must not leak the messages
+    // already posted (callers treat a throw as a fully failed post).
+    for (const id of ids) {
+      try {
+        await deleteMessage(env, channelId, id);
+      } catch {
+        // ignore
+      }
+    }
+    throw err;
   }
-  return ids.join(',');
 }
 
 // ── Post roster into an existing channel ────────────────────────────────────

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -87,7 +87,21 @@ function buildNameContext(
     const date = new Date(eventTime);
     if (!isNaN(date.getTime())) {
       const tz = timezone || DEFAULT_TIMEZONE;
-      const { dayOfWeek, hour } = getDatePartsInTz(date, tz);
+      let dayOfWeek: number;
+      let hour: number;
+      try {
+        ({ dayOfWeek, hour } = getDatePartsInTz(date, tz));
+      } catch (err) {
+        // Guild admins can configure the timezone. If it is mistyped or later
+        // becomes invalid in the runtime's ICU data, do not fail publishing for
+        // the whole server; fall back to the stable default and log the config
+        // problem for follow-up.
+        console.warn(
+          `[publish] invalid timezone "${tz}", falling back to ${DEFAULT_TIMEZONE}:`,
+          err,
+        );
+        ({ dayOfWeek, hour } = getDatePartsInTz(date, DEFAULT_TIMEZONE));
+      }
       ctx.dayShort = SHORT_DAYS[dayOfWeek];
       ctx.time = formatTime12h(hour);
     }

--- a/discord-bot/src/roster/publish.ts
+++ b/discord-bot/src/roster/publish.ts
@@ -339,17 +339,20 @@ export async function refreshRoster(
     // Direct-publish rosters live in KV, not the hub API
     const kvData = await env.ROSTERS.get(`${KV_PREFIX.ROSTER_DATA}:${rosterId}`);
     if (kvData) {
-      // Reconstruct a minimal snapshot — find any mapping for this roster
+      // Reconstruct the snapshot. Prefer persisted metadata (title/desc/tags)
+      // so a refresh keeps the original embed faithful; fall back to
+      // placeholders for rosters published before metadata persistence existed.
       const mappings = await findMappingsForRoster(env, rosterId);
       const mapping = mappings[0] ?? null;
+      const meta = await readDirectRosterMeta(env, rosterId);
       snapshot = {
         id: rosterId,
-        title: mapping?.channelNameOverride ?? 'Direct Roster',
-        description: '',
-        trial_id: '',
-        author_name: 'Unknown',
+        title: meta?.title ?? mapping?.channelNameOverride ?? 'Direct Roster',
+        description: meta?.description ?? '',
+        trial_id: meta?.trial_id ?? '',
+        author_name: meta?.author_name ?? 'Unknown',
         roster_data: kvData,
-        tags: [],
+        tags: meta?.tags ?? [],
         vote_count: 0,
         created_at: mapping?.createdAt ?? new Date().toISOString(),
         updated_at: new Date().toISOString(),
@@ -495,7 +498,7 @@ async function contentLockKey(req: DirectPublishRequest): Promise<string> {
     req.categoryId ?? '',
     req.eventTime ?? '',
     req.roster_data,
-  ].join(' ');
+  ].join('\0');
   const bytes = new TextEncoder().encode(material);
   const digest = await crypto.subtle.digest('SHA-256', bytes);
   const hex = Array.from(new Uint8Array(digest))
@@ -585,7 +588,43 @@ async function doPublishDirect(
     expirationTtl: DIRECT_TTL,
   });
 
+  // Persist snapshot metadata so a later refresh rebuilds the embed faithfully.
+  // Direct rosters have no hub record, so without this a refresh would degrade
+  // the title/description/tags to placeholders. Same TTL — expire together.
+  await env.ROSTERS.put(
+    `${KV_PREFIX.ROSTER_META}:${syntheticId}`,
+    JSON.stringify({
+      title: snapshot.title,
+      description: snapshot.description,
+      trial_id: snapshot.trial_id,
+      author_name: snapshot.author_name,
+      tags: snapshot.tags,
+    } satisfies DirectRosterMeta),
+    { expirationTtl: DIRECT_TTL },
+  );
+
   return { ok: true, channelId: result.channelId, channelName, messageId: result.messageId };
+}
+
+/** Snapshot metadata persisted for direct-publish rosters (no hub record). */
+interface DirectRosterMeta {
+  title?: string;
+  description?: string;
+  trial_id?: string;
+  author_name?: string;
+  tags?: string[];
+}
+
+/** Load persisted metadata for a direct-publish roster, or null if absent/corrupt. */
+async function readDirectRosterMeta(env: Env, rosterId: string): Promise<DirectRosterMeta | null> {
+  const raw = await env.ROSTERS.get(`${KV_PREFIX.ROSTER_META}:${rosterId}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as DirectRosterMeta;
+  } catch {
+    console.error(`[refresh] failed to parse direct roster meta for ${rosterId}`);
+    return null;
+  }
 }
 
 // ── Refresh a single channel for an existing mapping ────────────────────────

--- a/discord-bot/src/roster/rate-limit.test.ts
+++ b/discord-bot/src/roster/rate-limit.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { checkRosterRateLimit } from './kv';
+import { acquirePublishLock, checkRosterRateLimit, releasePublishLock } from './kv';
 import type { Env } from '../types';
 
-/** Minimal in-memory KV stub — only the get/put used by the rate limiter. */
+/** Minimal in-memory KV stub — get/put/delete used by the helpers under test. */
 function makeKv(): KVNamespace {
   const store = new Map<string, string>();
   return {
     get: async (key: string) => store.get(key) ?? null,
     put: async (key: string, value: string) => {
       store.set(key, value);
+    },
+    delete: async (key: string) => {
+      store.delete(key);
     },
   } as unknown as KVNamespace;
 }
@@ -33,5 +36,33 @@ describe('checkRosterRateLimit', () => {
     expect(await checkRosterRateLimit(env, 'publish:g:userA', 1, 60)).toBe(false);
     // Different user key is unaffected
     expect(await checkRosterRateLimit(env, 'publish:g:userB', 1, 60)).toBe(true);
+  });
+});
+
+describe('publish lock — fencing token', () => {
+  it('acquire returns a token, a second acquire is blocked until release', async () => {
+    const env = makeEnv();
+    const token = await acquirePublishLock(env, 'g', 'r');
+    expect(token).toBeTruthy();
+    // Held — a second acquire fails.
+    expect(await acquirePublishLock(env, 'g', 'r')).toBeNull();
+    // Release with the correct token frees it.
+    await releasePublishLock(env, 'g', 'r', token as string);
+    expect(await acquirePublishLock(env, 'g', 'r')).toBeTruthy();
+  });
+
+  it('release with a stale token does not delete the current owner lock', async () => {
+    const env = makeEnv();
+    const first = await acquirePublishLock(env, 'g', 'r');
+    // Simulate the first lock expiring and a second caller acquiring it.
+    await releasePublishLock(env, 'g', 'r', first as string); // first owner releases normally...
+    const second = await acquirePublishLock(env, 'g', 'r');
+    expect(second).toBeTruthy();
+    // ...the first owner's (stale) release must NOT free the second owner's lock.
+    await releasePublishLock(env, 'g', 'r', first as string);
+    expect(await acquirePublishLock(env, 'g', 'r')).toBeNull();
+    // The real owner can still release it.
+    await releasePublishLock(env, 'g', 'r', second as string);
+    expect(await acquirePublishLock(env, 'g', 'r')).toBeTruthy();
   });
 });

--- a/discord-bot/src/types.ts
+++ b/discord-bot/src/types.ts
@@ -180,6 +180,7 @@ export interface InteractionResponse {
     flags?: number;
     title?: string;
     custom_id?: string;
+    allowed_mentions?: { parse?: string[]; users?: string[]; roles?: string[] };
   };
 }
 
@@ -243,33 +244,38 @@ export const ButtonId = {
 } as const;
 
 // Response templates for quick replies
-export const ResponseTemplates: Record<string, { label: string; emoji: string; message: string }> = {
-  acknowledged: {
-    label: 'Acknowledged',
-    emoji: '✅',
-    message: 'Thank you for your report! We have acknowledged this issue and it has been added to our backlog. We will update you when there is progress.',
-  },
-  investigating: {
-    label: 'Investigating',
-    emoji: '🔍',
-    message: 'We are actively investigating this issue. Thank you for your patience!',
-  },
-  needs_info: {
-    label: 'Need More Info',
-    emoji: '❓',
-    message: 'We need more information to proceed. Could you please provide additional details about the issue?',
-  },
-  resolved: {
-    label: 'Resolved',
-    emoji: '✨',
-    message: 'This issue has been resolved! Thank you for your report. Please let us know if you encounter any further problems.',
-  },
-  wont_fix: {
-    label: "Won't Fix",
-    emoji: '🚫',
-    message: "Thank you for your report. After review, we've determined this will not be addressed at this time. We appreciate your feedback.",
-  },
-} as const;
+export const ResponseTemplates: Record<string, { label: string; emoji: string; message: string }> =
+  {
+    acknowledged: {
+      label: 'Acknowledged',
+      emoji: '✅',
+      message:
+        'Thank you for your report! We have acknowledged this issue and it has been added to our backlog. We will update you when there is progress.',
+    },
+    investigating: {
+      label: 'Investigating',
+      emoji: '🔍',
+      message: 'We are actively investigating this issue. Thank you for your patience!',
+    },
+    needs_info: {
+      label: 'Need More Info',
+      emoji: '❓',
+      message:
+        'We need more information to proceed. Could you please provide additional details about the issue?',
+    },
+    resolved: {
+      label: 'Resolved',
+      emoji: '✨',
+      message:
+        'This issue has been resolved! Thank you for your report. Please let us know if you encounter any further problems.',
+    },
+    wont_fix: {
+      label: "Won't Fix",
+      emoji: '🚫',
+      message:
+        "Thank you for your report. After review, we've determined this will not be addressed at this time. We appreciate your feedback.",
+    },
+  } as const;
 
 // Modal custom_id prefix
 export const ModalId = {

--- a/discord-bot/src/verify.ts
+++ b/discord-bot/src/verify.ts
@@ -3,15 +3,19 @@
  * Uses the Web Crypto API (built into the Workers runtime) — no external deps.
  */
 
-function hexToUint8Array(hex: string): Uint8Array {
+function hexToUint8Array(hex: string): Uint8Array<ArrayBuffer> {
   if (hex.length % 2 !== 0) {
     throw new Error('Invalid hex string length');
   }
-  const arr = new Uint8Array(hex.length / 2);
+  const arr = new Uint8Array(new ArrayBuffer(hex.length / 2));
   for (let i = 0; i < hex.length; i += 2) {
     arr[i / 2] = parseInt(hex.slice(i, i + 2), 16);
   }
   return arr;
+}
+
+function utf8Bytes(value: string): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(new TextEncoder().encode(value));
 }
 
 /**
@@ -37,7 +41,7 @@ export async function verifyDiscordSignature(
       'Ed25519',
       key,
       hexToUint8Array(signature),
-      new TextEncoder().encode(timestamp + body),
+      utf8Bytes(timestamp + body),
     );
 
     return valid;


### PR DESCRIPTION
### Motivation
- Prevent long/free-text roster fields from being silently truncated when splitting messages for Discord. 
- Avoid creating truncated `custom_id` values that make refresh/sign-up handlers unable to look up the roster mapping. 
- Make channel-name tokenization resilient to invalid guild timezone configurations so a bad timezone doesn't break publishing. 
- Resolve a Web Crypto typing issue that caused TypeScript `verify`/`importKey` calls to fail in the worker runtime. 

### Description
- Preserve over-limit roster text by updating `splitMessages` to hard-wrap individual lines longer than Discord's 2000-char limit instead of dropping/truncating content, and add a regression test. 
- Stop truncating roster IDs in button `custom_id`s by omitting an over-long roster ID (so buttons fall back to channel→roster mapping), and add tests that assert expected behavior for very long IDs. 
- Accept both `roster_refresh` and `roster_refresh:<rosterId>` in the button router so older buttons and the new fallback format are both handled. 
- Wrap timezone lookups in `buildNameContext` in a `try/catch` and fall back to `America/New_York` with a console warning when the configured timezone is invalid. 
- Fix `verify.ts` Web Crypto usage and typings by ensuring `Uint8Array<ArrayBuffer>`-backed buffers are passed to `importKey`/`verify` to satisfy `BufferSource` typing and avoid type errors. 

### Testing
- Ran the discord-bot unit test suite with `npm --prefix discord-bot test -- --run`, and all tests passed (`77 passed`). 
- Ran TypeScript checks for the bot with `npm --prefix discord-bot run typecheck`, and the typecheck passed with no errors. 
- Ran repository validation with `npm run validate` and `npm test -- --watchAll=false`, and both commands completed successfully (no failing tests or format/type errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34338ebc50832880dd3f2354aa6b4b)