### PR TITLE
fix(role-detection): use boss subType for taunt scoring + consistent class-analysis primary

### DIFF
--- a/src/hooks/useRoleDetection.ts
+++ b/src/hooks/useRoleDetection.ts
@@ -152,13 +152,19 @@ export function useRoleDetection({
       }
     }
 
+    // Resolve the real boss from actor metadata. fight.enemyNPCs has no defined
+    // ordering and no boss flag, so enemyNpcIds[0] is usually a trash add. Use
+    // the actor whose subType is 'Boss'; if none is present, leave it null so
+    // extractSignals' most-taunted-enemy auto-detection can run.
+    const primaryBossId = enemyNpcIds.find((id) => actorsById[id]?.subType === 'Boss') ?? null;
+
     const context: FightContext = {
       fightId: fight.id,
       startTime: fight.startTime,
       endTime: fight.endTime,
       friendlyPlayerIds,
       enemyNpcIds,
-      primaryBossId: enemyNpcIds.length > 0 ? enemyNpcIds[0] : null,
+      primaryBossId,
       playerNames,
     };
 

--- a/src/utils/classDetectionUtils.ts
+++ b/src/utils/classDetectionUtils.ts
@@ -408,8 +408,11 @@ export function detectClassFromTalents(talents: PlayerTalent[]): ClassAnalysisRe
     }))
     .sort((a, b) => b.count - a.count);
 
+  // `primary` is the primary *skill-line* name, matching the documented
+  // contract of analyzePlayerClassUsage (see playerToBuild.ts) and its tests.
+  // Returning className here previously made the same result shape ambiguous.
   return {
-    primary: skillLines.length > 0 ? skillLines[0].className : null,
+    primary: skillLines.length > 0 ? skillLines[0].skillLine : null,
     skillLines,
   };
 }


### PR DESCRIPTION
## Summary

Two role/class-detection accuracy fixes from a codebase audit.

### 1. Main-Tank taunt scoring used an arbitrary enemy as "the boss" (high)
`useRoleDetection` passed `enemyNpcIds[0]` as `primaryBossId`, but `fight.enemyNPCs` has no defined ordering and no boss flag — so that's usually a trash add. The boss taunt-uptime branch (the single strongest Main-Tank signal, +40) is scored against this id, so the real tank rarely accumulates uptime on it and Main-Tank vs Off-Tank ranking becomes unreliable. Worse, `extractSignals` contains a most-taunted-enemy **auto-detect** that only runs when `primaryBossId === null` — passing a non-null arbitrary id made that fallback dead in production (every offline analysis script passes `null` to rely on it).

Fix: resolve the boss from `actorsById[id]?.subType === 'Boss'` (subType is already selected on the actor fragment), falling back to `null` so the auto-detect runs when no boss subType is present.

### 2. `ClassAnalysisResult.primary` had two different meanings (low, latent)
`analyzePlayerClassUsage` returns the primary **skill-line name** in `.primary` (the documented contract — see `playerToBuild.ts:114` and its unit tests), but `detectClassFromTalents` returned a **class name** in the same field. Aligned `detectClassFromTalents` to return the skill-line name. Its only consumer (`logToRoster`) reads `.skillLines`, so behaviour is unchanged today — this just removes a trap for the next caller.

## Testing
- `tsc --noEmit` clean
- role_detection + classDetectionUtils suites pass (3 suites, 68 tests)
- prettier + eslint clean

> Note: a related finding — `shieldAppliedToOthers` is consumed by shield-healer scoring but never populated by `extractSignals` — is intentionally left for a separate PR, since fixing it changes role classifications and warrants validation against real logs.
