### PR TITLE
fix(build-editor): round-trip Class Mastery through CSPS export/import

### DIFF
--- a/src/features/build-editor/components/sections/PassivesSection.tsx
+++ b/src/features/build-editor/components/sections/PassivesSection.tsx
@@ -27,14 +27,22 @@ const PassivesSectionComponent: React.FC = () => {
   if (!setup) return null;
 
   // Class Mastery picks live on build.classMasteryPassives, not here. Defend
-  // against legacy/imported builds that left CM ids in setup.passives so they
-  // never show up as (unmanageable) tiles in the regular Passives picker.
+  // against legacy/imported builds that left CM ids in setup.passives: hide them
+  // from the picker, but carry them back on every edit so they aren't silently
+  // dropped before they can be recovered/migrated on export.
+  const hiddenClassMasteryIds = setup.passives.filter((id) => CLASS_MASTERY_SKILL_IDS.has(id));
   const regularPassives = setup.passives.filter((id) => !CLASS_MASTERY_SKILL_IDS.has(id));
 
   return (
     <PassivesPicker
       passives={regularPassives}
-      onChange={(updated) => dispatch(setPassives(updated))}
+      onChange={(updated) =>
+        dispatch(
+          setPassives(
+            hiddenClassMasteryIds.length ? [...updated, ...hiddenClassMasteryIds] : updated,
+          ),
+        )
+      }
       esoClass={esoClass}
       races={races}
       setupSkills={setup.skills}

--- a/src/features/build-editor/components/sections/PassivesSection.tsx
+++ b/src/features/build-editor/components/sections/PassivesSection.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { CLASS_MASTERY_SKILL_IDS } from '@/data/skill-lines/class/classMastery';
+
 import {
   selectActiveSetup,
   selectBuildEsoClass,
@@ -24,9 +26,14 @@ const PassivesSectionComponent: React.FC = () => {
 
   if (!setup) return null;
 
+  // Class Mastery picks live on build.classMasteryPassives, not here. Defend
+  // against legacy/imported builds that left CM ids in setup.passives so they
+  // never show up as (unmanageable) tiles in the regular Passives picker.
+  const regularPassives = setup.passives.filter((id) => !CLASS_MASTERY_SKILL_IDS.has(id));
+
   return (
     <PassivesPicker
-      passives={setup.passives}
+      passives={regularPassives}
       onChange={(updated) => dispatch(setPassives(updated))}
       esoClass={esoClass}
       races={races}

--- a/src/features/build-editor/engine/stat-engine.ts
+++ b/src/features/build-editor/engine/stat-engine.ts
@@ -9,6 +9,7 @@ import type { GearConfig } from '../../loadout-manager/types/loadout.types';
 import { EQUIP_SLOTS } from '../data/esoStaticData';
 import { resolveApparelWeight } from '../data/setArmorWeights';
 import type { Build, BuildSetup, GameMode } from '../types/build.types';
+import { isClassMasteryEligible } from '../utils/classMasteryEligibility';
 
 import {
   ANTHELMIR_DIVISOR,
@@ -287,9 +288,14 @@ export function calculateCritDamage(
   let { cap, max } = CRIT_DMG_CAPS;
   const items: StatItem[] = [];
 
-  // U50 Class Mastery passives the player selected (only relevant while not
-  // subclassed — the selection is build-level and already gated by the picker).
-  const selectedMastery = new Set(build.classMasteryPassives ?? []);
+  // U50 Class Mastery passives the player selected. The selection is build-level
+  // and is kept (inert) while subclassed, so re-check eligibility here — a
+  // subclassed build must not get its retained CM crit bonuses in the stats.
+  const selectedMastery = new Set(
+    isClassMasteryEligible(build.esoClass, build.classSkillLines)
+      ? (build.classMasteryPassives ?? [])
+      : [],
+  );
   const masteryCrit = CLASS_MASTERY_CRIT_PASSIVES.filter((p) => selectedMastery.has(p.id));
   // Buffs (e.g. Major Force / Major Brittle) supplied by a selected passive —
   // map buff name → the passive granting it, so the buff loop can force it on

--- a/src/features/build-editor/store/buildEditorSlice.ts
+++ b/src/features/build-editor/store/buildEditorSlice.ts
@@ -30,6 +30,7 @@ import type {
   SkilledAbility,
 } from '../types/build.types';
 import { CLASS_MASTERY_MAX_PICKS } from '../utils/classMasteryEligibility';
+import { migrateLeakedClassMasteryPicks } from '../utils/classMasteryTransfer';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -102,6 +103,9 @@ function loadFromStorage(): Pick<BuildEditorState, 'build' | 'activeSetupIndex'>
     if (!Array.isArray(parsed.build.classMasteryPassives)) {
       parsed.build.classMasteryPassives = [];
     }
+    // Migration: reclaim Class Mastery picks that pre-split builds left inside
+    // setup.passives so they're visible again (and out of the regular passives).
+    migrateLeakedClassMasteryPicks(parsed.build);
     // Migration: builds saved before stats feature won't have statOverrides
     for (const setup of parsed.build.setups) {
       if (!setup.statOverrides) {
@@ -522,6 +526,9 @@ export const buildEditorSlice = createSlice({
     /** Load an entire build object (e.g. from a decoded URL share). */
     loadBuild(state, action: PayloadAction<Build>) {
       state.build = action.payload;
+      // Reclaim any Class Mastery picks a pre-split source left in setup.passives
+      // so every editor entry point (URL decode, CSPS import, roster) is WYSIWYG.
+      migrateLeakedClassMasteryPicks(state.build);
       state.activeSetupIndex = 0;
       state.activeSidebarTab = 'general';
       state.activeSetupTab = 'info';

--- a/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
+++ b/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
@@ -1,10 +1,24 @@
 import {
   classFromMasteryIds,
   classOfClassMasteryId,
+  migrateLeakedClassMasteryPicks,
   partitionClassMasteryPicks,
   sanitizeClassMasteryPicks,
   stripClassMasteryIds,
 } from '../classMasteryTransfer';
+import type { Build } from '../../types/build.types';
+
+/** A minimal build-shaped object for the migration helper. */
+function leakyBuild(
+  classMasteryPassives: number[],
+  passivesPerSetup: number[][],
+): Pick<Build, 'esoClass' | 'classMasteryPassives' | 'setups'> {
+  return {
+    esoClass: 'dragonknight',
+    classMasteryPassives,
+    setups: passivesPerSetup.map((passives) => ({ passives })) as Build['setups'],
+  };
+}
 
 describe('classMasteryTransfer', () => {
   describe('classOfClassMasteryId', () => {
@@ -75,6 +89,29 @@ describe('classMasteryTransfer', () => {
       );
       expect(passives).toEqual([400]); // CM id removed regardless of class
       expect(classMasteryPassives).toEqual([]); // not a valid DK pick
+    });
+  });
+
+  describe('migrateLeakedClassMasteryPicks', () => {
+    it('lifts leaked CM ids from setup.passives into the empty build-level field', () => {
+      const build = leakyBuild([], [[400, 238232, 240268]]);
+      migrateLeakedClassMasteryPicks(build);
+      expect(build.classMasteryPassives).toEqual([238232, 240268]);
+      expect(build.setups[0].passives).toEqual([400]);
+    });
+
+    it('keeps existing build-level picks but still strips leaked ids from passives', () => {
+      const build = leakyBuild([238232], [[400, 240268]]);
+      migrateLeakedClassMasteryPicks(build);
+      expect(build.classMasteryPassives).toEqual([238232]); // not overwritten
+      expect(build.setups[0].passives).toEqual([400]); // 240268 stripped
+    });
+
+    it('is a no-op for a clean build with no leaked ids', () => {
+      const build = leakyBuild([], [[400, 500]]);
+      migrateLeakedClassMasteryPicks(build);
+      expect(build.classMasteryPassives).toEqual([]);
+      expect(build.setups[0].passives).toEqual([400, 500]);
     });
   });
 });

--- a/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
+++ b/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
@@ -1,0 +1,63 @@
+import {
+  classFromMasteryIds,
+  classOfClassMasteryId,
+  partitionClassMasteryPicks,
+  sanitizeClassMasteryPicks,
+} from '../classMasteryTransfer';
+
+describe('classMasteryTransfer', () => {
+  describe('classOfClassMasteryId', () => {
+    it('maps a Class Mastery passive id to its owning class', () => {
+      expect(classOfClassMasteryId(238232)).toBe('dragonknight'); // Inexorable Descent
+      expect(classOfClassMasteryId(263519)).toBe('warden'); // Tundra's Maw
+      expect(classOfClassMasteryId(263605)).toBe('nightblade'); // Above and Beyond
+    });
+
+    it('returns undefined for a non-Class-Mastery id', () => {
+      expect(classOfClassMasteryId(400)).toBeUndefined();
+    });
+  });
+
+  describe('sanitizeClassMasteryPicks', () => {
+    it('keeps only the class own ids, deduped and capped at the 2-pick max', () => {
+      expect(
+        sanitizeClassMasteryPicks([238232, 238232, 240268, 259224, 263519], 'dragonknight'),
+      ).toEqual([238232, 240268]);
+    });
+
+    it('returns [] for a class with no Class Mastery line or empty input', () => {
+      expect(sanitizeClassMasteryPicks([238232], 'any-class')).toEqual([]);
+      expect(sanitizeClassMasteryPicks(undefined, 'dragonknight')).toEqual([]);
+    });
+  });
+
+  describe('classFromMasteryIds', () => {
+    it('returns the class owning the most Class Mastery ids', () => {
+      expect(classFromMasteryIds([263519, 263520, 238232])).toBe('warden');
+    });
+
+    it('ignores non-Class-Mastery ids and returns undefined when none are present', () => {
+      expect(classFromMasteryIds([400, 500])).toBeUndefined();
+    });
+  });
+
+  describe('partitionClassMasteryPicks', () => {
+    it('splits Class Mastery ids out from the regular passives', () => {
+      const { passives, classMasteryPassives } = partitionClassMasteryPicks(
+        [400, 238232, 500, 240268],
+        'dragonknight',
+      );
+      expect(passives).toEqual([400, 500]);
+      expect(classMasteryPassives).toEqual([238232, 240268]);
+    });
+
+    it('strips foreign-class CM ids from passives without keeping them as picks', () => {
+      const { passives, classMasteryPassives } = partitionClassMasteryPicks(
+        [400, 263519], // 263519 = Warden CM id, build is dragonknight
+        'dragonknight',
+      );
+      expect(passives).toEqual([400]); // CM id removed regardless of class
+      expect(classMasteryPassives).toEqual([]); // not a valid DK pick
+    });
+  });
+});

--- a/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
+++ b/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
@@ -40,6 +40,12 @@ describe('classMasteryTransfer', () => {
     it('ignores non-Class-Mastery ids and returns undefined when none are present', () => {
       expect(classFromMasteryIds([400, 500])).toBeUndefined();
     });
+
+    it('returns undefined on an ambiguous cross-class tie (stale/corrupt data)', () => {
+      // 1 Dragonknight + 1 Warden CM id — impossible for a real character, so it
+      // is treated as inconclusive rather than letting a stale id pick the class.
+      expect(classFromMasteryIds([238232, 263519])).toBeUndefined();
+    });
   });
 
   describe('stripClassMasteryIds', () => {

--- a/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
+++ b/src/features/build-editor/utils/__tests__/classMasteryTransfer.test.ts
@@ -3,6 +3,7 @@ import {
   classOfClassMasteryId,
   partitionClassMasteryPicks,
   sanitizeClassMasteryPicks,
+  stripClassMasteryIds,
 } from '../classMasteryTransfer';
 
 describe('classMasteryTransfer', () => {
@@ -38,6 +39,16 @@ describe('classMasteryTransfer', () => {
 
     it('ignores non-Class-Mastery ids and returns undefined when none are present', () => {
       expect(classFromMasteryIds([400, 500])).toBeUndefined();
+    });
+  });
+
+  describe('stripClassMasteryIds', () => {
+    it('removes every Class Mastery id, keeping the regular passives in order', () => {
+      expect(stripClassMasteryIds([400, 238232, 500, 263519])).toEqual([400, 500]);
+    });
+
+    it('is a no-op when there are no Class Mastery ids', () => {
+      expect(stripClassMasteryIds([400, 500])).toEqual([400, 500]);
     });
   });
 

--- a/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
+++ b/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
@@ -1,3 +1,4 @@
+import { isClassMasteryEligible } from '../classMasteryEligibility';
 import {
   isCSPSExportCode,
   isCSPSNativeCode,
@@ -403,5 +404,23 @@ describe('Class Mastery in export codes', () => {
     expect(build.esoClass).toBe('warden');
     expect(build.classMasteryPassives).toEqual([263519, 263520]);
     expect(build.setups[0].passives).toEqual([500]);
+  });
+
+  it('decodes the native subclasses part so retained Class Mastery picks stay gated', () => {
+    const native = [
+      '-*263519:1*-*-*38', // skills: pass = Warden CM id; subclasses = 38 (Assassination, NB)
+      '0,0,0,0,0,0;0,0,0,0,0,0', // hotbars
+      '0;0;0', // attributes
+      '-', // mundus
+      '-', // champion points
+      '-', // gear
+      '-', // quickslots
+      '-', // outfits
+      '1', // role
+    ].join('#');
+    const { build } = parseCSPSNativeCode(native);
+    // an off-class line means the build is subclassed → Class Mastery is disabled
+    expect(build.classSkillLines).toContain('class.assassination');
+    expect(isClassMasteryEligible(build.esoClass, build.classSkillLines)).toBe(false);
   });
 });

--- a/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
+++ b/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
@@ -406,6 +406,24 @@ describe('Class Mastery in export codes', () => {
     expect(build.setups[0].passives).toEqual([500]);
   });
 
+  it('detects the native base class from Class Mastery ids over an off-class hotbar skill', () => {
+    const native = [
+      '-*263519:1,263520:1*-*-*-', // pass = Warden Class Mastery ids
+      '18429,0,0,0,0,0;0,0,0,0,0,0', // hotbar front slot 0 = Nightblade Assassination skill
+      '0;0;0', // attributes
+      '-', // mundus
+      '-', // champion points
+      '-', // gear
+      '-', // quickslots
+      '-', // outfits
+      '1', // role
+    ].join('#');
+    const { build } = parseCSPSNativeCode(native);
+    // CM owner (Warden) wins over the Nightblade hotbar skill → picks preserved
+    expect(build.esoClass).toBe('warden');
+    expect(build.classMasteryPassives).toEqual([263519, 263520]);
+  });
+
   it('decodes the native subclasses part so retained Class Mastery picks stay gated', () => {
     const native = [
       '-*263519:1*-*-*38', // skills: pass = Warden CM id; subclasses = 38 (Assassination, NB)

--- a/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
+++ b/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
@@ -420,8 +420,18 @@ describe('Class Mastery in export codes', () => {
     ].join('#');
     const { build } = parseCSPSNativeCode(native);
     // CM owner (Warden) wins over the Nightblade hotbar skill → picks preserved
+    // (Codex findings 5+6: CM ids uniquely identify the base class, so they must
+    // win detection, else the legitimate Warden picks get dropped as "foreign").
     expect(build.esoClass).toBe('warden');
     expect(build.classMasteryPassives).toEqual([263519, 263520]);
+    // DELIBERATE: "Warden CM ids + Nightblade hotbar skill" is impossible in-game
+    // (Class Mastery requires a pure class — a subclassed character has no active
+    // CM and cannot purchase CM passives). Given this contradictory input we
+    // normalize to a coherent, non-subclassed Warden-with-CM build rather than
+    // guessing a subclass; stat/export eligibility gates keep it internally
+    // consistent. A real subclassed code carries no CM ids, so this never fires
+    // for genuine data.
+    expect(isClassMasteryEligible(build.esoClass, build.classSkillLines)).toBe(true);
   });
 
   it('decodes the native subclasses part so retained Class Mastery picks stay gated', () => {

--- a/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
+++ b/src/features/build-editor/utils/__tests__/cspsExportCodeParser.test.ts
@@ -362,3 +362,46 @@ describe('parseCSPSNativeCode', () => {
     expect(() => parseCSPSNativeCode('a#b#c')).toThrow(/at least 5 sections/);
   });
 });
+
+describe('Class Mastery in export codes', () => {
+  it('partitions Class Mastery passives out of an ESO-Hub code', () => {
+    const code = [
+      '1', // class: Dragonknight
+      '3', // race
+      '1', // role
+      '0:0:64', // attributes
+      '0', // curse
+      '13975', // mundus
+      '35,36,37', // subclasses: all DK lines → not subclassed
+      '0', // hotbar 1
+      '0', // hotbar 2
+      '238232,240268,400', // passives: 2 DK Class Mastery + 1 regular
+      '0', // slotted CP
+      '0', // passive CP
+      '0', // gear
+      '0', // food
+      '0', // potions
+    ].join(';');
+    const { build } = parseCSPSExportCode(code);
+    expect(build.classMasteryPassives).toEqual([238232, 240268]);
+    expect(build.setups[0].passives).toEqual([400]);
+  });
+
+  it('partitions Class Mastery passives out of a native code and recovers the class', () => {
+    const native = [
+      '-*263519:1,263520:1,500:1*-*-*-', // skills: prog empty / pass = 2 Warden CM + 1 regular
+      '0,0,0,0,0,0;0,0,0,0,0,0', // hotbars empty → class recovered from CM ids
+      '0;0;0', // attributes
+      '-', // mundus
+      '-', // champion points
+      '-', // gear
+      '-', // quickslots
+      '-', // outfits
+      '1', // role
+    ].join('#');
+    const { build } = parseCSPSNativeCode(native);
+    expect(build.esoClass).toBe('warden');
+    expect(build.classMasteryPassives).toEqual([263519, 263520]);
+    expect(build.setups[0].passives).toEqual([500]);
+  });
+});

--- a/src/features/build-editor/utils/classMasteryTransfer.ts
+++ b/src/features/build-editor/utils/classMasteryTransfer.ts
@@ -6,9 +6,9 @@
  * addon (v6.1.6+) stores Class Mastery passives inside `werte.pass` as plain
  * `abilityId:1` pairs — mixed in with every other passive, with no dedicated
  * field. So any flat passive-id list crossing the CSPS boundary (SavedVariables
- * `werte.pass`, ESO-Hub export codes, native codes) must be split back out into
- * regular passives vs Class Mastery picks on the way in, and the picks must be
- * folded back into the passive list on the way out.
+ * `werte.pass` plus the export-code formats) must be split back out into regular
+ * passives vs Class Mastery picks on the way in, and the picks must be folded
+ * back into the passive list on the way out.
  *
  * These helpers are the single source of truth for that split + validation, so
  * the CSPS import/export paths and the URL-share encoding all behave identically.
@@ -55,7 +55,14 @@ export function sanitizeClassMasteryPicks(ids: number[] | undefined, esoClass: E
  * Best-guess base class implied by the Class Mastery passive ids present in a
  * flat id list — the class owning the most CM ids. Non-CM ids are ignored.
  * Used to recover the class on import when active-skill detection is
- * inconclusive (CM ids are unique per class, so they are a reliable signal).
+ * inconclusive (a real character's CM ids are all its single base class, so
+ * they are a reliable signal).
+ *
+ * Returns undefined when the top owner is TIED across classes — a real
+ * character can only ever have its own base class's CM ids, so a tie means
+ * stale/foreign (corrupt) data. Deferring to active-skill detection there
+ * avoids a stale id silently overriding the real base class and stripping the
+ * legitimate picks as "foreign".
  */
 export function classFromMasteryIds(ids: number[]): ESOClass | undefined {
   const counts = new Map<ESOClass, number>();
@@ -65,13 +72,17 @@ export function classFromMasteryIds(ids: number[]): ESOClass | undefined {
   }
   let best: ESOClass | undefined;
   let bestCount = 0;
+  let tied = false;
   for (const [cls, count] of counts) {
     if (count > bestCount) {
       bestCount = count;
       best = cls;
+      tied = false;
+    } else if (count === bestCount) {
+      tied = true;
     }
   }
-  return best;
+  return tied ? undefined : best;
 }
 
 /** Remove every Class Mastery passive id from a flat passive-id list. */

--- a/src/features/build-editor/utils/classMasteryTransfer.ts
+++ b/src/features/build-editor/utils/classMasteryTransfer.ts
@@ -20,7 +20,7 @@ import {
   getClassMasteryLine,
 } from '@/data/skill-lines/class/classMastery';
 
-import type { ESOClass } from '../types/build.types';
+import type { Build, ESOClass } from '../types/build.types';
 
 import { CLASS_MASTERY_MAX_PICKS } from './classMasteryEligibility';
 
@@ -110,4 +110,31 @@ export function partitionClassMasteryPicks(
     }
   }
   return { passives, classMasteryPassives: sanitizeClassMasteryPicks(masteryIds, esoClass) };
+}
+
+/**
+ * Reclaim Class Mastery picks that older builds (saved/shared before the
+ * build-level split, or imported by pre-split code) left inside `setup.passives`.
+ * Runs when a build enters the editor: if the build-level field is empty it
+ * lifts the leaked picks into it (making them visible in the Class Mastery
+ * section), and it always strips Class Mastery ids out of every setup's regular
+ * passives. After this, the editor is WYSIWYG — what the CM section shows is what
+ * exports — so the export path no longer needs to recover hidden ids. Mutates in
+ * place (safe for both an Immer draft and a freshly-decoded plain build).
+ */
+export function migrateLeakedClassMasteryPicks(
+  build: Pick<Build, 'esoClass' | 'classMasteryPassives' | 'setups'>,
+): void {
+  const hasExisting =
+    Array.isArray(build.classMasteryPassives) && build.classMasteryPassives.length > 0;
+  if (!hasExisting) {
+    const leaked = build.setups.flatMap((setup) => setup.passives ?? []);
+    const recovered = sanitizeClassMasteryPicks(leaked, build.esoClass);
+    if (recovered.length > 0) build.classMasteryPassives = recovered;
+  }
+  for (const setup of build.setups) {
+    if (Array.isArray(setup.passives)) {
+      setup.passives = stripClassMasteryIds(setup.passives);
+    }
+  }
 }

--- a/src/features/build-editor/utils/classMasteryTransfer.ts
+++ b/src/features/build-editor/utils/classMasteryTransfer.ts
@@ -74,6 +74,11 @@ export function classFromMasteryIds(ids: number[]): ESOClass | undefined {
   return best;
 }
 
+/** Remove every Class Mastery passive id from a flat passive-id list. */
+export function stripClassMasteryIds(ids: number[]): number[] {
+  return ids.filter((id) => !CLASS_MASTERY_SKILL_IDS.has(id));
+}
+
 /**
  * Split a flat passive-id list (e.g. CSPS `werte.pass`) into regular passives
  * and Class Mastery picks. Class Mastery ids are removed from `passives`

--- a/src/features/build-editor/utils/classMasteryTransfer.ts
+++ b/src/features/build-editor/utils/classMasteryTransfer.ts
@@ -1,0 +1,97 @@
+/**
+ * Class Mastery transfer helpers (U50).
+ *
+ * Class Mastery picks live on the TOP-LEVEL `build.classMasteryPassives` field,
+ * separate from per-setup `setup.passives`. The real Caro's Skill Point Saver
+ * addon (v6.1.6+) stores Class Mastery passives inside `werte.pass` as plain
+ * `abilityId:1` pairs — mixed in with every other passive, with no dedicated
+ * field. So any flat passive-id list crossing the CSPS boundary (SavedVariables
+ * `werte.pass`, ESO-Hub export codes, native codes) must be split back out into
+ * regular passives vs Class Mastery picks on the way in, and the picks must be
+ * folded back into the passive list on the way out.
+ *
+ * These helpers are the single source of truth for that split + validation, so
+ * the CSPS import/export paths and the URL-share encoding all behave identically.
+ */
+
+import {
+  CLASS_MASTERY_LINES,
+  CLASS_MASTERY_SKILL_IDS,
+  getClassMasteryLine,
+} from '@/data/skill-lines/class/classMastery';
+
+import type { ESOClass } from '../types/build.types';
+
+import { CLASS_MASTERY_MAX_PICKS } from './classMasteryEligibility';
+
+/**
+ * The ESOClass that owns a given Class Mastery passive ability id, or undefined
+ * if the id is not a Class Mastery passive. Each of the 35 ids belongs to
+ * exactly one class, so the id alone identifies its class.
+ */
+export function classOfClassMasteryId(id: number): ESOClass | undefined {
+  for (const line of CLASS_MASTERY_LINES) {
+    if (line.skills.some((skill) => skill.id === id)) {
+      // SkillLineData.class ("Dragonknight") lowercases to the ESOClass key.
+      return line.class.toLowerCase() as ESOClass;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Keep only the class's own Class Mastery passive ids, deduped and capped at the
+ * 2-pick max. Mirrors the rule the picker enforces so a corrupt/foreign payload
+ * can't soft-lock the Class Mastery section. Shared by the CSPS importers and
+ * the URL-share decoder.
+ */
+export function sanitizeClassMasteryPicks(ids: number[] | undefined, esoClass: ESOClass): number[] {
+  if (!Array.isArray(ids) || ids.length === 0) return [];
+  const valid = new Set(getClassMasteryLine(esoClass)?.skills.map((skill) => skill.id) ?? []);
+  return [...new Set(ids)].filter((id) => valid.has(id)).slice(0, CLASS_MASTERY_MAX_PICKS);
+}
+
+/**
+ * Best-guess base class implied by the Class Mastery passive ids present in a
+ * flat id list — the class owning the most CM ids. Non-CM ids are ignored.
+ * Used to recover the class on import when active-skill detection is
+ * inconclusive (CM ids are unique per class, so they are a reliable signal).
+ */
+export function classFromMasteryIds(ids: number[]): ESOClass | undefined {
+  const counts = new Map<ESOClass, number>();
+  for (const id of ids) {
+    const owner = classOfClassMasteryId(id);
+    if (owner) counts.set(owner, (counts.get(owner) ?? 0) + 1);
+  }
+  let best: ESOClass | undefined;
+  let bestCount = 0;
+  for (const [cls, count] of counts) {
+    if (count > bestCount) {
+      bestCount = count;
+      best = cls;
+    }
+  }
+  return best;
+}
+
+/**
+ * Split a flat passive-id list (e.g. CSPS `werte.pass`) into regular passives
+ * and Class Mastery picks. Class Mastery ids are removed from `passives`
+ * regardless of class so they never leak into the regular Passives section, and
+ * the returned picks are validated to `esoClass` (capped at the 2-pick max).
+ */
+export function partitionClassMasteryPicks(
+  passiveIds: number[],
+  esoClass: ESOClass,
+): { passives: number[]; classMasteryPassives: number[] } {
+  const passives: number[] = [];
+  const masteryIds: number[] = [];
+  for (const id of passiveIds) {
+    if (CLASS_MASTERY_SKILL_IDS.has(id)) {
+      masteryIds.push(id);
+    } else {
+      passives.push(id);
+    }
+  }
+  return { passives, classMasteryPassives: sanitizeClassMasteryPicks(masteryIds, esoClass) };
+}

--- a/src/features/build-editor/utils/cspsExport.ts
+++ b/src/features/build-editor/utils/cspsExport.ts
@@ -285,9 +285,20 @@ export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
   // Class Mastery is a character-wide selection (not per-setup) and is invalid
   // while subclassed, so resolve the eligible picks once and write the same set
   // into every setup/profile's werte.pass.
-  const classMasteryPassives = isClassMasteryEligible(build.esoClass, build.classSkillLines)
-    ? sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass)
-    : [];
+  let classMasteryPassives: number[] = [];
+  if (isClassMasteryEligible(build.esoClass, build.classSkillLines)) {
+    classMasteryPassives = sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass);
+    // Legacy / URL-decoded builds may carry Class Mastery picks only inside
+    // setup.passives (the pre-split leak). When there are no explicit picks,
+    // recover them so export/round-trip doesn't silently drop them before
+    // buildWerte strips leaked ids below. Explicit picks win over stale extras.
+    if (classMasteryPassives.length === 0) {
+      classMasteryPassives = sanitizeClassMasteryPicks(
+        build.setups.flatMap((setup) => setup.passives),
+        build.esoClass,
+      );
+    }
+  }
 
   // First setup → main character data
   const mainSetup = build.setups[0];

--- a/src/features/build-editor/utils/cspsExport.ts
+++ b/src/features/build-editor/utils/cspsExport.ts
@@ -40,6 +40,7 @@ import type {
 
 import { isClassMasteryEligible } from './classMasteryEligibility';
 import { sanitizeClassMasteryPicks, stripClassMasteryIds } from './classMasteryTransfer';
+import { serializeSubclassLines } from './cspsExportCodeParser';
 
 // ── Reverse mappings (Build Editor → CSPS) ───────────────────────────
 
@@ -160,6 +161,7 @@ function buildWerte(
   passives: number[],
   skilledAbilities?: BuildSetup['skilledAbilities'],
   classMasteryPassives: number[] = [],
+  scribeStyleSubclass = '',
 ): CSPSSkillData | undefined {
   const werte: CSPSSkillData = {};
   let hasData = false;
@@ -188,6 +190,13 @@ function buildWerte(
     }
   }
 
+  // Subclass lines → werte.scribeStyleSubclass (crafted*styles*subclasses) so a
+  // subclassed build round-trips its lines and Class Mastery stays gated.
+  if (scribeStyleSubclass) {
+    werte.scribeStyleSubclass = scribeStyleSubclass;
+    hasData = true;
+  }
+
   return hasData ? werte : undefined;
 }
 
@@ -208,6 +217,7 @@ function setupToCSPSCharacterData(
   name: string,
   role: CombatRole,
   classMasteryPassives: number[] = [],
+  scribeStyleSubclass = '',
 ): CSPSCharacterData {
   // Skills → hotbar (with scribed ability tracking)
   const hotbar = convertSkillsToHotbar(setup.skills);
@@ -253,8 +263,13 @@ function setupToCSPSCharacterData(
     outfitComp: '',
   };
 
-  // Passives + skilled abilities + Class Mastery picks → werte
-  const werte = buildWerte(setup.passives, setup.skilledAbilities, classMasteryPassives);
+  // Passives + skilled abilities + Class Mastery picks + subclass lines → werte
+  const werte = buildWerte(
+    setup.passives,
+    setup.skilledAbilities,
+    classMasteryPassives,
+    scribeStyleSubclass,
+  );
 
   const charData: CSPSCharacterData = {
     comp1: compressComp1(comp1),
@@ -284,26 +299,27 @@ export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
 
   // Class Mastery is a character-wide selection (not per-setup) and is invalid
   // while subclassed, so resolve the eligible picks once and write the same set
-  // into every setup/profile's werte.pass.
-  let classMasteryPassives: number[] = [];
-  if (isClassMasteryEligible(build.esoClass, build.classSkillLines)) {
-    classMasteryPassives = sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass);
-    // Legacy / URL-decoded builds may carry Class Mastery picks only inside
-    // setup.passives (the pre-split leak). When there are no explicit picks,
-    // recover them so export/round-trip doesn't silently drop them before
-    // buildWerte strips leaked ids below. Explicit picks win over stale extras.
-    if (classMasteryPassives.length === 0) {
-      classMasteryPassives = sanitizeClassMasteryPicks(
-        build.setups.flatMap((setup) => setup.passives),
-        build.esoClass,
-      );
-    }
-  }
+  // into every setup/profile's werte.pass. The editor is WYSIWYG (leaked picks
+  // are reclaimed into classMasteryPassives on load), so export reads only the
+  // build-level field — no recovery from setup.passives here.
+  const classMasteryPassives = isClassMasteryEligible(build.esoClass, build.classSkillLines)
+    ? sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass)
+    : [];
+
+  // Subclass lines → werte.scribeStyleSubclass for every setup (character-wide).
+  const subclassIds = serializeSubclassLines(build.classSkillLines);
+  const scribeStyleSubclass = subclassIds ? `-*-*${subclassIds}` : '';
 
   // First setup → main character data
   const mainSetup = build.setups[0];
   const charData: CSPSCharacterData = mainSetup
-    ? setupToCSPSCharacterData(mainSetup, characterName, build.role, classMasteryPassives)
+    ? setupToCSPSCharacterData(
+        mainSetup,
+        characterName,
+        build.role,
+        classMasteryPassives,
+        scribeStyleSubclass,
+      )
     : { comp1: '', comp2: '', $lastCharacterName: characterName };
 
   // Additional setups → profiles
@@ -316,6 +332,7 @@ export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
         setup.name,
         build.role,
         classMasteryPassives,
+        scribeStyleSubclass,
       );
       charData.profiles[i] = {
         ...profileData,

--- a/src/features/build-editor/utils/cspsExport.ts
+++ b/src/features/build-editor/utils/cspsExport.ts
@@ -39,7 +39,11 @@ import type {
 } from '../types/build.types';
 
 import { isClassMasteryEligible } from './classMasteryEligibility';
-import { sanitizeClassMasteryPicks, stripClassMasteryIds } from './classMasteryTransfer';
+import {
+  migrateLeakedClassMasteryPicks,
+  sanitizeClassMasteryPicks,
+  stripClassMasteryIds,
+} from './classMasteryTransfer';
 import { serializeSubclassLines } from './cspsExportCodeParser';
 
 // ── Reverse mappings (Build Editor → CSPS) ───────────────────────────
@@ -292,16 +296,29 @@ function setupToCSPSCharacterData(
  * The first setup becomes the active character build.
  * Additional setups become CSPS profiles.
  */
-export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
+export function convertBuildToCSPS(inputBuild: Build): CSPSSavedVariables {
+  // Normalize on a local copy so the export is correct for EVERY caller, not
+  // only builds that already went through the editor's load-time migration
+  // (e.g. BuildViewPage exports a build decoded straight from a URL share). This
+  // reclaims leaked Class Mastery ids into the build-level field and strips them
+  // from setup.passives using the SAME idempotent helper the editor runs on
+  // load, so both surfaces always agree. The caller's object is never mutated.
+  const build: Build = {
+    ...inputBuild,
+    classMasteryPassives: inputBuild.classMasteryPassives
+      ? [...inputBuild.classMasteryPassives]
+      : [],
+    setups: inputBuild.setups.map((setup) => ({ ...setup, passives: [...(setup.passives ?? [])] })),
+  };
+  migrateLeakedClassMasteryPicks(build);
+
   const characterName = build.name || 'Exported Build';
   const accountName = '@ESOToolkit';
   const characterId = '1';
 
   // Class Mastery is a character-wide selection (not per-setup) and is invalid
   // while subclassed, so resolve the eligible picks once and write the same set
-  // into every setup/profile's werte.pass. The editor is WYSIWYG (leaked picks
-  // are reclaimed into classMasteryPassives on load), so export reads only the
-  // build-level field — no recovery from setup.passives here.
+  // into every setup/profile's werte.pass.
   const classMasteryPassives = isClassMasteryEligible(build.esoClass, build.classSkillLines)
     ? sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass)
     : [];

--- a/src/features/build-editor/utils/cspsExport.ts
+++ b/src/features/build-editor/utils/cspsExport.ts
@@ -39,7 +39,7 @@ import type {
 } from '../types/build.types';
 
 import { isClassMasteryEligible } from './classMasteryEligibility';
-import { sanitizeClassMasteryPicks } from './classMasteryTransfer';
+import { sanitizeClassMasteryPicks, stripClassMasteryIds } from './classMasteryTransfer';
 
 // ── Reverse mappings (Build Editor → CSPS) ───────────────────────────
 
@@ -164,8 +164,13 @@ function buildWerte(
   const werte: CSPSSkillData = {};
   let hasData = false;
 
-  // Passives (+ Class Mastery picks) → werte.pass
-  const passIds = [...new Set([...passives.filter((id) => id > 0), ...classMasteryPassives])];
+  // Passives (+ Class Mastery picks) → werte.pass. Strip any Class Mastery ids
+  // that leaked into setup.passives (legacy/corrupt builds) so the ONLY CM ids
+  // written are the sanitized, eligibility-gated `classMasteryPassives` — never
+  // a stale id that would exceed the 2-pick cap or win on round-trip import.
+  const passIds = [
+    ...new Set([...stripClassMasteryIds(passives.filter((id) => id > 0)), ...classMasteryPassives]),
+  ];
   const passEntries: CSPSSkillEntry[] = passIds.map((abilityId) => ({ abilityId, value: 1 }));
   if (passEntries.length > 0) {
     werte.pass = compressSkillEntries(passEntries);

--- a/src/features/build-editor/utils/cspsExport.ts
+++ b/src/features/build-editor/utils/cspsExport.ts
@@ -38,6 +38,9 @@ import type {
   QuickslotEntry,
 } from '../types/build.types';
 
+import { isClassMasteryEligible } from './classMasteryEligibility';
+import { sanitizeClassMasteryPicks } from './classMasteryTransfer';
+
 // ── Reverse mappings (Build Editor → CSPS) ───────────────────────────
 
 /** Build editor mundus string IDs → CSPS mundus ability IDs */
@@ -147,18 +150,23 @@ function convertGearConfigToCSPS(gear: Record<number, GearPiece>): Record<number
 /**
  * Build werte object from passives + skilled abilities.
  * Combines werte.pass (passive skills) and werte.prog (active skills with morphs).
+ *
+ * Class Mastery picks (build-level) are merged into werte.pass as plain
+ * `abilityId:1` pairs, matching how the real CSPS addon stores them — there is
+ * no dedicated Class Mastery field, so the addon re-applies them via the Class
+ * Mastery Points pool on restore. Deduped against the regular passives.
  */
 function buildWerte(
   passives: number[],
   skilledAbilities?: BuildSetup['skilledAbilities'],
+  classMasteryPassives: number[] = [],
 ): CSPSSkillData | undefined {
   const werte: CSPSSkillData = {};
   let hasData = false;
 
-  // Passives → werte.pass
-  const passEntries: CSPSSkillEntry[] = passives
-    .filter((id) => id > 0)
-    .map((abilityId) => ({ abilityId, value: 1 }));
+  // Passives (+ Class Mastery picks) → werte.pass
+  const passIds = [...new Set([...passives.filter((id) => id > 0), ...classMasteryPassives])];
+  const passEntries: CSPSSkillEntry[] = passIds.map((abilityId) => ({ abilityId, value: 1 }));
   if (passEntries.length > 0) {
     werte.pass = compressSkillEntries(passEntries);
     hasData = true;
@@ -194,6 +202,7 @@ function setupToCSPSCharacterData(
   setup: BuildSetup,
   name: string,
   role: CombatRole,
+  classMasteryPassives: number[] = [],
 ): CSPSCharacterData {
   // Skills → hotbar (with scribed ability tracking)
   const hotbar = convertSkillsToHotbar(setup.skills);
@@ -239,8 +248,8 @@ function setupToCSPSCharacterData(
     outfitComp: '',
   };
 
-  // Passives + skilled abilities → werte
-  const werte = buildWerte(setup.passives, setup.skilledAbilities);
+  // Passives + skilled abilities + Class Mastery picks → werte
+  const werte = buildWerte(setup.passives, setup.skilledAbilities, classMasteryPassives);
 
   const charData: CSPSCharacterData = {
     comp1: compressComp1(comp1),
@@ -268,10 +277,17 @@ export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
   const accountName = '@ESOToolkit';
   const characterId = '1';
 
+  // Class Mastery is a character-wide selection (not per-setup) and is invalid
+  // while subclassed, so resolve the eligible picks once and write the same set
+  // into every setup/profile's werte.pass.
+  const classMasteryPassives = isClassMasteryEligible(build.esoClass, build.classSkillLines)
+    ? sanitizeClassMasteryPicks(build.classMasteryPassives, build.esoClass)
+    : [];
+
   // First setup → main character data
   const mainSetup = build.setups[0];
   const charData: CSPSCharacterData = mainSetup
-    ? setupToCSPSCharacterData(mainSetup, characterName, build.role)
+    ? setupToCSPSCharacterData(mainSetup, characterName, build.role, classMasteryPassives)
     : { comp1: '', comp2: '', $lastCharacterName: characterName };
 
   // Additional setups → profiles
@@ -279,7 +295,12 @@ export function convertBuildToCSPS(build: Build): CSPSSavedVariables {
     charData.profiles = {};
     for (let i = 1; i < build.setups.length; i++) {
       const setup = build.setups[i];
-      const profileData = setupToCSPSCharacterData(setup, setup.name, build.role);
+      const profileData = setupToCSPSCharacterData(
+        setup,
+        setup.name,
+        build.role,
+        classMasteryPassives,
+      );
       charData.profiles[i] = {
         ...profileData,
         name: setup.name,

--- a/src/features/build-editor/utils/cspsExportCodeParser.ts
+++ b/src/features/build-editor/utils/cspsExportCodeParser.ts
@@ -41,6 +41,8 @@ import type {
   SkilledAbility,
 } from '../types/build.types';
 
+import { classFromMasteryIds, partitionClassMasteryPicks } from './classMasteryTransfer';
+
 const logger = new Logger({ contextPrefix: 'CSPSExportCode' });
 
 // ── ESO ID → Build Editor mappings ──────────────────────────────────
@@ -564,8 +566,13 @@ export function parseCSPSExportCode(input: string): CSPSExportCodeResult {
   const skills = hotbarsToSkillsConfig(frontParsed.bar, backParsed.bar);
   const scribedAbilityIds = [...frontParsed.scribedIds, ...backParsed.scribedIds];
 
-  // Section 10: Passives (comma-separated ability IDs)
-  const passives = parseCommaInts(sections[9] || '');
+  // Section 10: Passives (comma-separated ability IDs). The real CSPS addon
+  // lists Class Mastery passives here too, so split them back out into the
+  // build-level Class Mastery field instead of the regular passives bucket.
+  const { passives, classMasteryPassives } = partitionClassMasteryPicks(
+    parseCommaInts(sections[9] || ''),
+    esoClass,
+  );
 
   // Section 11 & 12: Champion Points
   const cp = parseSlottedCP(sections[10] || '');
@@ -600,6 +607,7 @@ export function parseCSPSExportCode(input: string): CSPSExportCodeResult {
     shortDescription: 'Imported from CSPS export code',
     esoClass,
     classSkillLines,
+    classMasteryPassives,
     role,
     gameMode: 'pve',
     races: race ? [race] : [],
@@ -944,11 +952,17 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
   const roleIndex = sections[8] && sections[8] !== '-' ? parseIntSafe(sections[8]) : 0;
   const role = roleIndexToRole(roleIndex);
 
-  // Detect class from hotbar ability IDs (no explicit class field in native format)
+  // Detect class from hotbar ability IDs (no explicit class field in native
+  // format); fall back to the class implied by any Class Mastery passives.
   const allBarIds = [...hotbar.frontBar, ...hotbar.backBar].filter((n) => n > 0);
   const detectedClass = detectClassFromAbilityIds(allBarIds);
-  const esoClass: ESOClass = detectedClass ?? 'any-class';
+  const esoClass: ESOClass = detectedClass ?? classFromMasteryIds(skillPassives) ?? 'any-class';
   const classSkillLines = getDefaultLinesForClass(esoClass);
+  // Split Class Mastery passives out of the native pass list (see ESO-Hub path).
+  const { passives: regularPassives, classMasteryPassives } = partitionClassMasteryPicks(
+    skillPassives,
+    esoClass,
+  );
   const now = new Date().toISOString();
 
   const setup: BuildSetup = {
@@ -961,7 +975,7 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
     skills,
     cp,
     consumables: { potions: [], food: {} },
-    passives: skillPassives,
+    passives: regularPassives,
     screenshots: [],
     ...(allScribedIds.length > 0 ? { scribedAbilityIds: allScribedIds } : {}),
     ...(nativeSkilledAbilities.length > 0 ? { skilledAbilities: nativeSkilledAbilities } : {}),
@@ -974,6 +988,7 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
     shortDescription: 'Imported from CSPS native export code',
     esoClass,
     classSkillLines,
+    classMasteryPassives,
     role,
     gameMode: 'pve',
     races: [],

--- a/src/features/build-editor/utils/cspsExportCodeParser.ts
+++ b/src/features/build-editor/utils/cspsExportCodeParser.ts
@@ -729,13 +729,16 @@ function parseNativeSkills(s: string): {
   passives: number[];
   scribedIds: number[];
   skilledAbilities: SkilledAbility[];
+  subclasses: string;
 } {
-  if (!s || s === '-') return { passives: [], scribedIds: [], skilledAbilities: [] };
+  if (!s || s === '-')
+    return { passives: [], scribedIds: [], skilledAbilities: [], subclasses: '' };
 
   const parts = s.split('*');
   // parts[0] = prog (active skills with morph choices)
   // parts[1] = pass (passive skills)
   // parts[2] = crafted scribing
+  // parts[4] = subclasses (comma-separated skill-line ids)
   const passives: number[] = [];
   const scribedIds: number[] = [];
 
@@ -764,7 +767,7 @@ function parseNativeSkills(s: string): {
     }
   }
 
-  return { passives, scribedIds, skilledAbilities };
+  return { passives, scribedIds, skilledAbilities, subclasses: parts[4] ?? '' };
 }
 
 /**
@@ -892,6 +895,7 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
     passives: skillPassives,
     scribedIds: skillScribedIds,
     skilledAbilities: nativeSkilledAbilities,
+    subclasses: nativeSubclasses,
   } = parseNativeSkills(sections[0]);
 
   // Section 2: Hotbars (bar1;bar2;bar3 — slots comma-separated, scribed prefixed "c")
@@ -957,7 +961,10 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
   const allBarIds = [...hotbar.frontBar, ...hotbar.backBar].filter((n) => n > 0);
   const detectedClass = detectClassFromAbilityIds(allBarIds);
   const esoClass: ESOClass = detectedClass ?? classFromMasteryIds(skillPassives) ?? 'any-class';
-  const classSkillLines = getDefaultLinesForClass(esoClass);
+  // Honor the native subclasses part so a subclassed export decodes as
+  // subclassed — otherwise retained Class Mastery picks would be (wrongly)
+  // treated as active by the eligibility-gated stats/export.
+  const classSkillLines = parseSubclassLines(nativeSubclasses, esoClass);
   // Split Class Mastery passives out of the native pass list (see ESO-Hub path).
   const { passives: regularPassives, classMasteryPassives } = partitionClassMasteryPicks(
     skillPassives,

--- a/src/features/build-editor/utils/cspsExportCodeParser.ts
+++ b/src/features/build-editor/utils/cspsExportCodeParser.ts
@@ -956,11 +956,12 @@ export function parseCSPSNativeCode(input: string): CSPSExportCodeResult {
   const roleIndex = sections[8] && sections[8] !== '-' ? parseIntSafe(sections[8]) : 0;
   const role = roleIndexToRole(roleIndex);
 
-  // Detect class from hotbar ability IDs (no explicit class field in native
-  // format); fall back to the class implied by any Class Mastery passives.
+  // Class Mastery ids uniquely identify the BASE class, so prefer them — a
+  // subclassed character's hotbar carries off-class lines that would otherwise
+  // mislead detection. Fall back to hotbar detection, then 'any-class'.
   const allBarIds = [...hotbar.frontBar, ...hotbar.backBar].filter((n) => n > 0);
   const detectedClass = detectClassFromAbilityIds(allBarIds);
-  const esoClass: ESOClass = detectedClass ?? classFromMasteryIds(skillPassives) ?? 'any-class';
+  const esoClass: ESOClass = classFromMasteryIds(skillPassives) ?? detectedClass ?? 'any-class';
   // Honor the native subclasses part so a subclassed export decodes as
   // subclassed — otherwise retained Class Mastery picks would be (wrongly)
   // treated as active by the eligibility-gated stats/export.

--- a/src/features/build-editor/utils/cspsExportCodeParser.ts
+++ b/src/features/build-editor/utils/cspsExportCodeParser.ts
@@ -188,10 +188,12 @@ const ESO_SKILL_LINE_MAP: Record<number, ClassSkillLineId> = {
 };
 
 /**
- * Parse subclass skill line IDs from section 7 and map to ClassSkillLineId.
- * Returns [line1, line2, line3] or nulls if IDs are unknown.
+ * Parse subclass skill line IDs from a comma-separated id string and map to
+ * ClassSkillLineId. Returns [line1, line2, line3], or the class defaults when
+ * the string is empty/unknown. Shared with the SavedVariables import, which
+ * sources the ids from `werte.scribeStyleSubclass`.
  */
-function parseSubclassLines(
+export function parseSubclassLines(
   subclassStr: string,
   fallbackClass: ESOClass,
 ): [ClassSkillLineId | null, ClassSkillLineId | null, ClassSkillLineId | null] {

--- a/src/features/build-editor/utils/cspsExportCodeParser.ts
+++ b/src/features/build-editor/utils/cspsExportCodeParser.ts
@@ -212,6 +212,23 @@ export function parseSubclassLines(
   return [mapped[0], mapped[1], mapped[2]];
 }
 
+/** Reverse of ESO_SKILL_LINE_MAP — build editor line id → ESO skill-line id. */
+const CLASS_SKILL_LINE_TO_ESO_ID: Record<string, number> = Object.fromEntries(
+  Object.entries(ESO_SKILL_LINE_MAP).map(([esoId, lineId]) => [lineId, Number(esoId)]),
+);
+
+/**
+ * Serialize a build's classSkillLines into the comma-separated ESO skill-line id
+ * string CSPS stores in the `subclasses` slot of werte.scribeStyleSubclass.
+ * Inverse of parseSubclassLines; empty slots are skipped.
+ */
+export function serializeSubclassLines(classSkillLines: Build['classSkillLines']): string {
+  return classSkillLines
+    .map((lineId) => (lineId != null ? CLASS_SKILL_LINE_TO_ESO_ID[lineId] : undefined))
+    .filter((esoId): esoId is number => typeof esoId === 'number' && esoId > 0)
+    .join(',');
+}
+
 /** CSPS role index → build editor CombatRole */
 function roleIndexToRole(index: number): CombatRole {
   switch (index) {

--- a/src/features/build-editor/utils/cspsImport.ts
+++ b/src/features/build-editor/utils/cspsImport.ts
@@ -46,6 +46,7 @@ import type {
   SkilledAbility,
 } from '../types/build.types';
 
+import { classFromMasteryIds, partitionClassMasteryPicks } from './classMasteryTransfer';
 import {
   isCSPSExportCode,
   isCSPSNativeCode,
@@ -592,8 +593,24 @@ export function convertCSPSCharacterToBuild(character: CSPSCharacterOption): Bui
 
   const now = new Date().toISOString();
 
-  // Detect class from werte skill data (falls back to 'dragonknight')
-  const detectedClass = detectClassFromWerte(character.data.werte) ?? 'dragonknight';
+  // Detect class from werte skill data. If the active skills are inconclusive,
+  // fall back to the class implied by any Class Mastery passives present (those
+  // ids are unique per class) before defaulting to 'dragonknight'.
+  const allPassiveIds = setups.flatMap((s) => s.passives);
+  const detectedClass =
+    detectClassFromWerte(character.data.werte) ??
+    classFromMasteryIds(allPassiveIds) ??
+    'dragonknight';
+
+  // Class Mastery passives ride in werte.pass alongside regular passives, so
+  // split them back out of every setup (they must not pollute the regular
+  // Passives section) and lift the build-level picks from the main setup.
+  let classMasteryPassives: number[] = [];
+  setups.forEach((setup, i) => {
+    const partitioned = partitionClassMasteryPicks(setup.passives, detectedClass);
+    setup.passives = partitioned.passives;
+    if (i === 0) classMasteryPassives = partitioned.classMasteryPassives;
+  });
 
   // Detect role from comp1 (falls back to 'magicka-dps')
   const comp1 = decompressComp1(character.data.comp1);
@@ -608,6 +625,7 @@ export function convertCSPSCharacterToBuild(character: CSPSCharacterOption): Bui
     shortDescription: `Imported from CSPS — ${character.accountName}`,
     esoClass: detectedClass,
     classSkillLines,
+    classMasteryPassives,
     role,
     gameMode: 'pve',
     races: [],

--- a/src/features/build-editor/utils/cspsImport.ts
+++ b/src/features/build-editor/utils/cspsImport.ts
@@ -34,7 +34,7 @@ import {
   type CSPSSkillData,
 } from '../../loadout-manager/utils/cspsConverter';
 import { parseLuaSavedVariables } from '../../loadout-manager/utils/luaParser';
-import { getDefaultLinesForClass, EQUIP_SLOTS } from '../data/esoStaticData';
+import { EQUIP_SLOTS } from '../data/esoStaticData';
 import { esoTypeToArmorWeight } from '../data/setArmorWeights';
 import type {
   Build,
@@ -52,6 +52,7 @@ import {
   isCSPSNativeCode,
   parseCSPSExportCode,
   parseCSPSNativeCode,
+  parseSubclassLines,
 } from './cspsExportCodeParser';
 
 const logger = new Logger({ contextPrefix: 'CSPSImport' });
@@ -622,8 +623,13 @@ export function convertCSPSCharacterToBuild(character: CSPSCharacterOption): Bui
   const comp1 = decompressComp1(character.data.comp1);
   const role: CombatRole = comp1?.role ? cspsRoleToCombatRole(comp1.role) : 'magicka-dps';
 
-  // Default class skill lines for the detected class
-  const classSkillLines = getDefaultLinesForClass(detectedClass);
+  // Honor any subclass lines CSPS records in werte.scribeStyleSubclass
+  // (crafted*styles*subclasses) so a subclassed import decodes as subclassed —
+  // otherwise the retained Class Mastery picks lifted above would be wrongly
+  // treated as active by the eligibility-gated stats/export. Empty → class
+  // defaults (non-subclassed), unchanged from before.
+  const subclassStr = (character.data.werte?.scribeStyleSubclass ?? '').split('*')[2] ?? '';
+  const classSkillLines = parseSubclassLines(subclassStr, detectedClass);
 
   return {
     id: uuidv4(),

--- a/src/features/build-editor/utils/cspsImport.ts
+++ b/src/features/build-editor/utils/cspsImport.ts
@@ -604,12 +604,16 @@ export function convertCSPSCharacterToBuild(character: CSPSCharacterOption): Bui
 
   // Class Mastery passives ride in werte.pass alongside regular passives, so
   // split them back out of every setup (they must not pollute the regular
-  // Passives section) and lift the build-level picks from the main setup.
+  // Passives section). CM is character-wide, so lift a single build-level pick
+  // set: prefer the main setup, but fall back to the first profile that has any
+  // rather than discarding a profile-only selection.
   let classMasteryPassives: number[] = [];
-  setups.forEach((setup, i) => {
+  setups.forEach((setup) => {
     const partitioned = partitionClassMasteryPicks(setup.passives, detectedClass);
     setup.passives = partitioned.passives;
-    if (i === 0) classMasteryPassives = partitioned.classMasteryPassives;
+    if (classMasteryPassives.length === 0 && partitioned.classMasteryPassives.length > 0) {
+      classMasteryPassives = partitioned.classMasteryPassives;
+    }
   });
 
   // Detect role from comp1 (falls back to 'magicka-dps')

--- a/src/features/build-editor/utils/cspsImport.ts
+++ b/src/features/build-editor/utils/cspsImport.ts
@@ -593,13 +593,15 @@ export function convertCSPSCharacterToBuild(character: CSPSCharacterOption): Bui
 
   const now = new Date().toISOString();
 
-  // Detect class from werte skill data. If the active skills are inconclusive,
-  // fall back to the class implied by any Class Mastery passives present (those
-  // ids are unique per class) before defaulting to 'dragonknight'.
+  // Class Mastery ids uniquely identify the BASE class, so prefer them — a
+  // subclassed character's active skills can be off-class lines that would
+  // otherwise mislead detection (and cause the partition to drop the retained
+  // base-class picks as "foreign"). Fall back to active-skill detection, then
+  // 'dragonknight'.
   const allPassiveIds = setups.flatMap((s) => s.passives);
   const detectedClass =
-    detectClassFromWerte(character.data.werte) ??
     classFromMasteryIds(allPassiveIds) ??
+    detectClassFromWerte(character.data.werte) ??
     'dragonknight';
 
   // Class Mastery passives ride in werte.pass alongside regular passives, so

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -430,6 +430,25 @@ describe('cspsExport', () => {
       expect(reimported.setups[0].passives).toEqual([]);
     });
 
+    it('round-trips an empty (non-subclassed) classSkillLines build with CM intact', () => {
+      // [null,null,null] normalizes to the class defaults on reimport (the CSPS
+      // subclass list is compact, matching the real addon) — both are
+      // non-subclassed, so Class Mastery eligibility and picks are preserved.
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [238232, 240268],
+        setups: [makeSetup({ passives: [] })],
+      });
+      const lua = exportBuildToCSPSLua(build);
+      const reimported = convertCSPSCharacterToBuild(parseCSPSInput(lua).characters[0]);
+      // still non-subclassed → CM eligible and preserved
+      expect(reimported.classMasteryPassives).toEqual([238232, 240268]);
+      expect(
+        reimported.classSkillLines.every((line) => line == null || line.startsWith('class.')),
+      ).toBe(true);
+    });
+
     it('round-trips subclass lines through export → import while keeping CM gated', () => {
       const build = makeBuild({
         esoClass: 'dragonknight',

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -384,6 +384,25 @@ describe('cspsExport', () => {
       expect(charData.profiles![1].werte!.pass!.part1).toContain('238232:1');
     });
 
+    it('does not export stale Class Mastery ids left in setup.passives', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [238232, 240268],
+        // 259224 is a DK Class Mastery id wrongly left in setup.passives (legacy);
+        // 400 is a real passive. Only the sanitized picks should reach werte.pass.
+        setups: [makeSetup({ passives: [400, 259224] })],
+      });
+      const charData =
+        convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
+      expect(charData.werte!.pass!.part1).toContain('400:1');
+      expect(charData.werte!.pass!.part1).toContain('238232:1');
+      expect(charData.werte!.pass!.part1).toContain('240268:1');
+      // the stale CM id must NOT be exported — it would exceed the 2-pick cap
+      // and could win over the intended pick on round-trip import.
+      expect(charData.werte!.pass!.part1).not.toContain('259224:1');
+    });
+
     it('round-trips Class Mastery picks through export → import', () => {
       const build = makeBuild({
         esoClass: 'warden',

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -384,20 +384,18 @@ describe('cspsExport', () => {
       expect(charData.profiles![1].werte!.pass!.part1).toContain('238232:1');
     });
 
-    it('migrates leaked Class Mastery ids from setup.passives when there are no explicit picks (legacy build)', () => {
+    it('exports no Class Mastery when the build-level field is empty (WYSIWYG; migration happens on load)', () => {
       const build = makeBuild({
         esoClass: 'dragonknight',
         classSkillLines: [null, null, null],
-        classMasteryPassives: [], // legacy build: top-level field never populated
-        // CM ids leaked into setup.passives by the pre-split import; 400 is real
-        setups: [makeSetup({ passives: [400, 238232, 240268] })],
+        classMasteryPassives: [], // empty at the build level
+        // a stray CM id in setup.passives must NOT be resurrected on export
+        setups: [makeSetup({ passives: [400, 238232] })],
       });
       const charData =
         convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
       expect(charData.werte!.pass!.part1).toContain('400:1');
-      // leaked CM picks are recovered and exported rather than silently dropped
-      expect(charData.werte!.pass!.part1).toContain('238232:1');
-      expect(charData.werte!.pass!.part1).toContain('240268:1');
+      expect(charData.werte!.pass!.part1).not.toContain('238232:1');
     });
 
     it('does not export stale Class Mastery ids left in setup.passives', () => {
@@ -430,6 +428,22 @@ describe('cspsExport', () => {
       const reimported = convertCSPSCharacterToBuild(parseCSPSInput(lua).characters[0]);
       expect(reimported.classMasteryPassives).toEqual([263519, 263520]);
       expect(reimported.setups[0].passives).toEqual([]);
+    });
+
+    it('round-trips subclass lines through export → import while keeping CM gated', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: ['class.ardent-flame', 'class.assassination', null], // DK + NB subclass
+        classMasteryPassives: [238232, 240268], // retained, inert while subclassed
+        setups: [makeSetup({ passives: [] })],
+      });
+      const lua = exportBuildToCSPSLua(build);
+      const reimported = convertCSPSCharacterToBuild(parseCSPSInput(lua).characters[0]);
+      // subclass lines survive the round trip
+      expect(reimported.classSkillLines).toContain('class.ardent-flame');
+      expect(reimported.classSkillLines).toContain('class.assassination');
+      // Class Mastery is correctly omitted on a subclassed export — not resurrected
+      expect(reimported.classMasteryPassives).toEqual([]);
     });
   });
 });

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -384,6 +384,22 @@ describe('cspsExport', () => {
       expect(charData.profiles![1].werte!.pass!.part1).toContain('238232:1');
     });
 
+    it('migrates leaked Class Mastery ids from setup.passives when there are no explicit picks (legacy build)', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [], // legacy build: top-level field never populated
+        // CM ids leaked into setup.passives by the pre-split import; 400 is real
+        setups: [makeSetup({ passives: [400, 238232, 240268] })],
+      });
+      const charData =
+        convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
+      expect(charData.werte!.pass!.part1).toContain('400:1');
+      // leaked CM picks are recovered and exported rather than silently dropped
+      expect(charData.werte!.pass!.part1).toContain('238232:1');
+      expect(charData.werte!.pass!.part1).toContain('240268:1');
+    });
+
     it('does not export stale Class Mastery ids left in setup.passives', () => {
       const build = makeBuild({
         esoClass: 'dragonknight',

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -384,18 +384,36 @@ describe('cspsExport', () => {
       expect(charData.profiles![1].werte!.pass!.part1).toContain('238232:1');
     });
 
-    it('exports no Class Mastery when the build-level field is empty (WYSIWYG; migration happens on load)', () => {
+    it('recovers leaked legacy CM ids on direct export (caller bypassed editor migration)', () => {
+      // A legacy/shared build (e.g. BuildViewPage exporting a URL-decoded build)
+      // can have CM ids only in setup.passives with an empty build-level field.
+      // Export self-normalizes, so the picks are recovered, not lost. 400 is a
+      // real passive; 238232/240268 are DK Class Mastery ids.
       const build = makeBuild({
         esoClass: 'dragonknight',
         classSkillLines: [null, null, null],
-        classMasteryPassives: [], // empty at the build level
-        // a stray CM id in setup.passives must NOT be resurrected on export
-        setups: [makeSetup({ passives: [400, 238232] })],
+        classMasteryPassives: [],
+        setups: [makeSetup({ passives: [400, 238232, 240268] })],
       });
       const charData =
         convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
       expect(charData.werte!.pass!.part1).toContain('400:1');
-      expect(charData.werte!.pass!.part1).not.toContain('238232:1');
+      expect(charData.werte!.pass!.part1).toContain('238232:1');
+      expect(charData.werte!.pass!.part1).toContain('240268:1');
+    });
+
+    it('does not mutate the caller-supplied build during export', () => {
+      const setup = makeSetup({ passives: [400, 238232] });
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [],
+        setups: [setup],
+      });
+      convertBuildToCSPS(build);
+      // the original build object is untouched (normalization runs on a copy)
+      expect(build.classMasteryPassives).toEqual([]);
+      expect(build.setups[0].passives).toEqual([400, 238232]);
     });
 
     it('does not export stale Class Mastery ids left in setup.passives', () => {

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -341,4 +341,60 @@ describe('cspsExport', () => {
       expect(hotbar.backBar).toEqual([700, 800, 900, 1000, 1100, 1200]);
     });
   });
+
+  describe('Class Mastery (U50)', () => {
+    it('writes eligible Class Mastery picks into werte.pass as id:1', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [238232, 240268],
+        setups: [makeSetup({ passives: [400] })],
+      });
+      const charData =
+        convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
+      expect(charData.werte!.pass!.part1).toContain('238232:1');
+      expect(charData.werte!.pass!.part1).toContain('240268:1');
+      expect(charData.werte!.pass!.part1).toContain('400:1');
+    });
+
+    it('omits Class Mastery picks when the build is subclassed', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        // an off-class skill line makes the build subclassed → CM disabled in-game
+        classSkillLines: ['class.assassination', null, null],
+        classMasteryPassives: [238232, 240268],
+        setups: [makeSetup({ passives: [400] })],
+      });
+      const charData =
+        convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
+      expect(charData.werte!.pass!.part1).toContain('400:1');
+      expect(charData.werte!.pass!.part1).not.toContain('238232:1');
+    });
+
+    it('writes the same Class Mastery picks into every profile (character-wide)', () => {
+      const build = makeBuild({
+        esoClass: 'dragonknight',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [238232],
+        setups: [makeSetup({ passives: [400] }), makeSetup({ name: 'AoE', passives: [500] })],
+      });
+      const charData =
+        convertBuildToCSPS(build).Default!['@ESOToolkit'].$AccountWide.charData!['1'];
+      expect(charData.werte!.pass!.part1).toContain('238232:1');
+      expect(charData.profiles![1].werte!.pass!.part1).toContain('238232:1');
+    });
+
+    it('round-trips Class Mastery picks through export → import', () => {
+      const build = makeBuild({
+        esoClass: 'warden',
+        classSkillLines: [null, null, null],
+        classMasteryPassives: [263519, 263520],
+        setups: [makeSetup({ passives: [] })],
+      });
+      const lua = exportBuildToCSPSLua(build);
+      const reimported = convertCSPSCharacterToBuild(parseCSPSInput(lua).characters[0]);
+      expect(reimported.classMasteryPassives).toEqual([263519, 263520]);
+      expect(reimported.setups[0].passives).toEqual([]);
+    });
+  });
 });

--- a/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
@@ -366,6 +366,28 @@ describe('cspsImport', () => {
       expect(build.classMasteryPassives).toEqual([263519, 263520]);
     });
 
+    it('preserves profile-only Class Mastery picks when the active build has none', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '20657:1' }, // DK active → detected dragonknight
+          pass: { part1: '400:3' }, // active build: regular passive only, no CM
+        },
+        profiles: {
+          1: {
+            name: 'Profile 1',
+            comp1: '0;0;0#0,0,0,0,0,0;0,0,0,0,0,0####1#0',
+            comp2: 'gear#unique#outfit',
+            werte: { pass: { part1: '238232:1,240268:1' } }, // profile holds the CM picks
+          },
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      // profile-only picks are lifted to the build level rather than discarded
+      expect(build.classMasteryPassives).toEqual([238232, 240268]);
+      expect(build.setups[0].passives).toEqual([400]);
+      expect(build.setups[1].passives).toEqual([]); // CM stripped from the profile too
+    });
+
     it('caps imported Class Mastery picks at 2 and drops foreign-class ids', () => {
       const char = makeCSPSCharacterOption({
         werte: {

--- a/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { isClassMasteryEligible } from '../../../build-editor/utils/classMasteryEligibility';
 import {
   parseCSPSInput,
   convertCSPSCharacterToBuild,
@@ -386,6 +387,20 @@ describe('cspsImport', () => {
       expect(build.classMasteryPassives).toEqual([238232, 240268]);
       expect(build.setups[0].passives).toEqual([400]);
       expect(build.setups[1].passives).toEqual([]); // CM stripped from the profile too
+    });
+
+    it('decodes subclass lines from werte.scribeStyleSubclass so retained CM picks stay gated', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '20657:1' }, // DK active skill
+          pass: { part1: '238232:1' }, // retained DK Class Mastery id
+          scribeStyleSubclass: '-*-*39', // crafted*styles*subclasses; 39 = Nightblade Shadow
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      // an off-class subclass line means the build is subclassed → CM disabled
+      expect(build.classSkillLines).toContain('class.shadow');
+      expect(isClassMasteryEligible(build.esoClass, build.classSkillLines)).toBe(false);
     });
 
     it('treats Class Mastery ids as the base class over off-class active skills', () => {

--- a/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
@@ -388,6 +388,22 @@ describe('cspsImport', () => {
       expect(build.setups[1].passives).toEqual([]); // CM stripped from the profile too
     });
 
+    it('treats Class Mastery ids as the base class over off-class active skills', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          // off-class subclass active skill (Nightblade Assassination range 18342-18519)
+          prog: { part1: '18429:1' },
+          // retained base-class (Warden) Class Mastery picks in pass
+          pass: { part1: '263519:1,263520:1' },
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      // CM owner (Warden) wins over the Nightblade active skill, so the picks
+      // are kept rather than dropped as foreign.
+      expect(build.esoClass).toBe('warden');
+      expect(build.classMasteryPassives).toEqual([263519, 263520]);
+    });
+
     it('caps imported Class Mastery picks at 2 and drops foreign-class ids', () => {
       const char = makeCSPSCharacterOption({
         werte: {

--- a/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
@@ -338,4 +338,45 @@ describe('cspsImport', () => {
       expect(build.setups[0].skills[0]).toEqual({});
     });
   });
+
+  describe('Class Mastery (U50)', () => {
+    it('partitions Class Mastery passives from werte.pass into build.classMasteryPassives', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '20657:1' }, // DK Ardent Flame range → detected as dragonknight
+          pass: { part1: '238232:1,240268:1,400:3' }, // 2 DK Class Mastery + 1 regular passive
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      expect(build.esoClass).toBe('dragonknight');
+      expect(build.classMasteryPassives).toEqual([238232, 240268]);
+      // CM ids must not leak into the regular passives bucket
+      expect(build.setups[0].passives).toEqual([400]);
+    });
+
+    it('recovers the class from Class Mastery ids when active-skill detection is inconclusive', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '100:1' }, // unknown id → no class from active skills
+          pass: { part1: '263519:1,263520:1' }, // Warden Class Mastery ids
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      expect(build.esoClass).toBe('warden');
+      expect(build.classMasteryPassives).toEqual([263519, 263520]);
+    });
+
+    it('caps imported Class Mastery picks at 2 and drops foreign-class ids', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '20657:1' }, // dragonknight
+          pass: { part1: '238232:1,240268:1,259224:1,263519:1' }, // 3 DK CM + 1 Warden CM
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      expect(build.classMasteryPassives).toEqual([238232, 240268]);
+      // every Class Mastery id is stripped from regular passives
+      expect(build.setups[0].passives).toEqual([]);
+    });
+  });
 });

--- a/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsImport.test.ts
@@ -419,6 +419,21 @@ describe('cspsImport', () => {
       expect(build.classMasteryPassives).toEqual([263519, 263520]);
     });
 
+    it('defers to active-skill detection when CM ids are ambiguous, dropping the stale id', () => {
+      const char = makeCSPSCharacterOption({
+        werte: {
+          prog: { part1: '20657:1' }, // clear Dragonknight active skill
+          pass: { part1: '238232:1,263519:1' }, // legit DK CM + stale Warden CM (1-1 tie)
+        },
+      });
+      const build = convertCSPSCharacterToBuild(char);
+      // the active-skill signal wins on ambiguity, so the legit DK pick is kept
+      // and the stale Warden id is dropped rather than overriding the base class.
+      expect(build.esoClass).toBe('dragonknight');
+      expect(build.classMasteryPassives).toEqual([238232]);
+      expect(build.setups[0].passives).toEqual([]);
+    });
+
     it('caps imported Class Mastery picks at 2 and drops foreign-class ids', () => {
       const char = makeCSPSCharacterOption({
         werte: {

--- a/src/utils/buildEncoding.ts
+++ b/src/utils/buildEncoding.ts
@@ -12,8 +12,7 @@
  */
 
 import { ESO_POTION_LOOKUP } from '@/data/esoPotions';
-import { getClassMasteryLine } from '@/data/skill-lines/class/classMastery';
-import { CLASS_MASTERY_MAX_PICKS } from '@/features/build-editor/utils/classMasteryEligibility';
+import { sanitizeClassMasteryPicks } from '@/features/build-editor/utils/classMasteryTransfer';
 
 import type {
   Build,
@@ -392,17 +391,6 @@ function compactifyBuild(build: Build): CompactBuild {
   if (build.updatedAt) c.ua = Math.floor(new Date(build.updatedAt).getTime() / 1000);
 
   return c;
-}
-
-/**
- * A crafted/corrupted `cm` payload with ids the section never renders would
- * otherwise hit the 2-pick cap and soft-lock the picker — keep only the
- * decoded class's own Class Mastery passives, deduped and capped.
- */
-function sanitizeClassMasteryPicks(cm: number[] | undefined, esoClass: ESOClass): number[] {
-  if (!Array.isArray(cm) || cm.length === 0) return [];
-  const valid = new Set(getClassMasteryLine(esoClass)?.skills.map((skill) => skill.id) ?? []);
-  return [...new Set(cm)].filter((id) => valid.has(id)).slice(0, CLASS_MASTERY_MAX_PICKS);
 }
 
 function expandCompactBuild(c: CompactBuild): Build {


### PR DESCRIPTION
## Summary

U50 **Class Mastery** picks now round-trip correctly through the **Caro's Skill Point Saver (CSPS)** transfer — export, SavedVariables import, and both export-code formats. Previously every CSPS export silently dropped the player's Class Mastery selections and every import mis-filed them, so the headline U50 feature did not survive a transfer in either direction.

## Problem

Class Mastery picks live on the top-level `build.classMasteryPassives` (max 2, base-class-validated), which is a **separate** store from per-setup `setup.passives`. The CSPS code only ever touched `setup.passives`:

- **Export** (`cspsExport.ts`) built `werte.pass` from `setup.passives` only → CM picks were never written.
- **Import** (`cspsImport.ts`, plus the ESO-Hub and native parsers in `cspsExportCodeParser.ts`) dumped all `werte.pass` ids into `setup.passives` and never set `classMasteryPassives` → CM ids were lost from their section, mis-rendered as unmanageable regular-passive tiles, and ignored by the stat engine.

The generic passive picker deliberately excludes `CLASS_MASTERY_SKILL_IDS`, so CM ids only ever belong in `build.classMasteryPassives` — confirming the two stores must be kept disjoint across the CSPS boundary.

## Root cause / addon-format basis

The fix mirrors how the **real CSPS addon (v6.1.6, API 101050)** actually stores Class Mastery: as plain `abilityId:1` pairs inside `werte.pass` — there is **no dedicated field** (the addon re-applies them via the Class Mastery Points pool on restore). So a faithful transfer must merge eligible CM picks into `werte.pass` on the way out and partition them back out on the way in.

## Changes Made

- **New** `classMasteryTransfer.ts` — single source of truth: `partitionClassMasteryPicks`, `sanitizeClassMasteryPicks` (lifted out of `buildEncoding.ts`), `classOfClassMasteryId`, `classFromMasteryIds`.
- **Export** (`cspsExport.ts`): resolve the eligible picks once (gated on `isClassMasteryEligible`, so a subclassed build never emits inert picks), then merge them into `werte.pass` as `id:1` for the main character **and every profile** (Class Mastery is character-wide), deduped against regular passives.
- **Import** (`cspsImport.ts` + both parsers in `cspsExportCodeParser.ts`): partition Class Mastery ids out of the parsed passives into `build.classMasteryPassives`, strip them from `setup.passives`, and fall back to the class implied by the CM ids when active-skill detection is inconclusive.
- **Stat engine** (`stat-engine.ts`): gate Class Mastery crit contributions by `isClassMasteryEligible` — a subclassed build no longer applies its retained (inert) CM crit/cap, which previously overstated crit damage in the Stats panel.
- **PassivesSection** (`PassivesSection.tsx`): defensive filter so any legacy build that left CM ids in `setup.passives` doesn't render them as unmanageable tiles. (Behavioral filter only — no visual restyle, so no screenshots.)
- **buildEncoding** (`buildEncoding.ts`): reuse the shared sanitizer (removed the duplicate + two now-unused imports).

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (0 errors)
- [x] Formatting passes (`prettier --check`)
- [x] Unit tests pass — full suite **3635 passed / 0 failed**; **92** tests across 4 Class Mastery suites (new `classMasteryTransfer`, plus extended `cspsExport`, `cspsImport`, `cspsExportCodeParser`), including a build → CSPS → build round-trip test.

> Audit was driven by an adversarial-verify pass (5 review dimensions × per-finding refutation → 18 confirmed findings, deduped to the 6 fixes above).
>
> Out of scope: exporting the *subclass* skill-line selection into CSPS's `scribeStyleSubclass` field is a separate pre-existing gap and is intentionally not touched here.
