### PR TITLE
fix(build-editor): apply Warden Frozen Armor + accurate completeness/CP state

### DIFF
--- a/src/features/build-editor/components/pickers/ChampionPointsPicker.tsx
+++ b/src/features/build-editor/components/pickers/ChampionPointsPicker.tsx
@@ -623,9 +623,15 @@ export const ChampionPointsPicker: React.FC<ChampionPointsPickerProps> = ({ cp, 
     points: number,
   ): void => {
     const tree = cp[treeKey];
+    const nextPassives = { ...tree.passives };
+    if (points <= 0) {
+      delete nextPassives[cpId];
+    } else {
+      nextPassives[cpId] = points;
+    }
     onChange({
       ...cp,
-      [treeKey]: { ...tree, passives: { ...tree.passives, [cpId]: points } },
+      [treeKey]: { ...tree, passives: nextPassives },
     });
   };
 

--- a/src/features/build-editor/engine/stat-constants.ts
+++ b/src/features/build-editor/engine/stat-constants.ts
@@ -341,7 +341,7 @@ export const CLASS_PASSIVES: ClassPassive[] = [
   // Warden — Winter's Embrace: Frozen Armor (+1240 resistance per Winter's
   // Embrace ability slotted; modeled at the fully-slotted 5 abilities).
   {
-    skillLineId: 'class.winter-s-embrace',
+    skillLineId: 'class.winters-embrace',
     stat: 'armor',
     name: 'Frozen Armor',
     value: 6200, // 1240 × 5 slotted

--- a/src/features/build-editor/engine/stat-engine.baseClassPassives.test.ts
+++ b/src/features/build-editor/engine/stat-engine.baseClassPassives.test.ts
@@ -61,7 +61,7 @@ describe('calculateArmor — U50 base-class armor passives', () => {
   });
 
   it('Frozen Armor (Warden) adds +6200 resistance at 5 slotted', () => {
-    const r = calculateArmor(baseSetup(), buildWithLines(['class.winter-s-embrace']), overrides());
+    const r = calculateArmor(baseSetup(), buildWithLines(['class.winters-embrace']), overrides());
     expect(item(r, 'Frozen Armor')?.value).toBe(6200);
     expect(r.total).toBe(6200);
   });

--- a/src/features/build-editor/hooks/useBuildCompleteness.ts
+++ b/src/features/build-editor/hooks/useBuildCompleteness.ts
@@ -38,7 +38,7 @@ const selectHasMundus = (s: RootState): boolean => {
 
 const selectGearCount = (s: RootState): number => {
   const setup = s.buildEditor.build.setups[s.buildEditor.activeSetupIndex];
-  return setup ? Object.keys(setup.gear).length : 0;
+  return setup ? Object.values(setup.gear).filter((p) => p?.id != null).length : 0;
 };
 
 const selectSkillCount = (s: RootState): number => {

--- a/src/features/build-editor/hooks/useSectionProgress.ts
+++ b/src/features/build-editor/hooks/useSectionProgress.ts
@@ -58,7 +58,7 @@ const selectHasCharacter = (s: RootState): boolean => {
 
 const selectHasEquipment = (s: RootState): boolean => {
   const setup = s.buildEditor.build.setups[s.buildEditor.activeSetupIndex];
-  return setup ? Object.keys(setup.gear).length > 0 : false;
+  return setup ? Object.values(setup.gear).some((p) => p?.id != null) : false;
 };
 
 const selectHasSkills = (s: RootState): boolean => {


### PR DESCRIPTION
## Summary

Three build-editor correctness fixes found by a codebase audit. All are low-risk and independently verifiable.

### 1. Warden Frozen Armor passive never applied (high)
`CLASS_PASSIVES` modeled Frozen Armor with skill-line id `class.winter-s-embrace` (extra hyphen), but the engine stores Winter's Embrace as `class.winters-embrace` everywhere else (`build.types.ts`, `esoStaticData.ts`, `buildEncoding.ts`, `cspsExportCodeParser.ts`). `calculateArmor()` filters passives with `build.classSkillLines.includes(cp.skillLineId)`, so the ids never matched and a Warden build with Winter's Embrace active never received the **+6200 resistance** in the Stats panel. The existing unit test passed the wrong-form id, so it stayed green and masked the bug — it now asserts against the canonical id and guards the wiring.

### 2. Cleared gear slots inflated completeness (low)
Clearing a slot writes a tombstone `{ id: undefined }` that is never deleted from `setup.gear`. `selectGearCount` / `selectHasEquipment` counted `Object.keys(gear)`, so cleared-only builds reported gear, lit the equipment progress dot, and inflated the completeness %. Now count only real pieces (`id != null`).

### 3. Champion passive zero-value keys accumulated (low)
Decrementing a passive star to 0 persisted a dead `passives[cpId] = 0` entry, accumulating zero-value keys that bloat saved/encoded builds. Now the key is removed when `points <= 0`.

## Testing
- `tsc --noEmit` clean
- All 14 build-editor test suites pass (142 tests), including the corrected Frozen Armor test
- prettier + eslint clean on touched files
