### PR TITLE
fix(store): persist chartIntensity + prune fight index + clear stale context

### DIFF
--- a/src/store/report/reportSlice.ts
+++ b/src/store/report/reportSlice.ts
@@ -155,6 +155,18 @@ const ensureEntry = (state: ReportState, reportId: string): ReportEntry => {
   return state.entries[key];
 };
 
+// Keep fightIndexByReport in lockstep with the LRU cache: trimCache only evicts
+// from state.entries, so without this an entry's fight-index leaks every time a
+// report is evicted, growing unbounded across a long browsing session.
+const pruneFightIndexByReport = (state: ReportState): void => {
+  for (const reportId of Object.keys(state.fightIndexByReport)) {
+    const key = resolveReportKey(reportId);
+    if (!key || !state.entries[key]) {
+      delete state.fightIndexByReport[reportId];
+    }
+  }
+};
+
 const syncActiveReportState = (state: ReportState): void => {
   const fallbackReportId = state.reportId || null;
   const activeReportId = state.activeContext.reportId ?? fallbackReportId;
@@ -301,6 +313,7 @@ const reportSlice = createSlice({
       const { key } = resolveCacheKey({ reportCode: resolvedReportId });
       touchAccessOrder(state, key);
       trimCache(state, REPORT_CACHE_MAX_ENTRIES);
+      pruneFightIndexByReport(state);
 
       state.activeContext.reportId =
         payload?.code ?? state.activeContext.reportId ?? resolvedReportId;
@@ -342,12 +355,16 @@ const reportSlice = createSlice({
       delete state.fightIndexByReport[context.reportCode];
       if (state.activeContext.reportId === context.reportCode) {
         state.activeContext.reportId = null;
+        // Also clear the fight: leaving it set leaves activeContext pointing at
+        // a fight from the now-removed report.
+        state.activeContext.fightId = null;
       }
       syncActiveReportState(state);
     },
     trimReportCache(state, action: PayloadAction<{ maxEntries?: number } | undefined>) {
       const limit = action?.payload?.maxEntries ?? REPORT_CACHE_MAX_ENTRIES;
       trimCache(state, limit);
+      pruneFightIndexByReport(state);
       syncActiveReportState(state);
     },
   },
@@ -394,6 +411,7 @@ const reportSlice = createSlice({
 
         touchAccessOrder(state, cacheKey);
         trimCache(state, REPORT_CACHE_MAX_ENTRIES);
+        pruneFightIndexByReport(state);
 
         if (!state.activeContext.reportId) {
           state.activeContext.reportId = reportId;

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -64,6 +64,7 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       myReportsPage,
       perfTier,
       perfTierOverride,
+      chartIntensity,
     } = inboundState;
     return {
       darkMode,
@@ -72,6 +73,9 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       myReportsPage,
       perfTier,
       perfTierOverride,
+      // chartIntensity is a user preference, not report-specific state — without
+      // this it was reset to 'subtle' on every reload.
+      chartIntensity,
     };
   },
   // Transform state being rehydrated
@@ -143,7 +147,10 @@ const createStoreWithClient = (esoLogsClient: EsoLogsClient): AppStore => {
           // Only ignore Redux persist actions since thunk actions are now serializable
           ignoredActions: [FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE],
           // State paths that contain large datasets or computed data
-          ignoredPaths: ['events', 'playerData.playersById', 'workerResults'],
+          // playerData is a keyed cache (playerData.entries[key].playersById);
+          // the old 'playerData.playersById' path matched nothing, so the dev
+          // serializability check still deep-traversed every cached fight.
+          ignoredPaths: ['events', 'playerData.entries', 'workerResults'],
           // Increase warning threshold for better performance
           warnAfter: 128,
         },


### PR DESCRIPTION
## Summary

Four Redux store fixes from a codebase audit.

### 1. `chartIntensity` preference never persisted (low)
`chartIntensity` has a `setChartIntensity` reducer + selector, but the persist transform's inbound picker omitted it, so any value was dropped on reload and reset to `'subtle'`. Latent today (no UI control dispatches it yet) but would silently fail the moment one does. Added it to the persisted fields.

### 2. `fightIndexByReport` grew unbounded (low)
`trimCache` only evicts `state.entries`, so an evicted report left its `fightIndexByReport` entry behind — one per distinct report viewed while the cache is capped at 6. Added `pruneFightIndexByReport` (re-derives each key's cache key and drops it if the entry was evicted) and call it after every `trimCache`. Safe because the just-added report's entry exists before the prune runs.

### 3. `clearReportForContext` left a stale `fightId` (low)
When clearing the active report it nulled `activeContext.reportId` but left `activeContext.fightId` pointing at a fight from the removed report. Now clears `fightId` too.

### 4. Stale `serializableCheck.ignoredPaths` (low)
`'playerData.playersById'` matched nothing — `playerData` is a keyed cache (`playerData.entries[key].playersById`) — so the dev serializability/immutability middleware still deep-traversed every cached fight's player map. Corrected to `'playerData.entries'`.

## Testing
- `tsc --noEmit` clean
- store/report + ui + storeWithHistory suites pass (47 tests)
- prettier + eslint clean

> A related low finding — worker-task selector factories are allocated inline inside `useSelector` (wasted memoization, latent) — is left for a separate change.
