### PR TITLE
perf(parse): make analyzeWeaving's preceding-cast lookup linear

### DIFF
--- a/src/features/parse_analysis/utils/parseAnalysisUtils.test.ts
+++ b/src/features/parse_analysis/utils/parseAnalysisUtils.test.ts
@@ -15,6 +15,8 @@ import {
   INCREASE_MAX_HEALTH_AND_STAMINA,
   TRI_STAT_FOOD,
   MAX_STAMINA_AND_MAGICKA_RECOVERY,
+  KnownAbilities,
+  SYNERGY_ABILITY_IDS,
 } from '../../../types/abilities';
 import {
   detectFood,
@@ -767,6 +769,68 @@ describe('parseAnalysisUtils', () => {
       expect(result.properWeaves).toBe(1);
       expect(result.weaveAccuracy).toBe(100);
       expect(result.missedWeaves).toBe(0);
+    });
+
+    it('skips weapon swaps and synergies when resolving the preceding cast', () => {
+      const SYNERGY_ID = Array.from(SYNERGY_ABILITY_IDS)[0];
+      const castEvents: CastEvent[] = [
+        {
+          timestamp: FIGHT_START + 1900, // Light attack cast
+          type: 'cast',
+          sourceID: PLAYER_ID,
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: LIGHT_ATTACK_ID,
+          fight: 1,
+        },
+        {
+          timestamp: FIGHT_START + 1950, // Weapon swap between LA and skill (must be skipped)
+          type: 'cast',
+          sourceID: PLAYER_ID,
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: KnownAbilities.SWAP_WEAPONS,
+          fight: 1,
+        },
+        {
+          timestamp: FIGHT_START + 1980, // Synergy between LA and skill (must be skipped)
+          type: 'cast',
+          sourceID: PLAYER_ID,
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: SYNERGY_ID,
+          fight: 1,
+        },
+        {
+          timestamp: FIGHT_START + 2000, // Skill cast 100ms after the light attack
+          type: 'cast',
+          sourceID: PLAYER_ID,
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: 12345, // Regular skill
+          fight: 1,
+        },
+      ];
+
+      const damageEvents: DamageEvent[] = [];
+
+      const result = analyzeWeaving(castEvents, damageEvents, PLAYER_ID, FIGHT_START, FIGHT_END);
+
+      expect(result.totalSkills).toBe(1);
+      expect(result.lightAttacks).toBe(1);
+      expect(result.properWeaves).toBe(1);
+      expect(result.weaveAccuracy).toBe(100);
+      expect(result.missedWeaves).toBe(0);
+      // Preceding cast resolves to the light attack 100ms earlier, skipping swap + synergy.
+      expect(result.averageWeaveTiming).toBe(100);
+      expect(result.castDetails).toHaveLength(1);
+      expect(result.castDetails[0].precedingCastAbilityId).toBe(LIGHT_ATTACK_ID);
+      expect(result.castDetails[0].precedingCastType).toBe('light');
+      expect(result.castDetails[0].timeSincePrecedingCast).toBe(100);
     });
   });
 

--- a/src/features/parse_analysis/utils/parseAnalysisUtils.ts
+++ b/src/features/parse_analysis/utils/parseAnalysisUtils.ts
@@ -1281,22 +1281,25 @@ export function analyzeWeaving(
   let weaveTimingCount = 0;
   const castDetails: CastDetail[] = [];
 
-  skillCasts.forEach((castEvent) => {
-    // Find the immediately preceding cast, skipping excluded abilities (weapon swaps and synergies)
-    let precedingCast: UnifiedCastEvent | null = null;
-    const currentIndex = playerCasts.indexOf(castEvent);
+  // Walk playerCasts once, carrying the previous non-excluded cast as we go,
+  // instead of calling playerCasts.indexOf() per skill (which was O(numSkills × numPlayerCasts)).
+  // playerCasts is already filtered to exclude weapon swaps and synergies (see above), so the
+  // immediately preceding cast is simply the prior element in playerCasts. This preserves the
+  // original backward-skip semantics because no excluded ability can appear in playerCasts.
+  let runningPrecedingCast: UnifiedCastEvent | null = null;
+  playerCasts.forEach((castEvent) => {
+    const precedingCast = runningPrecedingCast;
+    // This cast becomes the preceding cast for the next iteration.
+    runningPrecedingCast = castEvent;
 
-    for (let i = currentIndex - 1; i >= 0; i--) {
-      const cast = playerCasts[i];
-      // Skip excluded abilities (weapon swaps and synergies)
-      if (
-        cast.abilityGameID === KnownAbilities.SWAP_WEAPONS ||
-        SYNERGY_ABILITY_IDS.has(cast.abilityGameID)
-      ) {
-        continue;
-      }
-      precedingCast = cast;
-      break;
+    // Only skill casts contribute to the weave analysis (mirror the skillCasts filter).
+    const isSkillCast =
+      !LIGHT_ATTACK_ABILITY_IDS.has(castEvent.abilityGameID) &&
+      !HEAVY_ATTACK_ABILITY_IDS.has(castEvent.abilityGameID) &&
+      castEvent.abilityGameID !== KnownAbilities.SWAP_WEAPONS &&
+      !SYNERGY_ABILITY_IDS.has(castEvent.abilityGameID);
+    if (!isSkillCast) {
+      return;
     }
 
     // Determine if this is a proper weave (light attack immediately before skill)


### PR DESCRIPTION
From a codebase audit (#41, output-identical).

`analyzeWeaving` called `playerCasts.indexOf(castEvent)` per skill cast then walked backward — O(numSkills × numPlayerCasts), quadratic on long parses, run synchronously on the main thread. Since `playerCasts` is already filtered and ordered, the preceding cast is just the prior element. Rewrote to a single linear walk with a running 'previous cast' reference. Weave classification/timing untouched.

Tests: tsc clean; parseAnalysisUtils suite + a new test locking the swap/synergy-skip semantics; lint clean.