### PR TITLE
fix(user-reports): correct display page size + clamp page + guard avatar read

### DIFF
--- a/src/features/user_reports/UserReports.tsx
+++ b/src/features/user_reports/UserReports.tsx
@@ -212,7 +212,13 @@ export const UserReports: React.FC = () => {
 
   // Get the current page from URL query parameter
   const currentPageFromUrl = parseInt(searchParams.get('page') || '1', 10);
-  const pageToUse = isNaN(currentPageFromUrl) || currentPageFromUrl < 1 ? 1 : currentPageFromUrl;
+  const lowerClampedPage =
+    isNaN(currentPageFromUrl) || currentPageFromUrl < 1 ? 1 : currentPageFromUrl;
+  // Clamp to the available range so an out-of-range ?page= (e.g. a stale shared
+  // URL like ?page=999) falls back to the last valid page instead of slicing
+  // past the end and showing a blank "no reports" state.
+  const pageToUse =
+    filteredTotalPages > 0 ? Math.min(lowerClampedPage, filteredTotalPages) : lowerClampedPage;
 
   // Track initial loading state
   const [initialLoading, setInitialLoading] = React.useState(true);

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -1040,13 +1040,23 @@ export const PublicProfilePage: React.FC = () => {
         return;
       }
 
-      // Read as data-URL for base64 upload
-      const dataUrl = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-      });
+      // Read as data-URL for base64 upload. This runs before the upload
+      // try/catch, so guard it separately — a failed read would otherwise be an
+      // unhandled rejection with no user feedback.
+      let dataUrl: string;
+      try {
+        dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(reader.error ?? new Error('File read failed'));
+          reader.readAsDataURL(file);
+        });
+      } catch {
+        enqueueSnackbar('Could not read the selected image. Please try another file.', {
+          variant: 'error',
+        });
+        return;
+      }
 
       setAvatarUploading(true);
       try {

--- a/src/store/user_reports/userReportsSlice.ts
+++ b/src/store/user_reports/userReportsSlice.ts
@@ -125,7 +125,7 @@ export const fetchAllUserReports = createAsyncThunk<
   { rejectValue: string; state: { userReports: UserReportsState } }
 >(
   'userReports/fetchAll',
-  async ({ client, userId, limit = 100 }, { dispatch, rejectWithValue, getState }) => {
+  async ({ client, userId, limit = 100 }, { dispatch, rejectWithValue, signal }) => {
     try {
       // Fetch first page to get total count
       const firstPageResult = await dispatch(
@@ -141,10 +141,10 @@ export const fetchAllUserReports = createAsyncThunk<
 
       // Fetch remaining pages sequentially to avoid overwhelming the API
       for (let page = 2; page <= totalPages; page++) {
-        // Check if user cancelled or if there was an error
-        const state = getState();
-        if (!state.userReports.isFetchingAll) {
-          break; // User cancelled
+        // Stop if this thunk was aborted (the previous `isFetchingAll` guard was
+        // dead — that flag is always true while the thunk is still running).
+        if (signal.aborted) {
+          break;
         }
 
         await dispatch(
@@ -205,7 +205,7 @@ const userReportsSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchUserReportsPage.fulfilled, (state, action) => {
-        const { reports, page, totalCount, perPage } = action.payload;
+        const { reports, page, totalCount } = action.payload;
 
         // Store reports in normalized structure
         reports.forEach((report) => {
@@ -215,9 +215,11 @@ const userReportsSlice = createSlice({
         // Store page mapping
         state.pages[page] = reports.map((r) => r.code);
 
-        // Update metadata
+        // Update metadata. Note: do NOT overwrite state.perPage with the API's
+        // per_page (the fetch batch size, 100) — it is the DISPLAY page size
+        // (10, see REPORTS_PER_PAGE) that the pagination selectors slice by.
+        // Fetch-all math uses the unwrapped result's perPage, not state.
         state.totalCount = totalCount;
-        state.perPage = perPage;
         state.loading = false;
         state.lastFetched = Date.now();
       })


### PR DESCRIPTION
## Summary

Four My-Reports / profile fixes from a codebase audit.

### 1. Display page size silently became 100 (medium)
`initialState.perPage` is 10 and the skeleton renders 10 rows, but the fulfilled reducer overwrote `state.perPage` with the API's `per_page` — the **fetch batch size (100)**. The pagination selectors slice by `state.perPage`, so the table rendered up to 100 rows per page and the Pagination control only appeared past 100 reports. Stopped overwriting it; fetch-all math already uses the unwrapped result's `perPage`, not state.

### 2. Out-of-range `?page=` → blank page (low)
`?page=999` was accepted as `currentPage` and sliced past the end, showing the "No reports found" empty state while the Pagination control showed the real count — a confusing dead state reachable via a stale shared URL. Clamp `pageToUse` to `[1, filteredTotalPages]`.

### 3. Avatar file-read had no error handling (low)
The `FileReader` read was awaited **before** the upload try/catch, so a failed read was an unhandled rejection with no user feedback. Wrapped it in its own try/catch with an error snackbar, and reject with a real `Error`.

### 4. Dead cancellation guard (low)
`fetchAllUserReports`'s page loop checked `isFetchingAll`, which is always `true` while the thunk runs (it only flips false on fulfilled/rejected) — so the "User cancelled" break was unreachable. Replaced with the idiomatic `thunkAPI.signal.aborted` check.

## Testing
- `tsc --noEmit` clean
- user_reports suites pass (3 suites, 74 tests)
- prettier + eslint clean
