### PR TITLE
fix(pack-hub): tolerate null fields, guard addon search, keep search paginating

### DIFF
--- a/src/features/pack-hub/api/pack-hub-api.ts
+++ b/src/features/pack-hub/api/pack-hub-api.ts
@@ -94,7 +94,7 @@ function hydratePack(pack: HubPack): HubPack {
     author_name: decodeHtmlEntities(pack.author_name),
     title: decodeHtmlEntities(pack.title),
     description: decodeHtmlEntities(pack.description),
-    tags: pack.tags.map(decodeHtmlEntities),
+    tags: (pack.tags ?? []).map(decodeHtmlEntities),
     addons: addons.map((a) => ({
       ...a,
       name: decodeHtmlEntities(a.name),
@@ -119,7 +119,9 @@ export async function searchEsouiAddons(query: string): Promise<EsouiAddonSearch
   const data = await request<{ results: EsouiAddonSearchResult[] }>(
     `/search-addons?${params.toString()}`,
   );
-  return data.results;
+  // The worker proxies an external service; guard against a malformed/empty
+  // payload so callers (e.g. <Autocomplete options>) always get an array.
+  return Array.isArray(data?.results) ? data.results : [];
 }
 
 // ─── Pack Hub CRUD ───────────────────────────────────────────────────────────

--- a/src/features/pack-hub/components/PackHubPage.tsx
+++ b/src/features/pack-hub/components/PackHubPage.tsx
@@ -34,8 +34,18 @@ export const PackHubPage: React.FC = () => {
   const { isLoggedIn, accessToken, currentUser } = useAuth();
   const token = isLoggedIn ? accessToken : undefined;
 
-  const { filteredPacks, loading, error, filters, hasMore, setFilter, loadMore, refresh, vote } =
-    usePackHub(token);
+  const {
+    packs,
+    filteredPacks,
+    loading,
+    error,
+    filters,
+    hasMore,
+    setFilter,
+    loadMore,
+    refresh,
+    vote,
+  } = usePackHub(token);
 
   React.useEffect(() => {
     document.title = 'Pack Hub | ESO Toolkit';
@@ -310,7 +320,10 @@ export const PackHubPage: React.FC = () => {
         )}
 
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
-          {loading && filteredPacks.length > 0 ? null : hasMore && filteredPacks.length > 0 ? (
+          {/* Gate "Load more" on the unfiltered packs: a client-side search that
+              matches nothing on the loaded pages must not hide pagination, or
+              matches on later pages become unreachable. */}
+          {loading && packs.length > 0 ? null : hasMore && packs.length > 0 ? (
             <Button variant="outlined" onClick={loadMore} aria-label="Load more packs">
               Load more
             </Button>

--- a/src/features/pack-hub/hooks/use-pack-hub.ts
+++ b/src/features/pack-hub/hooks/use-pack-hub.ts
@@ -3,6 +3,9 @@ import React from 'react';
 import { packHubApi } from '../api/pack-hub-api';
 import type { HubPack, PackHubFilters } from '../types/pack-hub.types';
 
+/** Server page size for pack listings (must match the roster-hub worker). */
+const PACK_HUB_PAGE_SIZE = 20;
+
 interface UsePackHubReturn {
   packs: HubPack[];
   filteredPacks: HubPack[];
@@ -54,7 +57,9 @@ export function usePackHub(token: string | undefined): UsePackHubReturn {
         if (fetchKey !== fetchKeyRef.current) return; // stale
 
         setPacks((prev) => (append ? [...prev, ...res.packs] : res.packs));
-        setHasMore(res.packs.length === 20);
+        // A full page implies there may be more. Use >= so an unexpected page
+        // size from the worker can't permanently disable "Load more".
+        setHasMore(res.packs.length >= PACK_HUB_PAGE_SIZE);
       } catch (err) {
         if (controller.signal.aborted) return;
         if (fetchKey !== fetchKeyRef.current) return;

--- a/src/utils/decodeHtmlEntities.ts
+++ b/src/utils/decodeHtmlEntities.ts
@@ -11,7 +11,11 @@
  * matching the server's allow-list exactly so no additional entities leak
  * through.
  */
-export function decodeHtmlEntities(input: string): string {
+export function decodeHtmlEntities(input: string | null | undefined): string {
+  // External data stores (e.g. D1 columns) can legitimately hold NULL even
+  // where the TS types claim a string, so tolerate non-strings rather than
+  // throwing on `null.replace`.
+  if (typeof input !== 'string') return '';
   return input
     .replace(/&#x27;/g, "'")
     .replace(/&quot;/g, '"')


### PR DESCRIPTION
## Summary

Pack Hub robustness fixes from a codebase audit — prevents a whole-page crash and makes search-while-paginating work.

### 1. Null D1 field crashed the whole Pack Hub (medium)
`decodeHtmlEntities` did `input.replace(...)` with no null check, and `hydratePack` fed it `pack.title/description/author_name` and mapped `pack.tags` straight from the roster-hub D1 API — where those columns can legitimately be `NULL`. A single bad row threw out of `data.packs.map(hydratePack)`, rejecting the request, so the entire page showed the error state. `decodeHtmlEntities` now tolerates non-strings (returns `''`) and `hydratePack` guards `pack.tags`.

### 2. Addon search could pass `undefined` to `<Autocomplete>` (low)
`searchEsouiAddons` returned `data.results` unguarded; a malformed/empty worker payload would hand `undefined` to MUI `<Autocomplete options>`. Now returns `[]` unless it's an array.

### 3. Search hid pagination (low)
"Load more" was gated on `filteredPacks.length`, so a client-side search matching nothing on the loaded pages hid the button and made matches on later pages unreachable. Now gated on the unfiltered `packs`.

### 4. Magic page-size (low)
`hasMore` used `=== 20`; replaced with a named `PACK_HUB_PAGE_SIZE` and `>=` so an unexpected worker page size can't permanently disable "Load more". (Server-provided `hasMore` would be the fully robust fix.)

## Testing
- `tsc --noEmit` clean
- pack-hub + decodeHtmlEntities suites pass
- prettier + eslint clean
