### PR TITLE
fix(roster): preserve DPS slot reorder across encode + fix Unknown set-id collision

### DIFF
--- a/src/pages/RosterBuilderPage.tsx
+++ b/src/pages/RosterBuilderPage.tsx
@@ -497,7 +497,14 @@ export const RosterBuilderPage: React.FC = () => {
 
         return {
           ...prev,
-          dpsSlots: arrayMove(prev.dpsSlots, oldIndex, newIndex),
+          // Renumber slotNumber to the new array position. The encoder keys DPS
+          // slots by slotNumber (sn) and rebuilds the array as dpsSlots[sn-1],
+          // so without renumbering the reorder is silently discarded on
+          // encode/save/share/reload.
+          dpsSlots: arrayMove(prev.dpsSlots, oldIndex, newIndex).map((slot, i) => ({
+            ...slot,
+            slotNumber: i + 1,
+          })),
           updatedAt: new Date().toISOString(),
         };
       });
@@ -510,7 +517,12 @@ export const RosterBuilderPage: React.FC = () => {
       if (newIndex < 0 || newIndex >= prev.dpsSlots.length) return prev;
       return {
         ...prev,
-        dpsSlots: arrayMove(prev.dpsSlots, slotIndex, newIndex),
+        // Renumber slotNumber to the new array position so the reorder survives
+        // encoding (see handleDPSDragEnd).
+        dpsSlots: arrayMove(prev.dpsSlots, slotIndex, newIndex).map((slot, i) => ({
+          ...slot,
+          slotNumber: i + 1,
+        })),
         updatedAt: new Date().toISOString(),
       };
     });

--- a/src/utils/setNameUtils.ts
+++ b/src/utils/setNameUtils.ts
@@ -337,10 +337,13 @@ export function getSetDisplayName(setId: KnownSetIDs | undefined | null): string
 // Avoids linear scans in findSetIdByName, which is called in hot paths like
 // Autocomplete groupBy callbacks (fires per-option, per render).
 const SET_NAME_TO_ID_INDEX: ReadonlyMap<string, KnownSetIDs> = new Map(
-  Object.entries(SET_DISPLAY_NAMES).map(([id, name]) => [
-    name.toLowerCase(),
-    Number(id) as KnownSetIDs,
-  ]),
+  Object.entries(SET_DISPLAY_NAMES)
+    // The placeholder ids 846/2268/2342 all map to the generic name 'Unknown',
+    // which would collapse to a single non-injective index key (only the
+    // last-inserted id surviving) and make findSetIdByName('Unknown') resolve a
+    // wrong id. 'Unknown' is a placeholder no user types, so exclude it.
+    .filter(([, name]) => name !== 'Unknown')
+    .map(([id, name]) => [name.toLowerCase(), Number(id) as KnownSetIDs]),
 );
 
 // Lowercase base names that actually HAVE a "Perfected <base>" entry in


### PR DESCRIPTION
## Summary

Two roster data-integrity fixes from a codebase audit. (Avoids the in-flight /rv collapsible-card UI in #1253 — these are encoding/data only.)

### 1. DPS slot reorder silently discarded (high)
`handleDPSDragEnd` and `handleMoveDPSSlot` call `arrayMove(dpsSlots, …)` but never renumber `slotNumber`. The encoder writes each DPS slot with `sn: slotNumber` and the decoder rebuilds the array as `dpsSlots[sn-1]`, re-sorting strictly by the original slotNumber. So any user reorder of DPS slots was lost the moment the roster was encoded to `?r=`, saved to My Rosters, shared, or URL-resynced — and in the editor the cards showed a scrambled number sequence (e.g. 3,1,2,4) that snapped back on reload.

Fix: renumber `slotNumber` to the new array position after `arrayMove`, matching the existing tank/healer renumber (line 947) and `resizeDPS`. Per-fight overrides key off the zero-based array index (`slotKey` = `dps:N`), so this also keeps encode/decode consistent with them.

### 2. Three placeholder set ids collide to one "Unknown" index key (low)
`SET_DISPLAY_NAMES` maps ids 846/2268/2342 all to the literal `'Unknown'`. `SET_NAME_TO_ID_INDEX` keys on lowercase name, so the three collapse to one key and only the last-inserted id (2342) survives — `findSetIdByName('Unknown')` returns 2342 for all three. Excluded the `'Unknown'` placeholder from the index so the resolver stays injective (it's a placeholder no user types).

## Testing
- `tsc --noEmit` clean
- rosterEncoding + setNameUtils + RosterBuilder suites pass (5 suites, 156 tests)
- prettier + eslint clean

> A related low/legacy finding — a DPS slot whose only data is the `@deprecated` single `group` field is counted as filled but not encoded — is left for a separate change, since preserving it correctly needs careful `group → groups` migration semantics.
