### PR TITLE
fix(utils): drop dead binary search + don't bypass source filter for sourceID 0

### DIFF
--- a/src/utils/BuffLookupUtils.ts
+++ b/src/utils/BuffLookupUtils.ts
@@ -178,38 +178,16 @@ export function isBuffActiveOnTarget(
     );
   }
 
-  // Binary search for intervals containing the timestamp on the specific target
-  let left = 0;
-  let right = intervals.length - 1;
-
-  while (left <= right) {
-    const mid = Math.floor((left + right) / 2);
-    const interval = intervals[mid];
-
-    if (
-      timestamp >= interval.start &&
-      timestamp <= interval.end &&
-      interval.targetID === targetID
-    ) {
-      return true;
-    } else if (timestamp < interval.start) {
-      right = mid - 1;
-    } else {
-      left = mid + 1;
-    }
-  }
-
-  // Also check adjacent intervals since they might overlap or be on different targets
-  for (const interval of intervals) {
-    const timestampCheck = timestamp >= interval.start && timestamp <= interval.end;
-    const targetCheck = interval.targetID === targetID;
-
-    if (timestampCheck && targetCheck) {
-      return true;
-    }
-  }
-
-  return false;
+  // Intervals are sorted by start time ONLY, so a binary search that also
+  // requires interval.targetID === targetID can't validly narrow the range —
+  // different targets' intervals are interleaved by start time. The previous
+  // code recognized this and fell back to a full linear scan anyway, so the
+  // "binary search" was dead complexity. Use the linear scan directly (O(n)
+  // over this ability id's intervals); behavior is identical.
+  return intervals.some(
+    (interval: BuffTimeInterval) =>
+      interval.targetID === targetID && timestamp >= interval.start && timestamp <= interval.end,
+  );
 }
 
 /**

--- a/src/utils/buffUptimeCalculator.ts
+++ b/src/utils/buffUptimeCalculator.ts
@@ -91,8 +91,11 @@ export function computeBuffUptimes(
         return false;
       }
 
-      // Filter by source IDs if specified
-      if (sourceIds && interval.sourceID && !sourceIds.has(interval.sourceID)) {
+      // Filter by source IDs if specified. Use a presence check (!= null) rather
+      // than truthiness: sourceID 0 is the environment/no-source actor, and the
+      // truthiness guard let it bypass an explicit player-source filter,
+      // inflating a single player's inverted-debuff uptime.
+      if (sourceIds && interval.sourceID != null && !sourceIds.has(interval.sourceID)) {
         return false;
       }
 


### PR DESCRIPTION
## Summary

Two pure-util fixes from a codebase audit.

### 1. Dead binary search in `isBuffActiveOnTarget` (low, perf/clarity)
The intervals array is sorted by **start time only**, but the binary-search predicate also required `interval.targetID === targetID`. Different targets' intervals are interleaved by start time, so the search can't validly narrow on the targetID dimension — and the code already fell back to a full linear scan afterward. The "O(log m)" lookup was actually O(m) plus dead, misleading complexity. Replaced with the linear scan directly (identical behavior). This runs per timestamp × player × source inside the damage-reduction worker.

### 2. Source filter bypassed for `sourceID 0` (low, correctness)
`buffUptimeCalculator`'s source filter used `interval.sourceID && !sourceIds.has(...)`, so an interval with `sourceID 0` (environment/no-source) bypassed an explicit player-source filter — leaking environment-sourced intervals into a single player's inverted-debuff uptime. Changed to `interval.sourceID != null` so `0` is filtered like any other source.

## Testing
- `tsc --noEmit` clean
- BuffLookupUtils + buffUptimeCalculator suites pass (25 tests)
- prettier + eslint clean

> A related low finding — active-percentage reports 0% for an actor with a single damage event (zero-width interval) — is left for a separate change, since the right floor value is a product decision.
