### PR TITLE
fix(events): re-fetch buff-event windows after partial failure instead of caching it

### DIFF
--- a/src/store/events_data/friendlyBuffEventsSlice.ts
+++ b/src/store/events_data/friendlyBuffEventsSlice.ts
@@ -244,11 +244,15 @@ export const fetchFriendlyBuffEvents = createAsyncThunk<
 
       const lastFetchedTimestamp = entry?.cacheMetadata.lastFetchedTimestamp;
       const isCached = Boolean(entry?.events.length);
+      // A partially-failed fetch (some 30s windows errored) is missing events;
+      // don't treat it as a complete cache hit, so the next access re-fetches
+      // and the gaps can fill in instead of silently undercounting uptime.
+      const isComplete = (entry?.cacheMetadata.failedIntervals ?? 0) === 0;
       const isFresh =
         typeof lastFetchedTimestamp === 'number' &&
         Date.now() - lastFetchedTimestamp < DATA_FETCH_CACHE_TIMEOUT;
 
-      if (isCached && isFresh && restrictMatches) {
+      if (isCached && isComplete && isFresh && restrictMatches) {
         logger.info('Using cached friendly buff events', {
           reportCode,
           fightId: Number(fight.id),

--- a/src/store/events_data/hostileBuffEventsSlice.ts
+++ b/src/store/events_data/hostileBuffEventsSlice.ts
@@ -181,11 +181,15 @@ export const fetchHostileBuffEvents = createAsyncThunk<
 
       const lastFetchedTimestamp = entry?.cacheMetadata.lastFetchedTimestamp;
       const isCached = Boolean(entry?.events.length);
+      // A partially-failed fetch (some 30s windows errored) is missing events;
+      // don't treat it as a complete cache hit, so the next access re-fetches
+      // and the gaps can fill in instead of silently undercounting uptime.
+      const isComplete = (entry?.cacheMetadata.failedIntervals ?? 0) === 0;
       const isFresh =
         typeof lastFetchedTimestamp === 'number' &&
         Date.now() - lastFetchedTimestamp < DATA_FETCH_CACHE_TIMEOUT;
 
-      if (isCached && isFresh) {
+      if (isCached && isComplete && isFresh) {
         return false; // Prevent thunk execution
       }
 


### PR DESCRIPTION
## Summary

Buff/debuff uptime was silently undercounting on partial fetch failures — found by a round-2 audit.

## Problem
Friendly and hostile buff-event fetches split a fight into 30s windows fetched in parallel. A failed window is caught and returns `events: []` + an error string rather than rejecting, so `Promise.all` always fulfills, the thunk is marked `succeeded`/`error: null`, and the **partial** event stream is cached as a complete, fresh entry. Downstream buff/debuff-uptime, checklists, scribing detection, and timelines then compute over a gap-ridden stream — buffs that were genuinely active read as gaps. `failedIntervals` is recorded in `cacheMetadata` but no production code reads it, so the failure is invisible, and the partial result is reused until the cache TTL expires (no retry).

## Fix
Treat a cached entry with `failedIntervals > 0` as **incomplete** in the fetch `condition`, so the next access re-fetches and the missing windows fill in (transient rate-limit failures then resolve) instead of serving partial data as complete. Minimal, low-risk change — no UX change, just don't cache-as-complete a known-partial result.

## Testing
- `tsc --noEmit` clean
- events_data suites pass (5 suites, 30 tests)
- prettier + eslint clean

> The related ParseAnalysisPage gate (runs the full analysis when an event fetch *failed*, presenting incomplete numbers as success) is left for a separate change since surfacing it cleanly needs the event hooks to expose error/`failed` status plus a product decision on whether to block the render or show a partial-data banner.
