### PR TITLE
fix(auth): clamp token-refresh timer + validate hash redirects + guard OAuth unmount

### DIFF
--- a/src/OAuthRedirect.tsx
+++ b/src/OAuthRedirect.tsx
@@ -95,22 +95,28 @@ export const OAuthRedirect: React.FC = () => {
                 refresh_token: data.refresh_token || null,
                 expires_in: data.expires_in || 3600,
               }),
+              signal: controller.signal,
             });
             if (!callbackResp.ok) {
               throw new Error(`Desktop app responded with ${callbackResp.status}`);
             }
           } catch {
+            // Don't surface an error (or touch state) if we were unmounted /
+            // aborted mid-flight.
+            if (controller.signal.aborted) return;
             setError(
               'Could not connect to the desktop application. ' +
                 'Please make sure it is running and try again.',
             );
             return;
           }
+          if (controller.signal.aborted) return;
           setKalpaSuccess(true);
           return;
         }
 
         // Normal web auth flow
+        if (controller.signal.aborted) return;
         localStorage.setItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY, data.access_token as string);
         // Store refresh token if provided
         if (data.refresh_token && typeof data.refresh_token === 'string') {

--- a/src/components/HashRouteRedirect.tsx
+++ b/src/components/HashRouteRedirect.tsx
@@ -106,6 +106,12 @@ export const HashRouteRedirect: React.FC = () => {
     if (hash && hash.startsWith('#/')) {
       // Extract the path after #/
       const hashPath = hash.substring(1); // Remove the # to get /path
+      // Validate before navigating — `#/` still admits protocol-relative
+      // values like `#//evil.com` (hashPath === `//evil.com`), the exact
+      // open-redirect case the other two branches already guard against.
+      if (!isValidRedirectPath(hashPath)) {
+        return;
+      }
       // Remove the hash from URL and navigate to the clean path (safe history operation)
       safeHistoryReplaceState({}, '', window.location.pathname);
       navigate(hashPath, { replace: true });

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -156,12 +156,31 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   useEffect(() => {
     if (!accessToken || !accessTokenExpiry || accessTokenExpired) return;
 
+    // setTimeout delays are stored as a signed 32-bit int; any delay larger
+    // than ~24.8 days overflows and fires almost immediately. ESO Logs access
+    // tokens are long-lived (expiry can be up to a year out), so scheduling the
+    // raw delay would fire on every mount — and with no refresh token available
+    // that would clear a perfectly valid session. Skip proactive refresh when
+    // expiry is beyond the timer's safe range; the effect re-runs on the next
+    // load with a fresh Date.now().
+    const MAX_TIMEOUT_MS = 2_147_483_647;
     const msUntilRefresh = accessTokenExpiry - Date.now() - 60_000;
+    if (msUntilRefresh > MAX_TIMEOUT_MS) return;
+
     const doRefresh = (): void => {
       void refreshAccessToken()
         ?.then((newToken) => {
-          if (newToken) updateAccessToken(newToken);
-          else updateAccessToken('');
+          if (newToken) {
+            updateAccessToken(newToken);
+            return;
+          }
+          // A null result means either no refresh token is stored (ESO Logs
+          // does not always issue one — the current access token is still
+          // valid, so keep it) or a hard refresh failure (refreshAccessToken
+          // already purged storage). Only log out in the latter case.
+          if (!localStorage.getItem(LOCAL_STORAGE_ACCESS_TOKEN_KEY)) {
+            updateAccessToken('');
+          }
         })
         ?.catch(() => updateAccessToken(''));
     };


### PR DESCRIPTION
## Summary

Three low-risk auth / app-shell robustness fixes from a codebase audit. None changes the login happy-path.

### 1. Token-refresh timer overflow logged users out on every load (high)
The proactive refresh `setTimeout` used `accessTokenExpiry - Date.now() - 60s` as its delay. ESO Logs access tokens are long-lived (expiry up to a year out), so the delay overflows `setTimeout`'s signed 32-bit limit (~24.8 days) and fires almost immediately on every mount. Since ESO Logs doesn't always issue a refresh token, `refreshAccessToken()` returns `null` and the handler then cleared the still-valid access token — logging the user out on essentially every page load.

Fix: skip proactive refresh entirely when expiry is beyond the timer's safe range (the effect re-runs on the next load with a fresh `Date.now()`), and only clear the token on a real refresh failure (storage already purged), not when there simply is no refresh token.

### 2. Hash-redirect open-redirect (low, security)
`HashRouteRedirect`'s hash branch navigated to any `#/...` value without validation, while the other two redirect branches run through `isValidRedirectPath()`. `#/` still admits protocol-relative values like `#//evil.com` → `//evil.com`. Now guarded by the same validator.

### 3. OAuth callback setState-after-unmount (low)
The desktop-app callback `fetch` had no `AbortController` signal, and `setKalpaSuccess`/`setError`/the normal-flow state updates ran after awaited fetches with no aborted check. Wired the signal and guarded the post-await updates.

## Testing
- `tsc --noEmit` clean
- auth + HashRouteRedirect + OAuthRedirect suites pass (4 suites, 35 tests)
- prettier + eslint clean

> A related finding — the ESO Logs PKCE flow omits a CSRF `state` parameter — is intentionally left for a separate PR, since it changes the login happy-path and needs StrictMode-safe one-time-state handling plus its own tests.
