### PR TITLE
fix(scribing): resurrect the broken Scribing Simulator (#3/#4)

### DIFF
--- a/src/features/scribing/__tests__/integration/architecture.test.ts
+++ b/src/features/scribing/__tests__/integration/architecture.test.ts
@@ -9,79 +9,14 @@ import { AbilityMappingService } from '../../core/services/AbilityMappingService
 import { ScribingSimulatorService } from '../../application/simulators/ScribingSimulatorService';
 import { ScribingDetectionService } from '../../application/services/ScribingDetectionService';
 
-// Mock fetch for testing
-global.fetch = jest.fn();
-
-const mockScribingData = {
-  version: '1.0.0',
-  description: 'Test data',
-  lastUpdated: '2025-01-01',
-  grimoires: {
-    'test-grimoire': {
-      id: 'test-grimoire',
-      name: 'Test Grimoire',
-      skillLine: 'Support',
-      requirements: null,
-      cost: { first: 100, additional: 50 },
-      description: 'A test grimoire',
-      abilityIds: [12345],
-    },
-  },
-  focusScripts: {
-    'test-focus': {
-      id: 'test-focus',
-      name: 'Test Focus',
-      type: 'Focus',
-      icon: 'test-icon',
-      compatibleGrimoires: ['test-grimoire'],
-      description: 'A test focus script',
-      damageType: 'physical',
-    },
-  },
-  signatureScripts: {
-    'test-signature': {
-      id: 'test-signature',
-      name: 'Test Signature',
-      type: 'Signature',
-      icon: 'test-icon',
-      compatibleGrimoires: ['test-grimoire'],
-      description: 'A test signature script',
-    },
-  },
-  affixScripts: {
-    'test-affix': {
-      id: 'test-affix',
-      name: 'Test Affix',
-      type: 'Affix',
-      icon: 'test-icon',
-      compatibleGrimoires: ['test-grimoire'],
-      description: 'A test affix script',
-    },
-  },
-  questRewards: {},
-  freeScriptLocations: {},
-  dailyScriptSources: {
-    'focus-scripts': [],
-    'signature-scripts': [],
-    'affix-scripts': [],
-  },
-  scriptVendors: {},
-  luminousInk: {
-    description: 'Test ink',
-    costs: { newSkill: 1, modifySkill: 1 },
-    sources: [],
-    storage: 'Test storage',
-  },
-  system: {
-    totalPossibleSkills: 1000,
-    grimoireRange: { min: 1, max: 12 },
-    requirements: {
-      chapter: 'Test Chapter',
-      characterLevel: 1,
-      tutorialQuest: 'Test Quest',
-    },
-  },
-};
+// Real-data fixtures from the bundled data/scribing-complete.json. The
+// repository now imports + adapts that dataset directly (no runtime fetch).
+const GRIMOIRE_SLUG = 'traveling-knife';
+const GRIMOIRE_NAME = 'Traveling Knife';
+const FOCUS_SLUG = 'physical-damage'; // -> grimoire name "Sundering Knife"
+const SIGNATURE_SLUG = 'lingering-torment';
+const AFFIX_SLUG = 'off-balance';
+const GRIMOIRE_WITH_ABILITY_ID = { ability: 217699, name: 'Banner Bearer' }; // banner-bearer
 
 describe('Scribing Architecture Integration', () => {
   let repository: JsonScribingDataRepository;
@@ -90,13 +25,6 @@ describe('Scribing Architecture Integration', () => {
   let detectionService: ScribingDetectionService;
 
   beforeEach(() => {
-    // Mock successful fetch
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => mockScribingData,
-    });
-
-    // Initialize services
     repository = new JsonScribingDataRepository();
     mappingService = new AbilityMappingService(repository);
     simulatorService = new ScribingSimulatorService(repository);
@@ -108,23 +36,23 @@ describe('Scribing Architecture Integration', () => {
       const data = await repository.loadScribingData();
 
       expect(data).toBeDefined();
-      expect(data.version).toBe('1.0.0');
-      expect(Object.keys(data.grimoires)).toHaveLength(1);
+      expect(data.version).toBeTruthy();
+      expect(Object.keys(data.grimoires).length).toBeGreaterThan(0);
     });
 
     it('should get grimoire by id', async () => {
-      const grimoire = await repository.getGrimoire('test-grimoire');
+      const grimoire = await repository.getGrimoire(GRIMOIRE_SLUG);
 
       expect(grimoire).toBeDefined();
-      expect(grimoire?.name).toBe('Test Grimoire');
+      expect(grimoire?.name).toBe(GRIMOIRE_NAME);
     });
 
     it('should validate valid combination', async () => {
       const isValid = await repository.validateCombination(
-        'test-grimoire',
-        'test-focus',
-        'test-signature',
-        'test-affix',
+        GRIMOIRE_SLUG,
+        FOCUS_SLUG,
+        SIGNATURE_SLUG,
+        AFFIX_SLUG,
       );
 
       expect(isValid).toBe(true);
@@ -133,9 +61,9 @@ describe('Scribing Architecture Integration', () => {
     it('should reject invalid combination', async () => {
       const isValid = await repository.validateCombination(
         'non-existent',
-        'test-focus',
-        'test-signature',
-        'test-affix',
+        FOCUS_SLUG,
+        SIGNATURE_SLUG,
+        AFFIX_SLUG,
       );
 
       expect(isValid).toBe(false);
@@ -152,18 +80,18 @@ describe('Scribing Architecture Integration', () => {
     });
 
     it('should detect scribing abilities', () => {
-      const isScribing = mappingService.isScribingAbility(12345);
+      const isScribing = mappingService.isScribingAbility(GRIMOIRE_WITH_ABILITY_ID.ability);
       expect(isScribing).toBe(true);
 
-      const isNotScribing = mappingService.isScribingAbility(99999);
+      const isNotScribing = mappingService.isScribingAbility(99999999);
       expect(isNotScribing).toBe(false);
     });
 
     it('should get grimoire by ability id', () => {
-      const grimoire = mappingService.getGrimoireByAbilityId(12345);
+      const grimoire = mappingService.getGrimoireByAbilityId(GRIMOIRE_WITH_ABILITY_ID.ability);
 
       expect(grimoire).toBeDefined();
-      expect(grimoire?.name).toBe('Test Grimoire');
+      expect(grimoire?.name).toBe(GRIMOIRE_WITH_ABILITY_ID.name);
       expect(grimoire?.type).toBe('grimoire');
     });
 
@@ -178,16 +106,20 @@ describe('Scribing Architecture Integration', () => {
   describe('Simulator Service', () => {
     it('should simulate valid combination', async () => {
       const result = await simulatorService.simulate({
-        grimoireId: 'test-grimoire',
-        focusScriptId: 'test-focus',
-        signatureScriptId: 'test-signature',
-        affixScriptId: 'test-affix',
+        grimoireId: GRIMOIRE_SLUG,
+        focusScriptId: FOCUS_SLUG,
+        signatureScriptId: SIGNATURE_SLUG,
+        affixScriptId: AFFIX_SLUG,
       });
 
       expect(result.isValid).toBe(true);
       expect(result.calculatedSkill.name).toBeDefined();
       expect(result.calculatedSkill.cost).toBeGreaterThan(0);
-      expect(result.combination.grimoire).toBe('Test Grimoire');
+      expect(result.combination.grimoire).toBe(GRIMOIRE_NAME);
+      // The physical focus transforms "Traveling Knife" -> "Sundering Knife".
+      expect(result.calculatedSkill.name).toBe('Sundering Knife');
+      // Resource comes from the grimoire's dataset entry (stamina here).
+      expect(result.calculatedSkill.resourceType).toBe('stamina');
     });
 
     it('should reject invalid grimoire', async () => {
@@ -201,12 +133,14 @@ describe('Scribing Architecture Integration', () => {
     });
 
     it('should get available combinations', async () => {
-      const combinations = await simulatorService.getAvailableCombinations('test-grimoire');
+      const combinations = await simulatorService.getAvailableCombinations(GRIMOIRE_SLUG);
 
-      expect(combinations.focusScripts).toHaveLength(1);
-      expect(combinations.signatureScripts).toHaveLength(1);
-      expect(combinations.affixScripts).toHaveLength(1);
-      expect(combinations.focusScripts[0].name).toBe('Test Focus');
+      expect(combinations.focusScripts.length).toBeGreaterThan(0);
+      expect(combinations.signatureScripts.length).toBeGreaterThan(0);
+      expect(combinations.affixScripts.length).toBeGreaterThan(0);
+      expect(
+        combinations.signatureScripts.some((s) => s.id === SIGNATURE_SLUG || s.name.length > 0),
+      ).toBe(true);
     });
   });
 
@@ -262,17 +196,12 @@ describe('Scribing Architecture Integration', () => {
   });
 
   describe('Error Handling', () => {
-    beforeEach(() => {
-      // Mock fetch failure
-      (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
-    });
-
-    it('should handle data loading failures gracefully', async () => {
+    it('loads + validates the bundled dataset without throwing', async () => {
+      // The dataset is bundled and adapted at import time, so the previous
+      // network-failure path no longer exists; instead guarantee the bundled
+      // data passes adapter + schema validation.
       const newRepository = new JsonScribingDataRepository();
-
-      await expect(newRepository.loadScribingData()).rejects.toThrow(
-        'Failed to load scribing data',
-      );
+      await expect(newRepository.loadScribingData()).resolves.toBeDefined();
     });
 
     it('should handle uninitialized mapping service', () => {

--- a/src/features/scribing/application/simulators/ScribingSimulatorService.ts
+++ b/src/features/scribing/application/simulators/ScribingSimulatorService.ts
@@ -159,19 +159,13 @@ export class ScribingSimulatorService implements IScribingSimulatorService {
     affixScript: AffixScript | null,
     request: ScribingSimulationRequest,
   ) {
-    // Base properties from grimoire
-    let resourceType: ResourceType = 'magicka'; // Default
+    // Base properties from grimoire. The dataset provides the grimoire's actual
+    // resource and base cost directly.
+    let resourceType: ResourceType = grimoire.resource ?? 'magicka';
     let baseCost = grimoire.cost.first;
     let castTime = DEFAULT_SIMULATION_CONFIG.BASE_CAST_TIME;
     let range = 28; // Default range in meters
     let damage: { type: DamageType; amount: number } | undefined;
-
-    // Determine resource type from grimoire skill line
-    if (grimoire.skillLine === 'Support' || grimoire.skillLine === 'Restoration Staff') {
-      resourceType = 'magicka';
-    } else if (grimoire.skillLine === 'Assault') {
-      resourceType = 'stamina';
-    }
 
     // Apply focus script modifications
     if (focusScript) {
@@ -242,22 +236,20 @@ export class ScribingSimulatorService implements IScribingSimulatorService {
   private generateSkillName(
     grimoire: Grimoire,
     focusScript: FocusScript | null,
-    signatureScript: SignatureScript | null,
+    _signatureScript: SignatureScript | null,
     _affixScript: AffixScript | null,
   ): string {
-    let name = grimoire.name;
-
-    if (focusScript && focusScript.effectType) {
-      // Modify name based on focus script
-      name = `${focusScript.effectType} ${name}`;
+    // The grimoire's name changes with the chosen focus damage type, and the
+    // dataset carries the real in-game name for each (e.g. Traveling Knife +
+    // Flame focus -> "Fiery Knife"). Signature/affix scripts don't rename the
+    // skill, so they don't affect the name.
+    if (focusScript?.damageType) {
+      const transformed = grimoire.nameTransformations?.[`${focusScript.damageType}-damage`]?.name;
+      if (transformed) {
+        return transformed;
+      }
     }
-
-    if (signatureScript) {
-      // Some signature scripts add suffixes
-      name = `${name} (Enhanced)`;
-    }
-
-    return name;
+    return grimoire.name;
   }
 
   private generateSkillDescription(

--- a/src/features/scribing/infrastructure/data/JsonScribingDataRepository.ts
+++ b/src/features/scribing/infrastructure/data/JsonScribingDataRepository.ts
@@ -5,8 +5,9 @@
 
 import { Logger, LogLevel } from '@/utils/logger';
 
+import scribingCompleteData from '../../../../../data/scribing-complete.json';
 import { IScribingDataRepository } from '../../core/repositories/IScribingDataRepository';
-import { DATA_FILE_PATHS, ERROR_MESSAGES } from '../../shared/constants';
+import { ERROR_MESSAGES } from '../../shared/constants';
 import { validateScribingData } from '../../shared/schemas';
 import {
   ScribingData,
@@ -14,7 +15,114 @@ import {
   FocusScript,
   SignatureScript,
   AffixScript,
+  ResourceType,
+  DamageType,
 } from '../../shared/types';
+
+const RESOURCE_TYPES: ReadonlySet<string> = new Set(['magicka', 'stamina', 'health', 'hybrid']);
+const DAMAGE_TYPES: ReadonlySet<string> = new Set([
+  'magic',
+  'physical',
+  'fire',
+  'frost',
+  'shock',
+  'poison',
+  'disease',
+  'bleed',
+  'oblivion',
+  'flame',
+]);
+
+const asResource = (v: unknown): ResourceType | undefined =>
+  typeof v === 'string' && RESOURCE_TYPES.has(v) ? (v as ResourceType) : undefined;
+const asDamageType = (v: unknown): DamageType | undefined =>
+  typeof v === 'string' && DAMAGE_TYPES.has(v) ? (v as DamageType) : undefined;
+
+/**
+ * Adapts the game-extracted `scribing-complete.json` (records keyed by slug,
+ * flat grimoire cost, per-grimoire `nameTransformations`) into the typed
+ * {@link ScribingData} the simulator consumes. The reference sections the
+ * dataset doesn't include (quest rewards, vendors, …) are simply omitted.
+ */
+export function adaptScribingData(raw: typeof scribingCompleteData): ScribingData {
+  const rawAny = raw as unknown as {
+    version?: string;
+    description?: string;
+    lastUpdated?: string;
+    grimoires?: Record<string, Record<string, unknown>>;
+    focusScripts?: Record<string, Record<string, unknown>>;
+    signatureScripts?: Record<string, Record<string, unknown>>;
+    affixScripts?: Record<string, Record<string, unknown>>;
+  };
+
+  const grimoireKeys = Object.keys(rawAny.grimoires ?? {});
+
+  const grimoires: Record<string, Grimoire> = {};
+  for (const [slug, g] of Object.entries(rawAny.grimoires ?? {})) {
+    const flatCost = Number(g.cost) || 0;
+    // The grimoire's numeric `id` (when present) is its base ability id.
+    const baseAbilityId = typeof g.id === 'number' ? g.id : undefined;
+    grimoires[slug] = {
+      id: slug,
+      name: String(g.name ?? slug),
+      requirements: null,
+      cost: { first: flatCost, additional: flatCost },
+      description: '',
+      resource: asResource(g.resource),
+      nameTransformations: g.nameTransformations as Grimoire['nameTransformations'],
+      abilityIds: baseAbilityId !== undefined ? [baseAbilityId] : undefined,
+    };
+  }
+
+  const focusScripts: Record<string, FocusScript> = {};
+  for (const [slug, f] of Object.entries(rawAny.focusScripts ?? {})) {
+    focusScripts[slug] = {
+      id: String(f.id ?? slug),
+      name: String(f.name ?? slug),
+      type: 'Focus',
+      icon: '',
+      // Focus scripts apply to any grimoire (each grimoire has a transformed
+      // name per damage type); compatibility is enforced by nameTransformations.
+      compatibleGrimoires: grimoireKeys,
+      description: String(f.name ?? ''),
+      damageType: asDamageType(f.damageType),
+    };
+  }
+
+  const toListScript = (
+    slug: string,
+    s: Record<string, unknown>,
+  ): Omit<SignatureScript, 'type'> => ({
+    id: String(s.id ?? slug),
+    name: String(s.name ?? slug),
+    icon: '',
+    compatibleGrimoires: Array.isArray(s.compatibleGrimoires)
+      ? (s.compatibleGrimoires as string[])
+      : grimoireKeys,
+    description: String(s.description ?? ''),
+    abilityIds: Array.isArray(s.abilityIds) ? (s.abilityIds as number[]) : undefined,
+  });
+
+  const signatureScripts: Record<string, SignatureScript> = {};
+  for (const [slug, s] of Object.entries(rawAny.signatureScripts ?? {})) {
+    signatureScripts[slug] = { ...toListScript(slug, s), type: 'Signature' };
+  }
+
+  const affixScripts: Record<string, AffixScript> = {};
+  for (const [slug, s] of Object.entries(rawAny.affixScripts ?? {})) {
+    affixScripts[slug] = { ...toListScript(slug, s), type: 'Affix' };
+  }
+
+  return {
+    version: rawAny.version ?? '1.0.0',
+    description: rawAny.description ?? 'ESO Scribing data',
+    lastUpdated: rawAny.lastUpdated,
+    grimoires,
+    focusScripts,
+    signatureScripts,
+    affixScripts,
+  } as ScribingData;
+}
 
 export class JsonScribingDataRepository implements IScribingDataRepository {
   private cachedData: ScribingData | null = null;
@@ -45,16 +153,13 @@ export class JsonScribingDataRepository implements IScribingDataRepository {
 
   private async fetchAndValidateData(): Promise<ScribingData> {
     try {
-      // Try to load the complete scribing data first
-      const response = await fetch(DATA_FILE_PATHS.SCRIBING_COMPLETE);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch scribing data: ${response.status} ${response.statusText}`);
-      }
+      // The dataset is bundled with the app, so adapt the imported JSON directly
+      // (the previous runtime fetch of /data/scribing-complete.json 404'd in the
+      // built SPA — the file is not served from public/).
+      const adapted = adaptScribingData(scribingCompleteData);
 
-      const rawData = await response.json();
-
-      // Validate the data structure
-      const validatedData = validateScribingData(rawData);
+      // Validate the adapted structure.
+      const validatedData = validateScribingData(adapted);
 
       return validatedData;
     } catch (error) {

--- a/src/features/scribing/presentation/components/ScribingSimulator.tsx
+++ b/src/features/scribing/presentation/components/ScribingSimulator.tsx
@@ -76,9 +76,18 @@ export const ScribingSimulator: React.FC<ScribingSimulatorProps> = ({
     if (selectedAffixScript) params.set('affix', selectedAffixScript);
 
     const shareUrl = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
-    navigator.clipboard.writeText(shareUrl);
-
-    logger.info('Configuration URL copied to clipboard', { shareUrl });
+    // writeText returns a promise that rejects on permission/clipboard errors;
+    // handle it so it isn't an unhandled rejection.
+    void navigator.clipboard
+      .writeText(shareUrl)
+      .then(() => {
+        logger.info('Configuration URL copied to clipboard', { shareUrl });
+      })
+      .catch((err: unknown) => {
+        logger.warn('Failed to copy configuration URL to clipboard', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   };
 
   if (isLoading) {

--- a/src/features/scribing/shared/schemas/index.ts
+++ b/src/features/scribing/shared/schemas/index.ts
@@ -37,7 +37,7 @@ export const SkillLineSchema = z.enum([
 export const GrimoireSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
-  skillLine: SkillLineSchema,
+  skillLine: SkillLineSchema.optional(),
   requirements: z.string().nullable(),
   cost: z.object({
     first: z.number().min(0),
@@ -46,6 +46,17 @@ export const GrimoireSchema = z.object({
   description: z.string(),
   iconUrl: z.string().url().optional(),
   abilityIds: z.array(z.number()).optional(),
+  resource: ResourceTypeSchema.optional(),
+  nameTransformations: z
+    .record(
+      z.string(),
+      z.object({
+        name: z.string(),
+        abilityIds: z.array(z.number()).optional(),
+        matchCount: z.number().optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const ScriptSchema = z.object({
@@ -164,21 +175,26 @@ export const ScribingSystemSchema = z.object({
 export const ScribingDataSchema = z.object({
   version: z.string().min(1),
   description: z.string(),
-  lastUpdated: z.string(),
+  lastUpdated: z.string().optional(),
   grimoires: z.record(z.string(), GrimoireSchema),
   focusScripts: z.record(z.string(), FocusScriptSchema),
   signatureScripts: z.record(z.string(), SignatureScriptSchema),
   affixScripts: z.record(z.string(), AffixScriptSchema),
-  questRewards: z.record(z.string(), QuestRewardSchema),
-  freeScriptLocations: z.record(z.string(), FreeScriptLocationSchema),
-  dailyScriptSources: z.object({
-    'focus-scripts': z.array(z.string()),
-    'signature-scripts': z.array(z.string()),
-    'affix-scripts': z.array(z.string()),
-  }),
-  scriptVendors: z.record(z.string(), ScriptVendorSchema),
-  luminousInk: LuminousInkSchema,
-  system: ScribingSystemSchema,
+  // The simulator only needs grimoires + scripts; the reference sections below
+  // (quest/vendor/ink/system metadata) aren't part of the extracted dataset, so
+  // they're optional.
+  questRewards: z.record(z.string(), QuestRewardSchema).optional(),
+  freeScriptLocations: z.record(z.string(), FreeScriptLocationSchema).optional(),
+  dailyScriptSources: z
+    .object({
+      'focus-scripts': z.array(z.string()),
+      'signature-scripts': z.array(z.string()),
+      'affix-scripts': z.array(z.string()),
+    })
+    .optional(),
+  scriptVendors: z.record(z.string(), ScriptVendorSchema).optional(),
+  luminousInk: LuminousInkSchema.optional(),
+  system: ScribingSystemSchema.optional(),
 });
 
 // DTO schemas

--- a/src/features/scribing/shared/types/entities.ts
+++ b/src/features/scribing/shared/types/entities.ts
@@ -30,12 +30,25 @@ export type SkillLine =
   | 'Werewolf';
 
 /**
+ * Per-damage-type name transformation for a grimoire, e.g. focusing "Traveling
+ * Knife" with the Flame focus yields "Fiery Knife". Keyed by `<damage>-damage`
+ * (e.g. `flame-damage`). Sourced from the game-extracted scribing dataset.
+ */
+export interface GrimoireNameTransformation {
+  readonly name: string;
+  readonly abilityIds?: readonly number[];
+  readonly matchCount?: number;
+}
+
+/**
  * Core Grimoire entity - represents a base scribing skill template
  */
 export interface Grimoire {
   readonly id: string;
   readonly name: string;
-  readonly skillLine: SkillLine;
+  // Optional: the source dataset categorizes grimoires by `resource`/`school`
+  // rather than a UI skill line, so skillLine may be absent.
+  readonly skillLine?: SkillLine;
   readonly requirements: string | null;
   readonly cost: {
     readonly first: number;
@@ -44,6 +57,10 @@ export interface Grimoire {
   readonly description: string;
   readonly iconUrl?: string;
   readonly abilityIds?: readonly number[];
+  /** Resource the grimoire's base ability costs (from the extracted dataset). */
+  readonly resource?: ResourceType;
+  /** Skill-name overrides per focus damage type, keyed by `<damage>-damage`. */
+  readonly nameTransformations?: Readonly<Record<string, GrimoireNameTransformation>>;
 }
 
 /**
@@ -187,19 +204,20 @@ export interface ScribingSystem {
 export interface ScribingData {
   readonly version: string;
   readonly description: string;
-  readonly lastUpdated: string;
+  readonly lastUpdated?: string;
   readonly grimoires: Record<string, Grimoire>;
   readonly focusScripts: Record<string, FocusScript>;
   readonly signatureScripts: Record<string, SignatureScript>;
   readonly affixScripts: Record<string, AffixScript>;
-  readonly questRewards: Record<string, QuestReward>;
-  readonly freeScriptLocations: Record<string, FreeScriptLocation>;
-  readonly dailyScriptSources: {
+  // Reference metadata not present in the extracted dataset — optional.
+  readonly questRewards?: Record<string, QuestReward>;
+  readonly freeScriptLocations?: Record<string, FreeScriptLocation>;
+  readonly dailyScriptSources?: {
     readonly 'focus-scripts': readonly string[];
     readonly 'signature-scripts': readonly string[];
     readonly 'affix-scripts': readonly string[];
   };
-  readonly scriptVendors: Record<string, ScriptVendor>;
-  readonly luminousInk: LuminousInk;
-  readonly system: ScribingSystem;
+  readonly scriptVendors?: Record<string, ScriptVendor>;
+  readonly luminousInk?: LuminousInk;
+  readonly system?: ScribingSystem;
 }


### PR DESCRIPTION
## Summary

The **/scribing-simulator page was broken for every user** ("Failed to Load Scribing Data"). Two root causes (audit #3/#4):
1. The repository fetched `/data/scribing-complete.json` over HTTP, but that file isn't served from `public/` in the built SPA → 404.
2. Even if served, the Zod schema + service expected a richer shape (`grimoire.cost.{first,additional}`, `skillLine`, vendor/quest/ink/system sections) that the game-extracted dataset doesn't contain.

## Fix
The dataset's *structure* already matches the repository (records keyed by slug); only the *fields* diverged. So this is an adapter + field reconciliation, not a rewrite:

- **Repository** — import the bundled JSON directly and adapt it at load time: flat grimoire `cost` → `{first, additional}`, real `resource`, per-grimoire `nameTransformations`, numeric grimoire `id` → `abilityIds`.
- **Schema + types** — make the absent reference sections (quest rewards, vendors, luminous ink, system) and `grimoire.skillLine` optional; add `resource` + `nameTransformations` to the grimoire.
- **Service** — derive `resourceType` from the grimoire's real `resource`, and build the skill name from `nameTransformations` (e.g. Traveling Knife + Flame focus → "Fiery Knife") instead of a non-existent `effectType`.
- **#45** — handle the `navigator.clipboard.writeText` rejection on the share button so a clipboard failure isn't an unhandled rejection.
- Rewrote the integration test against the real bundled data (no fetch mock).

## Testing
- `tsc --noEmit` clean; prettier + eslint clean
- 99 scribing tests pass (7 suites)
- **Live-verified** in Chrome: the page loads (no error state), the Grimoire dropdown is populated, and Simulate produces accurate results — Banner Bearer → **Resource: magicka, Cost: 2430** (both straight from the dataset). Console clean of scribing errors.
