### PR TITLE
fix(report-data): stale-response guards + coherent death% + refresh teardown

### DIFF
--- a/src/esologsClient.ts
+++ b/src/esologsClient.ts
@@ -160,6 +160,7 @@ export class EsoLogsClient {
         // Create a new observable that will retry the request after refreshing the token
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return new Observable((observer: any) => {
+          let innerSub: { unsubscribe: () => void } | undefined;
           refreshAccessToken()
             .then((newToken) => {
               if (newToken) {
@@ -187,7 +188,7 @@ export class EsoLogsClient {
                   },
                 };
 
-                forward(operation).subscribe(subscriber);
+                innerSub = forward(operation).subscribe(subscriber);
               } else {
                 // Refresh failed, clear tokens and notify user
                 logger.error('Token refresh failed - user needs to re-authenticate');
@@ -202,6 +203,15 @@ export class EsoLogsClient {
               this.isRefreshingToken = false;
               observer.error(err);
             });
+
+          // If the consumer unsubscribes (component unmount / cancelled query)
+          // while the refresh or forwarded request is in flight, tear down the
+          // inner subscription and clear the guard — otherwise isRefreshingToken
+          // can stay stuck at true and block all future refreshes on this client.
+          return () => {
+            innerSub?.unsubscribe();
+            this.isRefreshingToken = false;
+          };
         });
       }
 

--- a/src/hooks/useLatestReport.ts
+++ b/src/hooks/useLatestReport.ts
@@ -90,11 +90,11 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
   }, [client, currentUser?.id, isLoggedIn]);
 
   useEffect(() => {
+    // Each call bumps fetchIdRef, so when identity/login deps change the
+    // re-created fetchLatestReport supersedes any in-flight one (its stale
+    // result is dropped by the fetchId guard above). setState after unmount is
+    // a no-op in React 19, so no cleanup is needed.
     fetchLatestReport();
-    // Invalidate any in-flight fetch when deps change or the hook unmounts.
-    return () => {
-      fetchIdRef.current++;
-    };
   }, [fetchLatestReport]);
 
   return {

--- a/src/hooks/useLatestReport.ts
+++ b/src/hooks/useLatestReport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useEsoLogsClientInstance } from '../EsoLogsClientContext';
 import { useAuth } from '../features/auth/AuthContext';
@@ -29,7 +29,13 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
     error: null,
   });
 
+  // Identifies the latest fetch so a slower, superseded request (e.g. the user
+  // logged out / switched identity, or the component unmounted) can't overwrite
+  // newer state with a stale report.
+  const fetchIdRef = useRef(0);
+
   const fetchLatestReport = useCallback(async (): Promise<void> => {
+    const fetchId = ++fetchIdRef.current;
     if (!isLoggedIn || !currentUser?.id) {
       setState({
         report: null,
@@ -67,12 +73,14 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
       const latestReport = candidates.find((report) => !isReportEmpty(report)) ?? null;
       const fallbackReport = candidates[0] ?? null;
 
+      if (fetchId !== fetchIdRef.current) return; // superseded / unmounted
       setState({
         report: latestReport ?? fallbackReport,
         loading: false,
         error: null,
       });
     } catch {
+      if (fetchId !== fetchIdRef.current) return; // superseded / unmounted
       setState({
         report: null,
         loading: false,
@@ -83,6 +91,10 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
 
   useEffect(() => {
     fetchLatestReport();
+    // Invalidate any in-flight fetch when deps change or the hook unmounts.
+    return () => {
+      fetchIdRef.current++;
+    };
   }, [fetchLatestReport]);
 
   return {

--- a/src/services/DeathAnalysisService.ts
+++ b/src/services/DeathAnalysisService.ts
@@ -238,12 +238,19 @@ export class DeathAnalysisService {
         causeCounts.set(abilityId, (causeCounts.get(abilityId) || 0) + 1);
       }
 
+      // Divide by the hostile-death population (the same set the numerator
+      // counts), not total deaths — otherwise self/ally-caused deaths inflate
+      // the denominator and the percentages don't sum to 100%.
+      const hostileDeathCount = Array.from(causeCounts.values()).reduce(
+        (sum, count) => sum + count,
+        0,
+      );
       const topCausesOfDeath: CauseOfDeath[] = Array.from(causeCounts.entries())
         .map(([abilityId, count]) => ({
           abilityId,
           abilityName: abilities[abilityId]?.name || `Unknown (${abilityId})`,
           deathCount: count,
-          percentage: (count / playerData.deaths.length) * 100,
+          percentage: hostileDeathCount > 0 ? (count / hostileDeathCount) * 100 : 0,
         }))
         .sort((a, b) => b.deathCount - a.deathCount);
 
@@ -334,7 +341,9 @@ export class DeathAnalysisService {
       mechanicData.fightsAffected.add(death.fight);
     }
 
-    const totalDeaths = deathEvents.length;
+    // Match the population the loop above actually counts (it skips
+    // friendly-source deaths), so mechanic percentages are coherent.
+    const totalDeaths = deathEvents.filter((death) => !death.sourceIsFriendly).length;
     const analyses: MechanicDeathAnalysis[] = [];
 
     for (const [abilityId, mechanicData] of mechanicMap) {


### PR DESCRIPTION
## Summary

Three report-data robustness fixes from a codebase audit.

### 1. `useLatestReport` out-of-order results (low)
No stale guard: logging out or switching identity while a query was in flight let the resolved `setState` write the wrong user's report. Now each call bumps a `fetchId` ref and post-await `setState` bails when superseded. (setState-after-unmount is a no-op in React 19, so no cleanup needed.)

### 2. Death-analysis percentages didn't sum to 100% (low)
`topCausesOfDeath` and `analyzeMechanicDeaths` count only non-friendly-source deaths in the numerator but divided by the player's **total** deaths, so anyone with self/ally-caused deaths saw understated percentages that didn't sum to 100%. Both now divide by the hostile-death population.

### 3. Token-refresh Observable never tore down (low)
The error-link refresh Observable returned no teardown, so an unsubscribe (unmount / cancelled query) during a pending refresh left the forwarded request running and `isRefreshingToken` stuck at `true` — blocking all future refreshes on that client (a failure mode the code comments already acknowledged). Now captures the inner subscription and returns a teardown that unsubscribes and clears the guard.

## Testing
- `tsc --noEmit` clean
- useLatestReport + DeathAnalysisService + esologsClient suites pass (34 tests)
- prettier + eslint clean
