### PR TITLE
Update Kalpa banner from alpha to beta

### DIFF
--- a/src/components/KalpaBanner.tsx
+++ b/src/components/KalpaBanner.tsx
@@ -148,7 +148,7 @@ export const KalpaBanner: React.FC = () => {
             </Box>
             {' — ESO addon manager '}
             <Box component="span" sx={{ opacity: 0.65, fontStyle: 'italic' }}>
-              (alpha)
+              (beta)
             </Box>
           </Typography>
           <span className="kalpa-arrow" aria-hidden="true">
@@ -167,7 +167,7 @@ export const KalpaBanner: React.FC = () => {
           >
             Introducing <strong>Kalpa</strong> — a fast, open-source addon manager for ESO.{' '}
             <Box component="span" sx={{ opacity: 0.7, fontStyle: 'italic' }}>
-              Currently in alpha.
+              Currently in beta.
             </Box>
           </Typography>
           <BannerLink href={KALPA_URL} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary

Kalpa has moved into beta, so the homepage banner now reflects that status instead of alpha.

## Changes

- `src/components/KalpaBanner.tsx`: Updated both the mobile (`(alpha)` → `(beta)`) and desktop (`Currently in alpha.` → `Currently in beta.`) banner text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SohGe3XXQCPM9XYGm23yf

---
_Generated by [Claude Code](https://claude.ai/code/session_012SohGe3XXQCPM9XYGm23yf)_