### PR TITLE
fix(parse-analysis): attribute pet/summon damage to the owner in calculateDPS (#42)

### DIFF
--- a/src/features/parse_analysis/utils/parseAnalysisUtils.test.ts
+++ b/src/features/parse_analysis/utils/parseAnalysisUtils.test.ts
@@ -615,6 +615,80 @@ describe('parseAnalysisUtils', () => {
       expect(result.dps).toBe(0);
       expect(result.durationMs).toBe(60000);
     });
+
+    describe('pet/summon attribution', () => {
+      const PET_ACTOR_ID = 50;
+      const petDamageEvents: DamageEvent[] = [
+        {
+          timestamp: FIGHT_START + 1000,
+          type: 'damage',
+          sourceID: PLAYER_ID, // direct player damage
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: 12345,
+          fight: 1,
+          amount: 10000,
+          hitType: 1,
+          castTrackID: 1,
+          sourceResources: mockResources,
+          targetResources: mockResources,
+        },
+        {
+          timestamp: FIGHT_START + 2000,
+          type: 'damage',
+          sourceID: PET_ACTOR_ID, // pet/summon damage owned by PLAYER_ID
+          sourceIsFriendly: true,
+          targetID: 2,
+          targetIsFriendly: false,
+          abilityGameID: 12346,
+          fight: 1,
+          amount: 5000,
+          hitType: 1,
+          castTrackID: 2,
+          sourceResources: mockResources,
+          targetResources: mockResources,
+        },
+      ];
+
+      it('should count pet damage toward the owner when the pet map is provided', () => {
+        const petOwnerByActorId = { [PET_ACTOR_ID]: PLAYER_ID };
+
+        const result = calculateDPS(
+          petDamageEvents,
+          PLAYER_ID,
+          FIGHT_START,
+          FIGHT_END,
+          petOwnerByActorId,
+        );
+
+        // 10000 (player) + 5000 (pet) = 15000 over 60s = 250 DPS
+        expect(result.totalDamage).toBe(15000);
+        expect(result.dps).toBe(250);
+      });
+
+      it('should NOT count pet damage when the map is omitted (backward compatible)', () => {
+        const result = calculateDPS(petDamageEvents, PLAYER_ID, FIGHT_START, FIGHT_END);
+
+        // Only the direct player event counts
+        expect(result.totalDamage).toBe(10000);
+        expect(result.dps).toBeCloseTo(10000 / 60, 5);
+      });
+
+      it('should not count a pet owned by a different player', () => {
+        const petOwnerByActorId = { [PET_ACTOR_ID]: 999 };
+
+        const result = calculateDPS(
+          petDamageEvents,
+          PLAYER_ID,
+          FIGHT_START,
+          FIGHT_END,
+          petOwnerByActorId,
+        );
+
+        expect(result.totalDamage).toBe(10000);
+      });
+    });
   });
 
   describe('analyzeWeaving', () => {

--- a/src/features/parse_analysis/utils/parseAnalysisUtils.ts
+++ b/src/features/parse_analysis/utils/parseAnalysisUtils.ts
@@ -666,16 +666,27 @@ export interface DPSResult {
 
 /**
  * Calculate total damage and DPS for a player
+ *
+ * @param petOwnerByActorId - Optional map of pet actor IDs to owner player IDs
+ *   (see getPetOwnerMap in damageEventUtils). When provided, damage from a
+ *   player's pets/summons (Sorc atronachs, Warden bear, NB shades, etc.) is
+ *   attributed to that player. When omitted, only direct player damage counts
+ *   (backward-compatible behavior).
  */
 export function calculateDPS(
   damageEvents: DamageEvent[],
   playerId: number,
   fightStartTime: number,
   fightEndTime: number,
+  petOwnerByActorId?: Record<number, number>,
 ): DPSResult {
-  // Sum all damage dealt by the player
+  // Sum all damage dealt by the player (and, when provided, their pets/summons)
   const playerDamageEvents = damageEvents.filter(
-    (event) => event.sourceID === playerId && event.sourceIsFriendly,
+    (event) =>
+      event.sourceIsFriendly &&
+      event.sourceID != null &&
+      (event.sourceID === playerId ||
+        (petOwnerByActorId !== undefined && petOwnerByActorId[event.sourceID] === playerId)),
   );
 
   const totalDamage = playerDamageEvents.reduce((sum, event) => sum + event.amount, 0);

--- a/src/pages/ParseAnalysisPage.tsx
+++ b/src/pages/ParseAnalysisPage.tsx
@@ -674,13 +674,20 @@ const ParseAnalysisPageContent: React.FC = () => {
       debuffEventsCount: debuffEvents.length,
     });
 
-    // Only run if we have pending analysis and events are not loading
+    // Only run if we have pending analysis and events are not loading. Also wait
+    // for report master data: pet/summon DPS attribution reads actorsById, and
+    // running before it loads would build an empty pet-owner map and then clear
+    // pendingAnalysis, leaving pet-heavy parses undercounted. When master data
+    // finishes, actorsById changes and re-fires this effect. (A hard master-data
+    // failure leaves isMasterDataLoading false so analysis still runs, degrading
+    // gracefully to player-only DPS.)
     if (
       !pendingAnalysis ||
       isCastEventsLoading ||
       isDamageEventsLoading ||
       isCombatantInfoEventsLoading ||
-      isDebuffEventsLoading
+      isDebuffEventsLoading ||
+      isMasterDataLoading
     ) {
       return;
     }
@@ -903,6 +910,7 @@ const ParseAnalysisPageContent: React.FC = () => {
     isDebuffEventsLoading,
     abilityMapper,
     reportMasterData.actorsById,
+    isMasterDataLoading,
     state.fightName,
   ]);
 

--- a/src/pages/ParseAnalysisPage.tsx
+++ b/src/pages/ParseAnalysisPage.tsx
@@ -114,6 +114,7 @@ import { setParseReport, clearParseReport } from '../store/parse_analysis/parseA
 import { setReportData } from '../store/report/reportSlice';
 import { useAppDispatch } from '../store/useAppDispatch';
 import { createBuffLookup } from '../utils/BuffLookupUtils';
+import { getPetOwnerMap } from '../utils/damageEventUtils';
 import { detectBuildIssues, type BuildIssue } from '../utils/detectBuildIssues';
 import { Logger, LogLevel } from '../utils/logger';
 
@@ -718,7 +719,16 @@ const ParseAnalysisPageContent: React.FC = () => {
       combatantInfoEvents,
     );
     const cpm = calculateCPM(castEvents, playerId, fightStartTime, fightEndTime, abilityMapper);
-    const dpsResult = calculateDPS(damageEvents, playerId, fightStartTime, fightEndTime);
+    // Attribute pet/summon damage (Sorc atronachs, Warden bear, NB shades, etc.)
+    // back to their owner so pet-heavy builds aren't undercounted.
+    const petOwnerByActorId = getPetOwnerMap(reportMasterData.actorsById);
+    const dpsResult = calculateDPS(
+      damageEvents,
+      playerId,
+      fightStartTime,
+      fightEndTime,
+      petOwnerByActorId,
+    );
     const rotationResult = analyzeRotation(
       castEvents,
       playerId,
@@ -892,6 +902,7 @@ const ParseAnalysisPageContent: React.FC = () => {
     isCombatantInfoEventsLoading,
     isDebuffEventsLoading,
     abilityMapper,
+    reportMasterData.actorsById,
     state.fightName,
   ]);
 

--- a/src/utils/damageEventUtils.test.ts
+++ b/src/utils/damageEventUtils.test.ts
@@ -5,6 +5,7 @@
 
 import {
   getChargedReportActors,
+  getPetOwnerMap,
   getDamageEventsByPlayer,
   CHARGED_ATRONACH_GAME_ID,
 } from './damageEventUtils';
@@ -162,6 +163,45 @@ describe('damageEventUtils', () => {
           124: 456,
         });
       });
+    });
+  });
+
+  describe('getPetOwnerMap', () => {
+    it('should map every pet actor to its owner regardless of gameID', () => {
+      const actorsById = {
+        // Charged Atronach
+        123: createMockActor(123, CHARGED_ATRONACH_GAME_ID, 'Pet', 456),
+        // Some other pet/summon (Warden bear, NB shade, etc.) with a different gameID
+        124: createMockActor(124, 67890, 'Pet', 456),
+        125: createMockActor(125, 11111, 'Pet', 789),
+        // Players are ignored
+        456: createMockActor(456, 12345, 'Player'),
+        789: createMockActor(789, 12346, 'Player'),
+      };
+
+      const result = getPetOwnerMap(actorsById);
+
+      expect(result).toEqual({
+        123: 456,
+        124: 456,
+        125: 789,
+      });
+    });
+
+    it('should ignore non-Pet actors and pets without a valid owner', () => {
+      const actorsById = {
+        123: createMockActor(123, 67890, 'Player', 456), // not a Pet
+        124: createMockActor(124, 67890, 'Pet'), // no petOwner
+        125: createMockActor(125, 67890, 'Pet', 0), // zero owner is valid
+      };
+
+      const result = getPetOwnerMap(actorsById);
+
+      expect(result).toEqual({ 125: 0 });
+    });
+
+    it('should handle an empty actors record', () => {
+      expect(getPetOwnerMap({})).toEqual({});
     });
   });
 

--- a/src/utils/damageEventUtils.ts
+++ b/src/utils/damageEventUtils.ts
@@ -38,6 +38,43 @@ export function getChargedReportActors(
 }
 
 /**
+ * Builds a map of every pet/summon actor to its owner player ID.
+ *
+ * ESO Logs attributes pet damage (Sorc atronachs, Warden bear, NB shades, etc.)
+ * to the player who summoned the pet. This generalizes {@link getChargedReportActors}
+ * (which only handles the Charged Atronach) to cover ALL pets, so callers can
+ * attribute any pet's damage events back to their owner.
+ *
+ * @param actorsById - Record mapping actor IDs to actor data from report master data
+ * @returns Record mapping pet actor IDs to their owner player IDs
+ *
+ * @example
+ * ```typescript
+ * const petOwnerMap = getPetOwnerMap(actorsById);
+ * // Result: { "89": 123, "156": 456 } where keys are pet IDs, values are owner player IDs
+ * ```
+ */
+export function getPetOwnerMap(
+  actorsById: Record<string | number, ReportActor>,
+): Record<number, number> {
+  const petOwners: Record<number, number> = {};
+
+  Object.values(actorsById).forEach((actor) => {
+    if (
+      actor.id !== undefined &&
+      actor.id !== null &&
+      actor?.type === 'Pet' &&
+      actor.petOwner !== undefined &&
+      actor.petOwner !== null
+    ) {
+      petOwners[actor.id] = actor.petOwner;
+    }
+  });
+
+  return petOwners;
+}
+
+/**
  * Groups damage events by player ID, creating a record where keys are player IDs
  * and values are arrays of damage events associated with that player.
  * For charged atronach damage, attributes the damage to the player who cast the summoning spell.


### PR DESCRIPTION
## Summary

Audit #42: `calculateDPS` counted only `event.sourceID === playerId`, so **pet/summon damage was excluded** — Sorc atronachs, Warden bear, NB shades, etc. ESO Logs attributes pet damage to the owner (via `actor.petOwner`), so pet-heavy builds were undercounted on the Parse Analysis page.

The codebase already attributed *Charged Atronach* damage to owners (`getChargedReportActors`), but only that one pet and `calculateDPS` didn't use it.

## Change
- `damageEventUtils.getPetOwnerMap(actorsById)` — maps **every** `type === 'Pet'` actor with a non-null `petOwner` to its owner (generalizes the Charged-Atronach helper, which is kept).
- `calculateDPS` gains an **optional** `petOwnerByActorId` param; an event counts when `sourceIsFriendly && (sourceID === playerId || petOwnerByActorId[sourceID] === playerId)`. Omitting it preserves exact prior behavior (existing tests unchanged).
- `ParseAnalysisPage` builds the map from master-data actors and passes it.

## Testing
- `tsc` / prettier / eslint clean; 54 tests pass across the two suites (new `getPetOwnerMap` + pet-attribution tests: counted with map, not counted without, not counted for a different owner).
- **Live-verify** recommended on a Sorc/Warden sample report (DPS should rise to match ESO Logs).
