### PR TITLE
perf(replay): bucket damage-over-time in a single linear sweep

### DIFF
--- a/src/workers/calculations/CalculateDamageOverTime.test.ts
+++ b/src/workers/calculations/CalculateDamageOverTime.test.ts
@@ -166,6 +166,59 @@ describe('CalculateDamageOverTime', () => {
     expect(result.allTargets[PLAYER_ID_1].totalDamage).toBe(1500); // Only the enemy damage
   });
 
+  it('buckets boundary events correctly and excludes out-of-window events', () => {
+    const damageEvents = [
+      // Exactly on a bucket boundary -> belongs to bucket 10 (10s in)
+      createMockDamageEvent({
+        timestamp: FIGHT_START + 10000,
+        sourceID: PLAYER_ID_1,
+        targetID: TARGET_ID_1,
+        amount: 500,
+        sourceIsFriendly: true,
+        targetIsFriendly: false,
+      }),
+      // Before the fight window -> excluded from buckets (matched no bucket)
+      createMockDamageEvent({
+        timestamp: FIGHT_START - 5,
+        sourceID: PLAYER_ID_1,
+        targetID: TARGET_ID_1,
+        amount: 999,
+        sourceIsFriendly: true,
+        targetIsFriendly: false,
+      }),
+      // Exactly at fight end -> excluded (last bucket end is exclusive)
+      createMockDamageEvent({
+        timestamp: FIGHT_END,
+        sourceID: PLAYER_ID_1,
+        targetID: TARGET_ID_1,
+        amount: 777,
+        sourceIsFriendly: true,
+        targetIsFriendly: false,
+      }),
+    ];
+
+    const result = calculateDamageOverTimeData({
+      fight: mockFight,
+      players: mockPlayers,
+      damageEvents,
+      bucketSizeMs: 1000,
+    });
+
+    const p1t1 = result.byTarget[TARGET_ID_1][PLAYER_ID_1];
+    // Only the boundary event lands in a bucket; out-of-window events are dropped.
+    expect(p1t1.dataPoints[10].damage).toBe(500);
+    expect(p1t1.dataPoints[10].eventCount).toBe(1);
+    expect(p1t1.totalDamage).toBe(500);
+    // totalEvents counts all of the player's events (matches prior behavior).
+    expect(p1t1.totalEvents).toBe(3);
+
+    // Player 2 has no events but is in the players record -> all-zero buckets.
+    const p2t1 = result.byTarget[TARGET_ID_1][PLAYER_ID_2];
+    expect(p2t1.totalDamage).toBe(0);
+    expect(p2t1.dataPoints).toHaveLength(30);
+    expect(p2t1.dataPoints.every((d) => d.damage === 0 && d.eventCount === 0)).toBe(true);
+  });
+
   it('should calculate correct DPS values', () => {
     const damageEvents = [
       createMockDamageEvent({

--- a/src/workers/calculations/CalculateDamageOverTime.ts
+++ b/src/workers/calculations/CalculateDamageOverTime.ts
@@ -108,50 +108,78 @@ export function calculateDamageOverTimeData(
     allTargets: {},
   };
 
+  // Pre-group events by (target, player) and by player-across-all-targets in a
+  // single pass, so each player's buckets are filled by ONE linear sweep instead
+  // of re-filtering the player's whole event list once per time bucket (the old
+  // O(targets × players × buckets × events) inner loop). Output is identical.
+  const eventsByTargetPlayer = new Map<number, Map<number, DamageEvent[]>>();
+  const eventsByPlayerAllTargets = new Map<number, DamageEvent[]>();
+  for (const event of playerDamageEvents) {
+    let perPlayer = eventsByTargetPlayer.get(event.targetID);
+    if (!perPlayer) {
+      perPlayer = new Map();
+      eventsByTargetPlayer.set(event.targetID, perPlayer);
+    }
+    const tpArr = perPlayer.get(event.sourceID);
+    if (tpArr) tpArr.push(event);
+    else perPlayer.set(event.sourceID, [event]);
+
+    const pArr = eventsByPlayerAllTargets.get(event.sourceID);
+    if (pArr) pArr.push(event);
+    else eventsByPlayerAllTargets.set(event.sourceID, [event]);
+  }
+
+  const perSecond = bucketSizeMs / 1000;
+
+  // Bucket one player's events with a single linear sweep. `floor((ts-start)/
+  // bucketSizeMs)` reproduces the old per-bucket `>= bucketStart && < bucketEnd`
+  // membership exactly for events inside [startTime, endTime); events outside
+  // that window matched no bucket before and are skipped here too. An empty list
+  // yields all-zero buckets (preserving players with no damage on a target).
+  const buildBuckets = (
+    playerEvents: DamageEvent[],
+  ): { dataPoints: DamageOverTimeDataPoint[]; totalDamage: number; maxDps: number } => {
+    const dataPoints: DamageOverTimeDataPoint[] = new Array(buckets.length);
+    for (let i = 0; i < buckets.length; i++) {
+      dataPoints[i] = {
+        timestamp: buckets[i],
+        relativeTime: (buckets[i] - startTime) / 1000,
+        damage: 0,
+        eventCount: 0,
+      };
+    }
+
+    let totalDamage = 0;
+    for (const event of playerEvents) {
+      if (event.timestamp < startTime || event.timestamp >= endTime) continue;
+      const idx = Math.floor((event.timestamp - startTime) / bucketSizeMs);
+      const dp = dataPoints[idx];
+      dp.damage += event.amount;
+      dp.eventCount += 1;
+      totalDamage += event.amount;
+    }
+
+    let maxDps = 0;
+    for (const dp of dataPoints) {
+      const dps = dp.damage / perSecond;
+      if (dps > maxDps) maxDps = dps;
+    }
+
+    return { dataPoints, totalDamage, maxDps };
+  };
+
   // Process each target separately
   let targetIndex = 0;
   for (const targetId of targetIds) {
     result.byTarget[targetId] = {};
+    const perPlayer = eventsByTargetPlayer.get(targetId);
 
-    // Get events for this target
-    const targetEvents = playerDamageEvents.filter((event) => event.targetID === targetId);
-
-    // Process each player for this target
     for (const playerId of playerIds) {
       const player = players[playerId];
       if (!player) continue;
 
-      const playerEvents = targetEvents.filter((event) => event.sourceID === playerId);
-
-      // Create data points for each time bucket
-      const dataPoints: DamageOverTimeDataPoint[] = [];
-      let totalDamage = 0;
-      let maxDps = 0;
-
-      for (let i = 0; i < buckets.length; i++) {
-        const bucketStart = buckets[i];
-        const bucketEnd = buckets[i + 1] || endTime;
-
-        // Get events in this bucket
-        const bucketEvents = playerEvents.filter(
-          (event) => event.timestamp >= bucketStart && event.timestamp < bucketEnd,
-        );
-
-        const bucketDamage = bucketEvents.reduce((sum, event) => sum + event.amount, 0);
-        const dps = bucketDamage / (bucketSizeMs / 1000); // Convert to per-second
-
-        totalDamage += bucketDamage;
-        maxDps = Math.max(maxDps, dps);
-
-        dataPoints.push({
-          timestamp: bucketStart,
-          relativeTime: (bucketStart - startTime) / 1000,
-          damage: bucketDamage,
-          eventCount: bucketEvents.length,
-        });
-      }
-
-      const averageDps = totalDamage / (fightDuration / 1000);
+      const playerEvents = perPlayer?.get(playerId) ?? [];
+      const { dataPoints, totalDamage, maxDps } = buildBuckets(playerEvents);
 
       result.byTarget[targetId][playerId] = {
         playerId,
@@ -160,7 +188,7 @@ export function calculateDamageOverTimeData(
         dataPoints,
         totalDamage,
         totalEvents: playerEvents.length,
-        averageDps,
+        averageDps: totalDamage / (fightDuration / 1000),
         maxDps,
       };
     }
@@ -175,40 +203,12 @@ export function calculateDamageOverTimeData(
     const player = players[playerId];
     if (!player) continue;
 
-    const playerEvents = playerDamageEvents.filter((event) => event.sourceID === playerId);
+    const playerEvents = eventsByPlayerAllTargets.get(playerId) ?? [];
 
     // Skip players with no damage events
     if (playerEvents.length === 0) continue;
 
-    // Create data points for each time bucket (all targets combined)
-    const dataPoints: DamageOverTimeDataPoint[] = [];
-    let totalDamage = 0;
-    let maxDps = 0;
-
-    for (let i = 0; i < buckets.length; i++) {
-      const bucketStart = buckets[i];
-      const bucketEnd = buckets[i + 1] || endTime;
-
-      // Get events in this bucket
-      const bucketEvents = playerEvents.filter(
-        (event) => event.timestamp >= bucketStart && event.timestamp < bucketEnd,
-      );
-
-      const bucketDamage = bucketEvents.reduce((sum, event) => sum + event.amount, 0);
-      const dps = bucketDamage / (bucketSizeMs / 1000); // Convert to per-second
-
-      totalDamage += bucketDamage;
-      maxDps = Math.max(maxDps, dps);
-
-      dataPoints.push({
-        timestamp: bucketStart,
-        relativeTime: (bucketStart - startTime) / 1000,
-        damage: bucketDamage,
-        eventCount: bucketEvents.length,
-      });
-    }
-
-    const averageDps = totalDamage / (fightDuration / 1000);
+    const { dataPoints, totalDamage, maxDps } = buildBuckets(playerEvents);
 
     result.allTargets[playerId] = {
       playerId,
@@ -217,7 +217,7 @@ export function calculateDamageOverTimeData(
       dataPoints,
       totalDamage,
       totalEvents: playerEvents.length,
-      averageDps,
+      averageDps: totalDamage / (fightDuration / 1000),
       maxDps,
     };
   }


### PR DESCRIPTION
## Summary

Performance fix from a round-2 audit (no behavior change — output is identical).

The damage-over-time worker (DamageTimelineChart's data source) nested three event-array passes and, **inside the per-bucket loop, re-filtered each player's entire event list once per time bucket** — O(targets × players × buckets × events). A 5-minute fight is ~300 buckets, so on a 12-player trial with many boss targets and tens of thousands of damage events this took seconds and delayed the chart.

Now events are grouped by `(target, player)` and by player-across-all-targets in **one pass**, then each player's buckets are filled with a **single linear sweep** keyed by `floor((ts - startTime) / bucketSizeMs)`. I proved this reproduces the old `>= bucketStart && < bucketEnd` membership exactly (with a `[startTime, endTime)` window guard for out-of-window events), and it runs in O(events) instead of O(buckets × events).

## Testing
- `tsc --noEmit` clean
- existing CalculateDamageOverTime suite passes + **a new test** covering bucket-boundary events, out-of-window exclusion, and empty-player all-zero buckets (5 tests total)
- prettier + eslint clean
