### PR TITLE
fix(calculator): include armor pieces in PvE/PvP resistance + correct stat constants

### DIFF
--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -2124,8 +2124,12 @@ const CalculatorComponent: React.FC = () => {
   // Filter items based on current mode
   const getFilteredItems = useCallback(
     (data: CalculatorData, calcType: 'pen' | 'crit' | 'armor') => {
-      if (gameMode === 'both') {
-        // Return all items when both modes are selected
+      // Armor resistance is identical in PvE and PvP, so the armor tab is never
+      // mode-filtered. The per-mode allowlists only enumerate buffs/passives and
+      // omit the individual armor pieces, so filtering armor would drop every
+      // equipped piece. Only pen/crit differ by mode.
+      if (gameMode === 'both' || calcType === 'armor') {
+        // Return all items when both modes are selected (or for armor)
         return data;
       }
 
@@ -2197,7 +2201,9 @@ const CalculatorComponent: React.FC = () => {
   }, [criticalData, gameMode, calculateItemValue]);
 
   const armorResistanceTotal = useMemo(() => {
-    const allowedItems = gameMode === 'both' ? null : MODE_FILTER[gameMode]?.['armor'] || null;
+    // Armor resistance does not differ by PvE/PvP, so it is never mode-filtered
+    // (the per-mode allowlists omit the individual armor pieces, which would
+    // silently drop every equipped piece from the total).
     let total = 0;
 
     // Pre-calculate for performance
@@ -2211,14 +2217,14 @@ const CalculatorComponent: React.FC = () => {
 
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
-      if (item.enabled && (!allowedItems || allowedItems.includes(item.name))) {
+      if (item.enabled) {
         const value = calculateItemValue(item);
         total += value;
       }
     }
 
     return total;
-  }, [armorResistanceData, gameMode, calculateItemValue]);
+  }, [armorResistanceData, calculateItemValue]);
 
   // Status calculation
   const getPenStatus = useCallback((total: number, mode: GameMode) => {
@@ -6036,10 +6042,10 @@ const CalculatorComponent: React.FC = () => {
                           : undefined,
                       targetRanges:
                         gameMode === 'pve'
-                          ? 'Target: 18,200–18,999'
+                          ? `Target: ${PEN_OPTIMAL_MIN_PVE.toLocaleString()}–${PEN_OPTIMAL_MAX_PVE.toLocaleString()}`
                           : gameMode === 'pvp'
-                            ? 'Target: 33,100–33,500'
-                            : 'PvE: 18,200–18,999\nPvP: 33,100–33,500',
+                            ? `Target: ${PEN_OPTIMAL_MIN_PVP.toLocaleString()}–${PEN_OPTIMAL_MAX_PVP.toLocaleString()}`
+                            : `PvE: ${PEN_OPTIMAL_MIN_PVE.toLocaleString()}–${PEN_OPTIMAL_MAX_PVE.toLocaleString()}\nPvP: ${PEN_OPTIMAL_MIN_PVP.toLocaleString()}–${PEN_OPTIMAL_MAX_PVP.toLocaleString()}`,
                     },
                   })}
                 {selectedTab === 1 &&

--- a/src/data/skill-lines/armor-resistance-data.ts
+++ b/src/data/skill-lines/armor-resistance-data.ts
@@ -758,7 +758,7 @@ export const ARMOR_RESISTANCE_CAP = 33500;
 export const MAX_ARMOR_VALUE = 33100; // Maximum armor value before diminishing returns
 export const OVER_RESISTANCE_DIVISOR = 109; // Over-resistance calculation divisor
 export const MAX_DAMAGE_MITIGATION = 50; // Maximum damage mitigation percentage
-export const DAMAGE_MITIGATION_DIVISOR = 662; // 33100 / 50 - for percentage calculation
+export const DAMAGE_MITIGATION_DIVISOR = 660; // 660 resistance = 1% mitigation (33,000 = 50% soft cap)
 
 // NOTE: A previous `ARMOR_RESISTANCE_TOOLTIPS` map lived here but was never
 // imported (dead code) and had drifted out of date (e.g. it still called the

--- a/src/utils/damageReductionUtils.ts
+++ b/src/utils/damageReductionUtils.ts
@@ -252,10 +252,10 @@ export interface PlayerDamageReductionSnapshot {
 }
 
 /**
- * Convert resistance value to damage reduction percentage
- * ESO uses a diminishing returns formula, not linear
- * Formula: Damage Reduction % = Resistance / (Resistance + 33000) * 100
- * This gives: 33000 resistance = 50% damage reduction (soft cap)
+ * Convert resistance value to damage reduction percentage.
+ * ESO armor mitigation is linear, not diminishing-returns: every 660 resistance
+ * grants 1% mitigation, soft-capped at 50% (33,000 resistance).
+ * Formula: Damage Reduction % = min(50, Resistance / 660)
  */
 export function resistanceToDamageReduction(resistance: number): number {
   if (resistance <= 0) return 0;


### PR DESCRIPTION
## Summary

Four stat-math corrections in the classic Stats calculator (not the Ultimate tab / Gear Upgrade Optimizer), found by an audit.

### 1. Armor pieces dropped from PvE/PvP resistance total (high)
`armorResistanceTotal` and `getFilteredItems` name-allowlist the Armor tab by game mode via `MODE_FILTER[mode].armor`. But those allowlists only enumerate buffs/passives (`Major Resolve`, `Heavy Armor Passive`, …) and contain **none** of the individual armor pieces from `ARMOR_RESISTANCE_DATA.gear` (`Heavy Shoulders`, `Heavy Hands`, `Heavy Chest`, …). So in PvE/PvP mode every equipped armor piece — including the default-enabled `Heavy Shoulders` (2425) and `Heavy Hands` (1386) — was silently dropped from both the total and the displayed rows. The tab was only correct in "Both" mode. Armor resistance is identical in PvE and PvP, so the fix stops mode-filtering the armor tab (PvE/PvP now behave like "Both").

### 2. PvP penetration target text contradicted the at-cap badge (medium)
The footer printed `Target: 33,100–33,500` while `getPenStatus` marks PvP pen at-cap over `PEN_OPTIMAL_MIN_PVP..MAX_PVP` = **33,300–37,000**. A player at 36,000 pen got a green "at-cap" badge while the printed target said the band ended at 33,500. The printed range now derives from the same constants.

### 3. Mitigation divisor 662 → 660 (low)
`DAMAGE_MITIGATION_DIVISOR` was `662` (`33,100/50`) rather than ESO's canonical `660` (660 resistance = 1% mitigation; 33,000 = 50% soft cap). At the 33,000 cap this displayed 49.8% instead of 50%, and every intermediate value was slightly under-reported. The clamp at `MAX_DAMAGE_MITIGATION = 50` keeps the top end correct.

### 4. Misleading `resistanceToDamageReduction` JSDoc (low)
The JSDoc described a diminishing-returns `R/(R+33000)` formula the (correct, linear) code never implemented — a trap inviting a future "fix" that would break mitigation math. Comment corrected; no logic change.

## Testing
- `tsc --noEmit` clean
- damageReductionUtils suite passes (49 tests)
- prettier + eslint clean
