### PR TITLE
fix(fight-replay): don't dispose shared texture cache on unmount + center smoothing kernel

### DIFF
--- a/src/features/fight_replay/components/DynamicMapTexture.tsx
+++ b/src/features/fight_replay/components/DynamicMapTexture.tsx
@@ -367,13 +367,16 @@ export const DynamicMapTexture: React.FC<DynamicMapTextureProps> = ({
     }
   }, [mapTimeline, maplessTexture, onTextureChange]);
 
-  // Cleanup on unmount
+  // Cleanup on unmount: dispose only the per-instance resources this component created.
+  // Do NOT clear the module-global textureCache here — it is shared across all live
+  // DynamicMapTexture instances, so disposing it on one unmount is a use-after-dispose
+  // (blank/garbled floor) for every other instance and defeats the cross-mount cache.
+  // clearMapTextureCache remains available for explicit app-level teardown.
   useEffect(() => {
     return () => {
       geometry.dispose();
       fallbackTexture.dispose();
       maplessTexture.dispose();
-      clearMapTextureCache();
     };
   }, [geometry, fallbackTexture, maplessTexture]);
 

--- a/src/features/fight_replay/utils/pathUtils.test.ts
+++ b/src/features/fight_replay/utils/pathUtils.test.ts
@@ -6,12 +6,14 @@ import {
 import {
   DEFAULT_PATH_SAMPLING,
   PathSamplingConfig,
+  PathPoint,
   PlayerPath,
   calculateTrailOpacity,
   extractPlayerPaths,
   getPathPointsUpToTime,
   getPlayerInfo,
   getVisiblePlayerIds,
+  smoothPath,
 } from './pathUtils';
 
 function makeActor(
@@ -168,6 +170,62 @@ describe('extractPlayerPaths', () => {
       minSampleInterval: 100,
     });
     expect(paths.get(1)!.points.every((p) => p.rotation === undefined)).toBe(true);
+  });
+});
+
+describe('smoothPath', () => {
+  function makePoints(xs: number[]): PathPoint[] {
+    return xs.map((x, i) => ({
+      position: [x, 0, 0] as [number, number, number],
+      timestamp: i * 100,
+      actorId: 1,
+    }));
+  }
+
+  it('returns the input unchanged when there are fewer than 3 points or factor <= 0', () => {
+    const pts = makePoints([0, 10]);
+    expect(smoothPath(pts, 0.5)).toBe(pts);
+    const pts3 = makePoints([0, 10, 20]);
+    expect(smoothPath(pts3, 0)).toBe(pts3);
+  });
+
+  it('preserves point count and non-position metadata', () => {
+    const out = smoothPath(makePoints([0, 5, 10, 15, 20]), 0.5);
+    expect(out).toHaveLength(5);
+    expect(out.map((p) => p.timestamp)).toEqual([0, 100, 200, 300, 400]);
+    expect(out.every((p) => p.actorId === 1)).toBe(true);
+  });
+
+  // Boundary-weighting regression (#75): the Gaussian kernel must be centered on the
+  // point being smoothed (i), NOT on the clipped-window midpoint. At i=0 with factor=0.2
+  // the window is indices {0,1}; centering on i weights index 0 highest, so the smoothed
+  // x stays nearest the original first point. The old midpoint-centered weighting
+  // (Math.abs(j - start - windowLen/2)) put equal weight on {0,1}, pulling the first
+  // point toward the average and distorting the trail at the endpoint.
+  it('centers the kernel on i at clipped boundaries (not the window midpoint)', () => {
+    const factor = 0.2; // windowSize=3, halfWindow=1
+    const out = smoothPath(makePoints([0, 10, 20]), factor);
+
+    // Reference: i=0 window is {0,1}; weight uses distance |j - i|.
+    const w = (d: number) => Math.exp(-(d * d) / (2 * factor * factor));
+    const w0 = w(0); // |0-0|
+    const w1 = w(1); // |1-0|
+    const expectedFirstX = (0 * w0 + 10 * w1) / (w0 + w1);
+
+    expect(out[0].position[0]).toBeCloseTo(expectedFirstX, 10);
+
+    // The midpoint-centered bug would have weighted indices 0 and 1 equally
+    // (distance |j - 1| -> 1 and 0... actually equal magnitudes), yielding the
+    // plain average 5. The i-centered result must be strictly below that, hugging
+    // the true first point.
+    expect(out[0].position[0]).toBeLessThan(5);
+  });
+
+  it('keeps an interior point symmetric (kernel centered on i in a full window)', () => {
+    const factor = 0.2;
+    const out = smoothPath(makePoints([0, 10, 20, 30, 40]), factor);
+    // Interior point i=2: window {1,2,3} centered on i=2 -> stays at 20 by symmetry.
+    expect(out[2].position[0]).toBeCloseTo(20, 10);
   });
 });
 

--- a/src/features/fight_replay/utils/pathUtils.ts
+++ b/src/features/fight_replay/utils/pathUtils.ts
@@ -173,9 +173,13 @@ function calculateDistance3D(
 }
 
 /**
- * Apply smoothing to path points using moving average
+ * Apply smoothing to path points using a Gaussian-weighted moving average.
+ *
+ * Exported for testing: the Gaussian kernel must be centered on the point being
+ * smoothed (i), including at clipped window boundaries where the window midpoint
+ * differs from i.
  */
-function smoothPath(points: PathPoint[], factor: number): PathPoint[] {
+export function smoothPath(points: PathPoint[], factor: number): PathPoint[] {
   if (points.length < 3 || factor <= 0) {
     return points;
   }
@@ -187,7 +191,6 @@ function smoothPath(points: PathPoint[], factor: number): PathPoint[] {
   for (let i = 0; i < points.length; i++) {
     const start = Math.max(0, i - halfWindow);
     const end = Math.min(points.length, i + halfWindow + 1);
-    const windowLen = end - start;
 
     // Calculate weighted average position — iterate by index to avoid per-point allocation
     let x = 0,
@@ -196,8 +199,8 @@ function smoothPath(points: PathPoint[], factor: number): PathPoint[] {
     let totalWeight = 0;
 
     for (let j = start; j < end; j++) {
-      // Gaussian weight (higher weight for closer points)
-      const distance = Math.abs(j - start - windowLen / 2);
+      // Gaussian weight (higher weight for points closer to i, the point being smoothed)
+      const distance = Math.abs(j - i);
       const weight = Math.exp(-(distance * distance) / (2 * factor * factor));
 
       x += points[j].position[0] * weight;


### PR DESCRIPTION
Two fight-replay fixes from a codebase audit.

- **#26**: the per-instance unmount cleanup called `clearMapTextureCache()`, disposing the **module-global** texture cache shared across all instances — a use-after-dispose (blank/garbled floor) for any other live instance and defeated the cross-mount cache. Removed that call; still disposes the per-instance geometry/fallback/mapless textures.
- **#75**: the Gaussian path-smoothing weight used distance from the window **midpoint** (`j - start - windowLen/2`), which is off-center at clipped boundaries and distorts the trail near endpoints. Now `Math.abs(j - i)` (distance to the point being smoothed).

Tests: tsc clean; pathUtils suite + a new boundary-weighting test; lint clean.