### PR TITLE
fix(auth): add CSRF state to the ESO Logs PKCE flow (#24) — needs live login verification

### DIFF
--- a/src/OAuthRedirect.tsx
+++ b/src/OAuthRedirect.tsx
@@ -2,7 +2,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { APP_AUTH_PORT_KEY } from './AppAuth';
@@ -14,6 +14,7 @@ import {
   startPKCEAuth,
   getIntendedDestination,
   clearIntendedDestination,
+  validateOAuthState,
 } from './features/auth/auth';
 import { useAuth } from './features/auth/AuthContext';
 import { KalpaAuthSuccess } from './features/auth/KalpaAuthSuccess';
@@ -28,11 +29,18 @@ export const OAuthRedirect: React.FC = () => {
   const [params] = useSearchParams();
   const navigate = useNavigate();
 
+  // validateOAuthState() consumes (clears) the stored state, so it can only
+  // succeed once. Under React StrictMode the effect runs twice in dev; we cache
+  // the first run's outcome here so the second invocation reuses it instead of
+  // failing on an already-consumed state.
+  const stateValidRef = useRef<boolean | null>(null);
+
   useEffect(() => {
     // Parse parameters directly from window.location since OAuth redirects
     // add query params to the full URL, not just the hash part
     const code = params.get('code');
     const error = params.get('error');
+    const stateParam = params.get('state');
     const verifier = getPkceCodeVerifier();
 
     if (error) {
@@ -47,6 +55,17 @@ export const OAuthRedirect: React.FC = () => {
 
     if (!verifier) {
       setError('Missing PKCE code verifier. Please restart the authentication process.');
+      return;
+    }
+
+    // CSRF protection: validate the returned state against the value we stored
+    // before redirecting. Validate at most once (StrictMode-safe) and reuse the
+    // cached result on the second dev invocation.
+    if (stateValidRef.current === null) {
+      stateValidRef.current = validateOAuthState(stateParam);
+    }
+    if (!stateValidRef.current) {
+      setError('OAuth state mismatch. Possible CSRF — please restart the authentication process.');
       return;
     }
 

--- a/src/features/auth/auth.test.ts
+++ b/src/features/auth/auth.test.ts
@@ -16,6 +16,7 @@ import {
   _resetRefreshState,
   setOAuthState,
   validateOAuthState,
+  generateOAuthState,
   OAUTH_STATE_KEY,
   buildAuthUrl,
 } from './auth';
@@ -204,6 +205,41 @@ describe('OAuth Basic Functions', () => {
       mockSessionStorage.getItem.mockReturnValue('abc-123');
       validateOAuthState('abc-123');
       expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(OAUTH_STATE_KEY);
+    });
+
+    describe('generateOAuthState', () => {
+      const originalCrypto = window.crypto;
+      afterEach(() => {
+        Object.defineProperty(window, 'crypto', { value: originalCrypto, writable: true });
+      });
+
+      it('uses crypto.randomUUID when available', () => {
+        Object.defineProperty(window, 'crypto', {
+          value: {
+            randomUUID: () => 'uuid-value',
+            getRandomValues: originalCrypto.getRandomValues,
+          },
+          writable: true,
+        });
+        expect(generateOAuthState()).toBe('uuid-value');
+      });
+
+      it('falls back to getRandomValues when randomUUID is unavailable', () => {
+        Object.defineProperty(window, 'crypto', {
+          value: {
+            getRandomValues: (arr: Uint32Array) => {
+              for (let i = 0; i < arr.length; i++) arr[i] = i + 1;
+              return arr;
+            },
+          },
+          writable: true,
+        });
+        const state = generateOAuthState();
+        expect(typeof state).toBe('string');
+        expect(state.length).toBeGreaterThan(0);
+        // 8 x Uint32 hex-padded => 64 hex chars, no randomUUID needed
+        expect(state).toBe('0000000100000002000000030000000400000005000000060000000700000008');
+      });
     });
   });
 

--- a/src/features/auth/auth.test.ts
+++ b/src/features/auth/auth.test.ts
@@ -14,6 +14,10 @@ import {
   DEV_PREVIEW_OAUTH_RETURN_KEY,
   refreshAccessToken,
   _resetRefreshState,
+  setOAuthState,
+  validateOAuthState,
+  OAUTH_STATE_KEY,
+  buildAuthUrl,
 } from './auth';
 import { getBaseUrl } from '../../utils/envUtils';
 
@@ -167,6 +171,64 @@ describe('OAuth Basic Functions', () => {
         INTENDED_DESTINATION_KEY,
         '/leaderboards',
       );
+    });
+  });
+
+  describe('OAuth CSRF state management', () => {
+    it('setOAuthState stores the value under OAUTH_STATE_KEY', () => {
+      setOAuthState('abc-123');
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(OAUTH_STATE_KEY, 'abc-123');
+    });
+
+    it('validateOAuthState returns true when the param matches the stored value', () => {
+      mockSessionStorage.getItem.mockReturnValue('abc-123');
+      expect(validateOAuthState('abc-123')).toBe(true);
+    });
+
+    it('validateOAuthState returns false on a mismatch', () => {
+      mockSessionStorage.getItem.mockReturnValue('abc-123');
+      expect(validateOAuthState('different')).toBe(false);
+    });
+
+    it('validateOAuthState returns false when nothing is stored', () => {
+      mockSessionStorage.getItem.mockReturnValue(null);
+      expect(validateOAuthState('abc-123')).toBe(false);
+    });
+
+    it('validateOAuthState returns false when the callback param is missing', () => {
+      mockSessionStorage.getItem.mockReturnValue('abc-123');
+      expect(validateOAuthState(null)).toBe(false);
+    });
+
+    it('validateOAuthState clears the stored state (one-time consume)', () => {
+      mockSessionStorage.getItem.mockReturnValue('abc-123');
+      validateOAuthState('abc-123');
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(OAUTH_STATE_KEY);
+    });
+  });
+
+  describe('buildAuthUrl', () => {
+    const originalCrypto = window.crypto;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'crypto', { value: originalCrypto, writable: true });
+    });
+
+    it('includes the URL-encoded state parameter', async () => {
+      jest.mocked(getBaseUrl).mockReturnValue('https://esotk.com/');
+      Object.defineProperty(window, 'crypto', {
+        value: {
+          subtle: {
+            digest: jest.fn().mockResolvedValue(new ArrayBuffer(32)),
+          },
+        },
+        writable: true,
+      });
+
+      const url = await buildAuthUrl('verifier-xyz', 'state value/&=');
+
+      expect(url).toContain(`&state=${encodeURIComponent('state value/&=')}`);
+      expect(url).toContain('code_challenge_method=S256');
     });
   });
 

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -65,6 +65,23 @@ export function validateOAuthState(stateParam: string | null): boolean {
   return !!stored && stored === stateParam;
 }
 
+/**
+ * Generate a random OAuth CSRF state token. Prefers crypto.randomUUID when
+ * available but falls back to getRandomValues — the same primitive the PKCE
+ * code verifier already uses — so the login flow never gains a stricter crypto
+ * requirement than it already has (some browsers/WebViews expose getRandomValues
+ * + subtle.digest but not randomUUID).
+ */
+export function generateOAuthState(): string {
+  const cryptoObj = globalThis.crypto;
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+  const array = new Uint32Array(8);
+  cryptoObj.getRandomValues(array);
+  return Array.from(array, (dec) => dec.toString(16).padStart(8, '0')).join('');
+}
+
 export function setIntendedDestination(path: string): void {
   localStorage.setItem(INTENDED_DESTINATION_KEY, path);
   localStorage.setItem(INTENDED_DESTINATION_PROTECTED_KEY, '1');
@@ -140,7 +157,7 @@ export async function startPKCEAuth(): Promise<void> {
   // CSRF protection: generate a random state, persist it, and echo it on the
   // authorize URL. OAuthRedirect validates the returned state before exchanging
   // the authorization code.
-  const state = globalThis.crypto.randomUUID();
+  const state = generateOAuthState();
   setOAuthState(state);
 
   // For dev-preview deployments, store the current base path so the shared

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -26,6 +26,7 @@ export const getRedirectUri = (): string => {
 // Replace with your actual ESO Logs client ID
 export const CLIENT_ID = '9fd28ffc-300a-44ce-8a0e-6167db47a7e1';
 export const PKCE_CODE_VERIFIER_KEY = 'eso_code_verifier';
+export const OAUTH_STATE_KEY = 'eso_oauth_state';
 export const INTENDED_DESTINATION_KEY = 'eso_intended_destination';
 const INTENDED_DESTINATION_PROTECTED_KEY = 'eso_intended_destination_protected';
 
@@ -42,6 +43,26 @@ export function setPkceCodeVerifier(verifier: string): void {
 
 export function getPkceCodeVerifier(): string {
   return sessionStorage.getItem(PKCE_CODE_VERIFIER_KEY) || '';
+}
+
+/**
+ * Store the OAuth CSRF state value for the ESO Logs authorization flow.
+ */
+export function setOAuthState(state: string): void {
+  sessionStorage.setItem(OAUTH_STATE_KEY, state);
+}
+
+/**
+ * Validate the OAuth `state` parameter returned on the callback against the
+ * value we stored before redirecting. Consumes (clears) the stored state so it
+ * can only be validated once — mirrors the Discord flow's validateOAuthState.
+ *
+ * @returns true only when a stored state exists and matches the callback param.
+ */
+export function validateOAuthState(stateParam: string | null): boolean {
+  const stored = sessionStorage.getItem(OAUTH_STATE_KEY);
+  sessionStorage.removeItem(OAUTH_STATE_KEY);
+  return !!stored && stored === stateParam;
 }
 
 export function setIntendedDestination(path: string): void {
@@ -103,18 +124,24 @@ const generateCodeChallenge = async (verifier: string): Promise<string> => {
   return base64UrlEncode(digest);
 };
 
-export async function buildAuthUrl(verifier: string): Promise<string> {
+export async function buildAuthUrl(verifier: string, state: string): Promise<string> {
   const challenge = await generateCodeChallenge(verifier);
 
   // Use the documented scope for user profile access
   const scope = 'view-user-profile';
 
-  return `https://www.esologs.com/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&code_challenge=${challenge}&code_challenge_method=S256&redirect_uri=${encodeURIComponent(getRedirectUri())}&scope=${encodeURIComponent(scope)}`;
+  return `https://www.esologs.com/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&code_challenge=${challenge}&code_challenge_method=S256&redirect_uri=${encodeURIComponent(getRedirectUri())}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}`;
 }
 
 export async function startPKCEAuth(): Promise<void> {
   const verifier = generateCodeVerifier();
   setPkceCodeVerifier(verifier);
+
+  // CSRF protection: generate a random state, persist it, and echo it on the
+  // authorize URL. OAuthRedirect validates the returned state before exchanging
+  // the authorization code.
+  const state = globalThis.crypto.randomUUID();
+  setOAuthState(state);
 
   // For dev-preview deployments, store the current base path so the shared
   // OAuth bounce page knows which PR preview to redirect back to.
@@ -125,7 +152,7 @@ export async function startPKCEAuth(): Promise<void> {
 
   let authUrl: string | undefined;
   try {
-    authUrl = await buildAuthUrl(verifier);
+    authUrl = await buildAuthUrl(verifier, state);
     window.location.href = authUrl;
   } catch (err) {
     logger.error(


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until a real ESO Logs login is verified end-to-end (see checklist).

## Summary

Audit #24: the ESO Logs PKCE flow had no CSRF `state` parameter (the Discord flow already does). This mirrors that protection.

- `auth.ts`: `setOAuthState`/`validateOAuthState` (one-time consume), `startPKCEAuth` generates `crypto.randomUUID()` into **sessionStorage** and `buildAuthUrl` appends `&state=`.
- `OAuthRedirect.tsx`: reads `state` and **rejects** the callback (no token exchange) unless it matches. StrictMode-safe via a `useRef` that caches the first validation so the dev double-invoke doesn't fail on the already-consumed state.

## Why this is lower-risk than it looks
The `state` uses the **exact same sessionStorage** as the existing PKCE code-verifier (`eso_code_verifier`), consumed at the same point in the same callback. So its persistence — including the dev-preview bounce — is identical to the verifier that already works today. No new storage/origin lifecycle is introduced.

## Testing
- `tsc` clean; 30 auth tests + OAuthRedirect story test pass; prettier + eslint clean.
- New unit tests: state match / mismatch / missing-store / missing-param / one-time consume, and `buildAuthUrl` includes the URL-encoded state.

## Reviewer checklist (REQUIRED before prod merge — needs real credentials I don't have)
1. Real login happy-path: click Login → ESO Logs consent → redirected back → token stored → lands on intended destination.
2. Confirm the authorize URL contains `&state=` **and** ESO Logs echoes the same `state` back on the callback (standard OAuth2 providers do; verify for this client).
3. Negative: tamper with the callback `state` → shows the CSRF mismatch error and does NOT exchange the code.
4. Dev-preview bounce flow still logs in (same-origin sessionStorage as the verifier, so expected to pass).
