### PR TITLE
fix(ui): clear player-navigation timers on close + stale gear icon

### DIFF
--- a/src/components/GearDetailsPanel.tsx
+++ b/src/components/GearDetailsPanel.tsx
@@ -94,44 +94,56 @@ export const GearDetailsPanel: React.FC<GearDetailsPanelProps> = ({
     return sortedPlayers.findIndex((p) => p.id === currentPlayerId);
   }, [sortedPlayers, currentPlayerId]);
 
+  // Track the nested transition timers so we can cancel them on close/unmount
+  // (otherwise the inner callbacks still fire onPlayerChange, re-pointing the
+  // parent's selected player after dismissal) and when a new navigation starts.
+  const navTimersRef = React.useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearNavTimers = React.useCallback(() => {
+    navTimersRef.current.forEach(clearTimeout);
+    navTimersRef.current = [];
+  }, []);
+
   // Player navigation functions with fancy fade transition
+  const navigateTo = React.useCallback(
+    (nextIndex: number, direction: 'left' | 'right') => {
+      clearNavTimers();
+      setTransitionDirection(direction);
+      setFadeStage('out');
+      setIsTransitioning(true);
+
+      navTimersRef.current.push(
+        setTimeout(() => {
+          setDisplayedPlayerId(sortedPlayers[nextIndex].id);
+          setFadeStage('in');
+
+          navTimersRef.current.push(
+            setTimeout(() => {
+              onPlayerChange(sortedPlayers[nextIndex].id);
+              setFadeStage('none');
+              setIsTransitioning(false);
+            }, 300),
+          );
+        }, 300),
+      );
+    },
+    [sortedPlayers, onPlayerChange, clearNavTimers],
+  );
+
   const goToPreviousPlayer = React.useCallback(() => {
     if (sortedPlayers.length <= 1) return;
-    const prevIndex = currentPlayerIndex > 0 ? currentPlayerIndex - 1 : sortedPlayers.length - 1;
-    setTransitionDirection('right');
-    setFadeStage('out');
-    setIsTransitioning(true);
-
-    setTimeout(() => {
-      setDisplayedPlayerId(sortedPlayers[prevIndex].id);
-      setFadeStage('in');
-
-      setTimeout(() => {
-        onPlayerChange(sortedPlayers[prevIndex].id);
-        setFadeStage('none');
-        setIsTransitioning(false);
-      }, 300);
-    }, 300);
-  }, [sortedPlayers, currentPlayerIndex, onPlayerChange]);
+    navigateTo(currentPlayerIndex > 0 ? currentPlayerIndex - 1 : sortedPlayers.length - 1, 'right');
+  }, [sortedPlayers, currentPlayerIndex, navigateTo]);
 
   const goToNextPlayer = React.useCallback(() => {
     if (sortedPlayers.length <= 1) return;
-    const nextIndex = currentPlayerIndex < sortedPlayers.length - 1 ? currentPlayerIndex + 1 : 0;
-    setTransitionDirection('left');
-    setFadeStage('out');
-    setIsTransitioning(true);
+    navigateTo(currentPlayerIndex < sortedPlayers.length - 1 ? currentPlayerIndex + 1 : 0, 'left');
+  }, [sortedPlayers, currentPlayerIndex, navigateTo]);
 
-    setTimeout(() => {
-      setDisplayedPlayerId(sortedPlayers[nextIndex].id);
-      setFadeStage('in');
-
-      setTimeout(() => {
-        onPlayerChange(sortedPlayers[nextIndex].id);
-        setFadeStage('none');
-        setIsTransitioning(false);
-      }, 300);
-    }, 300);
-  }, [sortedPlayers, currentPlayerIndex, onPlayerChange]);
+  // Cancel pending transition timers on close and unmount.
+  React.useEffect(() => {
+    if (!open) clearNavTimers();
+    return () => clearNavTimers();
+  }, [open, clearNavTimers]);
 
   // Keyboard navigation
   React.useEffect(() => {

--- a/src/components/PlayerCardModal.tsx
+++ b/src/components/PlayerCardModal.tsx
@@ -64,43 +64,56 @@ export const PlayerCardModal: React.FC<PlayerCardModalProps> = ({
 
   const canNavigate = orderedPlayerIds.length > 1;
 
+  // Track the nested transition timers so we can cancel them when the modal
+  // closes / unmounts (otherwise the inner callbacks still fire onPlayerChange,
+  // mutating the parent's selected player after dismissal) and when a new
+  // navigation starts (so mashed arrow keys don't spawn fighting chains).
+  const navTimersRef = React.useRef<ReturnType<typeof setTimeout>[]>([]);
+  const clearNavTimers = React.useCallback(() => {
+    navTimersRef.current.forEach(clearTimeout);
+    navTimersRef.current = [];
+  }, []);
+
+  const navigateTo = React.useCallback(
+    (nextIndex: number) => {
+      clearNavTimers();
+      setFadeStage('out');
+      setIsTransitioning(true);
+
+      navTimersRef.current.push(
+        setTimeout(() => {
+          const nextId = orderedPlayerIds[nextIndex];
+          setDisplayedPlayerId(nextId);
+          setFadeStage('in');
+
+          navTimersRef.current.push(
+            setTimeout(() => {
+              onPlayerChange(nextId);
+              setFadeStage('none');
+              setIsTransitioning(false);
+            }, 250),
+          );
+        }, 250),
+      );
+    },
+    [orderedPlayerIds, onPlayerChange, clearNavTimers],
+  );
+
   const goToPreviousPlayer = React.useCallback(() => {
     if (!canNavigate) return;
-    const prevIndex = currentIndex > 0 ? currentIndex - 1 : orderedPlayerIds.length - 1;
-    setFadeStage('out');
-    setIsTransitioning(true);
-
-    setTimeout(() => {
-      const nextId = orderedPlayerIds[prevIndex];
-      setDisplayedPlayerId(nextId);
-      setFadeStage('in');
-
-      setTimeout(() => {
-        onPlayerChange(nextId);
-        setFadeStage('none');
-        setIsTransitioning(false);
-      }, 250);
-    }, 250);
-  }, [canNavigate, currentIndex, orderedPlayerIds, onPlayerChange]);
+    navigateTo(currentIndex > 0 ? currentIndex - 1 : orderedPlayerIds.length - 1);
+  }, [canNavigate, currentIndex, orderedPlayerIds, navigateTo]);
 
   const goToNextPlayer = React.useCallback(() => {
     if (!canNavigate) return;
-    const nextIndex = currentIndex < orderedPlayerIds.length - 1 ? currentIndex + 1 : 0;
-    setFadeStage('out');
-    setIsTransitioning(true);
+    navigateTo(currentIndex < orderedPlayerIds.length - 1 ? currentIndex + 1 : 0);
+  }, [canNavigate, currentIndex, orderedPlayerIds, navigateTo]);
 
-    setTimeout(() => {
-      const nextId = orderedPlayerIds[nextIndex];
-      setDisplayedPlayerId(nextId);
-      setFadeStage('in');
-
-      setTimeout(() => {
-        onPlayerChange(nextId);
-        setFadeStage('none');
-        setIsTransitioning(false);
-      }, 250);
-    }, 250);
-  }, [canNavigate, currentIndex, orderedPlayerIds, onPlayerChange]);
+  // Cancel pending transition timers on close and unmount.
+  React.useEffect(() => {
+    if (!open) clearNavTimers();
+    return () => clearNavTimers();
+  }, [open, clearNavTimers]);
 
   // Keyboard navigation
   React.useEffect(() => {

--- a/src/features/build-editor/components/primitives/GearSlotCard.tsx
+++ b/src/features/build-editor/components/primitives/GearSlotCard.tsx
@@ -230,11 +230,17 @@ const GearSlotCardComponent: React.FC<GearSlotCardProps> = ({
       setIconUrl(sync);
       return;
     }
+    // Clear the previous item's icon while the async fetch is in flight so we
+    // don't show the old item's art next to the new item; show the fallback if
+    // the fetch fails rather than leaving the stale icon forever.
+    setIconUrl(null);
     fetchItemIconUrl(itemId)
       .then((url) => {
         if (!cancelled) setIconUrl(url);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setIconFailed(true);
+      });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary

Uncleared timers and a stale gear icon, from a round-2 audit.

### 1. PlayerCardModal & GearDetailsPanel — navigation timers never cleared (low)
Both animate player navigation with nested `setTimeout` chains (250ms+250ms / 300ms+300ms) that captured no handle and had no cleanup. Closing the modal/dialog (or unmounting) mid-transition still ran the inner callback — calling `onPlayerChange`, which **re-points the parent grid's selected player after dismissal** — plus `setState` on a torn-down component. Holding an arrow key also spawned multiple overlapping chains that fought each other. Now both track timer ids in a ref and clear them on close/unmount and at the start of each navigation (so a new navigation cancels the in-flight one).

### 2. GearSlotCard (build editor) — stale icon (low)
When `itemId` changed to an item whose icon wasn't synchronously resolvable, the effect didn't clear `iconUrl` before awaiting `fetchItemIconUrl`, so the previous item's art stayed rendered mid-switch; and the `.catch(() => {})` swallowed errors, leaving the stale icon forever. Now clears the icon up front and sets `iconFailed` on error so the fallback renders. (Same class as the loadout-manager `GearSelector` fix, different component/path.)

## Testing
- `tsc --noEmit` clean
- relevant suites pass (3 tests)
- prettier + eslint clean
