### PR TITLE
perf(report-summary): activate the batch event fetch safely (#7)

### DIFF
--- a/src/graphql/optimizedSummaryQueries.ts
+++ b/src/graphql/optimizedSummaryQueries.ts
@@ -112,6 +112,7 @@ export const GET_ALL_EVENTS_TIME_BASED = gql`
     $code: String!
     $startTime: Float
     $endTime: Float
+    $hostilityType: HostilityType = Friendlies
     $limit: Int = 1000000
   ) {
     reportData {
@@ -122,6 +123,7 @@ export const GET_ALL_EVENTS_TIME_BASED = gql`
           dataType: All
           useActorIDs: true
           includeResources: true
+          hostilityType: $hostilityType
           limit: $limit
         ) {
           data

--- a/src/services/OptimizedReportEventsFetcher.test.ts
+++ b/src/services/OptimizedReportEventsFetcher.test.ts
@@ -1,0 +1,60 @@
+import { OptimizedReportEventsFetcher } from './OptimizedReportEventsFetcher';
+import type { EsoLogsClient } from '../esologsClient';
+import { HostilityType, type FightFragment } from '../graphql/gql/graphql';
+
+/**
+ * Builds the shape client.query() actually resolves to: the GraphQL `data`
+ * object directly (NOT wrapped in an extra `.data`). The previous code read
+ * response.data.reportData... which always resolved to undefined.
+ */
+const reportEventsResponse = (
+  data: unknown[],
+  nextPageTimestamp: number | null = null,
+): unknown => ({
+  reportData: { report: { events: { data, nextPageTimestamp } } },
+});
+
+const fight = (id: number, startTime: number, endTime: number): FightFragment =>
+  ({ id, startTime, endTime, name: `Fight ${id}` }) as unknown as FightFragment;
+
+describe('OptimizedReportEventsFetcher.fetchReportEventsParallel', () => {
+  it('extracts events from the unwrapped response (no outer .data) and does not fall back', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValue(reportEventsResponse([{ type: 'damage', timestamp: 5, amount: 1 }]));
+    const client = { query } as unknown as EsoLogsClient;
+    const fetcher = new OptimizedReportEventsFetcher(client);
+
+    const result = await fetcher.fetchReportEventsParallel('ABC', [fight(1, 0, 10)], 0, 10);
+
+    // Each of damage/death/healing is fetched for both hostilities => 6 calls.
+    // If the unwrap were still broken, every batch query would yield 0 events
+    // and the code would fall back to the per-fight path (different queries).
+    expect(query).toHaveBeenCalledTimes(6);
+    // Friendlies + Enemies were both requested.
+    const hostilities = query.mock.calls.map((c) => c[0].variables.hostilityType);
+    expect(hostilities).toContain(HostilityType.Friendlies);
+    expect(hostilities).toContain(HostilityType.Enemies);
+    // Both-hostility merge => the single damage event appears once per hostility.
+    expect(result.damageEvents.length).toBe(2);
+  });
+
+  it('falls back to the per-fight path when a batch query is truncated by the page cap', async () => {
+    // Always return a nextPageTimestamp so pagination never completes -> the
+    // 50-page cap is hit -> truncated -> fall back. The fallback issues its own
+    // per-fight queries (dynamically imported documents) which this same mock
+    // also answers, so we just assert it did NOT early-return the batch result
+    // by checking the query was invoked far more than the 6 batch calls.
+    const query = jest
+      .fn()
+      .mockResolvedValue(reportEventsResponse([{ type: 'damage', timestamp: 1 }], 999));
+    const client = { query } as unknown as EsoLogsClient;
+    const fetcher = new OptimizedReportEventsFetcher(client);
+
+    await fetcher.fetchReportEventsParallel('ABC', [fight(1, 0, 10)], 0, 10);
+
+    // 3 event types x 2 hostilities x 50 capped pages = 300 batch calls, then
+    // the per-fight fallback adds more — well beyond the 6 of a clean batch.
+    expect(query.mock.calls.length).toBeGreaterThan(6);
+  });
+});

--- a/src/services/OptimizedReportEventsFetcher.ts
+++ b/src/services/OptimizedReportEventsFetcher.ts
@@ -65,45 +65,31 @@ export class OptimizedReportEventsFetcher {
 
     // TRY OPTIMIZED BATCH QUERIES FIRST
     logger.info('Trying optimized batch queries');
-    const [damageData, deathData, healingData] = await Promise.all([
-      this.fetchWithPagination(
-        GET_REPORT_DAMAGE_EVENTS,
-        {
-          code: reportCode,
-          startTime: reportStartTime,
-          endTime: reportEndTime,
-          hostilityType: HostilityType.Friendlies,
-        },
-        'damage',
-      ),
-
-      this.fetchWithPagination(
-        GET_REPORT_DEATH_EVENTS,
-        {
-          code: reportCode,
-          startTime: reportStartTime,
-          endTime: reportEndTime,
-          hostilityType: HostilityType.Friendlies,
-        },
-        'death',
-      ),
-
-      this.fetchWithPagination(
-        GET_REPORT_HEALING_EVENTS,
-        {
-          code: reportCode,
-          startTime: reportStartTime,
-          endTime: reportEndTime,
-          hostilityType: HostilityType.Friendlies,
-        },
-        'healing',
-      ),
+    const baseVars = {
+      code: reportCode,
+      startTime: reportStartTime,
+      endTime: reportEndTime,
+    };
+    const [damageResult, deathResult, healingResult] = await Promise.all([
+      this.fetchBothHostilities(GET_REPORT_DAMAGE_EVENTS, baseVars, 'damage'),
+      this.fetchBothHostilities(GET_REPORT_DEATH_EVENTS, baseVars, 'death'),
+      this.fetchBothHostilities(GET_REPORT_HEALING_EVENTS, baseVars, 'healing'),
     ]);
+
+    const damageData = damageResult.events;
+    const deathData = deathResult.events;
+    const healingData = healingResult.events;
+
+    // If any query was truncated by the page cap, the report-wide result is
+    // incomplete — defer to the proven per-fight fallback (which paginates each
+    // fight independently) rather than render partial data.
+    const batchTruncated =
+      damageResult.truncated || deathResult.truncated || healingResult.truncated;
 
     // Check if batch queries worked
     const totalEvents = damageData.length + deathData.length + healingData.length;
 
-    if (totalEvents > 0) {
+    if (totalEvents > 0 && !batchTruncated) {
       const endTime = performance.now();
       logger.info(`Batch parallel fetching successful in ${(endTime - startTime).toFixed(2)}ms`);
       logger.info(
@@ -119,7 +105,9 @@ export class OptimizedReportEventsFetcher {
 
     // FALLBACK: Use proven individual fight approach
     logger.warn(
-      'Batch parallel queries returned 0 events - falling back to individual fight queries',
+      batchTruncated
+        ? 'Batch parallel queries were truncated by the page cap - falling back to individual fight queries'
+        : 'Batch parallel queries returned 0 events - falling back to individual fight queries',
     );
 
     try {
@@ -190,7 +178,7 @@ export class OptimizedReportEventsFetcher {
     // FIRST ATTEMPT: Try optimized batch query
     logger.info('Testing time-based batch query');
 
-    const allEvents = await this.fetchWithPagination(
+    const allEventsResult = await this.fetchBothHostilities(
       GET_ALL_EVENTS_TIME_BASED,
       {
         code: reportCode,
@@ -199,9 +187,11 @@ export class OptimizedReportEventsFetcher {
       },
       'all events',
     );
+    const allEvents = allEventsResult.events;
 
-    // Check if batch query worked
-    if (allEvents.length > 0) {
+    // Check if batch query worked. A truncated (page-capped) result is
+    // incomplete, so treat it as a miss and use the per-fight fallback.
+    if (allEvents.length > 0 && !allEventsResult.truncated) {
       logger.info(`Batch query successful: ${allEvents.length} events found`);
 
       // Filter events by type on client side
@@ -230,8 +220,12 @@ export class OptimizedReportEventsFetcher {
       };
     }
 
-    // FALLBACK: Batch query failed, use proven individual fight approach
-    logger.warn('Batch query returned 0 events - falling back to individual fight queries');
+    // FALLBACK: Batch query failed or was truncated, use proven per-fight path
+    logger.warn(
+      allEventsResult.truncated
+        ? 'Batch query was truncated by the page cap - falling back to individual fight queries'
+        : 'Batch query returned 0 events - falling back to individual fight queries',
+    );
 
     try {
       // Use the exact same approach as deathEventsSlice that works
@@ -484,13 +478,23 @@ export class OptimizedReportEventsFetcher {
   }
 
   /**
-   * Helper method to handle paginated queries
+   * Helper method to handle paginated queries.
+   *
+   * Returns the events plus a `truncated` flag: when the report-wide query is
+   * larger than the page-cap can cover, the result is incomplete and callers
+   * must fall back to the per-fight path rather than render partial data.
+   *
+   * NOTE: client.query() already unwraps to the GraphQL `data` object (there is
+   * no outer `.data`), so we read `response.reportData...` directly — the old
+   * `response.data.reportData...` always resolved to undefined, which silently
+   * made every batch query return 0 events.
    */
   private async fetchWithPagination(
     query: any,
     baseVariables: any,
     eventType: string,
-  ): Promise<LogEvent[]> {
+  ): Promise<{ events: LogEvent[]; truncated: boolean }> {
+    const MAX_PAGES = 50;
     let allEvents: LogEvent[] = [];
     let nextPageTimestamp: number | null = null;
     let pageCount = 0;
@@ -510,29 +514,57 @@ export class OptimizedReportEventsFetcher {
         fetchPolicy: 'no-cache',
       });
 
-      const events =
-        response.data?.reportData?.report?.events?.data ||
-        response.data?.reportData?.report?.damageEvents?.data ||
-        response.data?.reportData?.report?.deathEvents?.data ||
-        response.data?.reportData?.report?.healingEvents?.data ||
-        [];
+      const report = response?.reportData?.report;
+      const eventsNode =
+        report?.events || report?.damageEvents || report?.deathEvents || report?.healingEvents;
 
+      const events = eventsNode?.data || [];
       if (events.length > 0) {
         allEvents = allEvents.concat(events);
       }
 
-      nextPageTimestamp =
-        response.data?.reportData?.report?.events?.nextPageTimestamp ||
-        response.data?.reportData?.report?.damageEvents?.nextPageTimestamp ||
-        response.data?.reportData?.report?.deathEvents?.nextPageTimestamp ||
-        response.data?.reportData?.report?.healingEvents?.nextPageTimestamp ||
-        null;
-    } while (nextPageTimestamp && pageCount < 50); // Safety limit
+      nextPageTimestamp = eventsNode?.nextPageTimestamp || null;
+    } while (nextPageTimestamp && pageCount < MAX_PAGES);
+
+    const truncated = nextPageTimestamp != null && pageCount >= MAX_PAGES;
+    if (truncated) {
+      logger.warn(
+        `${eventType} pagination hit the ${MAX_PAGES}-page cap with more data pending; result is incomplete`,
+      );
+    }
 
     logger.info(
       `Completed ${eventType} pagination: ${allEvents.length} total events in ${pageCount} pages`,
     );
-    return allEvents;
+    return { events: allEvents, truncated };
+  }
+
+  /**
+   * Fetch one event type for BOTH hostilities (Friendlies + Enemies), matching
+   * the per-fight fallback's data completeness — enemy-source events (e.g. the
+   * killing blows used by death analysis) are otherwise missed.
+   */
+  private async fetchBothHostilities(
+    query: any,
+    baseVariables: any,
+    eventType: string,
+  ): Promise<{ events: LogEvent[]; truncated: boolean }> {
+    const [friendly, enemy] = await Promise.all([
+      this.fetchWithPagination(
+        query,
+        { ...baseVariables, hostilityType: HostilityType.Friendlies },
+        `${eventType} (friendlies)`,
+      ),
+      this.fetchWithPagination(
+        query,
+        { ...baseVariables, hostilityType: HostilityType.Enemies },
+        `${eventType} (enemies)`,
+      ),
+    ]);
+    return {
+      events: [...friendly.events, ...enemy.events],
+      truncated: friendly.truncated || enemy.truncated,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

The optimized report-event **batch fetch path was dead code** (audit #7): `fetchWithPagination` read `response.data.reportData...`, but `client.query()` already unwraps to the data object, so every batch query returned 0 events and the code **always** fell back to the slow per-fight path (dozens of extra API round-trips per report-summary load).

## Why fixing the unwrap alone was unsafe
The batch path fetched **Friendlies hostility only**, while the per-fight fallback fetches Friendlies + **Enemies** (enemy-source events are the death-recap killing blows), and it capped pagination globally at 50 pages. So just activating it would have silently rendered **incomplete** report summaries on large logs.

## The safe activation
- Fix the unwrap → read `response.reportData.report.events` directly.
- Fetch **both hostilities** for every event type and the All-events strategy (added a `hostilityType` variable to `GET_ALL_EVENTS_TIME_BASED`), matching the fallback's data completeness.
- `fetchWithPagination` now returns a `truncated` flag; if any query hits the page cap, **fall back to the proven per-fight path** so an incomplete batch never renders as complete.

Net: report summaries load with far fewer API calls, and any uncertainty (truncation / empty / error) still defers to the correct per-fight path.

## Testing
- `tsc --noEmit` clean; prettier + eslint clean
- New unit tests: unwrap extraction, both-hostility fetch (6 calls), truncation→fallback
- **Live-verification pending** on a sample report (confirming the batch path now activates and numbers match) — see PR thread.

> Reviewer note: please sanity-check a large multi-fight report too, since the 50-page truncation→fallback path can't be exercised by unit tests.
