### PR TITLE
fix(insights): resolve status-effect names/icons + Atronach/Horn icons

### DIFF
--- a/src/components/AbilityIcon.tsx
+++ b/src/components/AbilityIcon.tsx
@@ -8,6 +8,8 @@ export interface AbilityIconProps {
   abilityId: string | number;
   /** Optional icon filename (without extension) to use if the ability is missing from master data */
   fallbackIcon?: string;
+  /** Optional human-readable name to use for alt text if the ability is missing from master data */
+  fallbackName?: string;
 }
 
 export function AbilityIcon(props: AbilityIconProps): React.ReactElement | null {
@@ -27,7 +29,9 @@ export function AbilityIcon(props: AbilityIconProps): React.ReactElement | null 
   return (
     <Avatar
       src={src}
-      alt={ability?.name || `Ability ${props.abilityId}`}
+      // When master data lacks this ability, a real fallback icon is still shown,
+      // so prefer the caller-supplied name over the meaningless "Ability <id>".
+      alt={ability?.name || props.fallbackName || `Ability ${props.abilityId}`}
       sx={{ width: 32, height: 32, borderRadius: 1, boxShadow: 1 }}
       variant="rounded"
     />

--- a/src/features/report_details/insights/DamageBreakdownView.tsx
+++ b/src/features/report_details/insights/DamageBreakdownView.tsx
@@ -78,7 +78,11 @@ export const DamageBreakdownView: React.FC<DamageBreakdownViewProps> = React.mem
                   <ListItem key={damage.abilityGameID} sx={{ py: 1, pl: 0 }} divider>
                     <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', gap: 1.25 }}>
                       {damage.icon ? (
-                        <AbilityIcon abilityId={damage.abilityGameID} fallbackIcon={damage.icon} />
+                        <AbilityIcon
+                          abilityId={damage.abilityGameID}
+                          fallbackIcon={damage.icon}
+                          fallbackName={damage.abilityName}
+                        />
                       ) : (
                         <Avatar sx={{ width: 32, height: 32 }} variant="rounded">
                           {damage.abilityName.charAt(0)}

--- a/src/features/report_details/insights/DamageTypeBreakdownPanel.tsx
+++ b/src/features/report_details/insights/DamageTypeBreakdownPanel.tsx
@@ -124,12 +124,12 @@ const AOE_ABILITY_IDS = Object.freeze(
 const STATUS_EFFECT_ABILITY_IDS = Object.freeze(
   new Set([
     18084, // Burning
-    95136, // Chilled
-    95134, // Concussed
-    178127, // Poisoned
-    148801, // Diseased
-    178118, // Hemorrhaging
-    21929, // Overcharged
+    95136, // Chill
+    95134, // Concussion
+    178127, // Diseased
+    148801, // Hemorrhaging
+    178118, // Overcharged
+    21929, // Poisoned
     178123, // Sundered
   ]),
 );
@@ -280,8 +280,8 @@ export const DamageTypeBreakdownPanel: React.FC<DamageTypeBreakdownPanelProps> =
         statusEffectDamageData.events.push(event);
       }
 
-      // Add to fire damage category if it's a fire ability (ability.type == 4)
-      if (ability?.type === '4') {
+      // Add to fire damage category if it's a fire ability
+      if (ability?.type === DamageTypeFlags.FIRE) {
         fireDamageData.totalDamage += event.amount;
         fireDamageData.hitCount += 1;
         fireDamageData.criticalHits += fullCritHitCount;

--- a/src/features/report_details/insights/DamageTypeHelpModal.tsx
+++ b/src/features/report_details/insights/DamageTypeHelpModal.tsx
@@ -115,10 +115,10 @@ const STATUS_EFFECT_ABILITIES = [
   { id: 18084, name: 'Burning' },
   { id: 95136, name: 'Chilled' },
   { id: 95134, name: 'Concussed' },
-  { id: 178127, name: 'Poisoned' },
-  { id: 148801, name: 'Diseased' },
-  { id: 178118, name: 'Hemorrhaging' },
-  { id: 21929, name: 'Overcharged' },
+  { id: 178127, name: 'Diseased' },
+  { id: 148801, name: 'Hemorrhaging' },
+  { id: 178118, name: 'Overcharged' },
+  { id: 21929, name: 'Poisoned' },
   { id: 178123, name: 'Sundered' },
 ];
 

--- a/src/features/report_details/insights/InsightsPanelView.tsx
+++ b/src/features/report_details/insights/InsightsPanelView.tsx
@@ -53,7 +53,10 @@ const ABILITY_DATA: AbilityDatum[] = [
   {
     name: 'Atronach',
     ids: ['23495'],
-    icon: undefined,
+    // Summon Charged Atronach (Sorc). Master data often lacks this id in a given
+    // fight, so supply the canonical ESO Logs icon (verified 200 on the CDN) as a
+    // fallback — otherwise AbilityIcon renders nothing.
+    icon: 'ability_sorcerer_endless_atronachs',
     knownAbilities: [KnownAbilities.SUMMON_CHARGED_ATRONACH],
   },
   {
@@ -65,7 +68,9 @@ const ABILITY_DATA: AbilityDatum[] = [
   {
     name: 'Horn',
     ids: ['40223'],
-    icon: undefined,
+    // Aggressive Horn (Assault ult). Same master-data gap as Atronach above;
+    // supply the canonical ESO Logs icon (verified 200 on the CDN) as a fallback.
+    icon: 'ability_ava_003_a',
     knownAbilities: [KnownAbilities.AGGRESSIVE_HORN],
   },
 ];

--- a/src/features/report_details/insights/InsightsPanelView.tsx
+++ b/src/features/report_details/insights/InsightsPanelView.tsx
@@ -211,6 +211,8 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
                 Key Group Abilities:
               </Typography>
               <Box
+                role="list"
+                aria-label="Key group abilities"
                 sx={{
                   display: 'grid',
                   gridTemplateColumns: '1fr',
@@ -235,6 +237,7 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
                   return (
                     <Box
                       key={ability.name}
+                      role="listitem"
                       sx={{
                         display: 'flex',
                         alignItems: 'center',
@@ -268,7 +271,11 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
                           overflow: 'hidden',
                         }}
                       >
-                        <AbilityIcon abilityId={ability.ids[0]} fallbackIcon={ability.icon} />
+                        <AbilityIcon
+                          abilityId={ability.ids[0]}
+                          fallbackIcon={ability.icon}
+                          fallbackName={ability.name}
+                        />
                       </Box>
                       <Box sx={{ flex: 1, minWidth: 0 }}>
                         <Typography
@@ -285,6 +292,9 @@ export const InsightsPanelView: React.FC<InsightsPanelViewProps> = ({
                         </Typography>
                         <Typography
                           variant="caption"
+                          // Full list on hover: the line truncates with an ellipsis
+                          // when many players share an ultimate (e.g. a 12-player raid).
+                          title={hasPlayers ? equippedBy.join(', ') : undefined}
                           sx={{
                             display: 'block',
                             color: hasPlayers

--- a/src/features/report_details/insights/StatusEffectUptimesPanel.integration.test.ts
+++ b/src/features/report_details/insights/StatusEffectUptimesPanel.integration.test.ts
@@ -55,7 +55,7 @@ describe('StatusEffectUptimesPanel Target Segmentation Integration', () => {
   const mockTargetSegmentedData: StatusEffectUptimesByTarget[] = [
     {
       abilityGameID: KnownAbilities.BURNING.toString(),
-      abilityName: `Ability ${KnownAbilities.BURNING}`,
+      abilityName: 'Burning',
       isDebuff: true,
       hostilityType: 1,
       uniqueKey: `${KnownAbilities.BURNING}-status-effect`,
@@ -76,7 +76,7 @@ describe('StatusEffectUptimesPanel Target Segmentation Integration', () => {
     },
     {
       abilityGameID: KnownAbilities.POISONED.toString(),
-      abilityName: `Ability ${KnownAbilities.POISONED}`,
+      abilityName: 'Poisoned',
       isDebuff: true,
       hostilityType: 1,
       uniqueKey: `${KnownAbilities.POISONED}-status-effect`,
@@ -174,7 +174,7 @@ describe('StatusEffectUptimesPanel Target Segmentation Integration', () => {
       const partialData: StatusEffectUptimesByTarget[] = [
         {
           abilityGameID: KnownAbilities.BURNING.toString(),
-          abilityName: `Ability ${KnownAbilities.BURNING}`,
+          abilityName: 'Burning',
           isDebuff: true,
           hostilityType: 1,
           uniqueKey: `${KnownAbilities.BURNING}-status-effect`,
@@ -232,7 +232,7 @@ describe('StatusEffectUptimesPanel Target Segmentation Integration', () => {
       expect(burning?.isDebuff).toBe(true);
       expect(burning?.hostilityType).toBe(1);
       expect(burning?.uniqueKey).toBe(`${KnownAbilities.BURNING}-status-effect`);
-      expect(burning?.abilityName).toBe(`Ability ${KnownAbilities.BURNING}`);
+      expect(burning?.abilityName).toBe('Burning');
     });
   });
 

--- a/src/features/report_details/insights/StatusEffectUptimesPanel.tsx
+++ b/src/features/report_details/insights/StatusEffectUptimesPanel.tsx
@@ -289,15 +289,12 @@ export const StatusEffectUptimesPanel: React.FC<StatusEffectUptimesPanelProps> =
       return playerFilteredStatusEffectUptimes;
     }
 
-    // When a player is selected, we need to show their data compared to group average
-    // The key insight: playerFilteredStatusEffectUptimes already contains the player's data
-    // We just need to attach the group average to it
+    // When a player is selected, we need to show their data compared to group average.
+    // playerFilteredStatusEffectUptimes already contains the player's data either way;
+    // when a player is selected we additionally attach the group average below.
     const usePlayerData = selectedPlayerId && selectedFriendlyPlayerId;
-    const sourceData = usePlayerData
-      ? playerFilteredStatusEffectUptimes
-      : playerFilteredStatusEffectUptimes;
 
-    const enhanced = sourceData.map((uptime) => {
+    const enhanced = playerFilteredStatusEffectUptimes.map((uptime) => {
       const ability = reportMasterData.abilitiesById[uptime.abilityGameID as string];
       return {
         ...uptime,

--- a/src/features/report_details/insights/StatusEffectUptimesView.tsx
+++ b/src/features/report_details/insights/StatusEffectUptimesView.tsx
@@ -152,6 +152,7 @@ export const StatusEffectUptimesView: React.FC<StatusEffectUptimesViewProps> = (
           onChange={(e) => setNameFilter(e.target.value)}
           sx={{ mb: 1 }}
           slotProps={{
+            htmlInput: { 'aria-label': 'Filter status effects by name' },
             input: {
               startAdornment: (
                 <InputAdornment position="start">

--- a/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
+++ b/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
@@ -180,7 +180,7 @@ describe('CalculateStatusEffectUptimes', () => {
 
         // Hostile-buff branch also resolves a canonical name + icon.
         expect(overchargedResult.abilityName).toBe('Overcharged');
-        expect(overchargedResult.icon).toBe('ability_mage_065');
+        expect(overchargedResult.icon).toBe('death_recap_magic_dot_heavy');
 
         // Target 1: 6 seconds (2000-8000ms)
         const target1Data = overchargedResult.targetData[TARGET_ID_1];

--- a/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
+++ b/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
@@ -73,6 +73,12 @@ describe('CalculateStatusEffectUptimes', () => {
         expect(burningResult.hostilityType).toBe(1);
         expect(burningResult.uniqueKey).toBe(`${KnownAbilities.BURNING}-status-effect`);
 
+        // Status effects resolve a canonical name + icon from the static table,
+        // not the old raw "Ability <id>" placeholder (these ids are usually
+        // absent from per-report master data).
+        expect(burningResult.abilityName).toBe('Burning');
+        expect(burningResult.icon).toBe('ability_mage_062');
+
         // Check target segmentation
         expect(Object.keys(burningResult.targetData)).toHaveLength(1);
         expect(burningResult.targetData[TARGET_ID_1]).toBeDefined();
@@ -171,6 +177,10 @@ describe('CalculateStatusEffectUptimes', () => {
 
         expect(overchargedResult.isDebuff).toBe(false);
         expect(Object.keys(overchargedResult.targetData)).toHaveLength(2);
+
+        // Hostile-buff branch also resolves a canonical name + icon.
+        expect(overchargedResult.abilityName).toBe('Overcharged');
+        expect(overchargedResult.icon).toBe('ability_mage_065');
 
         // Target 1: 6 seconds (2000-8000ms)
         const target1Data = overchargedResult.targetData[TARGET_ID_1];
@@ -427,17 +437,17 @@ describe('CalculateStatusEffectUptimes', () => {
           (r) => r.abilityGameID === KnownAbilities.OVERCHARGED.toString(),
         );
 
-        // Check debuff properties
+        // Check debuff properties — canonical name resolved from the static table.
         expect(burningResult!.isDebuff).toBe(true);
         expect(burningResult!.hostilityType).toBe(1);
         expect(burningResult!.uniqueKey).toBe(`${KnownAbilities.BURNING}-status-effect`);
-        expect(burningResult!.abilityName).toContain('Ability'); // Generic name for now
+        expect(burningResult!.abilityName).toBe('Burning');
 
-        // Check buff properties
+        // Check buff properties — canonical name resolved from the static table.
         expect(overchargedResult!.isDebuff).toBe(false);
         expect(overchargedResult!.hostilityType).toBe(1);
         expect(overchargedResult!.uniqueKey).toBe(`${KnownAbilities.OVERCHARGED}-status-effect`);
-        expect(overchargedResult!.abilityName).toContain('Ability'); // Generic name for now
+        expect(overchargedResult!.abilityName).toBe('Overcharged');
       });
     });
 

--- a/src/workers/calculations/CalculateStatusEffectUptimes.ts
+++ b/src/workers/calculations/CalculateStatusEffectUptimes.ts
@@ -2,6 +2,8 @@ import { KnownAbilities } from '../../types/abilities';
 import { BuffLookupData } from '../../utils/BuffLookupUtils';
 import { OnProgressCallback } from '../Utils';
 
+import { getStatusEffectIcon, getStatusEffectName } from './statusEffectMetadata';
+
 /**
  * Status Effect Uptimes Calculation Worker
  *
@@ -187,7 +189,12 @@ export function calculateStatusEffectUptimes(
       if (Object.keys(allPlayers).length > 0) {
         results.set(abilityKey, {
           abilityGameID: abilityKey,
-          abilityName: `Ability ${abilityId}`, // Will be resolved by UI layer
+          // Canonical name/icon for this fixed status effect. The UI still
+          // prefers per-report master data when present, but these status-effect
+          // ids are frequently absent from it — without this fallback the panel
+          // rendered a raw "Ability <id>" placeholder with no icon.
+          abilityName: getStatusEffectName(abilityId),
+          icon: getStatusEffectIcon(abilityId),
           isDebuff: true,
           hostilityType: 1,
           uniqueKey: `${abilityId}-status-effect`,
@@ -301,7 +308,9 @@ export function calculateStatusEffectUptimes(
       if (Object.keys(allPlayers).length > 0) {
         results.set(abilityKey, {
           abilityGameID: abilityKey,
-          abilityName: `Ability ${abilityId}`, // Will be resolved by UI layer
+          // Canonical name/icon for this fixed status effect (see debuff branch).
+          abilityName: getStatusEffectName(abilityId),
+          icon: getStatusEffectIcon(abilityId),
           isDebuff: false,
           hostilityType: 1,
           uniqueKey: `${abilityId}-status-effect`,

--- a/src/workers/calculations/statusEffectMetadata.test.ts
+++ b/src/workers/calculations/statusEffectMetadata.test.ts
@@ -1,0 +1,51 @@
+import {
+  getStatusEffectIcon,
+  getStatusEffectName,
+  STATUS_EFFECT_METADATA,
+} from './statusEffectMetadata';
+import { KnownAbilities } from '../../types/abilities';
+
+// The exact set of status-effect ability ids the worker tracks. Kept in sync
+// with STATUS_EFFECT_BUFF_ABILITIES + STATUS_EFFECT_DEBUFF_ABILITIES in
+// CalculateStatusEffectUptimes.ts — if a new tracked effect is added there, this
+// guard fails until metadata is supplied, preventing a regression back to the
+// raw "Ability <id>" placeholder.
+const TRACKED_STATUS_EFFECTS = [
+  KnownAbilities.BURNING,
+  KnownAbilities.POISONED,
+  KnownAbilities.HEMMORRHAGING,
+  KnownAbilities.CHILL,
+  KnownAbilities.CONCUSSION,
+  KnownAbilities.DISEASED,
+  KnownAbilities.OVERCHARGED,
+  KnownAbilities.SUNDERED,
+];
+
+describe('statusEffectMetadata', () => {
+  it('has a name and icon for every tracked status effect', () => {
+    for (const id of TRACKED_STATUS_EFFECTS) {
+      const entry = STATUS_EFFECT_METADATA[id];
+      expect(entry).toBeDefined();
+      expect(entry.name).toBeTruthy();
+      expect(entry.name).not.toMatch(/^Ability \d+$/);
+      expect(entry.icon).toBeTruthy();
+    }
+  });
+
+  it('resolves canonical names for known status effects', () => {
+    expect(getStatusEffectName(KnownAbilities.BURNING)).toBe('Burning');
+    expect(getStatusEffectName(KnownAbilities.POISONED)).toBe('Poisoned');
+    expect(getStatusEffectName(KnownAbilities.HEMMORRHAGING)).toBe('Hemorrhaging');
+  });
+
+  it('resolves verified CDN icon filenames for known status effects', () => {
+    expect(getStatusEffectIcon(KnownAbilities.BURNING)).toBe('ability_mage_062');
+    expect(getStatusEffectIcon(KnownAbilities.POISONED)).toBe('ability_rogue_030');
+    expect(getStatusEffectIcon(KnownAbilities.HEMMORRHAGING)).toBe('death_recap_bleed_dot_heavy');
+  });
+
+  it('falls back to a readable placeholder for an unknown id', () => {
+    expect(getStatusEffectName(999999)).toBe('Ability 999999');
+    expect(getStatusEffectIcon(999999)).toBeUndefined();
+  });
+});

--- a/src/workers/calculations/statusEffectMetadata.ts
+++ b/src/workers/calculations/statusEffectMetadata.ts
@@ -27,6 +27,12 @@ export interface StatusEffectMetadata {
   icon: string;
 }
 
+// ESO Logs assigns five of these effects a generic placeholder icon
+// (`ability_mage_065`). We override those with the matching element-specific
+// `death_recap_*_dot_heavy` art so each status effect reads distinctly in the UI.
+// Every icon below was confirmed HTTP 200 (real PNG) on the rpglogs CDN.
+// Sundered has no dedicated physical-status icon, so it reuses the bleed art it
+// shares with Hemorrhaging (both are bleed-family) — an accepted overlap.
 export const STATUS_EFFECT_METADATA: Readonly<Record<number, StatusEffectMetadata>> = {
   [KnownAbilities.BURNING]: { name: 'Burning', icon: 'ability_mage_062' },
   [KnownAbilities.POISONED]: { name: 'Poisoned', icon: 'ability_rogue_030' },
@@ -34,11 +40,11 @@ export const STATUS_EFFECT_METADATA: Readonly<Record<number, StatusEffectMetadat
     name: 'Hemorrhaging',
     icon: 'death_recap_bleed_dot_heavy',
   },
-  [KnownAbilities.CHILL]: { name: 'Chill', icon: 'ability_mage_065' },
-  [KnownAbilities.CONCUSSION]: { name: 'Concussion', icon: 'ability_mage_065' },
-  [KnownAbilities.DISEASED]: { name: 'Diseased', icon: 'ability_mage_065' },
-  [KnownAbilities.OVERCHARGED]: { name: 'Overcharged', icon: 'ability_mage_065' },
-  [KnownAbilities.SUNDERED]: { name: 'Sundered', icon: 'ability_mage_065' },
+  [KnownAbilities.CHILL]: { name: 'Chill', icon: 'death_recap_cold_dot_heavy' },
+  [KnownAbilities.CONCUSSION]: { name: 'Concussion', icon: 'death_recap_shock_dot_heavy' },
+  [KnownAbilities.DISEASED]: { name: 'Diseased', icon: 'death_recap_disease_dot_heavy' },
+  [KnownAbilities.OVERCHARGED]: { name: 'Overcharged', icon: 'death_recap_magic_dot_heavy' },
+  [KnownAbilities.SUNDERED]: { name: 'Sundered', icon: 'death_recap_bleed_dot_heavy' },
 };
 
 /**

--- a/src/workers/calculations/statusEffectMetadata.ts
+++ b/src/workers/calculations/statusEffectMetadata.ts
@@ -1,0 +1,59 @@
+import { KnownAbilities } from '../../types/abilities';
+
+/**
+ * Canonical display name + icon for each tracked status effect.
+ *
+ * WHY THIS EXISTS
+ * ESO status effects (Burning, Poisoned, Hemorrhaging, …) are derived game
+ * mechanics. A report's `masterData.abilities` only lists abilities the ESO Logs
+ * API explicitly emits for that report, and these status-effect ability ids are
+ * frequently ABSENT from it. When they are, the UI's master-data lookup
+ * (`abilitiesById[id]?.name`) returns nothing, so the Status Effect Uptimes panel
+ * fell back to a raw `"Ability 18084"` placeholder with no icon.
+ *
+ * These ids are fixed, well-known game abilities, so we resolve them from a tiny
+ * static table instead of depending on per-report master data. The values are the
+ * exact ESO Logs game-data name + icon for each id (data/abilities.json oracle),
+ * and every icon filename below was confirmed HTTP 200 on the rpglogs CDN
+ * (https://assets.rpglogs.com/img/eso/abilities/<icon>.png).
+ *
+ * The panel still PREFERS report master data when it is present
+ * (`ability?.name || uptime.abilityName`), so this only supplies the fallback —
+ * it never overrides a real per-report name.
+ */
+export interface StatusEffectMetadata {
+  name: string;
+  /** rpglogs CDN icon filename, WITHOUT the `.png` extension. */
+  icon: string;
+}
+
+export const STATUS_EFFECT_METADATA: Readonly<Record<number, StatusEffectMetadata>> = {
+  [KnownAbilities.BURNING]: { name: 'Burning', icon: 'ability_mage_062' },
+  [KnownAbilities.POISONED]: { name: 'Poisoned', icon: 'ability_rogue_030' },
+  [KnownAbilities.HEMMORRHAGING]: {
+    name: 'Hemorrhaging',
+    icon: 'death_recap_bleed_dot_heavy',
+  },
+  [KnownAbilities.CHILL]: { name: 'Chill', icon: 'ability_mage_065' },
+  [KnownAbilities.CONCUSSION]: { name: 'Concussion', icon: 'ability_mage_065' },
+  [KnownAbilities.DISEASED]: { name: 'Diseased', icon: 'ability_mage_065' },
+  [KnownAbilities.OVERCHARGED]: { name: 'Overcharged', icon: 'ability_mage_065' },
+  [KnownAbilities.SUNDERED]: { name: 'Sundered', icon: 'ability_mage_065' },
+};
+
+/**
+ * Resolve the canonical display name for a tracked status-effect ability id,
+ * falling back to a readable `"Ability <id>"` placeholder for any id without an
+ * entry (should not happen for tracked effects, but keeps the worker total).
+ */
+export function getStatusEffectName(abilityId: number): string {
+  return STATUS_EFFECT_METADATA[abilityId]?.name ?? `Ability ${abilityId}`;
+}
+
+/**
+ * Resolve the canonical icon filename (no extension) for a tracked status-effect
+ * ability id, or `undefined` if unknown.
+ */
+export function getStatusEffectIcon(abilityId: number): string | undefined {
+  return STATUS_EFFECT_METADATA[abilityId]?.icon;
+}


### PR DESCRIPTION
## What

The Fight Insights page (`/report/.../fight/N/insights`) had two visible bugs, both from depending on per-report ESO Logs master data for fixed, well-known game abilities whose ids are frequently **absent** from a given report's `masterData`:

1. **Status Effect Uptimes** rendered raw `"Ability 18084"` / `"Ability 21929"` / `"Ability 148801"` placeholders (Burning / Poisoned / Hemorrhaging) instead of names, with no icon.
2. **Key Group Abilities** showed **blank icons** for Atronach and Horn.

## Root cause

The status-effect worker emitted an `"Ability <id>"` placeholder name (comment: "Will be resolved by UI layer"), but the UI's resolver reads `reportMasterData.abilitiesById[id]?.name` — and these status-effect ids aren't in master data, so it fell through to the placeholder. Atronach/Horn had `fallbackIcon: undefined` in `ABILITY_DATA`, so `AbilityIcon` returned `null` (no `<img>`) when master data lacked them.

## Fix

- **`statusEffectMetadata.ts`** (new): canonical name + icon for every tracked status effect, keyed by `KnownAbilities` id. The worker emits these as the fallback; the panel still **prefers** per-report master data when present.
- **Atronach/Horn**: supply canonical `fallbackIcon` filenames in `ABILITY_DATA`.
- **Distinct status-effect icons**: the five effects ESO Logs maps to its generic placeholder icon (`ability_mage_065`) now use element-matched `death_recap_*_dot_heavy` art.

All icon filenames were sourced from the ESO Logs game-data oracle, cross-verified by two independent research agents, and confirmed **HTTP 200 (real PNG)** on the rpglogs CDN.

## Audit fixes (from a full page audit)

- Corrected **scrambled inline labels** in `DamageTypeBreakdownPanel`'s status-effect id set (comments for Diseased/Hemorrhaging/Overcharged/Poisoned were rotated; membership testing was unaffected but the comments were misleading).
- `AbilityIcon`: optional `fallbackName` prop → alt text reads the real name instead of `"Ability <id>"` when master data is missing.
- a11y: `role=list/listitem` for Key Group Abilities, `aria-label` on the filter input, `title` tooltip on the truncated equipped-players line.
- `DamageTypeFlags.FIRE` instead of a bare `'4'` literal; removed a dead identical-branch ternary.

## Validation

- `tsc` clean, ESLint clean, Prettier clean
- Status-effect tests: **28 passed** (incl. new `statusEffectMetadata` coverage); full insights suite **85 passed**
- Live verification on the dev preview to follow.

## Note

Not related to PR #1264 (`claude/missing-gear-icons-ni0ozr`) — despite its branch name, that PR fixes gear-set *tooltip* tiers on `/bv` and touches none of the Fight Insights files. These are independent surfaces.

https://claude.ai/code/session_01GzV8m8xCsYXWBtxC1KasdX