### PR TITLE
fix(loadout): preserve mixed Lua tables + trash boss label on Wizard's Wardrobe round-trip

### DIFF
--- a/src/features/loadout-manager/utils/__tests__/wizardWardrobeConverter.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/wizardWardrobeConverter.test.ts
@@ -254,4 +254,39 @@ describe('wizardWardrobeConverter', () => {
     expect(setup?.food?.id).toBe(153629);
     expect(setup?.food?.link).toContain('item:153629');
   });
+
+  it('preserves the boss label on initialized trash setups', () => {
+    const state = convertAllCharactersToLoadoutState({
+      charKey: {
+        version: 1,
+        selectedZoneTag: 'SS',
+        setups: {
+          SS: [
+            {
+              1: {
+                name: 'Trash Setup',
+                disabled: false,
+                condition: { boss: 'Trash', trash: 2 },
+                skills: { 0: {}, 1: {} },
+                cp: {},
+                food: {},
+                gear: {},
+              },
+            },
+          ],
+        },
+        pages: {
+          SS: [{ name: 'Page 1' }],
+        },
+        $LastCharacterName: 'Trash Tester',
+      },
+    });
+
+    const characterId = 'trash-tester-charKey';
+    const condition = state.pages[characterId].SS[0].setups[0].condition;
+
+    // Both the boss label and the trash pack number must survive the round-trip.
+    expect(condition.boss).toBe('Trash');
+    expect(condition.trash).toBe(2);
+  });
 });

--- a/src/features/loadout-manager/utils/__tests__/wizardsWardrobeSavedVariables.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/wizardsWardrobeSavedVariables.test.ts
@@ -1,4 +1,5 @@
 import {
+  parseLuaAssignments,
   parseWizardsWardrobeSavedVariables,
   serializeWizardsWardrobeSavedVariables,
   type WizardWardrobeSavedVariables,
@@ -94,5 +95,28 @@ describe('wizardsWardrobeSavedVariables', () => {
 
     expect(parsed.Default?.['@Account']?.$AccountWide?.selectedZoneTag).toBe('GEN');
     expect(parsed.Default?.['@Account']?.$AccountWide?.setups).toBeDefined();
+  });
+
+  it('keeps both implicit positional and explicit numeric-key entries in a mixed table', () => {
+    // A Lua table that carries BOTH bare positional values AND explicit [N] = ...
+    // numeric-key entries must not drop the positional ("implicit") values.
+    const assignments = parseLuaAssignments(`Mixed = { "a", "b", [5] = "e", [6] = "f" }`);
+    const mixed = assignments.Mixed as Record<string, unknown>;
+
+    expect(Array.isArray(mixed)).toBe(false);
+    // Implicit values take consecutive 1-based indices.
+    expect(mixed['1']).toBe('a');
+    expect(mixed['2']).toBe('b');
+    // Explicit numeric keys are preserved.
+    expect(mixed['5']).toBe('e');
+    expect(mixed['6']).toBe('f');
+  });
+
+  it('does not change pure-array or pure-object tables', () => {
+    const arrayCase = parseLuaAssignments(`Arr = { "a", "b", "c" }`);
+    expect(arrayCase.Arr).toEqual(['a', 'b', 'c']);
+
+    const objectCase = parseLuaAssignments(`Obj = { ["x"] = 1, ["y"] = 2 }`);
+    expect(objectCase.Obj).toEqual({ x: 1, y: 2 });
   });
 });

--- a/src/features/loadout-manager/utils/wizardWardrobeConverter.ts
+++ b/src/features/loadout-manager/utils/wizardWardrobeConverter.ts
@@ -260,6 +260,7 @@ function normalizeCondition(condition: any): LoadoutSetup['condition'] {
   // Handle both boss and trash conditions
   if (condition.trash !== undefined) {
     return {
+      ...(condition.boss ? { boss: condition.boss } : {}),
       trash: Number(condition.trash),
     };
   }

--- a/src/features/loadout-manager/utils/wizardsWardrobeSavedVariables.ts
+++ b/src/features/loadout-manager/utils/wizardsWardrobeSavedVariables.ts
@@ -257,6 +257,18 @@ class LuaTableParser {
       }
     }
 
+    // Mixed case: a table carries BOTH implicit positional values AND explicit
+    // numeric-key entries. In Lua, implicit values take consecutive 1-based
+    // indices, so merge them into the index-keyed object alongside the explicit
+    // entries instead of silently dropping `arr`.
+    if (hasImplicitValues && arr.length > 0) {
+      let index = 1;
+      for (const value of arr) {
+        obj[String(index)] = value;
+        index += 1;
+      }
+    }
+
     return obj;
   }
 


### PR DESCRIPTION
Two loadout-manager data-loss fixes from a codebase audit.

- **#49**: the Lua table parser dropped a table that had BOTH implicit positional entries AND explicit `[N]=` numeric keys (returned the object, discarding the array). Now merges positional values into their 1-based indices so nothing is lost. Shared entry point for Wizard's Wardrobe/CSPS/AlphaGear.
- **#50**: `normalizeCondition` returned only `{ trash }` for trash setups, dropping the `boss` label that initialized trash setups carry. Now preserves both so it round-trips identically.

Tests: tsc clean; new focused tests for the mixed-table parse + trash round-trip; lint clean.