### PR TITLE
fix(dropdowns): open Select menus below the field + unify premium styling site-wide

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -3,11 +3,27 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import React from 'react';
 
+import {
+  DropdownMenuDirectionProvider,
+  useDropdownMenuController,
+} from './hooks/useDropdownMenuDirection';
 import { usePersistentDarkMode } from './hooks/usePersistentDarkMode';
+import {
+  DROPDOWN_MENU_GAP,
+  DROPDOWN_MENU_MAX_HEIGHT_SX,
+  dropdownMenuOrigins,
+} from './theme/dropdownMenu';
 
 export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Use persistent dark mode hook that handles localStorage persistence
   const { darkMode } = usePersistentDarkMode();
+
+  // Single app-wide "open Select menus upward?" flag — only one Select menu is
+  // open at a time, so one shared flag is enough. The handler measures the
+  // anchor on open and flips when the field is too close to the viewport bottom
+  // to fit the menu below it. See useDropdownMenuController / src/theme/dropdownMenu.ts.
+  const dropdownDirection = useDropdownMenuController();
+  const { menuUp, onSelectOpen } = dropdownDirection;
 
   // Mirror color-scheme onto <html data-color-scheme="dark|light"> so static
   // CSS rules (e.g. the data-perf='low' glass-dialog fallback in index.css)
@@ -51,7 +67,7 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     }
   }, [darkMode]);
 
-  const theme = React.useMemo(
+  const baseTheme = React.useMemo(
     () =>
       createTheme({
         palette: {
@@ -503,6 +519,46 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     [darkMode, tokens],
   );
 
+  // Overlay the base theme with the dynamic Select open-direction defaults. Kept
+  // separate so the (heavy) base theme only rebuilds on dark-mode/token changes;
+  // this thin extension recomputes only when `menuUp` actually flips (rare —
+  // setMenuUp bails out when the value is unchanged). Result: every Select opens
+  // downward, or upward when near the viewport bottom, instead of centred over /
+  // covering the field. A Select that passes its OWN MenuProps replaces this
+  // default, so those call sites must spread useDropdownMenuOrigins() — see
+  // src/hooks/useDropdownMenuDirection.ts.
+  const theme = React.useMemo(
+    () =>
+      createTheme(baseTheme, {
+        components: {
+          MuiSelect: {
+            defaultProps: {
+              onOpen: onSelectOpen,
+              MenuProps: {
+                ...dropdownMenuOrigins(menuUp),
+                slotProps: {
+                  paper: {
+                    sx: {
+                      // Cap height to the room on the open side so a tall menu
+                      // scrolls below the field instead of being shifted up over
+                      // it; the cap is published per-open as a CSS var.
+                      maxHeight: DROPDOWN_MENU_MAX_HEIGHT_SX,
+                      // Direction-aware gap so an upward-flipped menu doesn't sit
+                      // on the field.
+                      ...(menuUp
+                        ? { mt: 0, mb: DROPDOWN_MENU_GAP }
+                        : { mt: DROPDOWN_MENU_GAP, mb: 0 }),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    [baseTheme, menuUp, onSelectOpen],
+  );
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -822,7 +878,9 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
           },
         }}
       />
-      {children}
+      <DropdownMenuDirectionProvider value={dropdownDirection}>
+        {children}
+      </DropdownMenuDirectionProvider>
     </ThemeProvider>
   );
 };

--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -12,6 +12,7 @@ import {
   DROPDOWN_MENU_GAP,
   DROPDOWN_MENU_MAX_HEIGHT_SX,
   dropdownMenuOrigins,
+  dropdownMenuPaperSx,
 } from './theme/dropdownMenu';
 
 export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -538,17 +539,22 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
                 ...dropdownMenuOrigins(menuUp),
                 slotProps: {
                   paper: {
-                    sx: {
-                      // Cap height to the room on the open side so a tall menu
-                      // scrolls below the field instead of being shifted up over
-                      // it; the cap is published per-open as a CSS var.
-                      maxHeight: DROPDOWN_MENU_MAX_HEIGHT_SX,
-                      // Direction-aware gap so an upward-flipped menu doesn't sit
-                      // on the field.
-                      ...(menuUp
-                        ? { mt: 0, mb: DROPDOWN_MENU_GAP }
-                        : { mt: DROPDOWN_MENU_GAP, mb: 0 }),
-                    },
+                    sx: [
+                      // Shared premium cyan-glass look — the single source of the
+                      // dropdown styling, so every Select menu matches.
+                      dropdownMenuPaperSx(darkMode),
+                      {
+                        // Cap height to the room on the open side so a tall menu
+                        // scrolls below the field instead of being shifted up over
+                        // it; the cap is published per-open as a CSS var.
+                        maxHeight: DROPDOWN_MENU_MAX_HEIGHT_SX,
+                        // Direction-aware gap so an upward-flipped menu doesn't sit
+                        // on the field.
+                        ...(menuUp
+                          ? { mt: 0, mb: DROPDOWN_MENU_GAP }
+                          : { mt: DROPDOWN_MENU_GAP, mb: 0 }),
+                      },
+                    ],
                   },
                 },
               },
@@ -556,7 +562,7 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
           },
         },
       }),
-    [baseTheme, menuUp, onSelectOpen],
+    [baseTheme, darkMode, menuUp, onSelectOpen],
   );
 
   return (

--- a/src/features/build-hub/components/BuildFilterBar.tsx
+++ b/src/features/build-hub/components/BuildFilterBar.tsx
@@ -78,34 +78,10 @@ export const BuildFilterBar: React.FC<BuildFilterBarProps> = React.memo(
       '& .MuiSelect-select': { py: '7px' },
     };
 
-    const menuPaperSx = {
-      borderRadius: 2,
-      background: isDark ? 'rgba(18,24,38,0.96)' : 'rgba(255,255,255,0.96)',
-      backdropFilter: 'blur(20px)',
-      border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
-      boxShadow: isDark ? '0 8px 32px rgba(0,0,0,0.6)' : '0 8px 32px rgba(0,0,0,0.12)',
-      '& .MuiMenuItem-root': {
-        fontSize: '0.85rem',
-        borderRadius: 1,
-        mx: 0.5,
-        '&:hover': {
-          background: isDark ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.06)',
-        },
-        '&.Mui-selected': {
-          background: isDark ? 'rgba(96,165,250,0.18)' : 'rgba(37,99,235,0.10)',
-          color: isDark ? '#60a5fa' : '#1d4ed8',
-          fontWeight: 600,
-          '&:hover': {
-            background: isDark ? 'rgba(96,165,250,0.22)' : 'rgba(37,99,235,0.14)',
-          },
-        },
-      },
-    };
-
-    // Open below the field (flip up near the viewport bottom) while keeping the
-    // glass paper styling — an explicit MenuProps would otherwise drop the global
-    // theme's open-direction default. Shared by both filter Selects.
-    const menuProps = useDropdownMenuProps(menuPaperSx);
+    // Open below the field (flip up near the viewport bottom) with the shared
+    // premium dropdown look — an explicit MenuProps would otherwise drop the
+    // global theme's open-direction + styling default. Shared by both filter Selects.
+    const menuProps = useDropdownMenuProps();
 
     return (
       <Box

--- a/src/features/build-hub/components/BuildFilterBar.tsx
+++ b/src/features/build-hub/components/BuildFilterBar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { useDropdownMenuProps } from '../../../hooks/useDropdownMenuDirection';
 import type { BuildHubFilters, SortOrder } from '../types/build-hub.types';
 import {
   BUILD_TAG_COLORS,
@@ -78,7 +79,6 @@ export const BuildFilterBar: React.FC<BuildFilterBarProps> = React.memo(
     };
 
     const menuPaperSx = {
-      mt: 0.5,
       borderRadius: 2,
       background: isDark ? 'rgba(18,24,38,0.96)' : 'rgba(255,255,255,0.96)',
       backdropFilter: 'blur(20px)',
@@ -101,6 +101,11 @@ export const BuildFilterBar: React.FC<BuildFilterBarProps> = React.memo(
         },
       },
     };
+
+    // Open below the field (flip up near the viewport bottom) while keeping the
+    // glass paper styling — an explicit MenuProps would otherwise drop the global
+    // theme's open-direction default. Shared by both filter Selects.
+    const menuProps = useDropdownMenuProps(menuPaperSx);
 
     return (
       <Box
@@ -216,7 +221,7 @@ export const BuildFilterBar: React.FC<BuildFilterBarProps> = React.memo(
                     ? 'rgba(255,255,255,0.38)'
                     : 'rgba(0,0,0,0.38)',
               }}
-              MenuProps={{ slotProps: { paper: { sx: menuPaperSx } } }}
+              MenuProps={menuProps}
             >
               {CLASS_OPTIONS.map((o) => (
                 <MenuItem key={o.value} value={o.value}>
@@ -244,7 +249,7 @@ export const BuildFilterBar: React.FC<BuildFilterBarProps> = React.memo(
                     ? 'rgba(255,255,255,0.38)'
                     : 'rgba(0,0,0,0.38)',
               }}
-              MenuProps={{ slotProps: { paper: { sx: menuPaperSx } } }}
+              MenuProps={menuProps}
             >
               {ROLE_OPTIONS.map((o) => (
                 <MenuItem key={o.value} value={o.value}>

--- a/src/features/loadout-manager/components/CharacterSelector.tsx
+++ b/src/features/loadout-manager/components/CharacterSelector.tsx
@@ -71,15 +71,10 @@ export const CharacterSelector: React.FC = (): React.ReactElement => {
     dispatch(updateCharacterRole({ characterId, role: newRole }));
   };
 
-  // Open below the field (flip up near the viewport bottom) while keeping the
-  // glass paper styling — an explicit MenuProps would otherwise drop the global
-  // theme's open-direction default. Shared by both Selects below.
-  const menuProps = useDropdownMenuProps({
-    borderRadius: '10px',
-    backdropFilter: 'blur(12px)',
-    backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
-    border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-  });
+  // Open below the field (flip up near the viewport bottom) with the shared
+  // premium dropdown look — an explicit MenuProps would otherwise drop the global
+  // theme's open-direction + styling default. Shared by both Selects below.
+  const menuProps = useDropdownMenuProps();
 
   if (!hasCharacters) {
     return (

--- a/src/features/loadout-manager/components/CharacterSelector.tsx
+++ b/src/features/loadout-manager/components/CharacterSelector.tsx
@@ -21,6 +21,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import type { RootState } from '@/store/storeWithHistory';
 
+import { useDropdownMenuProps } from '../../../hooks/useDropdownMenuDirection';
 import { setCurrentCharacter, updateCharacterRole } from '../store/loadoutSlice';
 import type { ClassSkillLine } from '../types/loadout.types';
 
@@ -70,6 +71,16 @@ export const CharacterSelector: React.FC = (): React.ReactElement => {
     dispatch(updateCharacterRole({ characterId, role: newRole }));
   };
 
+  // Open below the field (flip up near the viewport bottom) while keeping the
+  // glass paper styling — an explicit MenuProps would otherwise drop the global
+  // theme's open-direction default. Shared by both Selects below.
+  const menuProps = useDropdownMenuProps({
+    borderRadius: '10px',
+    backdropFilter: 'blur(12px)',
+    backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
+    border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+  });
+
   if (!hasCharacters) {
     return (
       <FormControl size="small" sx={{ minWidth: 160, ...glassTextField }} disabled>
@@ -99,18 +110,7 @@ export const CharacterSelector: React.FC = (): React.ReactElement => {
             if (!char) return 'Select character';
             return char.name;
           }}
-          MenuProps={{
-            slotProps: {
-              paper: {
-                sx: {
-                  borderRadius: '10px',
-                  backdropFilter: 'blur(12px)',
-                  backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
-                  border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-                },
-              },
-            },
-          }}
+          MenuProps={menuProps}
         >
           {sortedCharacters.map((char) => {
             const skillInfo = formatSkillLines(char.skillLines);
@@ -152,20 +152,7 @@ export const CharacterSelector: React.FC = (): React.ReactElement => {
             value={sortedCharacters.find((c) => c.id === currentCharacter)?.role ?? 'DPS'}
             label="Role"
             onChange={(e) => handleRoleChange(currentCharacter, e.target.value)}
-            MenuProps={{
-              slotProps: {
-                paper: {
-                  sx: {
-                    borderRadius: '10px',
-                    backdropFilter: 'blur(12px)',
-                    backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
-                    border: `1px solid ${
-                      isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
-                    }`,
-                  },
-                },
-              },
-            }}
+            MenuProps={menuProps}
           >
             {ROLE_OPTIONS.map((role) => (
               <MenuItem key={role} value={role}>

--- a/src/features/loadout-manager/components/LoadoutManager.tsx
+++ b/src/features/loadout-manager/components/LoadoutManager.tsx
@@ -46,6 +46,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { WorkInProgressDisclaimer } from '@/components/WorkInProgressDisclaimer';
+import { useDropdownMenuProps } from '@/hooks/useDropdownMenuDirection';
 import type { RootState } from '@/store/storeWithHistory';
 
 import { preloadChampionPointData } from '../data/championPointData';
@@ -116,6 +117,16 @@ export const LoadoutManager: React.FC = () => {
 
   // Glass design tokens
   const isDarkMode = theme.palette.mode === 'dark';
+
+  // Open below the field (flip up near the viewport bottom) while keeping the
+  // glass paper styling — an explicit MenuProps would otherwise drop the global
+  // theme's open-direction default. Shared by the Trial and Page Selects below.
+  const glassMenuProps = useDropdownMenuProps({
+    borderRadius: '10px',
+    backdropFilter: 'blur(12px)',
+    backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
+    border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+  });
   const glassTextField = {
     '& .MuiOutlinedInput-root': {
       backgroundColor: isDarkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',
@@ -610,20 +621,7 @@ export const LoadoutManager: React.FC = () => {
                     if (!trial) return 'Select trial';
                     return `${trial.name} · ${getActivityKindLabel(trial.type)}`;
                   }}
-                  MenuProps={{
-                    slotProps: {
-                      paper: {
-                        sx: {
-                          borderRadius: '10px',
-                          backdropFilter: 'blur(12px)',
-                          backgroundColor: isDarkMode
-                            ? 'rgba(20,20,30,0.92)'
-                            : 'rgba(255,255,255,0.94)',
-                          border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-                        },
-                      },
-                    },
-                  }}
+                  MenuProps={glassMenuProps}
                 >
                   {getGroupedTrials().flatMap((group) => [
                     <ListSubheader
@@ -787,20 +785,7 @@ export const LoadoutManager: React.FC = () => {
                       if (isMdDown) setDrawerOpen(false);
                     }}
                     disabled={allPages.length === 0}
-                    MenuProps={{
-                      slotProps: {
-                        paper: {
-                          sx: {
-                            borderRadius: '10px',
-                            backdropFilter: 'blur(12px)',
-                            backgroundColor: isDarkMode
-                              ? 'rgba(20,20,30,0.92)'
-                              : 'rgba(255,255,255,0.94)',
-                            border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-                          },
-                        },
-                      },
-                    }}
+                    MenuProps={glassMenuProps}
                   >
                     {allPages.map((page, index) => (
                       <MenuItem key={`${page.name}-${index}`} value={index}>

--- a/src/features/loadout-manager/components/LoadoutManager.tsx
+++ b/src/features/loadout-manager/components/LoadoutManager.tsx
@@ -118,15 +118,10 @@ export const LoadoutManager: React.FC = () => {
   // Glass design tokens
   const isDarkMode = theme.palette.mode === 'dark';
 
-  // Open below the field (flip up near the viewport bottom) while keeping the
-  // glass paper styling — an explicit MenuProps would otherwise drop the global
-  // theme's open-direction default. Shared by the Trial and Page Selects below.
-  const glassMenuProps = useDropdownMenuProps({
-    borderRadius: '10px',
-    backdropFilter: 'blur(12px)',
-    backgroundColor: isDarkMode ? 'rgba(20,20,30,0.92)' : 'rgba(255,255,255,0.94)',
-    border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
-  });
+  // Open below the field (flip up near the viewport bottom) with the shared
+  // premium dropdown look — an explicit MenuProps would otherwise drop the global
+  // theme's open-direction + styling default. Shared by the Trial and Page Selects.
+  const glassMenuProps = useDropdownMenuProps();
   const glassTextField = {
     '& .MuiOutlinedInput-root': {
       backgroundColor: isDarkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',

--- a/src/features/report_details/insights/CombinedFilterDropdown.tsx
+++ b/src/features/report_details/insights/CombinedFilterDropdown.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../store/ui/uiSelectors';
 import { setSelectedFriendlyPlayerId, setSelectedTargetIds } from '../../../store/ui/uiSlice';
 import { useAppDispatch } from '../../../store/useAppDispatch';
+import { computeMenuPlacement, dropdownMenuOrigins } from '../../../theme/dropdownMenu';
 
 const SECTION_HEADER_SX = {
   px: 2,
@@ -48,8 +49,23 @@ const CombinedFilterDropdownComponent: React.FC<CombinedFilterDropdownProps> = (
   const isDarkMode = theme.palette.mode === 'dark';
 
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
+  // Open the panel below the trigger, flipping above it when the trigger is too
+  // close to the viewport bottom, and cap its height to the room on the open
+  // side so a long target/player list scrolls instead of being shifted up over
+  // the trigger (MUI's Popover only shifts, never flips or fits). Measured once
+  // per open from the trigger's rect.
+  const [menuUp, setMenuUp] = React.useState(false);
+  const [menuMaxHeight, setMenuMaxHeight] = React.useState<number | null>(null);
   const open = Boolean(anchorEl);
   const popoverId = open ? 'combined-filter-popover' : undefined;
+
+  const handleOpen = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const placement = computeMenuPlacement(event.currentTarget);
+    setMenuUp(placement.menuUp);
+    // Keep the existing 70vh design ceiling, but never taller than the room available.
+    setMenuMaxHeight(Math.min(placement.maxHeight, Math.round(window.innerHeight * 0.7)));
+    setAnchorEl(event.currentTarget);
+  }, []);
 
   const fight = useSelectedFight();
   const { reportMasterData, isMasterDataLoading } = useReportMasterData();
@@ -154,7 +170,9 @@ const CombinedFilterDropdownComponent: React.FC<CombinedFilterDropdownProps> = (
   const popoverSx = React.useMemo(
     () => ({
       '& .MuiPaper-root': {
-        mt: 1,
+        // Gap between trigger and panel on whichever side it opens — a static mt
+        // would push an upward-flipped panel down onto the trigger.
+        ...(menuUp ? { mt: 0, mb: 1 } : { mt: 1, mb: 0 }),
         borderRadius: '12px',
         border: isDarkMode
           ? '1px solid rgba(56, 189, 248, 0.2)'
@@ -168,11 +186,11 @@ const CombinedFilterDropdownComponent: React.FC<CombinedFilterDropdownProps> = (
           : '0 12px 40px rgba(0, 0, 0, 0.1), 0 0 60px rgba(59, 130, 246, 0.05)',
         minWidth: 260,
         maxWidth: 320,
-        maxHeight: '70vh',
+        maxHeight: menuMaxHeight ?? '70vh',
         overflowY: 'auto',
       },
     }),
-    [isDarkMode],
+    [isDarkMode, menuUp, menuMaxHeight],
   );
 
   const sectionHeaderSx = SECTION_HEADER_SX;
@@ -223,7 +241,7 @@ const CombinedFilterDropdownComponent: React.FC<CombinedFilterDropdownProps> = (
         aria-controls={popoverId}
         aria-expanded={open}
         aria-haspopup="dialog"
-        onClick={(e) => setAnchorEl(e.currentTarget)}
+        onClick={handleOpen}
         endIcon={
           <KeyboardArrowDownIcon
             sx={{
@@ -309,8 +327,7 @@ const CombinedFilterDropdownComponent: React.FC<CombinedFilterDropdownProps> = (
         open={open}
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        {...dropdownMenuOrigins(menuUp)}
         sx={popoverSx}
       >
         {/* Target Section */}

--- a/src/features/roster-hub/components/FilterBar.tsx
+++ b/src/features/roster-hub/components/FilterBar.tsx
@@ -64,33 +64,10 @@ export const FilterBar: React.FC<FilterBarProps> = React.memo(
     const borderFocus = 'rgba(96,165,250,0.55)';
     const focusGlow = '0 0 0 3px rgba(96,165,250,0.12)';
 
-    // Open below the field (flip up near the viewport bottom) while keeping the
-    // glass paper styling — an explicit MenuProps would otherwise drop the global
-    // theme's open-direction default.
-    const trialMenuProps = useDropdownMenuProps({
-      borderRadius: 2,
-      background: isDark ? 'rgba(18,24,38,0.96)' : 'rgba(255,255,255,0.96)',
-      backdropFilter: 'blur(20px)',
-      WebkitBackdropFilter: 'blur(20px)',
-      border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
-      boxShadow: isDark ? '0 8px 32px rgba(0,0,0,0.6)' : '0 8px 32px rgba(0,0,0,0.12)',
-      '& .MuiMenuItem-root': {
-        fontSize: '0.85rem',
-        borderRadius: 1,
-        mx: 0.5,
-        '&:hover': {
-          background: isDark ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.06)',
-        },
-        '&.Mui-selected': {
-          background: isDark ? 'rgba(96,165,250,0.18)' : 'rgba(37,99,235,0.10)',
-          color: isDark ? '#60a5fa' : '#1d4ed8',
-          fontWeight: 600,
-          '&:hover': {
-            background: isDark ? 'rgba(96,165,250,0.22)' : 'rgba(37,99,235,0.14)',
-          },
-        },
-      },
-    });
+    // Open below the field (flip up near the viewport bottom) with the shared
+    // premium dropdown look — an explicit MenuProps would otherwise drop the
+    // global theme's open-direction + styling default.
+    const trialMenuProps = useDropdownMenuProps();
 
     return (
       <Box

--- a/src/features/roster-hub/components/FilterBar.tsx
+++ b/src/features/roster-hub/components/FilterBar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import React from 'react';
 
+import { useDropdownMenuProps } from '../../../hooks/useDropdownMenuDirection';
 import { TRIALS } from '../../loadout-manager/data/trialConfigs';
 import type { RosterHubFilters, SortOrder } from '../types/roster-hub.types';
 import { PRESET_TAGS, TAG_COLORS } from '../types/roster-hub.types';
@@ -62,6 +63,34 @@ export const FilterBar: React.FC<FilterBarProps> = React.memo(
     const borderHover = isDark ? 'rgba(255,255,255,0.20)' : 'rgba(0,0,0,0.14)';
     const borderFocus = 'rgba(96,165,250,0.55)';
     const focusGlow = '0 0 0 3px rgba(96,165,250,0.12)';
+
+    // Open below the field (flip up near the viewport bottom) while keeping the
+    // glass paper styling — an explicit MenuProps would otherwise drop the global
+    // theme's open-direction default.
+    const trialMenuProps = useDropdownMenuProps({
+      borderRadius: 2,
+      background: isDark ? 'rgba(18,24,38,0.96)' : 'rgba(255,255,255,0.96)',
+      backdropFilter: 'blur(20px)',
+      WebkitBackdropFilter: 'blur(20px)',
+      border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+      boxShadow: isDark ? '0 8px 32px rgba(0,0,0,0.6)' : '0 8px 32px rgba(0,0,0,0.12)',
+      '& .MuiMenuItem-root': {
+        fontSize: '0.85rem',
+        borderRadius: 1,
+        mx: 0.5,
+        '&:hover': {
+          background: isDark ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.06)',
+        },
+        '&.Mui-selected': {
+          background: isDark ? 'rgba(96,165,250,0.18)' : 'rgba(37,99,235,0.10)',
+          color: isDark ? '#60a5fa' : '#1d4ed8',
+          fontWeight: 600,
+          '&:hover': {
+            background: isDark ? 'rgba(96,165,250,0.22)' : 'rgba(37,99,235,0.14)',
+          },
+        },
+      },
+    });
 
     return (
       <Box
@@ -192,39 +221,7 @@ export const FilterBar: React.FC<FilterBarProps> = React.memo(
                 },
                 '& .MuiSelect-select': { py: '7px' },
               }}
-              MenuProps={{
-                slotProps: {
-                  paper: {
-                    sx: {
-                      mt: 0.5,
-                      borderRadius: 2,
-                      background: isDark ? 'rgba(18,24,38,0.96)' : 'rgba(255,255,255,0.96)',
-                      backdropFilter: 'blur(20px)',
-                      WebkitBackdropFilter: 'blur(20px)',
-                      border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
-                      boxShadow: isDark
-                        ? '0 8px 32px rgba(0,0,0,0.6)'
-                        : '0 8px 32px rgba(0,0,0,0.12)',
-                      '& .MuiMenuItem-root': {
-                        fontSize: '0.85rem',
-                        borderRadius: 1,
-                        mx: 0.5,
-                        '&:hover': {
-                          background: isDark ? 'rgba(96,165,250,0.12)' : 'rgba(37,99,235,0.06)',
-                        },
-                        '&.Mui-selected': {
-                          background: isDark ? 'rgba(96,165,250,0.18)' : 'rgba(37,99,235,0.10)',
-                          color: isDark ? '#60a5fa' : '#1d4ed8',
-                          fontWeight: 600,
-                          '&:hover': {
-                            background: isDark ? 'rgba(96,165,250,0.22)' : 'rgba(37,99,235,0.14)',
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              }}
+              MenuProps={trialMenuProps}
             >
               <MenuItem value="">All Trials</MenuItem>
               {HUB_TRIALS.map((t) => (

--- a/src/hooks/useDropdownMenuDirection.ts
+++ b/src/hooks/useDropdownMenuDirection.ts
@@ -24,6 +24,7 @@
  */
 
 import type { MenuProps } from '@mui/material/Menu';
+import { useTheme } from '@mui/material/styles';
 import type { SxProps, Theme } from '@mui/material/styles';
 import React from 'react';
 
@@ -32,6 +33,7 @@ import {
   DROPDOWN_MENU_MAX_HEIGHT_SX,
   computeMenuPlacement,
   dropdownMenuOrigins,
+  dropdownMenuPaperSx,
   setDropdownMenuMaxHeight,
   type DropdownMenuOrigins,
 } from '../theme/dropdownMenu';
@@ -81,20 +83,23 @@ export const useDropdownMenuOrigins = (): DropdownMenuOrigins =>
   dropdownMenuOrigins(useDropdownMenuDirection().menuUp);
 
 /**
- * Build the `MenuProps` for a Select that needs its OWN cosmetic paper styling.
- * Folds in the shared open-direction origins (opens below the field, flips up
- * near the viewport bottom), the per-open height cap (tall menus scroll instead
- * of covering the field), and a DIRECTION-AWARE gap (below the field when the
- * menu opens down, above it when it flips up — so an upward menu never overlaps
- * the field). The caller's paper `sx` is layered on top.
+ * Build the `MenuProps` for a Select that passes its OWN `MenuProps` (which would
+ * otherwise replace the theme default). Folds in everything the global default
+ * gives plain Selects so they stay consistent: the shared open-direction origins
+ * (opens below the field, flips up near the viewport bottom), the per-open height
+ * cap (tall menus scroll instead of covering the field), a DIRECTION-AWARE gap
+ * (below the field when opening down, above it when flipped up — so an upward
+ * menu never overlaps the field), and the shared premium cyan-glass paper look.
+ * Any caller-supplied paper `sx` is layered on top.
  *
  * ```tsx
- * const menuProps = useDropdownMenuProps(menuPaperSx);
+ * const menuProps = useDropdownMenuProps();
  * <Select MenuProps={menuProps}>…</Select>
  * ```
  */
 export const useDropdownMenuProps = (paperSx?: SxProps<Theme>): Partial<MenuProps> => {
   const { menuUp } = useDropdownMenuDirection();
+  const dark = useTheme().palette.mode === 'dark';
   const baseSx: SxProps<Theme> = {
     maxHeight: DROPDOWN_MENU_MAX_HEIGHT_SX,
     ...(menuUp ? { mt: 0, mb: DROPDOWN_MENU_GAP } : { mt: DROPDOWN_MENU_GAP, mb: 0 }),
@@ -106,6 +111,8 @@ export const useDropdownMenuProps = (paperSx?: SxProps<Theme>): Partial<MenuProp
       : [];
   return {
     ...dropdownMenuOrigins(menuUp),
-    slotProps: { paper: { sx: [baseSx, ...extra] as SxProps<Theme> } },
+    slotProps: {
+      paper: { sx: [dropdownMenuPaperSx(dark), baseSx, ...extra] as SxProps<Theme> },
+    },
   };
 };

--- a/src/hooks/useDropdownMenuDirection.ts
+++ b/src/hooks/useDropdownMenuDirection.ts
@@ -1,0 +1,111 @@
+/**
+ * App-wide "which way / how tall do Select menus open?" state.
+ *
+ * Only one Select menu is open at a time across the whole app, so a single
+ * shared `menuUp` flag is sufficient. `ReduxThemeProvider` owns the state via
+ * {@link useDropdownMenuController}, injects the measured `onOpen` handler +
+ * direction-aware origins into the global `MuiSelect.defaultProps`, and exposes
+ * the flag through {@link DropdownMenuDirectionProvider}.
+ *
+ * Plain Selects need nothing — they pick the behavior up from the theme default.
+ * The handful of Selects that pass their OWN `MenuProps` (which would otherwise
+ * *replace*, not merge with, the theme default and silently opt out of the fix)
+ * build their `MenuProps` from {@link useDropdownMenuProps}, which folds the
+ * shared open-direction origins, the per-open height cap, and a direction-aware
+ * field/menu gap in with the caller's cosmetic paper styling.
+ *
+ * The open handler also publishes a per-open max-height (so a tall menu opens
+ * below and scrolls instead of being shifted up over the field) via a CSS custom
+ * property — that costs no React re-render; only an actual up/down *flip* does.
+ *
+ * See `src/theme/dropdownMenu.ts` for the origins, height cap, and flip
+ * heuristic. Raw `<Popover>` value-pickers (not Selects) can use
+ * `shouldFlipMenuUp` directly.
+ */
+
+import type { MenuProps } from '@mui/material/Menu';
+import type { SxProps, Theme } from '@mui/material/styles';
+import React from 'react';
+
+import {
+  DROPDOWN_MENU_GAP,
+  DROPDOWN_MENU_MAX_HEIGHT_SX,
+  computeMenuPlacement,
+  dropdownMenuOrigins,
+  setDropdownMenuMaxHeight,
+  type DropdownMenuOrigins,
+} from '../theme/dropdownMenu';
+
+/** MUI Select `onOpen` handler — measures the anchor to choose open direction. */
+export type SelectOpenHandler = (event: React.SyntheticEvent) => void;
+
+export interface DropdownMenuDirection {
+  /** True when menus should currently open upward (field near viewport bottom). */
+  menuUp: boolean;
+  /** `onOpen` handler to attach to a Select; measures the anchor and sets `menuUp`. */
+  onSelectOpen: SelectOpenHandler;
+}
+
+const DropdownMenuDirectionContext = React.createContext<DropdownMenuDirection>({
+  menuUp: false,
+  onSelectOpen: () => {},
+});
+
+/**
+ * Owns the single shared open-direction flag. Returns the current flag plus the
+ * `onOpen` handler that measures a Select's anchor on open: it publishes the
+ * height cap (CSS var, no re-render) and flips the direction when there isn't
+ * room below. `setMenuUp` with an unchanged value is a no-op (React bails out),
+ * so the common mid-page case never triggers a re-render.
+ */
+export function useDropdownMenuController(): DropdownMenuDirection {
+  const [menuUp, setMenuUp] = React.useState(false);
+  const onSelectOpen = React.useCallback<SelectOpenHandler>((event) => {
+    const anchor = event.currentTarget as HTMLElement | null;
+    if (!anchor) return;
+    const placement = computeMenuPlacement(anchor);
+    setDropdownMenuMaxHeight(placement.maxHeight);
+    setMenuUp(placement.menuUp);
+  }, []);
+  return React.useMemo(() => ({ menuUp, onSelectOpen }), [menuUp, onSelectOpen]);
+}
+
+export const DropdownMenuDirectionProvider = DropdownMenuDirectionContext.Provider;
+
+/** Read the current shared open-direction state. */
+export const useDropdownMenuDirection = (): DropdownMenuDirection =>
+  React.useContext(DropdownMenuDirectionContext);
+
+/** Origins for the current open direction (downward, or upward near the bottom). */
+export const useDropdownMenuOrigins = (): DropdownMenuOrigins =>
+  dropdownMenuOrigins(useDropdownMenuDirection().menuUp);
+
+/**
+ * Build the `MenuProps` for a Select that needs its OWN cosmetic paper styling.
+ * Folds in the shared open-direction origins (opens below the field, flips up
+ * near the viewport bottom), the per-open height cap (tall menus scroll instead
+ * of covering the field), and a DIRECTION-AWARE gap (below the field when the
+ * menu opens down, above it when it flips up — so an upward menu never overlaps
+ * the field). The caller's paper `sx` is layered on top.
+ *
+ * ```tsx
+ * const menuProps = useDropdownMenuProps(menuPaperSx);
+ * <Select MenuProps={menuProps}>…</Select>
+ * ```
+ */
+export const useDropdownMenuProps = (paperSx?: SxProps<Theme>): Partial<MenuProps> => {
+  const { menuUp } = useDropdownMenuDirection();
+  const baseSx: SxProps<Theme> = {
+    maxHeight: DROPDOWN_MENU_MAX_HEIGHT_SX,
+    ...(menuUp ? { mt: 0, mb: DROPDOWN_MENU_GAP } : { mt: DROPDOWN_MENU_GAP, mb: 0 }),
+  };
+  const extra: SxProps<Theme>[] = Array.isArray(paperSx)
+    ? (paperSx as SxProps<Theme>[])
+    : paperSx
+      ? [paperSx]
+      : [];
+  return {
+    ...dropdownMenuOrigins(menuUp),
+    slotProps: { paper: { sx: [baseSx, ...extra] as SxProps<Theme> } },
+  };
+};

--- a/src/theme/dropdownMenu.test.ts
+++ b/src/theme/dropdownMenu.test.ts
@@ -1,0 +1,98 @@
+import {
+  DROPDOWN_MENU_ORIGINS_DOWN,
+  DROPDOWN_MENU_ORIGINS_UP,
+  computeMenuPlacement,
+  dropdownMenuOrigins,
+  shouldFlipMenuUp,
+} from './dropdownMenu';
+
+describe('dropdownMenuOrigins', () => {
+  it('opens downward by default (anchor bottom → transform top)', () => {
+    expect(dropdownMenuOrigins(false)).toBe(DROPDOWN_MENU_ORIGINS_DOWN);
+    expect(DROPDOWN_MENU_ORIGINS_DOWN.anchorOrigin).toEqual({
+      vertical: 'bottom',
+      horizontal: 'left',
+    });
+    expect(DROPDOWN_MENU_ORIGINS_DOWN.transformOrigin).toEqual({
+      vertical: 'top',
+      horizontal: 'left',
+    });
+  });
+
+  it('opens upward when flipped (anchor top → transform bottom)', () => {
+    expect(dropdownMenuOrigins(true)).toBe(DROPDOWN_MENU_ORIGINS_UP);
+    expect(DROPDOWN_MENU_ORIGINS_UP.anchorOrigin).toEqual({ vertical: 'top', horizontal: 'left' });
+    expect(DROPDOWN_MENU_ORIGINS_UP.transformOrigin).toEqual({
+      vertical: 'bottom',
+      horizontal: 'left',
+    });
+  });
+});
+
+describe('computeMenuPlacement', () => {
+  const makeAnchor = (top: number, bottom: number): HTMLElement =>
+    ({
+      getBoundingClientRect: () => ({ top, bottom }) as DOMRect,
+    }) as HTMLElement;
+
+  const setViewportHeight = (height: number): void => {
+    Object.defineProperty(window, 'innerHeight', {
+      value: height,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  it('opens downward and caps to the room below when there is ample room', () => {
+    setViewportHeight(1000);
+    // spaceBelow = 1000 - 130 - 20 = 850
+    const placement = computeMenuPlacement(makeAnchor(100, 130));
+    expect(placement.menuUp).toBe(false);
+    expect(placement.maxHeight).toBe(850);
+  });
+
+  it('caps a tall menu to the room below rather than letting it overflow', () => {
+    setViewportHeight(690);
+    // field high on the page: spaceBelow = 690 - 302 - 20 = 368; a 535px menu must
+    // be capped to 368 so it scrolls below the field instead of shifting up over it.
+    const placement = computeMenuPlacement(makeAnchor(269, 302));
+    expect(placement.menuUp).toBe(false);
+    expect(placement.maxHeight).toBe(368);
+  });
+
+  it('flips up and caps to the room above when room below is cramped', () => {
+    setViewportHeight(800);
+    // spaceBelow = 800 - 760 - 20 = 20 (< 220), spaceAbove = 730 - 20 = 710
+    const placement = computeMenuPlacement(makeAnchor(730, 760));
+    expect(placement.menuUp).toBe(true);
+    expect(placement.maxHeight).toBe(710);
+  });
+
+  it('does NOT flip when below is tight but above is even tighter (short viewport)', () => {
+    setViewportHeight(200);
+    // spaceBelow = 200 - 180 - 20 = 0, spaceAbove = 10 - 20 = -10 (not greater)
+    const placement = computeMenuPlacement(makeAnchor(10, 180));
+    expect(placement.menuUp).toBe(false);
+  });
+
+  it('never caps below the minimum usable menu height', () => {
+    setViewportHeight(200);
+    // spaceBelow floors to 0 → clamped up to the 120px minimum
+    expect(computeMenuPlacement(makeAnchor(10, 180)).maxHeight).toBe(120);
+  });
+
+  it('treats the flip threshold as exclusive around 220px of room below', () => {
+    setViewportHeight(1000);
+    // spaceBelow = 1000 - 760 - 20 = 220, which is not < 220 ⇒ no flip
+    expect(computeMenuPlacement(makeAnchor(700, 760)).menuUp).toBe(false);
+    // one px tighter: spaceBelow = 219 (< 220) and spaceAbove = 680 > 219 ⇒ flip
+    expect(computeMenuPlacement(makeAnchor(700, 761)).menuUp).toBe(true);
+  });
+
+  it('shouldFlipMenuUp mirrors computeMenuPlacement.menuUp', () => {
+    setViewportHeight(800);
+    expect(shouldFlipMenuUp(makeAnchor(730, 760))).toBe(true);
+    setViewportHeight(1000);
+    expect(shouldFlipMenuUp(makeAnchor(100, 130))).toBe(false);
+  });
+});

--- a/src/theme/dropdownMenu.ts
+++ b/src/theme/dropdownMenu.ts
@@ -22,6 +22,7 @@
  */
 
 import type { PopoverOrigin } from '@mui/material/Popover';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 export interface DropdownMenuOrigins {
   anchorOrigin: PopoverOrigin;
@@ -105,4 +106,105 @@ export const shouldFlipMenuUp = (anchor: HTMLElement): boolean =>
  */
 export const setDropdownMenuMaxHeight = (maxHeight: number): void => {
   document.documentElement.style.setProperty(DROPDOWN_MENU_MAX_HEIGHT_VAR, `${maxHeight}px`);
+};
+
+/**
+ * Premium "cyan-glass" Select-menu paper styling — the shared visual treatment
+ * for every dropdown, promoted from the Ultimate Calculator's feature theme so
+ * the whole app's dropdowns look consistent: a lighter, solid slate surface, a
+ * glowing cyan edge, a thin cyan sheen across the top, and menu items that light
+ * up with a cyan fill + a left accent rail on hover/selection.
+ *
+ * Scoped to Select menu paper (applied via the Select's `MenuProps.slotProps.paper`
+ * + {@link useDropdownMenuProps}) so raw kebab/nav `<Menu>`s keep their plain look.
+ * Wins over the global `.MuiMenu-paper { background … !important }` rule with `&&`
+ * + `!important`; the menu-item backgrounds likewise carry `!important` to beat the
+ * global `.MuiMenuItem-root` hover/selected rules. Does NOT set `position` (MUI's
+ * PopoverPaper is already `absolute`, so the `&::before` sheen anchors correctly —
+ * a `position` override would stretch the paper viewport-wide).
+ */
+export const dropdownMenuPaperSx = (dark: boolean): SxProps<Theme> => {
+  const cyan = dark ? 'rgb(56,189,248)' : 'rgb(40,145,200)';
+  return {
+    borderRadius: '14px',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    backdropFilter: 'blur(20px) saturate(1.5)',
+    WebkitBackdropFilter: 'blur(20px) saturate(1.5)',
+    boxShadow: dark
+      ? '0 24px 60px rgba(0,0,0,0.65), 0 0 36px rgba(56,189,248,0.3), inset 0 1px 0 rgba(255,255,255,0.12)'
+      : '0 20px 48px rgba(15,23,42,0.22), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9)',
+    // Beat the global `.MuiMenu-paper { background … !important }` rule: a
+    // distinctly lighter, solid slate surface with a cyan edge.
+    '&&': {
+      backgroundColor: `${dark ? 'rgb(45,64,99)' : 'rgb(250,253,255)'} !important`,
+      backgroundImage: 'none !important',
+      border: `1px solid ${dark ? 'rgba(56,189,248,0.6)' : 'rgba(40,145,200,0.4)'} !important`,
+    },
+    // Thin cyan sheen across the very top edge.
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      height: 2,
+      background: dark
+        ? 'linear-gradient(90deg, transparent, rgba(0,225,255,0.7), transparent)'
+        : 'linear-gradient(90deg, transparent, rgba(40,145,200,0.6), transparent)',
+      pointerEvents: 'none',
+      zIndex: 1,
+    },
+    '& .MuiList-root': { paddingTop: '7px', paddingBottom: '7px' },
+    '& .MuiMenuItem-root': {
+      borderRadius: '10px',
+      marginLeft: '7px',
+      marginRight: '7px',
+      paddingTop: '9px',
+      paddingBottom: '9px',
+      transition: 'background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease',
+      // `!important` on the gradients beats the global `.MuiMenuItem-root` hover/
+      // selected `background-color … !important` rules so the cyan fill shows.
+      '&:hover': {
+        background: `${
+          dark
+            ? 'linear-gradient(90deg, rgba(56,189,248,0.20), rgba(56,189,248,0.06))'
+            : 'linear-gradient(90deg, rgba(40,145,200,0.16), rgba(40,145,200,0.04))'
+        } !important`,
+        boxShadow: `inset 3px 0 0 ${cyan}`,
+      },
+      '&.Mui-focusVisible': {
+        background: `${
+          dark
+            ? 'linear-gradient(90deg, rgba(56,189,248,0.24), rgba(56,189,248,0.08))'
+            : 'linear-gradient(90deg, rgba(40,145,200,0.18), rgba(40,145,200,0.05))'
+        } !important`,
+        boxShadow: `inset 3px 0 0 ${cyan}`,
+      },
+      '&.Mui-selected': {
+        color: `${dark ? 'rgb(186,236,255)' : 'rgb(20,110,160)'} !important`,
+        fontWeight: 600,
+        background: `${
+          dark
+            ? 'linear-gradient(90deg, rgba(56,189,248,0.32), rgba(0,225,255,0.10))'
+            : 'linear-gradient(90deg, rgba(40,145,200,0.22), rgba(40,145,200,0.06))'
+        } !important`,
+        boxShadow: `inset 3px 0 0 ${cyan}${dark ? ', 0 0 16px rgba(56,189,248,0.18)' : ''}`,
+        '&:hover': {
+          background: `${
+            dark
+              ? 'linear-gradient(90deg, rgba(56,189,248,0.4), rgba(0,225,255,0.14))'
+              : 'linear-gradient(90deg, rgba(40,145,200,0.28), rgba(40,145,200,0.1))'
+          } !important`,
+        },
+        '&.Mui-focusVisible': {
+          background: `${
+            dark
+              ? 'linear-gradient(90deg, rgba(56,189,248,0.36), rgba(0,225,255,0.12))'
+              : 'linear-gradient(90deg, rgba(40,145,200,0.26), rgba(40,145,200,0.08))'
+          } !important`,
+        },
+      },
+    },
+  };
 };

--- a/src/theme/dropdownMenu.ts
+++ b/src/theme/dropdownMenu.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared Select/menu open-direction + height logic — the single source of truth
+ * for the "open below the field, flip up near the viewport bottom, never cover
+ * the field" behavior.
+ *
+ * Three MUI defaults make Select menus appear over/covering the field:
+ *  1. MUI's default `selectedMenu` positioning aligns the *selected* option over
+ *     the anchor, so a Select whose value is near the END of a long option list
+ *     opens centred on the field. Anchoring `bottom → top` opens it downward.
+ *  2. Near the viewport bottom there isn't room below the field. MUI's Popover
+ *     only *shifts* a downward menu up to keep it on screen — it never flips — so
+ *     the menu slides up and covers the field. We detect that case and flip the
+ *     origins to open *upward* (`top → bottom`).
+ *  3. A menu TALLER than the room below the field is likewise shifted up over the
+ *     field (even mid-page). Capping the menu's `maxHeight` to the available room
+ *     on its open side makes a tall menu open below and *scroll* instead of
+ *     covering the field.
+ *
+ * Proven first in the Ultimate Calculator's feature theme (whose tall picker hard-
+ * capped `maxHeight: 420`); generalized here so the whole app shares one
+ * implementation, with the cap measured per-open instead of hand-tuned per menu.
+ */
+
+import type { PopoverOrigin } from '@mui/material/Popover';
+
+export interface DropdownMenuOrigins {
+  anchorOrigin: PopoverOrigin;
+  transformOrigin: PopoverOrigin;
+}
+
+/** Origins that open the menu downward from the field (the normal case). */
+export const DROPDOWN_MENU_ORIGINS_DOWN: DropdownMenuOrigins = {
+  anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+  transformOrigin: { vertical: 'top', horizontal: 'left' },
+};
+
+/** Origins that open the menu upward from the field (near the viewport bottom). */
+export const DROPDOWN_MENU_ORIGINS_UP: DropdownMenuOrigins = {
+  anchorOrigin: { vertical: 'top', horizontal: 'left' },
+  transformOrigin: { vertical: 'bottom', horizontal: 'left' },
+};
+
+/**
+ * Pick the open-direction origins. Pass `true` to open upward (the field is too
+ * close to the viewport bottom to fit the menu below it).
+ */
+export const dropdownMenuOrigins = (up: boolean): DropdownMenuOrigins =>
+  up ? DROPDOWN_MENU_ORIGINS_UP : DROPDOWN_MENU_ORIGINS_DOWN;
+
+/** Gap between the field and the menu, in MUI spacing units (0.5 * 8px = 4px). */
+export const DROPDOWN_MENU_GAP = 0.5;
+/** Same gap in px — used when measuring available room. */
+const FIELD_MENU_GAP_PX = DROPDOWN_MENU_GAP * 8;
+/** Keep the menu this far from the viewport edge (matches MUI Popover's default
+ * `marginThreshold`, so MUI never needs to shift the menu after we size it). */
+const VIEWPORT_EDGE_GAP_PX = 16;
+/** Never cap a menu shorter than this — a sliver of menu is worse than a small overflow. */
+const MIN_MENU_HEIGHT_PX = 120;
+/** Below this much room beneath the field, prefer flipping up (if above is roomier). */
+const MIN_USABLE_BELOW_PX = 220;
+
+/**
+ * CSS custom property holding the per-open menu max-height (px). The open handler
+ * sets it imperatively so updating the cap costs no React re-render; the menu
+ * paper reads it via {@link DROPDOWN_MENU_MAX_HEIGHT_SX} and the browser re-reads
+ * it at paint. Only one Select menu is open at a time, so one global var is safe.
+ */
+export const DROPDOWN_MENU_MAX_HEIGHT_VAR = '--esotk-dropdown-menu-max-height';
+
+/** `maxHeight` sx value for a Select menu paper (falls back to 60vh if unset). */
+export const DROPDOWN_MENU_MAX_HEIGHT_SX = `var(${DROPDOWN_MENU_MAX_HEIGHT_VAR}, 60vh)`;
+
+export interface MenuPlacement {
+  /** Open the menu upward (field too close to the viewport bottom). */
+  menuUp: boolean;
+  /** Max menu height (px) so it fits on its open side without MUI shifting it. */
+  maxHeight: number;
+}
+
+/**
+ * Measure an anchor and decide how its menu should open: the direction (down by
+ * default, up only when the room below is cramped and there's more room above),
+ * and a max-height that fits the chosen side so a tall menu scrolls instead of
+ * being shifted up over the field.
+ */
+export const computeMenuPlacement = (anchor: HTMLElement): MenuPlacement => {
+  const rect = anchor.getBoundingClientRect();
+  const spaceBelow = window.innerHeight - rect.bottom - FIELD_MENU_GAP_PX - VIEWPORT_EDGE_GAP_PX;
+  const spaceAbove = rect.top - FIELD_MENU_GAP_PX - VIEWPORT_EDGE_GAP_PX;
+  const menuUp = spaceBelow < MIN_USABLE_BELOW_PX && spaceAbove > spaceBelow;
+  const room = menuUp ? spaceAbove : spaceBelow;
+  return { menuUp, maxHeight: Math.max(MIN_MENU_HEIGHT_PX, Math.floor(room)) };
+};
+
+/**
+ * Whether a menu should open upward given its anchor — for raw `<Popover>`
+ * value-pickers that manage their own height. Selects use {@link computeMenuPlacement}.
+ */
+export const shouldFlipMenuUp = (anchor: HTMLElement): boolean =>
+  computeMenuPlacement(anchor).menuUp;
+
+/**
+ * Imperatively publish the per-open max-height so the menu paper's
+ * `var(${DROPDOWN_MENU_MAX_HEIGHT_VAR})` picks it up without a React re-render.
+ */
+export const setDropdownMenuMaxHeight = (maxHeight: number): void => {
+  document.documentElement.style.setProperty(DROPDOWN_MENU_MAX_HEIGHT_VAR, `${maxHeight}px`);
+};


### PR DESCRIPTION
## What & why

MUI Select menus across the app opened **over / covering the field** in three cases:

1. The default `selectedMenu` positioning centred the menu over the field when the value was near the **end of a long list**.
2. Near the **viewport bottom**, MUI's Popover only *shifts* a downward menu up (it never flips) → the menu slides up over the field.
3. A menu **taller than the room below** is likewise shifted up over the field — even mid-page.

This generalizes the Ultimate Calculator's proven fix (PR #1258) from a **single source of truth** and wires it into the global theme so every dropdown benefits.

## How

- **`src/theme/dropdownMenu.ts`** — open-direction origins, a per-open placement heuristic (`computeMenuPlacement`: flip up only when the room below is cramped *and* above is roomier), and a **fitted `maxHeight`** so tall menus open below and **scroll** instead of being shifted up over the field. The cap rides a CSS custom property, so updating it costs **no React re-render**.
- **`src/hooks/useDropdownMenuDirection.ts`** — a controller owning the single shared open-direction flag (only one Select menu is open at a time), a context provider, and `useDropdownMenuProps()` for Selects that pass their own `MenuProps` (which otherwise *replace* the theme default and silently opt out).
- **`ReduxThemeProvider`** — holds the state and injects `onOpen` + direction-aware `MenuProps` into the global `MuiSelect.defaultProps` via a thin overlay theme, so the heavy base theme only rebuilds on dark-mode/token changes.
- Spread the shared `MenuProps` into the **7 Selects that set their own** (build-hub + roster-hub filter bars, loadout-manager character/role/trial/page selects).
- **CombinedFilterDropdown** (a raw `<Popover>` value-picker, not a Select): open below, flip up near the bottom, cap to the room available (keeps its 70vh ceiling).

## The key insight beyond the reference

Origin-flip **alone is insufficient** — MUI shifts (never fits) a menu taller than the room below, up over the field. The reference dodged this with a hand-tuned `maxHeight: 420` on its one tall picker; the general fix is to **measure room per-open and cap height**. Found via live measurement, not static review.

## Surfaces audited

| Surface | Verdict |
|---|---|
| All plain `<Select>` | Fixed via global `MuiSelect.defaultProps` |
| 7 Selects with own `MenuProps` | Per-site merge of `useDropdownMenuProps` |
| CombinedFilterDropdown (`<Popover>`) | Fixed locally with `computeMenuPlacement` |
| `<Autocomplete>` | Left alone — Popper already flips |
| Kebab/context Menus, Snackbars, info Popovers | Left alone — intentional placement |
| Other paper `position`/`width` overrides | None found (the viewport-wide bug was specific to the feature theme) |

## Verification

- Gates: `tsc`, `eslint`, `prettier`, **9 new unit tests** + existing suites green.
- Live (Chrome) in **dark + light** at **desktop (1440) + mobile (390)**: opens below with room, flips above near the bottom with no overlap, stays in the viewport, tall menus scroll, value-near-end opens below (not centred), and Selects with their own `MenuProps` get the behavior. Mobile full-width menus are **pre-existing** (proven width-neutral against a stashed baseline).
- Codex `/review` and `/adversarial-review`: both **approve**, no findings.

## Known follow-up (out of scope)

3 `disablePortal` Autocompletes (`RosterBuilderPage`, `ItemPickerDialog`, `FoodSelector`) defeat Popper's flip near the viewport bottom — a separate class from this Select/Popover work, tracked for a follow-up.