### PR TITLE
fix(loadout-manager): harden setup rendering, fix mythic trait + stale gear icon

### DIFF
--- a/src/features/loadout-manager/components/GearSelector.tsx
+++ b/src/features/loadout-manager/components/GearSelector.tsx
@@ -274,17 +274,24 @@ const GearTile: React.FC<GearTileProps> = ({
   // Fetch item icon from UESP
   useEffect(() => {
     if (resolvedItemId && resolvedItemId > 0) {
+      let cancelled = false;
       setIconFailed(false);
+      // Clear the previous item's icon immediately so we don't show A's icon
+      // next to B's name while B's (possibly slow/failing) fetch resolves.
+      setIconUrl(null);
       fetchItemIconUrl(resolvedItemId)
         .then((url) => {
-          if (url) setIconUrl(url);
+          if (!cancelled) setIconUrl(url ?? null);
         })
         .catch(() => {
           /* silently fail; SVG fallback will show */
         });
-    } else {
-      setIconUrl(null);
+      return () => {
+        cancelled = true;
+      };
     }
+    setIconUrl(null);
+    return undefined;
   }, [resolvedItemId]);
 
   const setName = gearPiece?.setName || itemData?.setName;
@@ -713,7 +720,9 @@ export const GearSelector: React.FC<GearSelectorProps> = ({
       itemId: resolvedItemId,
       name: itemInfo.name,
       setName: itemInfo.setName,
-      trait: itemInfo.slot || 'Unknown',
+      // Note: itemInfo.slot is the slot kind, NOT a trait. Don't write it into
+      // `trait` — GearTile keys mythic styling off trait === 'mythic', so a
+      // slot string here would poison that detection. Leave trait unset.
       slot: pickerSlot.index,
       setId: collectionItem?.setId,
     };

--- a/src/features/loadout-manager/components/SetupList.tsx
+++ b/src/features/loadout-manager/components/SetupList.tsx
@@ -93,7 +93,7 @@ export const SetupList: React.FC<SetupListProps> = ({
         const progress = getSetupProgressSections(setup)
           .map((section) => formatProgressSection(section).toLowerCase())
           .join(' ');
-        const haystack = `${setup.name.toLowerCase()} ${tags} ${condition} ${progress}`;
+        const haystack = `${(setup.name ?? '').toLowerCase()} ${tags} ${condition} ${progress}`;
         return haystack.includes(normalizedFilter);
       });
   }, [setups, normalizedFilter]);

--- a/src/features/loadout-manager/utils/setupDisplay.ts
+++ b/src/features/loadout-manager/utils/setupDisplay.ts
@@ -26,16 +26,16 @@ const normalize = (value?: string | null): string => (value ?? '').trim();
 const isTrashKeyword = (value: string): boolean => value.includes('trash');
 
 export const isTrashSetup = (setup: LoadoutSetup): boolean => {
-  if (typeof setup.condition.trash === 'number') {
+  if (typeof setup.condition?.trash === 'number') {
     return true;
   }
 
-  const bossName = normalize(setup.condition.boss).toLowerCase();
+  const bossName = normalize(setup.condition?.boss).toLowerCase();
   return bossName !== '' && isTrashKeyword(bossName);
 };
 
 export const isBossSetup = (setup: LoadoutSetup): boolean => {
-  const bossName = normalize(setup.condition.boss);
+  const bossName = normalize(setup.condition?.boss);
   if (!bossName) {
     return false;
   }


### PR DESCRIPTION
## Summary

Three loadout-manager fixes from a codebase audit.

### 1. Malformed setup white-screened the page (medium)
A raw-JSON import is loaded verbatim with no per-setup normalization (the Wizard's Wardrobe / AlphaGear paths normalize, the native JSON path does not). A setup missing `name` or `condition` crashed rendering: `SetupList` did `setup.name.toLowerCase()` and `isTrashSetup`/`isBossSetup` read `setup.condition.trash`/`.boss` unguarded. Guarded those access points so malformed setups (from any source) degrade gracefully instead of crashing the whole list.

### 2. Manually-picked mythic never rendered as mythic (low)
`GearSelector` wrote the slot kind into the gear piece's `trait` (`trait: itemInfo.slot`). `GearTile` derives mythic styling from `trait === 'mythic'`, so the slot string permanently poisoned that detection. `trait` is now left unset on manual picks.

### 3. Stale gear icon (low)
The icon effect reset `iconFailed` but not `iconUrl` on item change, so a tile showed the previous item's icon next to the new item's name until the new fetch resolved — indefinitely if it resolved to null. Clear the icon up front, use `url ?? null`, and guard against out-of-order resolves.

## Testing
- `tsc --noEmit` clean
- loadout-manager suites pass (326 tests)
- prettier + eslint clean
