### PR TITLE
fix(store): memoize worker-task selector factories + skip already-aborted work

### DIFF
--- a/src/store/worker_results/selectors.test.ts
+++ b/src/store/worker_results/selectors.test.ts
@@ -1,0 +1,50 @@
+import {
+  selectWorkerTask,
+  selectWorkerTaskResult,
+  selectWorkerTaskLoading,
+  selectWorkerTaskProgress,
+  selectWorkerTaskError,
+  selectWorkerTaskLastUpdated,
+} from './selectors';
+
+describe('worker_results selector factory memoization', () => {
+  it('returns the same selectWorkerTask instance for a given taskName', () => {
+    expect(selectWorkerTask('calculateBuffLookup')).toBe(selectWorkerTask('calculateBuffLookup'));
+  });
+
+  it('returns the same selectWorkerTaskLoading instance for a given taskName', () => {
+    expect(selectWorkerTaskLoading('calculateBuffLookup')).toBe(
+      selectWorkerTaskLoading('calculateBuffLookup'),
+    );
+  });
+
+  it('returns the same selectWorkerTaskResult instance for a given taskName', () => {
+    expect(selectWorkerTaskResult('calculateBuffLookup')).toBe(
+      selectWorkerTaskResult('calculateBuffLookup'),
+    );
+  });
+
+  it('returns the same selectWorkerTaskProgress instance for a given taskName', () => {
+    expect(selectWorkerTaskProgress('calculateBuffLookup')).toBe(
+      selectWorkerTaskProgress('calculateBuffLookup'),
+    );
+  });
+
+  it('returns the same selectWorkerTaskError instance for a given taskName', () => {
+    expect(selectWorkerTaskError('calculateBuffLookup')).toBe(
+      selectWorkerTaskError('calculateBuffLookup'),
+    );
+  });
+
+  it('returns the same selectWorkerTaskLastUpdated instance for a given taskName', () => {
+    expect(selectWorkerTaskLastUpdated('calculateBuffLookup')).toBe(
+      selectWorkerTaskLastUpdated('calculateBuffLookup'),
+    );
+  });
+
+  it('returns distinct selector instances for different taskNames', () => {
+    expect(selectWorkerTaskLoading('calculateBuffLookup')).not.toBe(
+      selectWorkerTaskLoading('calculateDebuffLookup'),
+    );
+  });
+});

--- a/src/store/worker_results/selectors.ts
+++ b/src/store/worker_results/selectors.ts
@@ -10,16 +10,45 @@ import { WorkerTaskState } from './workerTaskSliceFactory';
 export const selectWorkerResults = (state: RootState): typeof state.workerResults =>
   state.workerResults;
 
+/**
+ * Per-taskName memoization caches for the selector factories below.
+ *
+ * Each factory builds a fresh `createSelector` (with its own empty memo cache)
+ * every time it's called. The worker-task hooks call these factories inline
+ * inside `useSelector`, so without caching a brand-new selector instance is
+ * created on every render and the memoization is permanently defeated. Keying
+ * the created selector by `taskName` guarantees a single stable instance per
+ * task name across renders, restoring memoization without changing behavior.
+ */
+const selectWorkerTaskCache = new Map<string, ReturnType<typeof createSelector>>();
+const selectWorkerTaskResultCache = new Map<string, ReturnType<typeof createSelector>>();
+const selectWorkerTaskLoadingCache = new Map<string, ReturnType<typeof createSelector>>();
+const selectWorkerTaskProgressCache = new Map<string, ReturnType<typeof createSelector>>();
+const selectWorkerTaskErrorCache = new Map<string, ReturnType<typeof createSelector>>();
+const selectWorkerTaskLastUpdatedCache = new Map<string, ReturnType<typeof createSelector>>();
+
 // Generic selector for a specific worker task
 export const selectWorkerTask = <T extends SharedComputationWorkerTaskType>(
   taskName: T,
 ): ReturnType<
   typeof createSelector<[typeof selectWorkerResults], WorkerTaskState<SharedWorkerResultType<T>>>
-> =>
-  createSelector(
+> => {
+  const cached = selectWorkerTaskCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<
+        [typeof selectWorkerResults],
+        WorkerTaskState<SharedWorkerResultType<T>>
+      >
+    >;
+  }
+  const selector = createSelector(
     [selectWorkerResults],
     (workerResults) => workerResults[taskName] as WorkerTaskState<SharedWorkerResultType<T>>,
   );
+  selectWorkerTaskCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 // Specific selectors for each worker task
 export const selectActorPositionsTask = selectWorkerTask('calculateActorPositions');
@@ -41,27 +70,76 @@ export const selectWorkerTaskResult = <T extends SharedComputationWorkerTaskType
   taskName: T,
 ): ReturnType<
   typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], SharedWorkerResultType<T> | null>
-> => createSelector([selectWorkerTask(taskName)], (task) => task.result);
+> => {
+  const cached = selectWorkerTaskResultCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<
+        [ReturnType<typeof selectWorkerTask<T>>],
+        SharedWorkerResultType<T> | null
+      >
+    >;
+  }
+  const selector = createSelector([selectWorkerTask(taskName)], (task) => task.result);
+  selectWorkerTaskResultCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 export const selectWorkerTaskLoading = <T extends SharedComputationWorkerTaskType>(
   taskName: T,
-): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], boolean>> =>
-  createSelector([selectWorkerTask(taskName)], (task) => task.isLoading);
+): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], boolean>> => {
+  const cached = selectWorkerTaskLoadingCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], boolean>
+    >;
+  }
+  const selector = createSelector([selectWorkerTask(taskName)], (task) => task.isLoading);
+  selectWorkerTaskLoadingCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 export const selectWorkerTaskProgress = <T extends SharedComputationWorkerTaskType>(
   taskName: T,
-): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>> =>
-  createSelector([selectWorkerTask(taskName)], (task) => task.progress);
+): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>> => {
+  const cached = selectWorkerTaskProgressCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>
+    >;
+  }
+  const selector = createSelector([selectWorkerTask(taskName)], (task) => task.progress);
+  selectWorkerTaskProgressCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 export const selectWorkerTaskError = <T extends SharedComputationWorkerTaskType>(
   taskName: T,
-): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], string | null>> =>
-  createSelector([selectWorkerTask(taskName)], (task) => task.error);
+): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], string | null>> => {
+  const cached = selectWorkerTaskErrorCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], string | null>
+    >;
+  }
+  const selector = createSelector([selectWorkerTask(taskName)], (task) => task.error);
+  selectWorkerTaskErrorCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 export const selectWorkerTaskLastUpdated = <T extends SharedComputationWorkerTaskType>(
   taskName: T,
-): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>> =>
-  createSelector([selectWorkerTask(taskName)], (task) => task.lastUpdated);
+): ReturnType<typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>> => {
+  const cached = selectWorkerTaskLastUpdatedCache.get(taskName);
+  if (cached) {
+    return cached as ReturnType<
+      typeof createSelector<[ReturnType<typeof selectWorkerTask<T>>], number | null>
+    >;
+  }
+  const selector = createSelector([selectWorkerTask(taskName)], (task) => task.lastUpdated);
+  selectWorkerTaskLastUpdatedCache.set(taskName, selector as ReturnType<typeof createSelector>);
+  return selector;
+};
 
 // Convenience selectors for specific results
 export const selectActorPositionsResult = selectWorkerTaskResult('calculateActorPositions');

--- a/src/store/worker_results/workerTaskSliceFactory.test.ts
+++ b/src/store/worker_results/workerTaskSliceFactory.test.ts
@@ -633,6 +633,65 @@ describe('workerTaskSliceFactory', () => {
         expect(state.workerResults[mockTaskName].error).toBeNull();
         expect(state.workerResults[mockTaskName].isLoading).toBe(false);
       });
+
+      it('should not start the worker when the signal is already aborted before scheduling', async () => {
+        // Early-abort guard: if the request's signal is already aborted by the
+        // time the payload creator reaches the guard, the worker is never
+        // scheduled. We force this by aborting the in-flight request from inside
+        // `createInputHash`, which the creator calls synchronously right before
+        // the guard (the second call overall — the first is the thunk
+        // `condition`).
+        let hashCalls = 0;
+        let abortControllerRef: AbortController | null = null;
+        const abortingHash = (input: SharedWorkerInputType<typeof mockTaskName>): string => {
+          hashCalls += 1;
+          // Second call is inside the payload creator, immediately before the guard.
+          if (hashCalls === 2) {
+            abortControllerRef?.abort();
+          }
+          return JSON.stringify(input);
+        };
+
+        // Capture the AbortController RTK installs for this dispatch by wrapping
+        // the global so the creator's `signal` reflects our abort synchronously.
+        const RealAbortController = global.AbortController;
+        global.AbortController = class extends RealAbortController {
+          constructor() {
+            super();
+            abortControllerRef = this;
+          }
+        } as typeof AbortController;
+
+        const abortSlice = createWorkerTaskSlice(mockTaskName, abortingHash);
+        const abortStore = configureStore({
+          reducer: {
+            workerResults: combineReducers({
+              [mockTaskName]: abortSlice.reducer,
+            }),
+          },
+        });
+
+        try {
+          const promise = abortStore.dispatch(abortSlice.executeTask(mockInput));
+          await promise.catch(() => {});
+        } finally {
+          global.AbortController = RealAbortController;
+        }
+
+        // Worker must never have been scheduled for already-cancelled work.
+        expect(mockWorkerManager.executeTask).not.toHaveBeenCalled();
+
+        const state = abortStore.getState() as {
+          workerResults: {
+            [mockTaskName]: WorkerTaskState<SharedWorkerResultType<typeof mockTaskName>>;
+          };
+        };
+
+        // Aborted task: no error, not loading, no result.
+        expect(state.workerResults[mockTaskName].error).toBeNull();
+        expect(state.workerResults[mockTaskName].isLoading).toBe(false);
+        expect(state.workerResults[mockTaskName].result).toBeNull();
+      });
     });
   });
 });

--- a/src/store/worker_results/workerTaskSliceFactory.ts
+++ b/src/store/worker_results/workerTaskSliceFactory.ts
@@ -115,6 +115,14 @@ export const createWorkerTaskSlice = <T extends SharedComputationWorkerTaskType>
           return taskState.resultCache[inputHash];
         }
 
+        // If the request was already aborted before we got a chance to start the
+        // worker, bail out early so we don't kick off work that's already been
+        // cancelled. (Note: this only avoids *starting* already-cancelled work;
+        // a worker that's already running is still not terminated mid-flight.)
+        if (signal.aborted) {
+          return rejectWithValue('Task was aborted');
+        }
+
         const result = await workerManager.executeTask(taskName, input, (progress: number) => {
           // Only dispatch progress updates if the task hasn't been aborted
           if (!signal.aborted) {


### PR DESCRIPTION
Two worker_results fixes from a codebase audit.

- **#64**: `selectWorkerTask*` factories built a fresh `createSelector` (empty memo cache) on every call, and the worker-task hooks call them inline inside `useSelector` every render — permanently defeating memoization. Memoized each factory by `taskName` via a module-level Map, so each task name yields one stable selector instance (behavior unchanged).
- **#63 (conservative)**: the worker thunk's AbortSignal only gated progress/result; already-aborted work still started. Added an early `signal.aborted` bail before scheduling. (Threading abort through WorkerPool/terminating workers is intentionally left out of scope.)

Tests: tsc clean; worker_results suites + new tests (incl. stable-selector-reference); lint clean.