### PR TITLE
fix(insights): unique React keys for build issues + uptime timeline legend

### DIFF
--- a/src/features/report_details/insights/EffectUptimeTimelineModal.tsx
+++ b/src/features/report_details/insights/EffectUptimeTimelineModal.tsx
@@ -163,12 +163,21 @@ export const EffectUptimeTimelineModal: React.FC<EffectUptimeTimelineModalProps>
       tooltip: {
         trigger: 'axis',
         appendToBody: true,
-        formatter: (params: Array<{ seriesName: string; value: number[]; color: string }>) => {
+        formatter: (
+          params: Array<{
+            seriesName: string;
+            seriesIndex: number;
+            value: number[];
+            color: string;
+          }>,
+        ) => {
           if (!params[0]) return '';
           const time = formatSeconds(params[0].value[0]);
           const active = params.filter((p) => {
-            const idx = series.findIndex((s) => s.label === p.seriesName);
-            return p.value[1] > idx + 0.4;
+            // Use the series index ECharts provides rather than resolving by
+            // name — two series can share a display name, and findIndex-by-name
+            // would always pick the first, mislabeling the duplicate.
+            return p.value[1] > p.seriesIndex + 0.4;
           });
           if (active.length === 0) {
             return `<div style="font-size:13px"><div style="color:${echartsTheme.mutedColor}">Time: ${time}</div><div>No active effects</div></div>`;
@@ -254,7 +263,7 @@ export const EffectUptimeTimelineModal: React.FC<EffectUptimeTimelineModalProps>
                 const rgb = hexToRgb(color);
                 return (
                   <Box
-                    key={s.label}
+                    key={s.id}
                     sx={{
                       height: 24,
                       borderRadius: '12px',

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -2116,7 +2116,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
 
                             issues.push(
                               <Box
-                                key="quality"
+                                key={`quality-${message}`}
                                 sx={{
                                   display: 'flex',
                                   alignItems: 'center',
@@ -2326,7 +2326,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
 
                             issues.push(
                               <Box
-                                key="enchant"
+                                key={`enchant-${message}`}
                                 sx={{
                                   display: 'flex',
                                   alignItems: 'center',
@@ -2547,7 +2547,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
 
                             issues.push(
                               <Box
-                                key="level"
+                                key={`level-${message}`}
                                 sx={{
                                   display: 'flex',
                                   alignItems: 'center',


### PR DESCRIPTION
## Summary

Two React-key correctness fixes in the report insights view, from a codebase audit.

### 1. Duplicate keys in the build-issues renderer (low)
`PlayerCard` pushes sibling elements into a flat `issues` array using **constant** keys — `key="quality"` / `key="enchant"` / `key="level"` — inside an `Object.entries(...).forEach` loop. `detectBuildIssues` embeds the unique gear name in each message, so a player with the same issue category on two pieces produces two groups → two siblings with the same key. React warns and can mis-reconcile (drop/merge the second issue row). Key on the unique `message` (matching the already-correct `buff-${id}` keys in the missing-buffs section).

### 2. Uptime-timeline legend + tooltip keyed on name (low)
The legend chips key on `s.label` (the ability name); two series can share a name (perfected/non-perfected variants, or the same Major/Minor effect from different ability ids) → duplicate keys. Key on the guaranteed-unique `s.id`. The ECharts tooltip also recovered each series' lane via `findIndex((s) => s.label === seriesName)`, which always resolves to the first match for duplicate names; use the `seriesIndex` ECharts already provides (the chart series are built in `series`-array order).

## Testing
- `tsc --noEmit` clean
- insights suites pass (8 suites, 85 tests)
- prettier + eslint clean
