### PR TITLE
fix(replay): split multi-instance NPCs into per-copy pucks

### DIFF
--- a/src/types/combatlogEvents.ts
+++ b/src/types/combatlogEvents.ts
@@ -10,8 +10,12 @@ export interface DamageEvent {
   type: 'damage';
   sourceID: number;
   sourceIsFriendly: boolean;
+  // ESO Logs assigns ONE actor id to all simultaneous copies of a multi-instance NPC; these optional
+  // per-event fields identify WHICH physical copy this event is about (absent/0 for single-instance).
+  sourceInstance?: number;
   targetID: number;
   targetIsFriendly: false;
+  targetInstance?: number;
   abilityGameID: number;
   fight: number;
   hitType: HitType;
@@ -29,6 +33,7 @@ export interface DeathEvent {
   type: 'death';
   sourceID: number;
   sourceIsFriendly: boolean;
+  sourceInstance?: number;
   targetID: number;
   targetInstance: number;
   targetIsFriendly: boolean;
@@ -45,8 +50,10 @@ export interface ResourceChangeEvent {
   type: 'resourcechange';
   sourceID: number;
   sourceIsFriendly: boolean;
+  sourceInstance?: number;
   targetID: number;
   targetIsFriendly: boolean;
+  targetInstance?: number;
   abilityGameID: number;
   fight: number;
   resourceChange: number;
@@ -88,8 +95,10 @@ export interface HealEvent {
   type: 'heal';
   sourceID: number;
   sourceIsFriendly: boolean;
+  sourceInstance?: number;
   targetID: number;
   targetIsFriendly: boolean;
+  targetInstance?: number;
   abilityGameID: number;
   fight: number;
   hitType: number;
@@ -123,8 +132,10 @@ export interface CastEvent {
   type: 'cast';
   sourceID: number;
   sourceIsFriendly: boolean;
+  sourceInstance?: number;
   targetID: number;
   targetIsFriendly: boolean;
+  targetInstance?: number;
   abilityGameID: number;
   fight: number;
   fake?: boolean;

--- a/src/workers/calculations/CalculateActorPositions.test.ts
+++ b/src/workers/calculations/CalculateActorPositions.test.ts
@@ -494,4 +494,176 @@ describe('calculateActorPositions', () => {
       });
     });
   });
+
+  describe('multi-instance NPC splitting', () => {
+    // ESO Logs assigns ONE actor id to all simultaneous copies of an NPC; each copy is distinguished
+    // on events by sourceInstance/targetInstance. Before the fix, all copies merged into one position
+    // history and the single rendered puck teleported between their separate map positions. These
+    // tests pin the split: genuinely multi-instance NPCs become one independent puck per copy, while
+    // single-instance actors stay byte-identical (same id, same behavior).
+    const INSTANCE_STRIDE = 1_000_000;
+    const PLAYER_ID = 101;
+    const ENEMY_ID = 202; // default mock fight classifies 202 as a regular enemy NPC
+    // Two copies at clearly distinct map positions: copy A near (1000,1000), copy B near (9000,9000).
+    const POS_A = { x: 1000, y: 1000 };
+    const POS_B = { x: 9000, y: 9000 };
+
+    // Build a stream of player-on-enemy damage events for the given enemy instance at a fixed enemy
+    // position, dense enough (every 1s) that the copy stays visible across the queried window.
+    const enemyHits = (
+      targetInstance: number | undefined,
+      pos: { x: number; y: number },
+      relTimes: number[],
+    ) =>
+      relTimes.map((rel) =>
+        createMockPositionalDamageEvent(
+          1_000_000 + rel,
+          PLAYER_ID,
+          ENEMY_ID,
+          createEnhancedMockResources(5235, 5410, 0), // player's own position
+          createEnhancedMockResources(pos.x, pos.y, 0), // this enemy copy's position
+          targetInstance === undefined ? undefined : { targetInstance },
+        ),
+      );
+
+    const baseFight = () => createEnhancedMockFight({ startTime: 1_000_000, endTime: 1_060_000 });
+    const dense = [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000];
+
+    it('splits a multi-instance enemy into one puck per copy at distinct positions', () => {
+      const events = createMockEvents();
+      // Copy A logged as instance 1, copy B as instance 2 — two distinct copies of enemy 202.
+      events.damage = [...enemyHits(1, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      // Two synthetic ids exist: the primary keeps the bare id, the extra copy gets the offset id.
+      const copyA = ENEMY_ID; // instance 1 → primary slot → bare id
+      const copyB = ENEMY_ID + 2 * INSTANCE_STRIDE; // instance 2 → slot 2
+      expect(result.actorIds).toContain(copyA);
+      expect(result.actorIds).toContain(copyB);
+
+      // At a shared timestamp both copies are present, at their OWN distinct positions (no merge).
+      const actors = getAllActorPositionsAtTimestamp(result, 4000);
+      const a = actors.find((act) => act.id === copyA);
+      const b = actors.find((act) => act.id === copyB);
+      expect(a).toBeDefined();
+      expect(b).toBeDefined();
+      // Both are enemies sharing the base NPC name (resolved via baseActorId, not "Actor <synthId>").
+      expect(a?.type).toBe('enemy');
+      expect(b?.type).toBe('enemy');
+      expect(a?.name).toBe('Regular Enemy');
+      expect(b?.name).toBe('Regular Enemy');
+      expect(a?.baseActorId).toBe(ENEMY_ID);
+      expect(b?.baseActorId).toBe(ENEMY_ID);
+      // Distinct converted positions — the whole point: they don't collapse onto one teleporting puck.
+      expect(a?.position[0]).not.toBeCloseTo(b?.position[0] ?? 0, 1);
+      expect(a?.position[2]).not.toBeCloseTo(b?.position[2] ?? 0, 1);
+    });
+
+    it('leaves a single-instance enemy unchanged (no synthetic ids)', () => {
+      const events = createMockEvents();
+      // All events for enemy 202 use instance 0 (the single-instance encoding).
+      events.damage = enemyHits(0, POS_A, dense);
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      expect(result.actorIds).toContain(ENEMY_ID);
+      // No id was promoted into the synthetic namespace.
+      expect(result.actorIds?.every((id) => id < INSTANCE_STRIDE)).toBe(true);
+    });
+
+    it('does not split when copies are logged as instance 0 and 1 (both primary)', () => {
+      const events = createMockEvents();
+      // {0, 1} collapse to the same primary slot → a single puck, not two.
+      events.damage = [...enemyHits(0, POS_A, dense), ...enemyHits(1, POS_A, dense)];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      const enemyIds = (result.actorIds ?? []).filter(
+        (id) => id % INSTANCE_STRIDE === ENEMY_ID || id === ENEMY_ID,
+      );
+      expect(enemyIds).toEqual([ENEMY_ID]);
+    });
+
+    it('splits {0,1,2} into the primary plus one extra copy', () => {
+      const events = createMockEvents();
+      events.damage = [
+        ...enemyHits(0, POS_A, dense),
+        ...enemyHits(1, POS_A, dense),
+        ...enemyHits(2, POS_B, dense),
+      ];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      const enemyIds = (result.actorIds ?? [])
+        .filter((id) => id % INSTANCE_STRIDE === ENEMY_ID)
+        .sort((x, y) => x - y);
+      expect(enemyIds).toEqual([ENEMY_ID, ENEMY_ID + 2 * INSTANCE_STRIDE]);
+    });
+
+    it('death of one copy does not remove the other copy', () => {
+      const events = createMockEvents();
+      events.damage = [...enemyHits(1, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+      // Copy B (instance 2) dies at t+4500; copy A (instance 1) keeps taking hits afterward.
+      events.death = [
+        createMockDeathEvent({
+          timestamp: 1_004_500,
+          sourceID: PLAYER_ID,
+          targetID: ENEMY_ID,
+          targetInstance: 2,
+          targetIsFriendly: false,
+        }),
+      ];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      const copyA = ENEMY_ID;
+      const copyB = ENEMY_ID + 2 * INSTANCE_STRIDE;
+      // After copy B's death, it has stopped emitting positions (enemy NPCs vanish on death)...
+      const after = getAllActorPositionsAtTimestamp(result, 7000);
+      expect(after.find((act) => act.id === copyB)).toBeUndefined();
+      // ...while copy A is still present.
+      expect(after.find((act) => act.id === copyA)).toBeDefined();
+    });
+
+    it('produces deterministic synthetic ids across recomputation (deep-link safe)', () => {
+      const events = createMockEvents();
+      events.damage = [...enemyHits(1, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+      const task: ActorPositionsCalculationTask = {
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      };
+
+      const first = calculateActorPositions(task);
+      const second = calculateActorPositions(task);
+      expect(second.actorIds).toEqual(first.actorIds);
+    });
+  });
 });

--- a/src/workers/calculations/CalculateActorPositions.test.ts
+++ b/src/workers/calculations/CalculateActorPositions.test.ts
@@ -9,7 +9,10 @@ import {
   createMockPlayersById,
   createMockActorsById,
 } from '../../test/utils/enhancedMockFactories';
-import { createMockDeathEvent } from '../../test/utils/combatLogMockFactories';
+import {
+  createMockDeathEvent,
+  createMockResourceChangeEvent,
+} from '../../test/utils/combatLogMockFactories';
 import { BuffLookupData } from '../../utils/BuffLookupUtils';
 
 import {
@@ -664,6 +667,103 @@ describe('calculateActorPositions', () => {
       const first = calculateActorPositions(task);
       const second = calculateActorPositions(task);
       expect(second.actorIds).toEqual(first.actorIds);
+    });
+
+    it('splits from resource events too (the densest position source)', () => {
+      // Enemy copies are most often located via periodic resourcechange ticks, not just damage.
+      const enemyResourceTicks = (
+        targetInstance: number,
+        pos: { x: number; y: number },
+        relTimes: number[],
+      ) =>
+        relTimes.map((rel) =>
+          createMockResourceChangeEvent({
+            timestamp: 1_000_000 + rel,
+            sourceID: PLAYER_ID,
+            sourceIsFriendly: true,
+            targetID: ENEMY_ID,
+            targetIsFriendly: false,
+            targetInstance,
+            sourceResources: createEnhancedMockResources(5235, 5410, 0),
+            targetResources: createEnhancedMockResources(pos.x, pos.y, 0),
+          }),
+        );
+
+      const events = createMockEvents();
+      events.resource = [
+        ...enemyResourceTicks(1, POS_A, dense),
+        ...enemyResourceTicks(2, POS_B, dense),
+      ];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      expect(result.actorIds).toContain(ENEMY_ID);
+      expect(result.actorIds).toContain(ENEMY_ID + 2 * INSTANCE_STRIDE);
+      const actors = getAllActorPositionsAtTimestamp(result, 4000);
+      expect(actors.find((a) => a.id === ENEMY_ID)).toBeDefined();
+      expect(actors.find((a) => a.id === ENEMY_ID + 2 * INSTANCE_STRIDE)).toBeDefined();
+    });
+
+    it('populates baseActorId and instance on each split puck', () => {
+      const events = createMockEvents();
+      events.damage = [...enemyHits(1, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      const actors = getAllActorPositionsAtTimestamp(result, 4000);
+      const primary = actors.find((a) => a.id === ENEMY_ID);
+      const copy = actors.find((a) => a.id === ENEMY_ID + 2 * INSTANCE_STRIDE);
+      // Both decode back to the real report id; the slot distinguishes them.
+      expect(primary?.baseActorId).toBe(ENEMY_ID);
+      expect(primary?.instance).toBe(0);
+      expect(copy?.baseActorId).toBe(ENEMY_ID);
+      expect(copy?.instance).toBe(2);
+    });
+
+    it('splits {0,2} (skipped instance 1) into the primary plus the explicit copy', () => {
+      const events = createMockEvents();
+      events.damage = [...enemyHits(0, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      const enemyIds = (result.actorIds ?? [])
+        .filter((id) => id % INSTANCE_STRIDE === ENEMY_ID)
+        .sort((x, y) => x - y);
+      expect(enemyIds).toEqual([ENEMY_ID, ENEMY_ID + 2 * INSTANCE_STRIDE]);
+    });
+
+    it('does not split a co-present single-instance player when an enemy splits', () => {
+      const events = createMockEvents();
+      // Player 101 (always instance 0 as the source) hits two enemy copies.
+      events.damage = [...enemyHits(1, POS_A, dense), ...enemyHits(2, POS_B, dense)];
+
+      const result = calculateActorPositions({
+        fight: baseFight(),
+        events,
+        playersById: createMockPlayersById(),
+        actorsById: createMockActorsById(),
+      });
+
+      // The player keeps exactly one entry at its real id, never promoted to the synthetic band.
+      const playerIds = (result.actorIds ?? []).filter((id) => id % INSTANCE_STRIDE === PLAYER_ID);
+      expect(playerIds).toEqual([PLAYER_ID]);
+      const player = getAllActorPositionsAtTimestamp(result, 4000).find((a) => a.id === PLAYER_ID);
+      expect(player?.type).toBe('player');
     });
   });
 });

--- a/src/workers/calculations/CalculateActorPositions.ts
+++ b/src/workers/calculations/CalculateActorPositions.ts
@@ -15,9 +15,11 @@ import { Logger, LogLevel } from '../../utils/logger';
 import { resolveActorName } from '../../utils/resolveActorName';
 import { OnProgressCallback } from '../Utils';
 
-// Create logger instance for actor position calculations (worker context)
+// Create logger instance for actor position calculations (worker context). INFO so the one-line
+// multi-instance split summary surfaces (once per fight) — the signal for live-verifying that
+// previously-teleporting packs of adds now render as separate pucks. Warnings still pass through.
 const logger = new Logger({
-  level: LogLevel.WARN,
+  level: LogLevel.INFO,
   contextPrefix: 'ActorPositions',
 });
 
@@ -563,14 +565,39 @@ export function calculateActorPositions(
     }
   }
   const multiInstanceActors = new Set<number>();
+  let splitCopyCount = 0; // total pucks emitted for split NPCs (for observability)
   slotsByActor.forEach((slots, actorId) => {
-    if (slots.size >= 2) multiInstanceActors.add(actorId);
+    if (slots.size < 2) return;
+    // Safety: the synthetic render id is `actorId + slot * INSTANCE_STRIDE`, and baseActorIdOf reverses
+    // it with `% INSTANCE_STRIDE`. That round-trip is only exact while the real id is below the stride.
+    // Real ESO-Logs report actor ids are small sequential ints, so this never trips in practice; if a
+    // report ever exceeded it we keep the (merged) pre-fix behavior for that actor rather than risk a
+    // corrupted id, and log it.
+    if (actorId >= INSTANCE_STRIDE) {
+      logger.warn('Skipping multi-instance split for out-of-range actor id', {
+        actorId,
+        instanceStride: INSTANCE_STRIDE,
+      });
+      return;
+    }
+    multiInstanceActors.add(actorId);
+    splitCopyCount += slots.size;
   });
 
   // Map a (real actorId, raw instance) to the id under which its position history / death / event
   // times are keyed and the puck is rendered. Single-instance actors keep their real id verbatim.
   const resolveRenderId = (actorId: number, rawInstance: number | undefined): number =>
     multiInstanceActors.has(actorId) ? makeRenderId(actorId, rawInstance) : actorId;
+
+  // Observability: surface when the split actually fires. A fight with no multi-instance NPCs logs
+  // nothing (and behaves exactly as before); a trash pull logs how many NPC ids fanned out into how
+  // many pucks — the signal to look for when live-verifying that "teleporting adds" are now split.
+  if (multiInstanceActors.size > 0) {
+    logger.info('Split multi-instance NPCs into per-copy pucks', {
+      multiInstanceNpcs: multiInstanceActors.size,
+      totalCopies: splitCopyCount,
+    });
+  }
 
   // Collect position data from events
   for (const event of allEvents) {

--- a/src/workers/calculations/CalculateActorPositions.ts
+++ b/src/workers/calculations/CalculateActorPositions.ts
@@ -35,6 +35,15 @@ export interface ActorPosition {
     max: number;
     percentage: number;
   };
+  /**
+   * Real ESO-Logs report actor id this puck derives from. Equals `id` for single-instance actors;
+   * for a multi-instance NPC copy, `id` is a synthetic render id and `baseActorId` recovers the real
+   * report id. Any consumer that joins back to report data (actorsById / playersById / event indices)
+   * MUST use `baseActorId`, never `id`. See INSTANCE_STRIDE / baseActorIdOf below.
+   */
+  baseActorId?: number;
+  /** Instance slot for a multi-instance NPC copy (0 = primary/single-instance; >=2 = extra copies). */
+  instance?: number;
 }
 
 export interface TimestampPositionLookup {
@@ -158,6 +167,59 @@ const MIN_VISIBILITY_MS = 1000;
 const BOSS_DEATH_VISIBILITY_WINDOW_MS = 2000;
 const SAMPLE_INTERVAL_MS = 4.7; // 240Hz sampling rate (better performance vs quality balance)
 const MAX_TIMESTAMPS = 72000; // Cap at 5 minutes worth of 240Hz data to prevent excessive computation
+
+// ---- Multi-instance NPC splitting --------------------------------------------------------------
+//
+// ESO Logs assigns ONE ReportFightNPC `id` to ALL simultaneous copies of an NPC (the schema:
+// `id` "is used in events to identify sources and targets" + `instanceCount` = "how many instances
+// of the NPC were seen"). Each physical copy is distinguished on events by sourceInstance /
+// targetInstance. Position history was keyed by `id` alone, so a pack of identical adds
+// (instanceCount > 1) merged into ONE history array and the interpolator slid a single puck across
+// the copies' separate map positions — the "enemies bug out and move rapidly" report.
+//
+// Fix: give each copy of a genuinely multi-instance NPC its own puck via a synthetic, REVERSIBLE
+// render id. Single-instance actors (the overwhelming common case) keep their real id unchanged, so
+// the lookup is byte-identical to before for them. If ESO Logs ever omits instance fields entirely,
+// every actor collapses to a single slot and NOTHING splits → no behavior change (fail-safe).
+//
+// Instance numbering is small and varies across reports: single-instance NPCs log instance 0 (or
+// omit it); multi-instance copies log 1, 2, 3, .... We map a raw instance to a copy "slot" where 0
+// and 1 both mean the primary copy, so {0}, {1}, {0,1} are all single-instance (never split) and
+// {1,2}, {0,2}, {1,2,3} split into the right number of pucks without phantom copies.
+const INSTANCE_STRIDE = 1_000_000; // >> any real ReportActor.id (small sequential ints); copy counts are tiny
+
+/** Map a raw per-event instance value to its copy slot: 0/undefined/1 => 0 (primary), N>=2 => N. */
+function instanceSlot(rawInstance: number | undefined | null): number {
+  const v = rawInstance ?? 0;
+  return v <= 1 ? 0 : v;
+}
+
+/**
+ * Synthetic render id for a (real actorId, instance) pair. The primary slot keeps the bare actorId,
+ * so single-instance actors and every NPC's primary copy are unchanged; extra copies get
+ * `actorId + slot * INSTANCE_STRIDE`, which cannot collide with real ids (all < INSTANCE_STRIDE) nor
+ * with other copies. Reversible: see baseActorIdOf / instanceSlotOf.
+ */
+function makeRenderId(actorId: number, rawInstance: number | undefined | null): number {
+  const slot = instanceSlot(rawInstance);
+  return slot === 0 ? actorId : actorId + slot * INSTANCE_STRIDE;
+}
+
+/** Recover the real ESO-Logs actor id from a render id (for name/type/role/taunt joins). */
+function baseActorIdOf(renderId: number): number {
+  return renderId % INSTANCE_STRIDE;
+}
+
+/** Recover the copy slot from a render id (0 = primary/single-instance). */
+function instanceSlotOf(renderId: number): number {
+  return Math.floor(renderId / INSTANCE_STRIDE);
+}
+
+/** Minimal accessor for the optional instance discriminators on any positional event. */
+interface EventWithInstances {
+  sourceInstance?: number;
+  targetInstance?: number;
+}
 
 // Memory-efficient batch size for processing
 const ACTOR_BATCH_SIZE = 50; // Process actors in batches to manage memory
@@ -477,15 +539,51 @@ export function calculateActorPositions(
 
   onProgress?.(0.1);
 
+  // Pre-pass: discover which actors are genuinely multi-instance so we only split those. For every
+  // event, record the copy slot seen for the source and target actor. An actor is multi-instance iff
+  // it shows >= 2 distinct slots (slot 0 = primary/single). This is cheap (one extra scan) and makes
+  // the split fail-safe: if instance fields are absent everywhere, every actor has just slot 0 and
+  // nothing is split (identical to the pre-fix behavior).
+  const slotsByActor = new Map<number, Set<number>>();
+  const noteSlot = (actorId: number, rawInstance: number | undefined): void => {
+    let set = slotsByActor.get(actorId);
+    if (!set) {
+      set = new Set<number>();
+      slotsByActor.set(actorId, set);
+    }
+    set.add(instanceSlot(rawInstance));
+  };
+  for (const event of allEvents) {
+    const withInstances = event as EventWithInstances;
+    if ('sourceID' in event) {
+      noteSlot((event as { sourceID: number }).sourceID, withInstances.sourceInstance);
+    }
+    if ('targetID' in event) {
+      noteSlot((event as { targetID: number }).targetID, withInstances.targetInstance);
+    }
+  }
+  const multiInstanceActors = new Set<number>();
+  slotsByActor.forEach((slots, actorId) => {
+    if (slots.size >= 2) multiInstanceActors.add(actorId);
+  });
+
+  // Map a (real actorId, raw instance) to the id under which its position history / death / event
+  // times are keyed and the puck is rendered. Single-instance actors keep their real id verbatim.
+  const resolveRenderId = (actorId: number, rawInstance: number | undefined): number =>
+    multiInstanceActors.has(actorId) ? makeRenderId(actorId, rawInstance) : actorId;
+
   // Collect position data from events
   for (const event of allEvents) {
-    // Track death and resurrection status
+    const withInstances = event as EventWithInstances;
+    // Track death and resurrection status. Death events carry targetInstance, so a copy's death is
+    // recorded under that copy's render id — only the dying copy stops rendering, not its siblings.
     if (event.type === 'death') {
       const deathEvent = event as DeathEvent;
-      if (!actorDeathEvents.has(deathEvent.targetID)) {
-        actorDeathEvents.set(deathEvent.targetID, []);
+      const deathRenderId = resolveRenderId(deathEvent.targetID, deathEvent.targetInstance);
+      if (!actorDeathEvents.has(deathRenderId)) {
+        actorDeathEvents.set(deathRenderId, []);
       }
-      const events = actorDeathEvents.get(deathEvent.targetID);
+      const events = actorDeathEvents.get(deathRenderId);
       if (events) {
         events.push({
           type: 'death',
@@ -494,14 +592,17 @@ export function calculateActorPositions(
       }
     }
 
-    // Handle resurrection cast events
+    // Handle resurrection cast events (resurrection targets are players, which are single-instance,
+    // so this resolves to the real id; a multi-instance NPC with no instance on the cast resolves to
+    // its primary copy).
     if (event.type === 'cast') {
       const castEvent = event as CastEvent;
       if (castEvent.abilityGameID === KnownAbilities.RESURRECT && castEvent.targetID) {
-        if (!actorDeathEvents.has(castEvent.targetID)) {
-          actorDeathEvents.set(castEvent.targetID, []);
+        const resRenderId = resolveRenderId(castEvent.targetID, castEvent.targetInstance);
+        if (!actorDeathEvents.has(resRenderId)) {
+          actorDeathEvents.set(resRenderId, []);
         }
-        const events = actorDeathEvents.get(castEvent.targetID);
+        const events = actorDeathEvents.get(resRenderId);
         if (events) {
           events.push({
             type: 'resurrection',
@@ -511,18 +612,33 @@ export function calculateActorPositions(
       }
     }
 
-    // Process source and target actors
-    const actorsToProcess: Array<{ id: number; isTarget: boolean }> = [];
+    // Process source and target actors. Each role's events are keyed by the render id of the specific
+    // copy they belong to, so a multi-instance NPC's copies build SEPARATE position histories (the
+    // fix: the interpolator can no longer bridge two physically distinct copies into one teleporting
+    // puck).
+    const actorsToProcess: Array<{ renderId: number; isTarget: boolean }> = [];
     if ('sourceID' in event) {
-      actorsToProcess.push({ id: event.sourceID, isTarget: false });
+      actorsToProcess.push({
+        renderId: resolveRenderId(
+          (event as { sourceID: number }).sourceID,
+          withInstances.sourceInstance,
+        ),
+        isTarget: false,
+      });
     }
     if ('targetID' in event) {
-      actorsToProcess.push({ id: event.targetID, isTarget: true });
+      actorsToProcess.push({
+        renderId: resolveRenderId(
+          (event as { targetID: number }).targetID,
+          withInstances.targetInstance,
+        ),
+        isTarget: true,
+      });
     }
 
-    for (const { id: actorId, isTarget } of actorsToProcess) {
+    for (const { renderId, isTarget } of actorsToProcess) {
       trackActorEvent(
-        actorId,
+        renderId,
         event.timestamp,
         actorFirstEventTime,
         actorEventTimes,
@@ -535,7 +651,7 @@ export function calculateActorPositions(
         if (resourceKey in event) {
           extractPositionData(
             event as DamageEvent | HealEvent | DeathEvent | ResourceChangeEvent,
-            actorId,
+            renderId,
             resourceKey,
             actorPositionHistory,
           );
@@ -668,18 +784,25 @@ export function calculateActorPositions(
   for (let batchIndex = 0; batchIndex < actorBatches.length; batchIndex++) {
     const actorBatch = actorBatches[batchIndex];
 
-    for (const actorId of actorBatch) {
-      const history = actorPositionHistory.get(actorId) || [];
+    for (const renderId of actorBatch) {
+      const history = actorPositionHistory.get(renderId) || [];
       if (history.length === 0) {
         processedActors++;
         continue;
       }
 
+      // `renderId` is the per-copy key (== real id for single-instance actors). ALL report-data joins
+      // (type/role/name classification, taunt lookup) must use the REAL id; only position history,
+      // death, event-times, and the emitted puck id are keyed by renderId. Every copy of one NPC
+      // shares the same name/type/role, so resolving them off the base id is correct.
+      const baseActorId = baseActorIdOf(renderId);
+      const instance = instanceSlotOf(renderId);
+
       // Determine actor type and role
-      const isPlayer = fight.friendlyPlayers?.includes(actorId) ?? false;
+      const isPlayer = fight.friendlyPlayers?.includes(baseActorId) ?? false;
 
       // Get actor data early for boss and pet detection and name resolution
-      const actorData = actorsById?.[actorId];
+      const actorData = actorsById?.[baseActorId];
 
       // Check if actor is a boss by looking at actorsById data
       const isBoss = actorData?.subType === 'Boss' && actorData?.type === 'NPC';
@@ -687,8 +810,8 @@ export function calculateActorPositions(
       // Check if actor is a pet by looking at actorsById data
       const isPet = actorData?.subType === 'Pet' && actorData?.type === 'Pet';
 
-      const isFriendlyNPC = fight.friendlyNPCs?.some((npc) => npc?.id === actorId) ?? false;
-      const isEnemyNPC = fight.enemyNPCs?.some((npc) => npc?.id === actorId) ?? false;
+      const isFriendlyNPC = fight.friendlyNPCs?.some((npc) => npc?.id === baseActorId) ?? false;
+      const isEnemyNPC = fight.enemyNPCs?.some((npc) => npc?.id === baseActorId) ?? false;
 
       let type: 'player' | 'enemy' | 'boss' | 'friendly_npc' | 'pet' = 'friendly_npc';
       if (isPlayer) type = 'player';
@@ -699,14 +822,14 @@ export function calculateActorPositions(
       } else if (isFriendlyNPC) type = 'friendly_npc';
 
       // Get role for players
-      const playerData = isPlayer && playersById ? playersById[actorId] : undefined;
+      const playerData = isPlayer && playersById ? playersById[baseActorId] : undefined;
       const role = playerData?.role;
 
       // Get actor name (reusing actorData from above)
-      const actorName = resolveActorName(actorData, actorId, `Actor ${actorId}`);
+      const actorName = resolveActorName(actorData, baseActorId, `Actor ${baseActorId}`);
 
       // Get first event time for this actor
-      const firstEventTime = actorFirstEventTime.get(actorId);
+      const firstEventTime = actorFirstEventTime.get(renderId);
       const isNPC = type !== 'player' && type !== 'boss'; // Includes pets, enemies, and friendly NPCs
 
       // Process each timestamp and directly populate the lookup structure
@@ -719,7 +842,7 @@ export function calculateActorPositions(
         }
 
         // Check if actor is dead at this timestamp
-        const actorEvents = actorDeathEvents.get(actorId) || [];
+        const actorEvents = actorDeathEvents.get(renderId) || [];
 
         // Sort events chronologically and determine if actor is dead at current timestamp
         const sortedEvents = actorEvents.slice().sort((a, b) => a.timestamp - b.timestamp);
@@ -734,7 +857,7 @@ export function calculateActorPositions(
           }
         }
 
-        const lastEventTimestamp = actorLastEventTime.get(actorId);
+        const lastEventTimestamp = actorLastEventTime.get(renderId);
         const hasRecordedDeath = actorEvents.some((event) => event.type === 'death');
 
         // If actor is dead, handle based on actor type
@@ -774,7 +897,7 @@ export function calculateActorPositions(
               debuffLookupData,
               fight,
               relativeTime,
-              actorId,
+              baseActorId,
               actorDeathEvents,
             );
 
@@ -794,8 +917,8 @@ export function calculateActorPositions(
             }
 
             // Directly add to lookup structure
-            positionsByTimestamp[relativeTime][actorId] = {
-              id: actorId,
+            positionsByTimestamp[relativeTime][renderId] = {
+              id: renderId,
               name: actorName,
               type,
               role,
@@ -804,6 +927,8 @@ export function calculateActorPositions(
               isDead: true,
               isTaunted,
               health,
+              baseActorId,
+              instance,
             };
           }
           continue;
@@ -821,11 +946,11 @@ export function calculateActorPositions(
 
         // For NPCs (including pets) or bosses without death records, skip positions if no recent event within 5 seconds
         // Use pre-sorted event times for better performance
-        const sortedEventTimes = sortedEventTimesCache.get(actorId) || [];
+        const sortedEventTimes = sortedEventTimesCache.get(renderId) || [];
         const enforceRecentEventVisibility = isNPC || (type === 'boss' && !hasRecordedDeath);
         if (
           enforceRecentEventVisibility &&
-          !hasRecentEvent(actorId, currentTimestamp, sortedEventTimes)
+          !hasRecentEvent(renderId, currentTimestamp, sortedEventTimes)
         ) {
           continue;
         }
@@ -904,7 +1029,7 @@ export function calculateActorPositions(
                 debuffLookupData,
                 fight,
                 relativeTime,
-                actorId,
+                baseActorId,
                 actorDeathEvents,
               )
             : false;
@@ -932,8 +1057,8 @@ export function calculateActorPositions(
         }
 
         // Directly add to lookup structure
-        positionsByTimestamp[relativeTime][actorId] = {
-          id: actorId,
+        positionsByTimestamp[relativeTime][renderId] = {
+          id: renderId,
           name: actorName,
           type,
           role,
@@ -942,6 +1067,8 @@ export function calculateActorPositions(
           isDead, // Use the calculated death status
           isTaunted,
           health,
+          baseActorId,
+          instance,
         };
       }
 


### PR DESCRIPTION
## Problem

Certain enemies in the 3D fight replay "bug out" and move rapidly — sliding/teleporting across the arena in a way that never happened in the actual fight.

## Root cause

ESO Logs assigns **one report actor `id` to *all* simultaneous copies of an NPC** (the schema: `ReportFightNPC.id` "is used in events to identify sources and targets" and `instanceCount` = "how many instances of the NPC were seen"). Individual copies are distinguished only by per-event `sourceInstance` / `targetInstance` (already typed on `DeathEvent.targetInstance`).

`CalculateActorPositions` keyed actor position history by `actorId` **alone**, so a pack of identical adds (`instanceCount > 1`) merged into a single history array, and the interpolator slid one puck rapidly between the copies' separate map positions. It only affected NPCs that spawn in multiples — hence "certain enemies."

## Fix

Split genuinely multi-instance NPCs into **one puck per copy** using a reversible synthetic render id, entirely inside the position worker:

- A pre-pass collects the distinct instance "slots" per actor (folding `0`/`1` → primary, so `{0}`, `{1}`, `{0,1}` never split). Only actors with ≥2 distinct slots are split.
- Each copy gets `renderId = actorId + slot * 1_000_000`; the primary keeps the bare id. Reversible via `baseActorIdOf`. Position history / death / event-times / the emitted puck id are keyed by `renderId`; **name/type/role/taunt resolve via the real `baseActorId`** (all copies share them).
- Per-copy death (death events carry `targetInstance`), so one copy dying no longer removes its siblings.
- `ActorPosition` gains optional `baseActorId` / `instance`.

### Key properties
- **Single-instance actors are byte-identical to before** (keep their real id) — zero regression for the common case.
- **Fail-safe**: if instance fields are ever absent, every actor collapses to one slot and nothing splits.
- **No consumer changes** — the renderer, names, selection, camera-follow, panels and path trails are all lookup-driven and render the extra pucks transparently.
- Defensive guard skips the split (and logs) for any real id ≥ the stride, keeping the id round-trip exact.
- One-line `INFO` log per fight when the split activates (observability).

### Documented limitation
Taunt intervals carry no instance, so the taunt ring shows on all copies of a multi-instance NPC — strictly better than the prior teleporting, called out in a code comment.

## Verification
- `tsc` / ESLint / Prettier clean
- **26** worker unit tests (10 new: split → N pucks at distinct positions, single-instance unchanged, `{0,1}` no-split, `{0,1,2}` / `{0,2}` split, per-copy death, determinism, resource-event-driven split, field population, player-unaffected) · **544** replay + integration tests green
- 4-lens adversarial review (keying consistency, no-regression, edge cases, consumer integration) → **0 confirmed defects**
- **Live-verified** on the public Dreadsail Reef sample report, fight 1: the split log fires; the lookup holds 65 pucks (29 synthetic across 12 split NPCs) with counts matching the report's `instanceCount`; e.g. "Dreadsail Stormrider" renders as 5 simultaneous pucks at 5 distinct positions (pre-fix: one teleporting puck).