### PR TITLE
fix(async): guard out-of-order responses in guild-config, avatars, comments, death-analysis

### DIFF
--- a/src/features/report_summary/hooks/useMultiFightDeathAnalysis.ts
+++ b/src/features/report_summary/hooks/useMultiFightDeathAnalysis.ts
@@ -110,9 +110,21 @@ export function useMultiFightDeathAnalysis(reportCode: string): UseMultiFightDea
           }),
       );
 
-      await Promise.all(fetchPromises);
+      // Use allSettled so one fight's failed fetch doesn't blank the entire
+      // report's death analysis — proceed with whatever loaded, and only fail
+      // hard if every fight failed.
+      const settled = await Promise.allSettled(fetchPromises);
+      if (settled.every((r) => r.status === 'rejected')) {
+        const firstReason = settled.find((r) => r.status === 'rejected') as
+          | PromiseRejectedResult
+          | undefined;
+        throw firstReason?.reason instanceof Error
+          ? firstReason.reason
+          : new Error('Failed to load death events for any fight');
+      }
 
-      // Now that all events are cached in Redux, retrieve them along with master data
+      // Now that the available events are cached in Redux, retrieve them along
+      // with master data (fights whose fetch failed simply contribute no deaths)
       const state = (dispatch as any).getState() as RootState;
 
       const fightDeathData: DeathAnalysisInput[] = cleanFights.map((fight) => {

--- a/src/features/report_summary/hooks/useMultiFightDeathAnalysis.ts
+++ b/src/features/report_summary/hooks/useMultiFightDeathAnalysis.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useEsoLogsClientInstance } from '../../../EsoLogsClientContext';
@@ -46,6 +46,10 @@ export function useMultiFightDeathAnalysis(reportCode: string): UseMultiFightDea
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
   const [deathAnalysis, setDeathAnalysis] = useState<ReportDeathAnalysis | null>(null);
 
+  // Identifies the latest analysis run so a slower, superseded run (reportCode
+  // changed mid-flight, or unmount) can't overwrite newer results.
+  const runIdRef = useRef(0);
+
   // Use Redux selectors to get cached data for each fight
   const getFightDeathData = useCallback(
     (fight: FightFragment, state: RootState): DeathEvent[] => {
@@ -81,6 +85,8 @@ export function useMultiFightDeathAnalysis(reportCode: string): UseMultiFightDea
     if (!client || !fights || fights.length === 0) {
       return;
     }
+
+    const runId = ++runIdRef.current;
 
     try {
       setIsLoading(true);
@@ -127,15 +133,20 @@ export function useMultiFightDeathAnalysis(reportCode: string): UseMultiFightDea
 
       // Perform comprehensive death analysis
       const analysis = DeathAnalysisService.analyzeReportDeaths(fightDeathData);
+      if (runId !== runIdRef.current) return; // superseded by a newer run
       setDeathAnalysis(analysis);
     } catch (err) {
+      if (runId !== runIdRef.current) return; // superseded by a newer run
       const errorMessage = err instanceof Error ? err.message : 'Failed to analyze death events';
       setError(errorMessage);
       // eslint-disable-next-line no-console
       console.error('Death analysis error:', err);
     } finally {
-      setIsLoading(false);
-      setProgress(null);
+      // Only the latest run owns the loading/progress UI.
+      if (runId === runIdRef.current) {
+        setIsLoading(false);
+        setProgress(null);
+      }
     }
   }, [client, fights, reportCode, dispatch, getFightDeathData, getFightActors, getFightAbilities]);
 

--- a/src/features/roster-hub/components/CommentSection.tsx
+++ b/src/features/roster-hub/components/CommentSection.tsx
@@ -252,17 +252,27 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
   const [replyTo, setReplyTo] = React.useState<{ id: string; authorName: string } | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
   const pendingIdsRef = React.useRef<Set<string>>(new Set());
+  // Identifies the latest list load so a slower, superseded reload (rosterId
+  // change, or overlapping post/delete reloads) can't clobber the newer list.
+  const fetchKeyRef = React.useRef(0);
 
   const fetchComments = React.useCallback((): void => {
+    const fetchKey = ++fetchKeyRef.current;
     setLoading(true);
     setError('');
     rosterHubApi
       .listComments(rosterId)
-      .then((res) => setComments(res.comments))
-      .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : 'Failed to load comments'),
-      )
-      .finally(() => setLoading(false));
+      .then((res) => {
+        if (fetchKey === fetchKeyRef.current) setComments(res.comments);
+      })
+      .catch((err: unknown) => {
+        if (fetchKey === fetchKeyRef.current) {
+          setError(err instanceof Error ? err.message : 'Failed to load comments');
+        }
+      })
+      .finally(() => {
+        if (fetchKey === fetchKeyRef.current) setLoading(false);
+      });
   }, [rosterId]);
 
   React.useEffect(() => {

--- a/src/hooks/usePlayerAvatars.ts
+++ b/src/hooks/usePlayerAvatars.ts
@@ -52,8 +52,15 @@ export function usePlayerAvatars(players: PlayerIdentity[]): Record<string, stri
 
     rosterHubApi
       .lookupPlayerAvatars(unique)
-      .then((res) => setAvatars(res.avatars))
-      .catch(() => setAvatars({}));
+      // Guard against out-of-order resolution: if the player set changed while
+      // this lookup was in flight, cacheKeyRef now holds a newer key, so drop
+      // this stale response rather than overwriting the newer avatars.
+      .then((res) => {
+        if (cacheKey === cacheKeyRef.current) setAvatars(res.avatars);
+      })
+      .catch(() => {
+        if (cacheKey === cacheKeyRef.current) setAvatars({});
+      });
   }, [players]);
 
   return avatars;

--- a/src/pages/DiscordServerConfigPage.tsx
+++ b/src/pages/DiscordServerConfigPage.tsx
@@ -349,6 +349,8 @@ export const DiscordServerConfigPage: React.FC = () => {
 
   // Dirty tracking — snapshot of form values at load time
   const initialFormRef = useRef<string>('');
+  // Monotonic id so a superseded guild config fetch can't commit stale data.
+  const configFetchIdRef = useRef(0);
 
   const currentFormSnapshot = useMemo(
     () =>
@@ -451,6 +453,12 @@ export const DiscordServerConfigPage: React.FC = () => {
   useEffect(() => {
     if (!selectedGuild || !discordToken) return;
 
+    // Guard against a slower earlier guild's response resolving last: switching
+    // guild A -> B before A resolves would otherwise overwrite B's channels/
+    // roles/config and the dirty-tracking snapshot with A's data while the UI
+    // shows B selected.
+    const fetchId = ++configFetchIdRef.current;
+
     setConfigLoading(true);
     setConfigError(null);
 
@@ -467,6 +475,8 @@ export const DiscordServerConfigPage: React.FC = () => {
             discordToken,
           ),
         ]);
+
+        if (fetchId !== configFetchIdRef.current) return; // superseded by a newer guild
 
         setChannels(channelsRes.channels);
         setRoles(rolesRes.roles);
@@ -493,6 +503,7 @@ export const DiscordServerConfigPage: React.FC = () => {
 
         // Snapshot for dirty tracking (deferred to next tick so state is settled)
         setTimeout(() => {
+          if (fetchId !== configFetchIdRef.current) return; // superseded
           initialFormRef.current = JSON.stringify({
             defaultChannelId: cfg.defaultChannelId ?? '',
             defaultCategoryId: detectedCategory,
@@ -505,9 +516,10 @@ export const DiscordServerConfigPage: React.FC = () => {
           });
         }, 0);
       } catch (err) {
+        if (fetchId !== configFetchIdRef.current) return; // superseded
         setConfigError(err instanceof Error ? err.message : 'Failed to load server data');
       } finally {
-        setConfigLoading(false);
+        if (fetchId === configFetchIdRef.current) setConfigLoading(false);
       }
     })();
   }, [selectedGuild, discordToken]);


### PR DESCRIPTION
## Summary

Four out-of-order async fixes from a round-2 audit. Each path committed resolved results with no latest-request guard, so a slower earlier response could overwrite newer state.

- **DiscordServerConfigPage** (medium): the guild-config effect fires 3 parallel requests then calls ~12 setters with no guard. Switching guild A→B before A resolved overwrote B's channels/roles/config and the dirty-tracking snapshot with A's data while the UI showed B selected — the admin could then save A's data into B. Now guards every commit (and the deferred snapshot `setTimeout`) behind a fetch id.
- **usePlayerAvatars** (low): `cacheKeyRef` only deduped identical sets; an A→B player-set change with A resolving last overwrote B's avatars. Guards `setAvatars` on the still-current `cacheKey`.
- **CommentSection** (low): list reloads on `rosterId` change and after each post/delete had no guard, so a stale `listComments` could resurrect a deleted comment or hide a just-posted one. Guards `setComments`/`setError`/`setLoading` behind a fetch key.
- **useMultiFightDeathAnalysis** (low): a long multi-fight analysis could finish after `reportCode` changed and overwrite `deathAnalysis`/`error` with the previous report's results. Guards the commits behind a run id (and only the latest run clears the loading/progress UI).

(setState-after-unmount is a no-op in React 19, so these use the same generation-guard pattern without cleanup functions.)

## Testing
- `tsc --noEmit` clean
- prettier + eslint clean (no dedicated test files for these; covered by CI's full suite)



---

### Also: multi-fight death analysis is no longer all-or-nothing
`useMultiFightDeathAnalysis` fetched every fight's death events with `Promise.all` + `unwrap`, so a single rejected fight rejected the whole batch and left `deathAnalysis` null — a full error state even though every other fight loaded. Now uses `allSettled` and proceeds with the fights that resolved; only fails hard when all fights fail.
