### PR TITLE
fix(role-detection): populate shieldAppliedToOthers so shield healers are classified (#12)

### DIFF
--- a/src/features/role_detection/__tests__/classifyPlayers.test.ts
+++ b/src/features/role_detection/__tests__/classifyPlayers.test.ts
@@ -349,6 +349,30 @@ describe('classifyPlayers', () => {
       expect(healer.role).toBe(DetectedRole.ShieldHealer);
     });
 
+    it('should detect Shield Healer from shieldAppliedToOthers alone (no barrier)', () => {
+      // A damage-shield healer with a shield set but no Barrier ultimate scores
+      // exactly 15 on shieldScore (set only), which is NOT > 15 → would be
+      // mislabeled GroupHealer. Populating shieldAppliedToOthers (+10) pushes it
+      // to 25 → ShieldHealer. This guards the previously-unpopulated signal.
+      const signals = [
+        createSignals({
+          playerId: 1,
+          healingShareOfGroup: 0.3,
+          healerSetIds: [194], // Combat Physician (shield healer set)
+          barrierCasts: 0,
+          shieldAppliedToOthers: 80000, // shields cast on allies
+          damageShareOfGroup: 0.02,
+        }),
+        createSignals({ playerId: 2, damageShareOfGroup: 0.49, dpsSetIds: [389] }),
+        createSignals({ playerId: 3, damageShareOfGroup: 0.49, dpsSetIds: [389] }),
+      ];
+
+      const results = classifyPlayers(signals, FIGHT_DURATION_MS);
+
+      const healer = results.find((r) => r.playerId === 1)!;
+      expect(healer.role).toBe(DetectedRole.ShieldHealer);
+    });
+
     it('should detect Buff Healer with >= 2 offensive buff categories', () => {
       const signals = [
         createSignals({

--- a/src/features/role_detection/__tests__/extractSignals.test.ts
+++ b/src/features/role_detection/__tests__/extractSignals.test.ts
@@ -209,6 +209,82 @@ describe('extractSignals', () => {
     });
   });
 
+  describe('shield signals', () => {
+    function makeShieldHealEvent(
+      sourceID: number,
+      targetID: number,
+      absorb: number,
+      timestamp: number,
+    ): HealEvent {
+      return {
+        timestamp,
+        type: 'heal',
+        sourceID,
+        sourceIsFriendly: true,
+        targetID,
+        targetIsFriendly: true,
+        abilityGameID: 5678,
+        fight: FIGHT_ID,
+        hitType: 1,
+        amount: 0,
+        overheal: 0,
+        castTrackID: 0,
+        sourceResources: {} as HealEvent['sourceResources'],
+        targetResources: { absorb } as HealEvent['targetResources'],
+      };
+    }
+
+    it('should credit a player who raises an ally absorb pool with shieldAppliedToOthers', () => {
+      const events = emptyEvents({
+        healEvents: [makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 12000, FIGHT_START + 1000)],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const healer = result.find((s) => s.playerId === PLAYER_HEALER)!;
+      expect(healer.shieldAppliedToOthers).toBe(12000);
+    });
+
+    it('should count only the increase, not the standing absorb pool', () => {
+      const events = emptyEvents({
+        healEvents: [
+          makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 12000, FIGHT_START + 1000),
+          // pool decayed (soaked damage) then re-shielded higher
+          makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 4000, FIGHT_START + 2000),
+          makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 10000, FIGHT_START + 3000),
+        ],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const healer = result.find((s) => s.playerId === PLAYER_HEALER)!;
+      // +12000 (0→12000), decay ignored, +6000 (4000→10000)
+      expect(healer.shieldAppliedToOthers).toBe(18000);
+    });
+
+    it('should ignore self-shields', () => {
+      const events = emptyEvents({
+        healEvents: [makeShieldHealEvent(PLAYER_DPS1, PLAYER_DPS1, 15000, FIGHT_START + 1000)],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const dps1 = result.find((s) => s.playerId === PLAYER_DPS1)!;
+      expect(dps1.shieldAppliedToOthers).toBe(0);
+    });
+
+    it('should leave shieldAppliedToOthers at 0 when no absorb is present', () => {
+      const events = emptyEvents({
+        healEvents: [makeHealEvent(PLAYER_HEALER, 20000)],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const healer = result.find((s) => s.playerId === PLAYER_HEALER)!;
+      expect(healer.shieldAppliedToOthers).toBe(0);
+    });
+  });
+
   describe('damage taken signals', () => {
     it('should track damage taken per player', () => {
       const events = emptyEvents({

--- a/src/features/role_detection/__tests__/extractSignals.test.ts
+++ b/src/features/role_detection/__tests__/extractSignals.test.ts
@@ -287,6 +287,33 @@ describe('extractSignals', () => {
       expect(healer.shieldAppliedToOthers).toBe(0);
     });
 
+    it('should not reset the baseline on heals that omit absorb (no false re-credit)', () => {
+      // Shield to 12000, then a resource-less heal (no absorb) lands while the
+      // pool still stands, then another heal still reports 12000. The standing
+      // pool must NOT be re-counted as a new shield.
+      const resourcelessHeal = makeShieldHealEvent(
+        PLAYER_HEALER,
+        PLAYER_DPS1,
+        0,
+        FIGHT_START + 2000,
+      );
+      delete (resourcelessHeal.targetResources as { absorb?: number }).absorb;
+
+      const events = emptyEvents({
+        healEvents: [
+          makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 12000, FIGHT_START + 1000),
+          resourcelessHeal,
+          makeShieldHealEvent(PLAYER_HEALER, PLAYER_DPS1, 12000, FIGHT_START + 3000),
+        ],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const healer = result.find((s) => s.playerId === PLAYER_HEALER)!;
+      // Only the initial 0->12000 counts; the standing pool is not re-credited.
+      expect(healer.shieldAppliedToOthers).toBe(12000);
+    });
+
     it('should leave shieldAppliedToOthers at 0 when no absorb is present', () => {
       const events = emptyEvents({
         healEvents: [makeHealEvent(PLAYER_HEALER, 20000)],

--- a/src/features/role_detection/__tests__/extractSignals.test.ts
+++ b/src/features/role_detection/__tests__/extractSignals.test.ts
@@ -273,6 +273,20 @@ describe('extractSignals', () => {
       expect(dps1.shieldAppliedToOthers).toBe(0);
     });
 
+    it('should ignore absorb applied to non-player targets (pets/NPCs)', () => {
+      const NON_PLAYER_TARGET = 99999; // not in friendlyPlayerIds
+      const events = emptyEvents({
+        healEvents: [
+          makeShieldHealEvent(PLAYER_HEALER, NON_PLAYER_TARGET, 20000, FIGHT_START + 1000),
+        ],
+      });
+
+      const result = extractSignals(events, createContext());
+
+      const healer = result.find((s) => s.playerId === PLAYER_HEALER)!;
+      expect(healer.shieldAppliedToOthers).toBe(0);
+    });
+
     it('should leave shieldAppliedToOthers at 0 when no absorb is present', () => {
       const events = emptyEvents({
         healEvents: [makeHealEvent(PLAYER_HEALER, 20000)],

--- a/src/features/role_detection/extractSignals.ts
+++ b/src/features/role_detection/extractSignals.ts
@@ -91,6 +91,9 @@ export function extractSignals(
   // --- Pass 3: Healing output ---
   const groupTotalHealing = extractHealingSignals(events.healEvents, playerSignals, context);
 
+  // --- Pass 3b: Damage shields applied to allies ---
+  extractShieldSignals(events.healEvents, playerSignals, context);
+
   // --- Pass 4: Damage taken ---
   const groupTotalDamageTaken = extractDamageTakenSignals(
     events.damageEvents,
@@ -305,6 +308,62 @@ function extractHealingSignals(
   }
 
   return groupTotal;
+}
+
+// ============================================================
+// Damage Shield Signals
+// ============================================================
+
+/**
+ * Estimate how much damage-shield (absorb) value each player granted to OTHER
+ * allies. This drives the Shield Healer classification.
+ *
+ * ESO Logs does not emit a dedicated "shield applied" event, and the set of
+ * damage-shield ability IDs is large, version-volatile, and mostly self-only,
+ * so matching on a hardcoded ability-ID list is unreliable. Instead we use the
+ * one signal that is actually present in the event stream and is correctly
+ * source-attributed: heal events carry the recipient's current absorb pool in
+ * `targetResources.absorb`. When a player casts a shield on an ally, that ally's
+ * absorb pool rises on the same heal event, and the event names the caster as
+ * `sourceID`. We therefore credit the source with any increase in the target's
+ * absorb pool observed on a heal event the source produced on another ally.
+ *
+ * Only increases are counted (absorb naturally decays as it soaks damage, which
+ * is not a shield application), and self-heals are ignored so a player shielding
+ * only themselves is not mistaken for a group shield healer.
+ */
+function extractShieldSignals(
+  healEvents: HealEvent[],
+  playerSignals: Map<number, PlayerRoleSignals>,
+  context: FightContext,
+): void {
+  // Process in timestamp order so the per-target "previous absorb" baseline is
+  // chronologically correct even if the caller passes unsorted events.
+  const sorted = [...healEvents]
+    .filter((e) => e.fight === context.fightId)
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  // Most-recent observed absorb pool per target (across ALL heal events to that
+  // target, regardless of source) so we measure true increases.
+  const lastAbsorbByTarget = new Map<number, number>();
+
+  for (const event of sorted) {
+    const currentAbsorb = event.targetResources?.absorb ?? 0;
+    const previousAbsorb = lastAbsorbByTarget.get(event.targetID) ?? 0;
+    lastAbsorbByTarget.set(event.targetID, currentAbsorb);
+
+    // Only friendly source applying to a DIFFERENT ally counts as a group shield.
+    if (!event.sourceIsFriendly) continue;
+    if (event.sourceID === event.targetID) continue;
+
+    const signals = playerSignals.get(event.sourceID);
+    if (!signals) continue;
+
+    const increase = currentAbsorb - previousAbsorb;
+    if (increase > 0) {
+      signals.shieldAppliedToOthers += increase;
+    }
+  }
 }
 
 // ============================================================

--- a/src/features/role_detection/extractSignals.ts
+++ b/src/features/role_detection/extractSignals.ts
@@ -347,6 +347,12 @@ function extractShieldSignals(
   // target, regardless of source) so we measure true increases.
   const lastAbsorbByTarget = new Map<number, number>();
 
+  // The signal is "shields granted to other PLAYERS", so only credit absorb
+  // applied to friendly players — not to pets, summons, or friendly NPCs (whose
+  // absorb pools would otherwise inflate a healer's score, and the classifier
+  // only checks `> 0`).
+  const friendlyPlayers = new Set(context.friendlyPlayerIds);
+
   for (const event of sorted) {
     const currentAbsorb = event.targetResources?.absorb ?? 0;
     const previousAbsorb = lastAbsorbByTarget.get(event.targetID) ?? 0;
@@ -355,6 +361,7 @@ function extractShieldSignals(
     // Only friendly source applying to a DIFFERENT ally counts as a group shield.
     if (!event.sourceIsFriendly) continue;
     if (event.sourceID === event.targetID) continue;
+    if (!friendlyPlayers.has(event.targetID)) continue;
 
     const signals = playerSignals.get(event.sourceID);
     if (!signals) continue;

--- a/src/features/role_detection/extractSignals.ts
+++ b/src/features/role_detection/extractSignals.ts
@@ -354,7 +354,14 @@ function extractShieldSignals(
   const friendlyPlayers = new Set(context.friendlyPlayerIds);
 
   for (const event of sorted) {
-    const currentAbsorb = event.targetResources?.absorb ?? 0;
+    // Heal events that don't report an absorb reading carry no information about
+    // the target's shield pool, so skip them entirely — treating a missing value
+    // as 0 would reset the baseline and make the next resource-bearing heal look
+    // like a brand-new shield (a false credit). Only events that actually report
+    // absorb (including an explicit 0) update the baseline.
+    const rawAbsorb = event.targetResources?.absorb;
+    if (rawAbsorb == null) continue;
+    const currentAbsorb = rawAbsorb;
     const previousAbsorb = lastAbsorbByTarget.get(event.targetID) ?? 0;
     lastAbsorbByTarget.set(event.targetID, currentAbsorb);
 

--- a/src/features/role_detection/extractSignals.ts
+++ b/src/features/role_detection/extractSignals.ts
@@ -331,6 +331,15 @@ function extractHealingSignals(
  * Only increases are counted (absorb naturally decays as it soaks damage, which
  * is not a shield application), and self-heals are ignored so a player shielding
  * only themselves is not mistaken for a group shield healer.
+ *
+ * Known limitation: the baseline is built from heal events only, so absorb
+ * consumed by incoming damage (which appears on damage events, not heals) is not
+ * observed. A reapplication that merely restores a partially-soaked pool to a
+ * value at or below the last heal-observed peak is therefore under-counted. This
+ * does not affect classification: `shieldAppliedToOthers` is consumed only as a
+ * `> 0` gate, and an actual group shield healer crosses it on the first in-fight
+ * application (the per-target baseline starts at 0). Threading damage-event
+ * absorb readings in would refine the magnitude but not the boolean outcome.
  */
 function extractShieldSignals(
   healEvents: HealEvent[],

--- a/src/features/role_detection/types.ts
+++ b/src/features/role_detection/types.ts
@@ -109,8 +109,9 @@ export interface PlayerRoleSignals {
 
   // --- Absorb/shield signals ---
   /**
-   * Total shield (absorb) value this player granted to OTHER players,
-   * estimated from heal events where the target's absorb increased.
+   * Total damage-shield (absorb) value this player granted to OTHER players.
+   * Estimated from heal events to allies where the recipient's
+   * `targetResources.absorb` pool increased; self-shields are excluded.
    */
   shieldAppliedToOthers: number;
 


### PR DESCRIPTION
## Summary

Audit #12: `shieldAppliedToOthers` is consumed by `computeShieldHealerScore` (+10 when > 0) but `extractSignals` never populated it, so a damage-shield healer running a shield set but no Barrier scored exactly 15 and was mislabeled **GroupHealer** instead of ShieldHealer.

## Approach (investigated, then implemented)
The codebase has no damage-shield ability-ID registry, and the abilities oracle returns dozens of legacy/volatile IDs per shield — a hardcoded set would be fragile. Instead this uses the only **event-grounded, source-attributed** shield data present: `HealEvent.targetResources.absorb`. `extractShieldSignals` walks heal events in time order, tracks each ally's absorb pool, and credits a friendly source with any **increase** in a *different* ally's absorb (self-shields excluded; decay ignored). Populating the signal pushes a barrier-less shield healer from 15 → 25 → ShieldHealer.

## Testing
- `tsc` clean; all 42 role_detection tests pass; prettier + eslint clean.
- New tests: ally-absorb-increase credited, increase-only accounting across decay+reapply, self-shield exclusion, no-absorb no-op, and a classification test proving a barrier-less shield healer is now ShieldHealer.
- Degrades gracefully to 0 (today's behavior) when absorb data is absent — no false positives.

> Reviewer: **live-verify against real logs** that `HealEvent.targetResources.absorb` is populated for ally-shield heals and the attribution looks right on multi-healer fights, since this changes role classification.
