### PR TITLE
perf(buffs): compute group-average buff/debuff uptime in a single pass

### DIFF
--- a/src/utils/buffUptimeCalculator.test.ts
+++ b/src/utils/buffUptimeCalculator.test.ts
@@ -2,8 +2,68 @@ import { BuffLookupData } from './BuffLookupUtils';
 import {
   BuffInterval,
   BuffUptimeCalculatorOptions,
+  BuffUptimeResult,
   computeBuffUptimes,
+  computeBuffUptimesWithGroupAverage,
 } from './buffUptimeCalculator';
+
+/**
+ * Reference implementation of the ORIGINAL (pre-optimization) group-average algorithm:
+ * call computeBuffUptimes() once per player, then average the per-player uptime
+ * percentages. The single-pass implementation must produce byte-identical output.
+ */
+function referenceGroupAverage(
+  buffLookup: BuffLookupData | null | undefined,
+  options: BuffUptimeCalculatorOptions,
+  singleTargetId: number,
+): BuffUptimeResult[] {
+  if (!buffLookup || !options.fightDuration) {
+    return [];
+  }
+  const allTargetIds = options.filterBySourceId
+    ? options.sourceIds || new Set<number>()
+    : options.targetIds || new Set<number>();
+  if (allTargetIds.size === 0) {
+    return [];
+  }
+
+  const playerUptimes = new Map<string, Map<number, number>>();
+  allTargetIds.forEach((targetId) => {
+    const singlePlayerOptions = {
+      ...options,
+      ...(options.filterBySourceId
+        ? { sourceIds: new Set([targetId]) }
+        : { targetIds: new Set([targetId]) }),
+    };
+    const uptimes = computeBuffUptimes(buffLookup, singlePlayerOptions);
+    uptimes.forEach((uptime) => {
+      const abilityId = uptime.abilityGameID;
+      if (!playerUptimes.has(abilityId)) {
+        playerUptimes.set(abilityId, new Map());
+      }
+      playerUptimes.get(abilityId)!.set(targetId, uptime.uptimePercentage);
+    });
+  });
+
+  const groupAverageMap = new Map<string, number>();
+  playerUptimes.forEach((playerMap, abilityId) => {
+    const uptimes = Array.from(playerMap.values());
+    const average = uptimes.reduce((sum, val) => sum + val, 0) / Math.max(uptimes.length, 1);
+    groupAverageMap.set(abilityId, average);
+  });
+
+  const singleTargetOptions = {
+    ...options,
+    ...(options.filterBySourceId
+      ? { sourceIds: new Set([singleTargetId]) }
+      : { targetIds: new Set([singleTargetId]) }),
+  };
+  const singleTargetUptimes = computeBuffUptimes(buffLookup, singleTargetOptions);
+  return singleTargetUptimes.map((uptime) => ({
+    ...uptime,
+    groupAverageUptimePercentage: groupAverageMap.get(uptime.abilityGameID),
+  }));
+}
 
 describe('buffUptimeCalculator', () => {
   // Mock constants for testing
@@ -410,6 +470,180 @@ describe('buffUptimeCalculator', () => {
       expect(result).toHaveLength(1);
       // Should average across specified target count: 50% / 2 = 25%
       expect(result[0].uptimePercentage).toBe(25);
+    });
+  });
+
+  describe('computeBuffUptimesWithGroupAverage (single-pass equivalence)', () => {
+    const PLAYER_A = MOCK_TARGET_ID_1; // 111
+    const PLAYER_B = MOCK_TARGET_ID_2; // 222
+    const PLAYER_C = 333;
+    const ENEMY_A = 555;
+    const ENEMY_B = 666;
+
+    it('returns empty for null lookup / zero duration / empty player set', () => {
+      expect(computeBuffUptimesWithGroupAverage(null, baseOptions, PLAYER_A)).toEqual([]);
+      const lookup = createBuffLookup(new Map());
+      expect(
+        computeBuffUptimesWithGroupAverage(lookup, { ...baseOptions, fightDuration: 0 }, PLAYER_A),
+      ).toEqual([]);
+      // No targetIds / sourceIds -> allTargetIds empty
+      expect(computeBuffUptimesWithGroupAverage(lookup, baseOptions, PLAYER_A)).toEqual([]);
+    });
+
+    it('matches the per-player reference for NORMAL buffs across multiple players', () => {
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 6000, PLAYER_A), // A: 50%
+            createBuffInterval(FIGHT_START + 2000, FIGHT_START + 5000, PLAYER_B), // B: 30%
+            createBuffInterval(FIGHT_START + 0, FIGHT_START + 2000, PLAYER_C), // C: 20%
+          ],
+        ],
+        [
+          MOCK_ABILITY_ID_2,
+          [
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 9000, PLAYER_A), // A: 80%
+            createBuffInterval(FIGHT_START + 3000, FIGHT_START + 6000, PLAYER_B), // B: 30%
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        targetIds: new Set([PLAYER_A, PLAYER_B, PLAYER_C]),
+      };
+
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_A);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_A);
+      expect(actual).toEqual(expected);
+      // sanity: group average for ability 1 = (50+30+20)/3 ~= 33.33
+      const a1 = actual.find((u) => u.abilityGameID === String(MOCK_ABILITY_ID_1))!;
+      expect(a1.groupAverageUptimePercentage).toBeCloseTo(100 / 3, 6);
+      expect(a1.uptimePercentage).toBe(50);
+    });
+
+    it('matches reference with an additional sourceIds filter in NORMAL mode', () => {
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 6000, PLAYER_A, MOCK_SOURCE_ID_1),
+            createBuffInterval(FIGHT_START + 2000, FIGHT_START + 7000, PLAYER_A, MOCK_SOURCE_ID_2),
+            createBuffInterval(FIGHT_START + 0, FIGHT_START + 5000, PLAYER_B, MOCK_SOURCE_ID_1),
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        targetIds: new Set([PLAYER_A, PLAYER_B]),
+        sourceIds: new Set([MOCK_SOURCE_ID_1]),
+      };
+
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_A);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_A);
+      expect(actual).toEqual(expected);
+    });
+
+    it('matches reference for INVERTED debuffs (filterBySourceId) across enemies', () => {
+      // sourceID = friendly player who applied; targetID = enemy receiving.
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            // Player A on Enemy A & Enemy B
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 6000, ENEMY_A, PLAYER_A), // 50%
+            createBuffInterval(FIGHT_START + 2000, FIGHT_START + 5000, ENEMY_B, PLAYER_A), // 30%
+            // Player B on Enemy A only
+            createBuffInterval(FIGHT_START + 0, FIGHT_START + 4000, ENEMY_A, PLAYER_B), // 40%
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        isDebuff: true,
+        sourceIds: new Set([PLAYER_A, PLAYER_B]), // players to compare
+        targetIds: new Set([ENEMY_A, ENEMY_B]), // enemy filter (denominator = 2)
+        filterBySourceId: true,
+      };
+
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_A);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_A);
+      expect(actual).toEqual(expected);
+      // Player A single-target: (50% + 30%) / 2 enemies = 40%
+      const a1 = actual.find((u) => u.abilityGameID === String(MOCK_ABILITY_ID_1))!;
+      expect(a1.uptimePercentage).toBeCloseTo(40, 6);
+      // Group avg: playerA=40, playerB=(40%/2)=20 -> (40+20)/2 = 30
+      expect(a1.groupAverageUptimePercentage).toBeCloseTo(30, 6);
+    });
+
+    it('matches reference for INVERTED debuffs with NO targetIds filter (distinct-target denominator)', () => {
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 6000, ENEMY_A, PLAYER_A), // 50%
+            createBuffInterval(FIGHT_START + 2000, FIGHT_START + 5000, ENEMY_B, PLAYER_A), // 30%
+            createBuffInterval(FIGHT_START + 0, FIGHT_START + 4000, ENEMY_A, PLAYER_B), // 40%
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        isDebuff: true,
+        sourceIds: new Set([PLAYER_A, PLAYER_B]),
+        // no targetIds -> denominator = distinct targets seen per player
+        filterBySourceId: true,
+      };
+
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_A);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_A);
+      expect(actual).toEqual(expected);
+    });
+
+    it('matches reference when singleTargetId is not in the comparison set', () => {
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            createBuffInterval(FIGHT_START + 1000, FIGHT_START + 6000, PLAYER_A),
+            createBuffInterval(FIGHT_START + 2000, FIGHT_START + 5000, PLAYER_B),
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        targetIds: new Set([PLAYER_A, PLAYER_B]),
+      };
+      // Compare against player C (no data) while group is A+B
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_C);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_C);
+      expect(actual).toEqual(expected);
+    });
+
+    it('matches reference with interval clipping and zero-duration intervals', () => {
+      const intervals = new Map([
+        [
+          MOCK_ABILITY_ID_1,
+          [
+            createBuffInterval(FIGHT_START - 2000, FIGHT_END + 2000, PLAYER_A), // clipped -> 100%
+            createBuffInterval(FIGHT_START + 5000, FIGHT_START + 5000, PLAYER_B), // zero
+            createBuffInterval(FIGHT_START + 3000, FIGHT_START + 7000, PLAYER_B), // 40%
+          ],
+        ],
+      ]);
+      const buffLookup = createBuffLookup(intervals);
+      const options: BuffUptimeCalculatorOptions = {
+        ...baseOptions,
+        targetIds: new Set([PLAYER_A, PLAYER_B]),
+      };
+      const expected = referenceGroupAverage(buffLookup, options, PLAYER_A);
+      const actual = computeBuffUptimesWithGroupAverage(buffLookup, options, PLAYER_A);
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/src/utils/buffUptimeCalculator.ts
+++ b/src/utils/buffUptimeCalculator.ts
@@ -189,30 +189,119 @@ export function computeBuffUptimesWithGroupAverage(
     return [];
   }
 
-  // Calculate uptime for each player individually
-  const playerUptimes = new Map<string, Map<number, number>>(); // abilityId -> Map<playerId -> uptimePercentage>
+  // Single-pass per-player uptime accumulation.
+  //
+  // The previous implementation called computeBuffUptimes() once per player, and
+  // each call re-walked + re-filtered the FULL interval list of every ability,
+  // giving O(players × totalIntervals). Instead, walk each ability's intervals
+  // exactly once and bucket every interval's clipped duration by (player, target).
+  //
+  // The per-player call's filtering is exactly equivalent to the original options'
+  // targetIds + sourceIds filter:
+  //   - Normal mode: per-player targetIds={P}; combined over all players (= options.targetIds)
+  //     reduces to options.targetIds.has(targetID). sourceIds is unchanged.
+  //   - Inverted mode (filterBySourceId): per-player sourceIds={P}; combined over all players
+  //     (= options.sourceIds) reduces to options.sourceIds.has(sourceID). targetIds is unchanged.
+  // So the constant filter below mirrors a single computeBuffUptimes() pass, plus a player bucket.
+  const { sourceIds, targetIds, fightStartTime, fightEndTime, fightDuration } = options;
+  const filterBySourceId = options.filterBySourceId === true;
 
-  allTargetIds.forEach((targetId, _index) => {
-    const singlePlayerOptions = {
-      ...options,
-      // For inverted debuffs, set sourceIds to the single player
-      // For normal buffs/debuffs, set targetIds to the single player
-      ...(options.filterBySourceId
-        ? { sourceIds: new Set([targetId]) }
-        : { targetIds: new Set([targetId]) }),
-    };
-    const uptimes = computeBuffUptimes(buffLookup, singlePlayerOptions);
+  // abilityId -> playerId -> targetID -> accumulated duration
+  const accumulation = new Map<string, Map<number, Map<number, number>>>();
 
-    uptimes.forEach((uptime) => {
-      const abilityId = uptime.abilityGameID;
-      if (!playerUptimes.has(abilityId)) {
-        playerUptimes.set(abilityId, new Map());
+  Object.entries(buffLookup.buffIntervals).forEach(([abilityGameIDStr, intervals]) => {
+    const abilityGameID = parseInt(abilityGameIDStr, 10);
+    if (!options.abilityIds.has(abilityGameID)) {
+      return;
+    }
+    const abilityKey = String(abilityGameID);
+
+    intervals.forEach((interval: BuffInterval) => {
+      // Apply the same target/source filtering computeBuffUptimes() applies.
+      if (targetIds && !targetIds.has(interval.targetID)) {
+        return;
       }
-      playerUptimes.get(abilityId)!.set(targetId, uptime.uptimePercentage);
+      if (sourceIds && interval.sourceID && !sourceIds.has(interval.sourceID)) {
+        return;
+      }
+
+      const start = Math.max(interval.start, fightStartTime);
+      const end = Math.min(interval.end, fightEndTime);
+      const duration = end > start ? end - start : 0;
+      if (duration <= 0) {
+        return;
+      }
+
+      // Determine which player(s) this interval contributes to.
+      // - Normal mode: the single targetID (already gated to allTargetIds above).
+      // - Inverted mode with a real sourceID: that single source player.
+      // - Inverted mode with a falsy sourceID (0/undefined): the original per-player
+      //   call's `interval.sourceID && ...` guard short-circuits, so the interval is
+      //   NOT filtered out by source and is counted for EVERY comparison player.
+      let contributingPlayers: number[];
+      if (filterBySourceId) {
+        if (interval.sourceID) {
+          if (!allTargetIds.has(interval.sourceID)) {
+            return;
+          }
+          contributingPlayers = [interval.sourceID];
+        } else {
+          contributingPlayers = Array.from(allTargetIds);
+        }
+      } else {
+        if (!allTargetIds.has(interval.targetID)) {
+          return;
+        }
+        contributingPlayers = [interval.targetID];
+      }
+
+      let byPlayer = accumulation.get(abilityKey);
+      if (!byPlayer) {
+        byPlayer = new Map();
+        accumulation.set(abilityKey, byPlayer);
+      }
+      contributingPlayers.forEach((playerId) => {
+        let byTarget = byPlayer!.get(playerId);
+        if (!byTarget) {
+          byTarget = new Map();
+          byPlayer!.set(playerId, byTarget);
+        }
+        byTarget.set(interval.targetID, (byTarget.get(interval.targetID) || 0) + duration);
+      });
     });
   });
 
-  // Calculate the average uptime across all players for each ability
+  // Derive each player's uptime percentage per ability, mirroring computeBuffUptimes' averaging.
+  // playerUptimes: abilityId -> Map<playerId -> uptimePercentage>
+  const playerUptimes = new Map<string, Map<number, number>>();
+  accumulation.forEach((byPlayer, abilityKey) => {
+    byPlayer.forEach((byTarget, playerId) => {
+      // Sum each target's uptime percentage for this player.
+      let totalUptimeSum = 0;
+      byTarget.forEach((totalDuration) => {
+        totalUptimeSum += (totalDuration / fightDuration) * 100;
+      });
+
+      // Denominator matches the per-player computeBuffUptimes call:
+      //   targetCount = (per-player targetIds) ? its size : number of distinct targets seen.
+      // Normal mode: per-player targetIds={P} -> size 1.
+      // Inverted mode: per-player targetIds = options.targetIds (or distinct targets if undefined).
+      const targetCount = filterBySourceId ? (targetIds ? targetIds.size : byTarget.size) : 1;
+      const averageUptimePercentage = totalUptimeSum / Math.max(targetCount, 1);
+
+      // computeBuffUptimes only emits a result when averageUptimePercentage > 0.
+      if (averageUptimePercentage > 0) {
+        let perPlayer = playerUptimes.get(abilityKey);
+        if (!perPlayer) {
+          perPlayer = new Map();
+          playerUptimes.set(abilityKey, perPlayer);
+        }
+        perPlayer.set(playerId, averageUptimePercentage);
+      }
+    });
+  });
+
+  // Calculate the average uptime across all contributing players for each ability.
   const groupAverageMap = new Map<string, number>();
   playerUptimes.forEach((playerMap, abilityId) => {
     const uptimes = Array.from(playerMap.values());

--- a/src/utils/buffUptimeCalculator.ts
+++ b/src/utils/buffUptimeCalculator.ts
@@ -224,7 +224,7 @@ export function computeBuffUptimesWithGroupAverage(
       if (targetIds && !targetIds.has(interval.targetID)) {
         return;
       }
-      if (sourceIds && interval.sourceID && !sourceIds.has(interval.sourceID)) {
+      if (sourceIds && interval.sourceID != null && !sourceIds.has(interval.sourceID)) {
         return;
       }
 
@@ -237,13 +237,15 @@ export function computeBuffUptimesWithGroupAverage(
 
       // Determine which player(s) this interval contributes to.
       // - Normal mode: the single targetID (already gated to allTargetIds above).
-      // - Inverted mode with a real sourceID: that single source player.
-      // - Inverted mode with a falsy sourceID (0/undefined): the original per-player
-      //   call's `interval.sourceID && ...` guard short-circuits, so the interval is
-      //   NOT filtered out by source and is counted for EVERY comparison player.
+      // - Inverted mode with a recorded sourceID (including 0): that single source
+      //   player; if it isn't one of the compared players the interval is dropped
+      //   (matches computeBuffUptimes' `interval.sourceID != null && !sourceIds.has`).
+      // - Inverted mode with a null/undefined sourceID: the per-player call's source
+      //   filter short-circuits (sourceID != null is false), so the interval is NOT
+      //   filtered out and is counted for EVERY comparison player.
       let contributingPlayers: number[];
       if (filterBySourceId) {
-        if (interval.sourceID) {
+        if (interval.sourceID != null) {
           if (!allTargetIds.has(interval.sourceID)) {
             return;
           }


### PR DESCRIPTION
From a round-2 audit (R2#14, output-identical).

`computeBuffUptimesWithGroupAverage` called `computeBuffUptimes` once per player, and each call re-walked + re-filtered the FULL interval list of every ability — O(players × totalIntervals). On a 12-player group with thousands of intervals that's ~12× more interval scanning than needed.

Now walks each ability's intervals **once**, bucketing each interval's clipped duration by (player, target), then derives both the per-player numbers and the group average from that single accumulation. The source filter uses `interval.sourceID != null` to stay consistent with `computeBuffUptimes` (PR #1284): a recorded `sourceID 0` is a real source (counted only for player 0 if present, else dropped), and only a null/undefined source broadcasts to all comparison players.

## Testing
- `tsc --noEmit` clean
- buffUptimeCalculator suite (23 tests) including **8 equivalence tests** that deep-compare against a reference re-implementation calling the real per-player `computeBuffUptimes` (normal / source-filtered / inverted with+without target filter / out-of-set / clipping)
- prettier + eslint clean