### PR TITLE
fix(workers): terminate threads, release progress proxies, recover on timeout

### DIFF
--- a/src/workers/WorkerPool.test.ts
+++ b/src/workers/WorkerPool.test.ts
@@ -350,6 +350,23 @@ describe('WorkerPool', () => {
 
       clearIntervalSpy.mockRestore();
     });
+
+    it('recovers the worker slot when a task times out (does not deadlock)', async () => {
+      // First task hangs forever; the timeout must tear the worker down and
+      // free the single pool slot so the second task can still run.
+      mockWorker.calculateBuffLookup
+        .mockImplementationOnce(() => new Promise<never>(() => {}))
+        .mockResolvedValueOnce({ ok: true } as never);
+
+      const pool = new WorkerPool({ maxWorkers: 1, taskTimeout: 50, logger: mockLogger });
+
+      await expect(pool.execute('calculateBuffLookup', {})).rejects.toThrow(/timeout/i);
+
+      // The worker slot is recovered, so a fresh worker handles the next task.
+      await expect(pool.execute('calculateBuffLookup', {})).resolves.toEqual({ ok: true });
+
+      pool.destroy();
+    });
   });
 
   describe('Logging', () => {

--- a/src/workers/WorkerPool.ts
+++ b/src/workers/WorkerPool.ts
@@ -6,6 +6,7 @@ import { SharedComputationWorkerTaskType } from './SharedWorker';
 import type { WorkerPoolConfig, WorkerTask, WorkerInfo, WorkerStats } from './types';
 import { OnProgressCallback } from './Utils';
 import { createSharedWorker } from './workerFactories';
+import { releaseAndTerminate } from './workerRegistry';
 
 /**
  * WorkerPool manages a pool of web workers for executing computationally intensive tasks
@@ -93,10 +94,7 @@ export class WorkerPool {
       if (this.config.taskTimeout) {
         task.timeoutId = setTimeout(() => {
           if (this.pendingTasks.has(taskId)) {
-            this.handleTaskError(
-              taskId,
-              new Error(`Task timeout after ${this.config.taskTimeout}ms: ${taskType}`),
-            );
+            this.handleTaskTimeout(taskId, taskType);
           }
         }, this.config.taskTimeout);
       }
@@ -118,9 +116,9 @@ export class WorkerPool {
       clearInterval(this.cleanupInterval);
     }
 
-    // Terminate all workers
+    // Terminate all workers (release the proxy AND stop the thread)
     for (const workerInfo of this.workers.values()) {
-      workerInfo.worker[releaseProxy]();
+      releaseAndTerminate(workerInfo.worker);
     }
 
     // Reject all pending tasks
@@ -248,6 +246,20 @@ export class WorkerPool {
       this.handleTaskComplete(task.id, result);
     } catch (err) {
       this.handleTaskError(task.id, err as Error);
+    } finally {
+      // Release the per-task progress proxy so its MessagePort doesn't leak.
+      // comlink only auto-releases proxied callbacks via non-deterministic GC.
+      try {
+        (onProgress as unknown as { [releaseProxy]?: () => void })[releaseProxy]?.();
+      } catch {
+        /* already released */
+      }
+    }
+
+    // If this task already timed out, its worker was torn down and recovered by
+    // handleTaskTimeout; don't resurrect the detached worker's bookkeeping.
+    if (!this.workers.has(workerInfo.id)) {
+      return;
     }
 
     // Mark worker as available
@@ -316,6 +328,32 @@ export class WorkerPool {
   }
 
   /**
+   * Handle a task that exceeded its timeout. The worker may be hung (the very
+   * scenario the timeout defends against), in which case its `busy` flag would
+   * otherwise stay true forever and permanently strand the pool slot. So we
+   * tear the worker down, reject the caller, and re-run the queue on a fresh
+   * worker.
+   */
+  private handleTaskTimeout(taskId: string, taskType: string): void {
+    for (const [workerId, workerInfo] of this.workers.entries()) {
+      if (workerInfo.currentTaskId === taskId) {
+        releaseAndTerminate(workerInfo.worker);
+        this.workers.delete(workerId);
+        this.stats.activeWorkers = this.workers.size;
+        break;
+      }
+    }
+
+    this.handleTaskError(
+      taskId,
+      new Error(`Task timeout after ${this.config.taskTimeout}ms: ${taskType}`),
+    );
+
+    // A pool slot just freed up — let any queued work proceed.
+    this.processNextTask();
+  }
+
+  /**
    * Clean up task resources (timeout timer)
    */
   private cleanupTask(task: WorkerTask<unknown, unknown>): void {
@@ -344,7 +382,7 @@ export class WorkerPool {
 
     for (const [workerId, workerInfo] of this.workers.entries()) {
       if (!workerInfo.busy && now - workerInfo.lastUsed > idleTimeout) {
-        workerInfo.worker[releaseProxy]();
+        releaseAndTerminate(workerInfo.worker);
         this.workers.delete(workerId);
 
         if (this.config.enableLogging && this.logger) {

--- a/src/workers/workerFactories.ts
+++ b/src/workers/workerFactories.ts
@@ -5,6 +5,7 @@
 import { wrap, Remote } from 'comlink';
 
 import { SharedComputationWorker } from './SharedWorker';
+import { registerRawWorker } from './workerRegistry';
 
 /**
  * Creates a new instance of the buff calculation worker
@@ -14,5 +15,9 @@ export function createSharedWorker(): Remote<SharedComputationWorker> {
     type: 'module',
   });
 
-  return wrap<SharedComputationWorker>(worker);
+  const proxy = wrap<SharedComputationWorker>(worker);
+  // Remember the raw worker so the pool can terminate the thread on cleanup
+  // (releaseProxy alone never stops a Worker endpoint).
+  registerRawWorker(proxy, worker);
+  return proxy;
 }

--- a/src/workers/workerRegistry.ts
+++ b/src/workers/workerRegistry.ts
@@ -1,0 +1,37 @@
+import { releaseProxy, type Remote } from 'comlink';
+
+import type { SharedComputationWorker } from './SharedWorker';
+
+/**
+ * Maps a comlink `Remote` proxy back to the raw `Worker` that backs it.
+ *
+ * comlink's `releaseProxy()` only closes `MessagePort` endpoints — it is a
+ * no-op for a `Worker` endpoint — so releasing a wrapped worker proxy never
+ * terminates the underlying OS thread. The pool therefore needs the raw worker
+ * to actually `terminate()` it; we stash it here keyed by the proxy so the
+ * factory's return type stays unchanged for all existing callers.
+ */
+const rawWorkerByProxy = new WeakMap<object, Worker>();
+
+/** Associate a wrapped proxy with its raw worker so it can be terminated later. */
+export function registerRawWorker(proxy: Remote<SharedComputationWorker>, worker: Worker): void {
+  rawWorkerByProxy.set(proxy as object, worker);
+}
+
+/**
+ * Release the comlink proxy AND terminate the underlying worker thread.
+ * Safe to call with a proxy that has no registered raw worker (e.g. test mocks)
+ * — it simply releases the proxy and skips termination.
+ */
+export function releaseAndTerminate(proxy: Remote<SharedComputationWorker>): void {
+  try {
+    (proxy as unknown as { [releaseProxy]?: () => void })[releaseProxy]?.();
+  } catch {
+    /* proxy may already be released */
+  }
+  const worker = rawWorkerByProxy.get(proxy as object);
+  if (worker) {
+    worker.terminate();
+    rawWorkerByProxy.delete(proxy as object);
+  }
+}


### PR DESCRIPTION
## Summary

Three `WorkerPool` resource fixes from a codebase audit — it leaked worker threads + MessagePorts and could deadlock.

### 1. Worker threads were never terminated (medium)
`WorkerInfo` only held the comlink `Remote` proxy. `proxy[releaseProxy]()` never stops a `Worker` endpoint (comlink's `closeEndPoint` only acts on `MessagePort`), so `destroy()` and `cleanupIdleWorkers()` dropped the `WorkerInfo` while the OS thread kept running — leaking threads and their retained heap (combat-event arrays) across a session. Added a tiny `workerRegistry` that maps each proxy back to its raw `Worker` (factory return type unchanged → no caller/mock churn) and `releaseAndTerminate()` that releases the proxy **and** `terminate()`s the thread.

### 2. Per-task progress proxy leaked a MessagePort (medium)
Each `execute` wrapped its progress callback in `proxy()` — a fresh `MessageChannel`/port — that was never released. On hot paths (every fight/encounter navigation, several task types each) these accumulated for the life of the page. Now released in a `finally` after the worker call settles.

### 3. Timed-out task stranded its worker (medium)
On timeout the caller was rejected but `workerInfo.busy` was never cleared. If the worker was actually hung (the scenario the timeout exists for), the slot was lost forever and the pool would eventually deadlock while still reporting `activeWorkers`. `handleTaskTimeout` now tears the stuck worker down, removes it, and re-runs the queue on a fresh worker. The post-await bookkeeping skips a worker that was already torn down.

## Testing
- `tsc --noEmit` clean
- WorkerPool + WorkerManager suites pass (45 tests) incl. a **new timeout-recovery regression test**
- prettier + eslint clean

The registry's `releaseAndTerminate` is a safe no-op on test mocks (no registered raw worker), so existing mocks are unaffected.
