### PR TITLE
fix(data): damage-type flag parsing + duplicate/mislabeled ultimate ids

### DIFF
--- a/src/features/parse_analysis/utils/parseAnalysisUtils.ts
+++ b/src/features/parse_analysis/utils/parseAnalysisUtils.ts
@@ -1608,10 +1608,9 @@ const KNOWN_ULTIMATE_ABILITY_IDS = new Set([
   24799, // Suppression Field
   27706, // Absorption Field
   // Templar
-  22223, // Crescent Sweep
-  22226, // Radiant Glory (morph ult)
-  22139, // Flawless Dawnbreaker
-  40161, // Flawless Dawnbreaker (morph)
+  22223, // Rite of Passage
+  22226, // Practiced Incantation (Rite of Passage morph)
+  22139, // Crescent Sweep
   // Necromancer
   115238, // Pestilent Colossus
   122174, // Glacial Colossus
@@ -1625,7 +1624,6 @@ const KNOWN_ULTIMATE_ABILITY_IDS = new Set([
   183623, // Exhausting Fatecarver
   183625, // Pragmatic Fatecarver
   // Weapon skill lines
-  22139, // Flawless Dawnbreaker
   40161, // Flawless Dawnbreaker (morph)
   40158, // Dawnbreaker of Smiting
   // Fighters Guild

--- a/src/types/abilities.damageTypeFlags.test.ts
+++ b/src/types/abilities.damageTypeFlags.test.ts
@@ -1,0 +1,41 @@
+import { DamageTypeFlags, getDamageTypesFromFlags, parseDamageTypeFlags } from './abilities';
+
+describe('parseDamageTypeFlags', () => {
+  it('resolves a single flag to its display name', () => {
+    expect(parseDamageTypeFlags(1)).toEqual(['Physical']);
+    expect(parseDamageTypeFlags(4)).toEqual(['Fire']);
+    expect(parseDamageTypeFlags(512)).toEqual(['Shock']);
+  });
+
+  it('resolves a combined bitmask to all matching types', () => {
+    // 12 === FIRE (4) | POISON (8)
+    expect(parseDamageTypeFlags(12)).toEqual(['Fire', 'Poison']);
+    // 80 === FROST (16) | MAGIC (64)
+    expect(parseDamageTypeFlags(80)).toEqual(['Frost', 'Magic']);
+  });
+
+  it('accepts numeric strings (ESO ability.type is a string)', () => {
+    expect(parseDamageTypeFlags('4')).toEqual(['Fire']);
+    expect(parseDamageTypeFlags('12')).toEqual(['Fire', 'Poison']);
+  });
+
+  it('returns Generic for empty / zero / invalid input', () => {
+    expect(parseDamageTypeFlags(0)).toEqual(['Generic']);
+    expect(parseDamageTypeFlags(null)).toEqual(['Generic']);
+    expect(parseDamageTypeFlags(undefined)).toEqual(['Generic']);
+    expect(parseDamageTypeFlags('not-a-number')).toEqual(['Generic']);
+  });
+});
+
+describe('getDamageTypesFromFlags', () => {
+  it('returns the flag/name pairs for a bitmask', () => {
+    expect(getDamageTypesFromFlags(12)).toEqual([
+      { flag: DamageTypeFlags.FIRE, name: 'Fire' },
+      { flag: DamageTypeFlags.POISON, name: 'Poison' },
+    ]);
+  });
+
+  it('returns an empty array when no flags match', () => {
+    expect(getDamageTypesFromFlags(0)).toEqual([]);
+  });
+});

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -46,8 +46,13 @@ export function parseDamageTypeFlags(type: string | number | null | undefined): 
 
   const damageTypes: string[] = [];
 
+  // DamageTypeFlags is a string enum, so Object.values() yields the string
+  // values ('1','2','4',...). Coerce to a number for the bitmask test —
+  // `typeof flag === 'number'` would never be true here and silently collapsed
+  // every result to 'Unknown'.
   Object.values(DamageTypeFlags).forEach((flag) => {
-    if (typeof flag === 'number' && (typeNum & flag) === flag) {
+    const flagNum = Number(flag);
+    if (flagNum !== 0 && (typeNum & flagNum) === flagNum) {
       damageTypes.push(DAMAGE_TYPE_DISPLAY_NAMES[flag]);
     }
   });
@@ -63,8 +68,11 @@ export function getDamageTypesFromFlags(
 ): { flag: DamageTypeFlags; name: string }[] {
   const result: { flag: DamageTypeFlags; name: string }[] = [];
 
+  // DamageTypeFlags is a string enum; coerce to a number for the bitmask test
+  // (see parseDamageTypeFlags — the `typeof === 'number'` guard never matched).
   Object.values(DamageTypeFlags).forEach((flag) => {
-    if (typeof flag === 'number' && (flagValue & flag) === flag) {
+    const flagNum = Number(flag);
+    if (flagNum !== 0 && (flagValue & flagNum) === flagNum) {
       result.push({ flag, name: DAMAGE_TYPE_DISPLAY_NAMES[flag] });
     }
   });


### PR DESCRIPTION
## Summary

Two contained data/correctness fixes from a codebase audit.

### 1. Damage-type flag parsing always returned "Unknown" (medium)
`DamageTypeFlags` is a **string** enum (`PHYSICAL = '1'`, `FIRE = '4'`, …). `parseDamageTypeFlags` and `getDamageTypesFromFlags` iterate `Object.values(DamageTypeFlags)` (the string values) and guard each with `typeof flag === 'number'`, which is never true for a string enum — so the bitmask loop never executed. `parseDamageTypeFlags` returned `['Unknown']` for every non-empty `ability.type` and `getDamageTypesFromFlags` always returned `[]`. Both are live (`DamageBreakdownPanel`, `AbilitiesDebugPanel`). Fixed by coercing each flag to a number for the bitmask test; added a regression test.

### 2. Mislabeled & duplicated ultimate ids (low)
`KNOWN_ULTIMATE_ABILITY_IDS` had three Templar entries with wrong inline names — verified against the repo's own `scripts/class-skill-ids.json`:
- `22223` is **Rite of Passage** (was commented "Crescent Sweep")
- `22226` is **Practiced Incantation** (was "Radiant Glory" — Radiant Glory is `63044`, a spammable, not an ultimate)
- `22139` is **Crescent Sweep** (was "Flawless Dawnbreaker")

`22139` and `40161` were also each listed twice. Corrected the comments and removed the duplicates. The ids are all genuine ultimates so the cast count was unaffected, but the false mapping invited adding a truly-wrong id.

## Testing
- `tsc --noEmit` clean
- new `abilities.damageTypeFlags.test.ts` + parseAnalysisUtils suites pass (2 suites, 32 tests)
- prettier + eslint clean

> A related medium finding — gear-set `setType` contradicts itself across the per-weight files (~130 sets, registry last-write-wins) — and a low food-id duplicate are left for separate changes since both need per-entry authoritative verification.
