### PR TITLE
fix(build-viewer): sanitize banner URL + harden ?b= decode + stabilize gear memo

### DIFF
--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -72,7 +72,7 @@ import { selectSavedBuilds } from '../store/saved_builds';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
 import { decodeBuildFromURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
-import { sanitizeYoutubeUrl } from '../utils/sanitize-url';
+import { sanitizeImageUrl, sanitizeYoutubeUrl } from '../utils/sanitize-url';
 import { useSetPieceCounts } from '../utils/setPieceCounting';
 import { buildTooltipPropsFromAbilityId } from '../utils/skillTooltipMapper';
 
@@ -643,10 +643,14 @@ const GearSlotDisplay: React.FC<{
   );
 
   useEffect(() => {
-    if (iconUrl || resolvedIconId == null) return;
+    if (iconUrl || resolvedIconId == null) return undefined;
+    let active = true;
     void fetchItemIconUrl(resolvedIconId).then((url) => {
-      if (url) setIconUrl(url);
+      if (active && url) setIconUrl(url);
     });
+    return () => {
+      active = false;
+    };
   }, [resolvedIconId, iconUrl]);
 
   // Swap the generic " Weapon"/" Off-Hand"/" Gear" suffix for a specific
@@ -832,13 +836,18 @@ const SetupDisplay: React.FC<{ setup: BuildSetup; build: Build; races?: string[]
   const totalAttributes =
     setup.attributes.magicka + setup.attributes.health + setup.attributes.stamina;
 
-  const gearEntries = GEAR_SLOT_ORDER.filter((slot) => setup.gear[slot]?.id != null).map(
-    (slot) => ({
-      slot,
-      id: setup.gear[slot].id as number,
-      trait: setup.gear[slot].trait,
-      enchant: setup.gear[slot].enchant,
-    }),
+  // Memoize on setup.gear so the array identity is stable: setPieceCounts and
+  // every per-row gearTooltipProps memo key off this, and an unstable identity
+  // busted all ~14 gear-set tooltip lookups on any parent re-render.
+  const gearEntries = React.useMemo(
+    () =>
+      GEAR_SLOT_ORDER.filter((slot) => setup.gear[slot]?.id != null).map((slot) => ({
+        slot,
+        id: setup.gear[slot].id as number,
+        trait: setup.gear[slot].trait,
+        enchant: setup.gear[slot].enchant,
+      })),
+    [setup.gear],
   );
 
   // Count set pieces treating a two-handed weapon as 2 (ESO's in-game math), so
@@ -2258,7 +2267,7 @@ export const BuildViewPage: React.FC = () => {
             animate="visible"
           >
             {/* ── Banner image ── */}
-            {build.guide.bannerImageUrl && (
+            {sanitizeImageUrl(build.guide.bannerImageUrl) && (
               <motion.div variants={fadeInUp}>
                 <Box
                   sx={{
@@ -2282,7 +2291,7 @@ export const BuildViewPage: React.FC = () => {
                   }}
                 >
                   <img
-                    src={build.guide.bannerImageUrl}
+                    src={sanitizeImageUrl(build.guide.bannerImageUrl) ?? undefined}
                     alt={`${build.name} banner`}
                     style={{
                       width: '100%',

--- a/src/utils/buildEncoding.ts
+++ b/src/utils/buildEncoding.ts
@@ -322,9 +322,14 @@ function expandSetup(compact: CompactSetup, index: number): BuildSetup {
   return {
     id: `decoded-setup-${index}`,
     name: compact.nm ?? 'Default',
-    attributes: compact.at
-      ? { magicka: compact.at[0], health: compact.at[1], stamina: compact.at[2] }
-      : { magicka: 0, health: 0, stamina: 0 },
+    // Coerce defensively: a malformed/hand-crafted ?b= blob can carry a short
+    // or non-numeric `at` array, which would otherwise yield undefined/NaN
+    // attributes that render as "NaN%" bars and poison stat math.
+    attributes: {
+      magicka: Number(compact.at?.[0]) || 0,
+      health: Number(compact.at?.[1]) || 0,
+      stamina: Number(compact.at?.[2]) || 0,
+    },
     curse: compact.cu ?? 'none',
     mundusStone: compact.ms ?? '',
     gear: expandGear(compact.g, compact.gt, compact.ge, compact.gw),

--- a/src/utils/sanitize-url.ts
+++ b/src/utils/sanitize-url.ts
@@ -15,3 +15,22 @@ export function sanitizeYoutubeUrl(url: string | undefined | null): string | nul
   }
   return null;
 }
+
+/**
+ * Sanitize an image URL coming from untrusted, user-shareable data (e.g. a
+ * decoded `?b=` build blob). Only absolute http(s) URLs are allowed — this
+ * rejects `data:`, `javascript:`, `blob:` and other schemes that could be used
+ * for tracking beacons or other abuse via an <img src>.
+ */
+export function sanitizeImageUrl(url: string | undefined | null): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return parsed.href;
+    }
+  } catch {
+    // invalid / relative URL
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Build View page is rendered entirely from an attacker-controllable `?b=` blob, so these harden it. From a codebase audit.

### 1. Banner image URL rendered without sanitization (low, security)
`guide.youtubeUrl` is run through `sanitizeYoutubeUrl`, but `guide.bannerImageUrl` (decoded from `?b=`) was used directly as an `<img src>`. An arbitrary remote URL enables passive tracking / IP-logging beacons and forced third-party requests on every shared-link open (and `data:`/other schemes). Added `sanitizeImageUrl` (http(s)-only) and applied it to the banner.

### 2. Decoded attributes not validated (low)
`expandSetup` read `compact.at[0..2]` unchecked, so a short/non-numeric array produced `undefined`/`NaN` attributes that render as `NaN%` bars and poison `calculateBuildStats`. Each value is now coerced to a finite number.

### 3. Icon fetch had no unmount/stale guard (low)
The per-gear-row icon `useEffect` called `setIconUrl` after an await with no cancellation flag; switching the active setup remounts the subtree and fired late writes. Added a cancellation flag.

### 4. Unmemoized `gearEntries` busted tooltip memos (low, perf)
`gearEntries` was rebuilt with a new identity every render, so `setPieceCounts` (keyed on it) returned a new `Map` each render, cascading to all ~14 per-row `gearTooltipProps` memos on any parent re-render (hover, copy/export toggles). Memoized on `setup.gear`.

## Testing
- `tsc --noEmit` clean
- buildEncoding + BuildViewPage suites pass (13 tests)
- prettier + eslint clean

> A separate low finding — the skill-slot format heuristic mislabels native bars that only use slots ≤ 5 — is left for a follow-up since the robust fix needs a format flag carried through encoding.
