### PR TITLE
feat(ultimate-calculator): make Solo/Group/PvP + role drive realistic archetype presets

### DIFF
--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -164,4 +164,23 @@ describe('UltimateCalculator', () => {
     expect(sourceSwitch(/^Major Heroism/i)).not.toBeChecked();
     expect(sourceSwitch(/^Minor Heroism/i)).toBeChecked();
   });
+
+  it('does not freeze archetype auto-apply when only a cost reduction is toggled', () => {
+    renderCalc();
+    // Sorcerer has Power Stone (−15%) as a default-on cost reduction.
+    fireEvent.mouseDown(screen.getByLabelText(/Class/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Sorcerer'));
+
+    // A cost reduction is orthogonal to the archetype source layer — toggling it
+    // must NOT mark the build customized.
+    fireEvent.click(screen.getByLabelText(/Power Stone/i));
+    expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
+
+    // …so switching context still auto-applies the new archetype preset…
+    fireEvent.click(screen.getByRole('button', { name: /^Solo/i }));
+    expect(screen.getByText(/^Typical Solo/i)).toBeInTheDocument();
+    expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
+    // …while preserving the reduction toggle the user changed.
+    expect(screen.getByLabelText(/Power Stone/i)).not.toBeChecked();
+  });
 });

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -100,4 +100,68 @@ describe('UltimateCalculator', () => {
     const costAfter = screen.getByText(/\d+ ult cost/i).textContent;
     expect(costAfter).toBe(costBefore);
   });
+
+  // --- Archetype presets: the Solo/Group/PvP + role controls are now meaningful ---
+
+  it('opens on a realistic Group · DPS build (archetype explainer + sources enabled)', () => {
+    renderCalc();
+    // Anchored ^Typical matches the explainer title, not the "Reset to typical …" button.
+    expect(screen.getByText(/^Typical Group/i)).toBeInTheDocument();
+    // The preset enables more than just base income (base + class proc + group
+    // sources), so the headline is well above an inert base-only number.
+    expect(readTotal()).toBeGreaterThan(700);
+  });
+
+  it('changes the headline when switching context (Solo is lower than Group)', () => {
+    renderCalc();
+    const group = readTotal();
+    fireEvent.click(screen.getByRole('button', { name: /^Solo/i }));
+    const solo = readTotal();
+    // Solo loses the group-only batteries → strictly less generation.
+    expect(solo).toBeLessThan(group);
+    expect(screen.getByText(/^Typical Solo/i)).toBeInTheDocument();
+  });
+
+  it('changes the headline when switching role (Group Tank out-generates Group DPS)', () => {
+    renderCalc();
+    const dps = readTotal();
+    fireEvent.mouseDown(screen.getByLabelText(/Role/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Tank'));
+    const tank = readTotal();
+    // Tank adds Bloodspawn + Major Heroism + Pillager's on top → higher.
+    expect(tank).toBeGreaterThan(dps);
+    expect(screen.getByText(/^Typical Group.*Tank/i)).toBeInTheDocument();
+  });
+
+  it('marks the build customized after a manual edit and stops auto-applying on switch', () => {
+    renderCalc();
+    // The source switch + its uptime slider share a label prefix; pick the
+    // checkbox input specifically (the slider is a range input).
+    const sourceSwitch = (label: RegExp): HTMLInputElement =>
+      screen
+        .getAllByLabelText(label)
+        .find((el) => el.getAttribute('type') === 'checkbox') as HTMLInputElement;
+
+    expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
+
+    // Enable Major Heroism — a manual source edit. (Its Heroism group stays open
+    // because Minor Heroism is on, so the control stays visible to assert on.)
+    const majorToggle = sourceSwitch(/^Major Heroism/i);
+    expect(majorToggle).not.toBeChecked();
+    fireEvent.click(majorToggle);
+    expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
+    expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
+
+    // Switching context must NOT overwrite the edit (Major Heroism stays on).
+    fireEvent.click(screen.getByRole('button', { name: /^Solo/i }));
+    expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
+    expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
+
+    // Applying the typical build restores the preset (Solo DPS has no Major
+    // Heroism) and clears the custom flag.
+    fireEvent.click(screen.getByRole('button', { name: /Apply typical Solo/i }));
+    expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
+    expect(sourceSwitch(/^Major Heroism/i)).not.toBeChecked();
+    expect(sourceSwitch(/^Minor Heroism/i)).toBeChecked();
+  });
 });

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -183,6 +183,30 @@ describe('UltimateCalculator', () => {
     expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
   });
 
+  it('prunes a reverted toggle so it cannot leak into another archetype', () => {
+    renderCalc(); // Group DPS: Minor Heroism on by preset.
+    fireEvent.click(sourceSwitch(/^Minor Heroism/i)); // off — a real edit
+    expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
+    fireEvent.click(sourceSwitch(/^Minor Heroism/i)); // back on — matches preset again
+    // The delta is pruned, so the build is pristine once more…
+    expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
+
+    // …and switching to a Major-Heroism archetype does NOT leave Minor on too
+    // (which would double-count the non-stacking buff).
+    fireEvent.mouseDown(screen.getByLabelText(/Role/i));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('Tank'));
+    expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
+    expect(sourceSwitch(/^Minor Heroism/i)).not.toBeChecked();
+  });
+
+  it('enabling Major Heroism disables Minor (they do not stack)', () => {
+    renderCalc(); // Group DPS: Minor on, Major off.
+    expect(sourceSwitch(/^Minor Heroism/i)).toBeChecked();
+    fireEvent.click(sourceSwitch(/^Major Heroism/i));
+    expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
+    expect(sourceSwitch(/^Minor Heroism/i)).not.toBeChecked();
+  });
+
   it('does not freeze archetype auto-apply when only a cost reduction is toggled', () => {
     renderCalc();
     // Sorcerer has Power Stone (−15%) as a default-on cost reduction.

--- a/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
+++ b/src/features/ultimate-simulator/presentation/__tests__/UltimateCalculator.test.tsx
@@ -133,15 +133,15 @@ describe('UltimateCalculator', () => {
     expect(screen.getByText(/^Typical Group.*Tank/i)).toBeInTheDocument();
   });
 
-  it('marks the build customized after a manual edit and stops auto-applying on switch', () => {
-    renderCalc();
-    // The source switch + its uptime slider share a label prefix; pick the
-    // checkbox input specifically (the slider is a range input).
-    const sourceSwitch = (label: RegExp): HTMLInputElement =>
-      screen
-        .getAllByLabelText(label)
-        .find((el) => el.getAttribute('type') === 'checkbox') as HTMLInputElement;
+  // The source switch + its uptime slider share a label prefix; pick the
+  // checkbox input specifically (the slider is a range input).
+  const sourceSwitch = (label: RegExp): HTMLInputElement =>
+    screen
+      .getAllByLabelText(label)
+      .find((el) => el.getAttribute('type') === 'checkbox') as HTMLInputElement;
 
+  it('preserves a hand-edit across an archetype switch and restores it on apply-typical', () => {
+    renderCalc();
     expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
 
     // Enable Major Heroism — a manual source edit. (Its Heroism group stays open
@@ -152,17 +152,35 @@ describe('UltimateCalculator', () => {
     expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
     expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
 
-    // Switching context must NOT overwrite the edit (Major Heroism stays on).
+    // Switching context replays the edit on top of the new archetype (Major
+    // Heroism stays on) rather than discarding it.
     fireEvent.click(screen.getByRole('button', { name: /^Solo/i }));
     expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
     expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
 
-    // Applying the typical build restores the preset (Solo DPS has no Major
-    // Heroism) and clears the custom flag.
+    // Applying the typical build drops the edit and restores the pure preset
+    // (Solo DPS has no Major Heroism) and clears the custom flag.
     fireEvent.click(screen.getByRole('button', { name: /Apply typical Solo/i }));
     expect(screen.queryByText(/customized this build/i)).not.toBeInTheDocument();
     expect(sourceSwitch(/^Major Heroism/i)).not.toBeChecked();
     expect(sourceSwitch(/^Minor Heroism/i)).toBeChecked();
+  });
+
+  it('adopts the new archetype defaults on a customized switch (no stale hybrid)', () => {
+    renderCalc();
+    // Group DPS does not run Colovian Highlands General; PvP DPS does. Customize
+    // the build with an unrelated edit, then switch playstyle.
+    fireEvent.click(sourceSwitch(/^Major Heroism/i));
+    expect(screen.getByText(/customized this build/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^PvP/i }));
+
+    // The build must adopt the PvP archetype's defaults (Colovian on), proving the
+    // preset is re-resolved — not a frozen Group snapshot…
+    expect(screen.getByText(/^Typical PvP/i)).toBeInTheDocument();
+    expect(sourceSwitch(/Colovian Highlands General/i)).toBeChecked();
+    // …while still replaying the user's edit on top.
+    expect(sourceSwitch(/^Major Heroism/i)).toBeChecked();
   });
 
   it('does not freeze archetype auto-apply when only a cost reduction is toggled', () => {

--- a/src/features/ultimate-simulator/presentation/__tests__/useUltimateCalculator.test.ts
+++ b/src/features/ultimate-simulator/presentation/__tests__/useUltimateCalculator.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Hook-level tests for the numeric-input guards. These exercise the setters
+ * directly because a browser `<input type="number">` (and jsdom) sanitizes most
+ * invalid text, making non-finite values hard to inject through the UI — yet a
+ * transient or out-of-range value can still reach the setter, and must never
+ * poison the results with NaN/Infinity.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useUltimateCalculator } from '../useUltimateCalculator';
+
+describe('useUltimateCalculator numeric guards', () => {
+  it('rejects non-finite numeric input and keeps results finite', () => {
+    const { result } = renderHook(() => useUltimateCalculator());
+
+    const fightBefore = result.current.state.fightDurationSeconds;
+    act(() => result.current.setFightDuration(NaN));
+    expect(result.current.state.fightDurationSeconds).toBe(fightBefore);
+    act(() => result.current.setFightDuration(Infinity));
+    expect(result.current.state.fightDurationSeconds).toBe(fightBefore);
+
+    act(() => result.current.setStartingUltimate(NaN));
+    expect(Number.isFinite(result.current.state.startingUltimate)).toBe(true);
+
+    act(() => result.current.setPillagerHealerUltCost(Number.POSITIVE_INFINITY));
+    expect(Number.isFinite(result.current.state.pillagerHealerUltCost)).toBe(true);
+
+    act(() => result.current.setCustomUltimateCost(NaN));
+    // A NaN custom cost is rejected — it stays at its initial null.
+    expect(result.current.state.customUltimateCost).toBeNull();
+
+    // The headline results never become NaN/Infinity.
+    expect(Number.isFinite(result.current.expected.totalUltimate)).toBe(true);
+    expect(Number.isFinite(result.current.expected.ultimatePerSecond)).toBe(true);
+    expect(Number.isFinite(result.current.effectiveCost)).toBe(true);
+  });
+
+  it('still accepts valid numeric edits', () => {
+    const { result } = renderHook(() => useUltimateCalculator());
+
+    act(() => result.current.setFightDuration(120));
+    expect(result.current.state.fightDurationSeconds).toBe(120);
+
+    act(() => result.current.setCustomUltimateCost(180));
+    expect(result.current.state.customUltimateCost).toBe(180);
+
+    act(() => result.current.setCustomUltimateCost(null));
+    expect(result.current.state.customUltimateCost).toBeNull();
+
+    act(() => result.current.setStartingUltimate(75));
+    expect(result.current.state.startingUltimate).toBe(75);
+  });
+});

--- a/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateCalculator.tsx
@@ -101,6 +101,12 @@ const CONTEXT_META: Record<CombatContext, { label: string; hint: string }> = {
   pvp: { label: 'PvP', hint: 'Cyrodiil · BG' },
 };
 
+const ROLE_LABELS: Record<CombatRole, string> = { dps: 'DPS', healer: 'Healer', tank: 'Tank' };
+
+/** Short, human archetype label, e.g. "Group · DPS" — used in the explainer + nudges. */
+const archetypeLabel = (context: CombatContext, role: CombatRole): string =>
+  `${CONTEXT_META[context].label} · ${ROLE_LABELS[role]}`;
+
 /**
  * Canonical per-class accent colors (mirrors the repo's class palette in
  * build-editor/data/esoStaticData.ts). Cosmetic only — used for swatches in the
@@ -744,6 +750,15 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
     [],
   );
 
+  // --- Archetype explainer --------------------------------------------------
+  // The active (context × role) preset, how many of its sources are currently
+  // enabled, and whether the assumptions list is expanded. Drives the explainer
+  // card under the Solo/Group/PvP + role controls.
+  const [showAssumptions, setShowAssumptions] = React.useState(false);
+  const enabledSourceCount = availableSourceEntries.filter((s) =>
+    calc.isEnabled(s.id, s.defaultEnabled),
+  ).length;
+
   // ones, usable by everyone) surface first; other classes' ults follow.
   const orderedUltimates = React.useMemo(() => {
     const rank = (owner: string): number => {
@@ -1174,6 +1189,159 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
                   </Select>
                 </FormControl>
               </Stack>
+
+              {/* Archetype explainer — turns the Solo/Group/PvP + role choice into
+                  a real, transparent starting build: a one-line summary, an
+                  expandable "what this assumes", a live "N sources on" count, and
+                  (once you've customized) a one-tap way back to the typical build. */}
+              <Box
+                sx={{
+                  p: 1.5,
+                  borderRadius: 1.4, // 14px — card tier
+                  border: `1px solid ${
+                    theme.palette.mode === 'dark' ? 'rgba(56,189,248,0.28)' : 'rgba(40,145,200,0.3)'
+                  }`,
+                  background:
+                    theme.palette.mode === 'dark'
+                      ? 'linear-gradient(135deg, rgba(56,189,248,0.1), rgba(56,189,248,0.02))'
+                      : 'rgba(40,145,200,0.04)',
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? 'inset 0 1px 0 rgba(255,255,255,0.05), 0 4px 14px rgba(0,0,0,0.25)'
+                      : '0 2px 8px rgba(15,23,42,0.05)',
+                }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+                >
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
+                    <InsightsOutlined sx={{ fontSize: 17, color: accent, flexShrink: 0 }} />
+                    <Typography variant="body2" sx={{ fontWeight: 700, minWidth: 0 }} noWrap>
+                      Typical {archetypeLabel(state.context, state.role)}
+                    </Typography>
+                  </Stack>
+                  <Box
+                    component="span"
+                    sx={{
+                      flexShrink: 0,
+                      px: 0.75,
+                      py: 0.1,
+                      borderRadius: 999,
+                      fontSize: 10.5,
+                      fontWeight: 700,
+                      lineHeight: 1.7,
+                      color: accentText,
+                      border: `1px solid ${accent}55`,
+                      background:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(56,189,248,0.1)'
+                          : 'rgba(40,145,200,0.08)',
+                    }}
+                  >
+                    {enabledSourceCount} {enabledSourceCount === 1 ? 'source' : 'sources'} on
+                  </Box>
+                </Stack>
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'text.secondary', display: 'block', mt: 0.75, lineHeight: 1.5 }}
+                >
+                  {calc.activePreset.summary}
+                </Typography>
+
+                {calc.customized ? (
+                  // Edited away from the preset — never silently overwrite; offer
+                  // an explicit one-tap re-apply (kept distinct from the wording
+                  // "reset" so it reads as a deliberate, safe action).
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: 'center', mt: 1.25, flexWrap: 'wrap', rowGap: 0.75 }}
+                  >
+                    <Typography
+                      variant="caption"
+                      sx={{ color: 'text.secondary', fontStyle: 'italic' }}
+                    >
+                      You’ve customized this build.
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<RestartAltOutlined sx={{ fontSize: 15 }} />}
+                      onClick={calc.applyActivePreset}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      Apply typical {archetypeLabel(state.context, state.role)}
+                    </Button>
+                  </Stack>
+                ) : (
+                  <Box sx={{ mt: 0.75 }}>
+                    <Stack
+                      direction="row"
+                      spacing={0.5}
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={showAssumptions}
+                      aria-controls="ult-archetype-assumptions"
+                      onClick={() => setShowAssumptions((v) => !v)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setShowAssumptions((v) => !v);
+                        }
+                      }}
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        cursor: 'pointer',
+                        userSelect: 'none',
+                        color: accentText,
+                        borderRadius: 1,
+                        '&:focus-visible': { outline: `2px solid ${accent}`, outlineOffset: 2 },
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.5,
+                        }}
+                      >
+                        What this assumes
+                      </Typography>
+                      <ExpandMore
+                        aria-hidden
+                        sx={{
+                          fontSize: 16,
+                          transition: prefersReducedMotion ? 'none' : 'transform 0.2s ease',
+                          transform: showAssumptions ? 'rotate(0deg)' : 'rotate(-90deg)',
+                        }}
+                      />
+                    </Stack>
+                    <Collapse in={showAssumptions} timeout={prefersReducedMotion ? 0 : 'auto'}>
+                      <Stack
+                        component="ul"
+                        id="ult-archetype-assumptions"
+                        spacing={0.5}
+                        sx={{ m: 0, mt: 0.75, pl: 2.25 }}
+                      >
+                        {calc.activePreset.assumptions.map((a, i) => (
+                          <Typography
+                            key={i}
+                            component="li"
+                            variant="caption"
+                            sx={{ color: 'text.secondary', lineHeight: 1.45 }}
+                          >
+                            {a}
+                          </Typography>
+                        ))}
+                      </Stack>
+                    </Collapse>
+                  </Box>
+                )}
+              </Box>
 
               <TextField
                 label="Fight duration"
@@ -1631,13 +1799,13 @@ export const UltimateCalculator: React.FC<UltimateCalculatorProps> = ({ classNam
               })}
 
               <Button
-                onClick={calc.reset}
+                onClick={calc.applyActivePreset}
                 size="small"
                 variant="text"
                 startIcon={<RestartAltOutlined sx={{ fontSize: 16 }} />}
                 sx={{ alignSelf: 'flex-start', color: 'text.secondary', mt: 0.5 }}
               >
-                Reset to defaults
+                Reset to typical {archetypeLabel(state.context, state.role)}
               </Button>
             </Stack>
           </Paper>

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -388,9 +388,16 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     (role: CombatRole) => patch((s) => applyArchetype({ ...s, role }, true)),
     [patch],
   );
+  // Numeric setters reject non-finite input (NaN/Infinity from a transient or
+  // out-of-range field value) so it can never poison effective cost / time-to-ult
+  // / the results with NaN. An invalid edit leaves the prior value untouched.
   const setFightDuration = useCallback(
     (seconds: number) =>
-      patch((s) => ({ ...s, fightDurationSeconds: Math.max(1, Math.round(seconds)) })),
+      patch((s) =>
+        Number.isFinite(seconds)
+          ? { ...s, fightDurationSeconds: Math.max(1, Math.round(seconds)) }
+          : s,
+      ),
     [patch],
   );
   const setDecisiveEnabled = useCallback(
@@ -432,30 +439,41 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
   );
   const setCustomUltimateCost = useCallback(
     (customUltimateCost: number | null) =>
-      patch((s) => ({
-        ...s,
-        customUltimateCost:
-          customUltimateCost == null ? null : Math.max(0, Math.round(customUltimateCost)),
-      })),
+      patch((s) => {
+        if (customUltimateCost == null) return { ...s, customUltimateCost: null };
+        if (!Number.isFinite(customUltimateCost)) return s;
+        return { ...s, customUltimateCost: Math.max(0, Math.round(customUltimateCost)) };
+      }),
     [patch],
   );
   const setStartingUltimate = useCallback(
     (startingUltimate: number) =>
-      patch((s) => ({
-        ...s,
-        startingUltimate: Math.min(MAX_ULTIMATE_POOL, Math.max(0, Math.round(startingUltimate))),
-      })),
+      patch((s) =>
+        Number.isFinite(startingUltimate)
+          ? {
+              ...s,
+              startingUltimate: Math.min(
+                MAX_ULTIMATE_POOL,
+                Math.max(0, Math.round(startingUltimate)),
+              ),
+            }
+          : s,
+      ),
     [patch],
   );
   const setPillagerHealerUltCost = useCallback(
     (pillagerHealerUltCost: number) =>
-      patch((s) => ({
-        ...s,
-        pillagerHealerUltCost: Math.min(
-          MAX_ULTIMATE_POOL,
-          Math.max(0, Math.round(pillagerHealerUltCost)),
-        ),
-      })),
+      patch((s) =>
+        Number.isFinite(pillagerHealerUltCost)
+          ? {
+              ...s,
+              pillagerHealerUltCost: Math.min(
+                MAX_ULTIMATE_POOL,
+                Math.max(0, Math.round(pillagerHealerUltCost)),
+              ),
+            }
+          : s,
+      ),
     [patch],
   );
   // Drop the user's hand-edits and restore the pure archetype preset (keeps

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -70,25 +70,40 @@ export interface UltimateCalculatorState {
   /** Healer's ultimate cost for the Pillager's Profit external source (10% of it per cast). */
   pillagerHealerUltCost: number;
   /**
-   * True once the user has hand-edited the source layer (toggled a source or
-   * moved an uptime). While false ("pristine"), switching context/role/class
-   * auto-applies the matching archetype preset so the headline visibly tracks the
-   * playstyle; once true, switches preserve the user's edits and the UI offers an
-   * explicit "Apply typical {archetype}" instead. Scenario inputs (Decisive,
-   * fight length, the chosen ultimate, etc.) never flip this.
+   * Generation-source enable toggles the user changed by hand, keyed by source
+   * id. These are the user's *deltas* over the archetype preset — they are
+   * replayed on top of the preset whenever the archetype is re-resolved (a
+   * context/role/class switch), so the build always reflects the selected
+   * archetype PLUS the user's edits, never a stale snapshot. Cleared by
+   * "Apply / Reset to typical". Cost-reduction toggles are not tracked here.
    */
-  customized: boolean;
+  userEnabledEdits: Record<string, boolean>;
+  /** Per-source uptime values the user set by hand — replayed like userEnabledEdits. */
+  userUptimeEdits: Record<string, number>;
 }
 
 /** Cost-reduction ids — preserved across preset applies (a preset never changes them). */
 const COST_REDUCTION_IDS = new Set(COST_REDUCTION_CATALOG.map((r) => r.id));
 
+/** Whether the build carries any hand-edit over its archetype preset. */
+const isCustomized = (state: UltimateCalculatorState): boolean =>
+  Object.keys(state.userEnabledEdits).length > 0 || Object.keys(state.userUptimeEdits).length > 0;
+
 /**
  * Re-seed the source layer (enabled toggles + uptimes) from the archetype preset
- * for the state's current context / role / class, preserving the user's scenario
- * inputs and any cost-reduction toggles, and marking the build pristine.
+ * for the state's current context / role / class.
+ *
+ * The preset is resolved fresh, so the source layer always reflects the selected
+ * archetype — never a stale snapshot of a previous one. Cost-reduction toggles
+ * are carried over (a preset never governs them). When `keepUserEdits` is true
+ * (context/role/class switches), the user's hand-edits are replayed on top so a
+ * customized build follows the player across playstyles; when false ("Apply /
+ * Reset to typical"), the edits are dropped and the pure preset is restored.
  */
-function applyArchetype(state: UltimateCalculatorState): UltimateCalculatorState {
+function applyArchetype(
+  state: UltimateCalculatorState,
+  keepUserEdits: boolean,
+): UltimateCalculatorState {
   const preset = getArchetypePreset(state.context, state.role);
   const { enabledOverrides, uptimeOverrides } = resolvePresetOverrides(preset, state.esoClass);
   // Carry over cost-reduction toggles; the preset only governs generation sources.
@@ -96,11 +111,14 @@ function applyArchetype(state: UltimateCalculatorState): UltimateCalculatorState
   for (const [id, on] of Object.entries(state.enabledOverrides)) {
     if (COST_REDUCTION_IDS.has(id)) preservedReductions[id] = on;
   }
+  const userEnabledEdits = keepUserEdits ? state.userEnabledEdits : {};
+  const userUptimeEdits = keepUserEdits ? state.userUptimeEdits : {};
   return {
     ...state,
-    enabledOverrides: { ...preservedReductions, ...enabledOverrides },
-    uptimeOverrides,
-    customized: false,
+    enabledOverrides: { ...preservedReductions, ...enabledOverrides, ...userEnabledEdits },
+    uptimeOverrides: { ...uptimeOverrides, ...userUptimeEdits },
+    userEnabledEdits,
+    userUptimeEdits,
   };
 }
 
@@ -119,12 +137,13 @@ const BASE_INITIAL_STATE: UltimateCalculatorState = {
   startingUltimate: 0,
   // A typical healer ultimate (e.g. ~250 cost) → 25 ult per affecting cast.
   pillagerHealerUltCost: 250,
-  customized: false,
+  userEnabledEdits: {},
+  userUptimeEdits: {},
 };
 
 // Open on a realistic build rather than the inert base-only number: seed the
 // typical Group · DPS archetype so the headline is meaningful at first paint.
-const INITIAL_STATE: UltimateCalculatorState = applyArchetype(BASE_INITIAL_STATE);
+const INITIAL_STATE: UltimateCalculatorState = applyArchetype(BASE_INITIAL_STATE, false);
 
 export interface UltimateCalculatorResult {
   state: UltimateCalculatorState;
@@ -154,7 +173,7 @@ export interface UltimateCalculatorResult {
   activePreset: ArchetypePreset;
   /** True once the user has hand-edited the source layer away from the preset. */
   customized: boolean;
-  /** Re-apply the active archetype preset's source layer (keeps scenario inputs). */
+  /** Drop hand-edits and restore the pure archetype preset (keeps scenario inputs). */
   applyActivePreset: () => void;
   // setters
   setContext: (c: CombatContext) => void;
@@ -287,32 +306,21 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     setDistribution(null);
   }, []);
 
-  // Context / role / class drive the archetype preset. While the build is
-  // pristine, changing any of them re-seeds the source layer to the new
-  // archetype so the headline visibly tracks the playstyle; once customized,
-  // the switch keeps the user's edits (the UI then offers an explicit re-apply).
+  // Context / role / class drive the archetype preset. Each re-resolves the new
+  // archetype's source layer and replays the user's hand-edits on top, so the
+  // build always reflects the selected playstyle PLUS any customizations — never
+  // a stale snapshot of the previous archetype. (A pristine build simply has no
+  // edits to replay, so it becomes the pure new preset.)
   const setContext = useCallback(
-    (context: CombatContext) =>
-      patch((s) => {
-        const next = { ...s, context };
-        return s.customized ? next : applyArchetype(next);
-      }),
+    (context: CombatContext) => patch((s) => applyArchetype({ ...s, context }, true)),
     [patch],
   );
   const setClass = useCallback(
-    (esoClass: EsoClass) =>
-      patch((s) => {
-        const next = { ...s, esoClass };
-        return s.customized ? next : applyArchetype(next);
-      }),
+    (esoClass: EsoClass) => patch((s) => applyArchetype({ ...s, esoClass }, true)),
     [patch],
   );
   const setRole = useCallback(
-    (role: CombatRole) =>
-      patch((s) => {
-        const next = { ...s, role };
-        return s.customized ? next : applyArchetype(next);
-      }),
+    (role: CombatRole) => patch((s) => applyArchetype({ ...s, role }, true)),
     [patch],
   );
   const setFightDuration = useCallback(
@@ -332,29 +340,35 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     (decisiveTwoHanded: boolean) => patch((s) => ({ ...s, decisiveTwoHanded })),
     [patch],
   );
-  // Hand-editing a generation SOURCE marks the build "customized" so a later
-  // context/role/class switch won't overwrite the user's choices. Cost
-  // reductions also flow through toggleSource, but they're orthogonal to the
-  // archetype source layer (a preset never sets them, and applyArchetype
-  // preserves them), so toggling one must NOT freeze preset auto-apply —
-  // otherwise switching playstyle after, say, turning off Power Stone would
-  // leave stale source uptimes from the previous archetype.
+  // Hand-editing a generation SOURCE records a user delta (replayed across
+  // archetype switches). Cost reductions also flow through toggleSource, but
+  // they're orthogonal to the archetype source layer (a preset never sets them,
+  // and applyArchetype preserves them), so toggling one updates the override but
+  // is NOT tracked as a customization — otherwise switching playstyle after,
+  // say, turning off Power Stone would be treated as a custom build.
   const toggleSource = useCallback(
     (id: string, enabled: boolean) =>
-      patch((s) => ({
-        ...s,
-        enabledOverrides: { ...s.enabledOverrides, [id]: enabled },
-        customized: s.customized || !COST_REDUCTION_IDS.has(id),
-      })),
+      patch((s) => {
+        const enabledOverrides = { ...s.enabledOverrides, [id]: enabled };
+        if (COST_REDUCTION_IDS.has(id)) return { ...s, enabledOverrides };
+        return {
+          ...s,
+          enabledOverrides,
+          userEnabledEdits: { ...s.userEnabledEdits, [id]: enabled },
+        };
+      }),
     [patch],
   );
   const setUptime = useCallback(
     (id: string, uptime: number) =>
-      patch((s) => ({
-        ...s,
-        uptimeOverrides: { ...s.uptimeOverrides, [id]: Math.min(1, Math.max(0, uptime)) },
-        customized: true,
-      })),
+      patch((s) => {
+        const clamped = Math.min(1, Math.max(0, uptime));
+        return {
+          ...s,
+          uptimeOverrides: { ...s.uptimeOverrides, [id]: clamped },
+          userUptimeEdits: { ...s.userUptimeEdits, [id]: clamped },
+        };
+      }),
     [patch],
   );
   const setUltimateAbility = useCallback(
@@ -390,15 +404,17 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
       })),
     [patch],
   );
-  // Re-apply the current archetype's typical source layer (keeps context, role,
-  // class and every scenario input). Backs both the "Apply typical {archetype}"
-  // nudge and the "Reset to typical {archetype}" button.
-  const applyActivePreset = useCallback(() => patch((s) => applyArchetype(s)), [patch]);
+  // Drop the user's hand-edits and restore the pure archetype preset (keeps
+  // context, role, class and every scenario input). Backs both the "Apply
+  // typical {archetype}" nudge and the "Reset to typical {archetype}" button.
+  const applyActivePreset = useCallback(() => patch((s) => applyArchetype(s, false)), [patch]);
 
   const activePreset = useMemo(
     () => getArchetypePreset(state.context, state.role),
     [state.context, state.role],
   );
+
+  const customized = useMemo(() => isCustomized(state), [state]);
 
   const reset = useCallback(() => {
     setState(INITIAL_STATE);
@@ -409,7 +425,7 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     state,
     selection,
     activePreset,
-    customized: state.customized,
+    customized,
     applyActivePreset,
     availableSourceEntries,
     availableReductionEntries,

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -122,6 +122,71 @@ function applyArchetype(
   };
 }
 
+/**
+ * Minor and Major Heroism are the same buff at two tiers — they never stack
+ * (Major overrides Minor). Enabling one disables the other so the engine, which
+ * does not de-duplicate buffs, can never sum both.
+ */
+const HEROISM_EXCLUSIVE: Record<string, string> = {
+  'minor-heroism': 'major-heroism',
+  'major-heroism': 'minor-heroism',
+};
+
+/**
+ * Set a generation source's enabled state, recording it as a user delta ONLY
+ * when it differs from the active archetype preset. Reverting a toggle back to
+ * the preset value therefore clears the delta (the build returns to pristine),
+ * so a stale "matches the preset anyway" delta can never leak into — and
+ * double-count against — a later archetype. Enabling a Heroism tier disables the
+ * other (recorded as a delta too) to preserve the non-stacking invariant.
+ */
+function setSourceEnabled(
+  state: UltimateCalculatorState,
+  id: string,
+  enabled: boolean,
+): Pick<UltimateCalculatorState, 'enabledOverrides' | 'userEnabledEdits'> {
+  const presetEnabled = resolvePresetOverrides(
+    getArchetypePreset(state.context, state.role),
+    state.esoClass,
+  ).enabledOverrides;
+  const enabledOverrides = { ...state.enabledOverrides };
+  const userEnabledEdits = { ...state.userEnabledEdits };
+  const set = (sid: string, val: boolean): void => {
+    enabledOverrides[sid] = val;
+    if (val === presetEnabled[sid]) delete userEnabledEdits[sid];
+    else userEnabledEdits[sid] = val;
+  };
+  set(id, enabled);
+  const exclusive = HEROISM_EXCLUSIVE[id];
+  if (exclusive && enabled) set(exclusive, false);
+  return { enabledOverrides, userEnabledEdits };
+}
+
+/**
+ * Set a source's uptime, recording it as a delta only when it differs from the
+ * resolved preset value (preset override, else the catalog default). Comparison
+ * is by whole percent — the only granularity the slider exposes — so dragging a
+ * slider back to the preset value clears the delta.
+ */
+function setSourceUptime(
+  state: UltimateCalculatorState,
+  id: string,
+  uptime: number,
+): Pick<UltimateCalculatorState, 'uptimeOverrides' | 'userUptimeEdits'> {
+  const clamped = Math.min(1, Math.max(0, uptime));
+  const presetUptimes = resolvePresetOverrides(
+    getArchetypePreset(state.context, state.role),
+    state.esoClass,
+  ).uptimeOverrides;
+  const catalogDefault = ULTIMATE_SOURCE_CATALOG.find((s) => s.id === id)?.uptime ?? 0;
+  const presetValue = presetUptimes[id] ?? catalogDefault;
+  const uptimeOverrides = { ...state.uptimeOverrides, [id]: clamped };
+  const userUptimeEdits = { ...state.userUptimeEdits };
+  if (Math.round(clamped * 100) === Math.round(presetValue * 100)) delete userUptimeEdits[id];
+  else userUptimeEdits[id] = clamped;
+  return { uptimeOverrides, userUptimeEdits };
+}
+
 const BASE_INITIAL_STATE: UltimateCalculatorState = {
   context: 'groupPve',
   esoClass: 'arcanist',
@@ -341,34 +406,23 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     [patch],
   );
   // Hand-editing a generation SOURCE records a user delta (replayed across
-  // archetype switches). Cost reductions also flow through toggleSource, but
-  // they're orthogonal to the archetype source layer (a preset never sets them,
-  // and applyArchetype preserves them), so toggling one updates the override but
-  // is NOT tracked as a customization — otherwise switching playstyle after,
-  // say, turning off Power Stone would be treated as a custom build.
+  // archetype switches, pruned when it matches the preset). Cost reductions also
+  // flow through toggleSource, but they're orthogonal to the archetype source
+  // layer (a preset never sets them, and applyArchetype preserves them), so
+  // toggling one updates the override but is NOT tracked as a customization —
+  // otherwise switching playstyle after, say, turning off Power Stone would be
+  // treated as a custom build.
   const toggleSource = useCallback(
     (id: string, enabled: boolean) =>
-      patch((s) => {
-        const enabledOverrides = { ...s.enabledOverrides, [id]: enabled };
-        if (COST_REDUCTION_IDS.has(id)) return { ...s, enabledOverrides };
-        return {
-          ...s,
-          enabledOverrides,
-          userEnabledEdits: { ...s.userEnabledEdits, [id]: enabled },
-        };
-      }),
+      patch((s) =>
+        COST_REDUCTION_IDS.has(id)
+          ? { ...s, enabledOverrides: { ...s.enabledOverrides, [id]: enabled } }
+          : { ...s, ...setSourceEnabled(s, id, enabled) },
+      ),
     [patch],
   );
   const setUptime = useCallback(
-    (id: string, uptime: number) =>
-      patch((s) => {
-        const clamped = Math.min(1, Math.max(0, uptime));
-        return {
-          ...s,
-          uptimeOverrides: { ...s.uptimeOverrides, [id]: clamped },
-          userUptimeEdits: { ...s.userUptimeEdits, [id]: clamped },
-        };
-      }),
+    (id: string, uptime: number) => patch((s) => ({ ...s, ...setSourceUptime(s, id, uptime) })),
     [patch],
   );
   const setUltimateAbility = useCallback(

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -36,6 +36,11 @@ import {
   ULTIMATE_ABILITIES,
   ULTIMATE_SOURCE_CATALOG,
 } from '../shared/constants/catalog';
+import {
+  getArchetypePreset,
+  resolvePresetOverrides,
+  type ArchetypePreset,
+} from '../shared/constants/presets';
 import type { ExpectedValueResult, MonteCarloResult, TimeToUltimateResult } from '../shared/types';
 import type {
   CatalogCostReduction,
@@ -64,9 +69,42 @@ export interface UltimateCalculatorState {
   startingUltimate: number;
   /** Healer's ultimate cost for the Pillager's Profit external source (10% of it per cast). */
   pillagerHealerUltCost: number;
+  /**
+   * True once the user has hand-edited the source layer (toggled a source or
+   * moved an uptime). While false ("pristine"), switching context/role/class
+   * auto-applies the matching archetype preset so the headline visibly tracks the
+   * playstyle; once true, switches preserve the user's edits and the UI offers an
+   * explicit "Apply typical {archetype}" instead. Scenario inputs (Decisive,
+   * fight length, the chosen ultimate, etc.) never flip this.
+   */
+  customized: boolean;
 }
 
-const INITIAL_STATE: UltimateCalculatorState = {
+/** Cost-reduction ids — preserved across preset applies (a preset never changes them). */
+const COST_REDUCTION_IDS = new Set(COST_REDUCTION_CATALOG.map((r) => r.id));
+
+/**
+ * Re-seed the source layer (enabled toggles + uptimes) from the archetype preset
+ * for the state's current context / role / class, preserving the user's scenario
+ * inputs and any cost-reduction toggles, and marking the build pristine.
+ */
+function applyArchetype(state: UltimateCalculatorState): UltimateCalculatorState {
+  const preset = getArchetypePreset(state.context, state.role);
+  const { enabledOverrides, uptimeOverrides } = resolvePresetOverrides(preset, state.esoClass);
+  // Carry over cost-reduction toggles; the preset only governs generation sources.
+  const preservedReductions: Record<string, boolean> = {};
+  for (const [id, on] of Object.entries(state.enabledOverrides)) {
+    if (COST_REDUCTION_IDS.has(id)) preservedReductions[id] = on;
+  }
+  return {
+    ...state,
+    enabledOverrides: { ...preservedReductions, ...enabledOverrides },
+    uptimeOverrides,
+    customized: false,
+  };
+}
+
+const BASE_INITIAL_STATE: UltimateCalculatorState = {
   context: 'groupPve',
   esoClass: 'arcanist',
   role: 'dps',
@@ -81,7 +119,12 @@ const INITIAL_STATE: UltimateCalculatorState = {
   startingUltimate: 0,
   // A typical healer ultimate (e.g. ~250 cost) → 25 ult per affecting cast.
   pillagerHealerUltCost: 250,
+  customized: false,
 };
+
+// Open on a realistic build rather than the inert base-only number: seed the
+// typical Group · DPS archetype so the headline is meaningful at first paint.
+const INITIAL_STATE: UltimateCalculatorState = applyArchetype(BASE_INITIAL_STATE);
 
 export interface UltimateCalculatorResult {
   state: UltimateCalculatorState;
@@ -107,6 +150,12 @@ export interface UltimateCalculatorResult {
   /** Lazily-computed Monte Carlo distribution (null until requested). */
   distribution: MonteCarloResult | null;
   computeDistribution: () => void;
+  /** The preset describing the current (context × role) archetype. */
+  activePreset: ArchetypePreset;
+  /** True once the user has hand-edited the source layer away from the preset. */
+  customized: boolean;
+  /** Re-apply the active archetype preset's source layer (keeps scenario inputs). */
+  applyActivePreset: () => void;
   // setters
   setContext: (c: CombatContext) => void;
   setClass: (c: EsoClass) => void;
@@ -238,12 +287,34 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     setDistribution(null);
   }, []);
 
+  // Context / role / class drive the archetype preset. While the build is
+  // pristine, changing any of them re-seeds the source layer to the new
+  // archetype so the headline visibly tracks the playstyle; once customized,
+  // the switch keeps the user's edits (the UI then offers an explicit re-apply).
   const setContext = useCallback(
-    (context: CombatContext) => patch((s) => ({ ...s, context })),
+    (context: CombatContext) =>
+      patch((s) => {
+        const next = { ...s, context };
+        return s.customized ? next : applyArchetype(next);
+      }),
     [patch],
   );
-  const setClass = useCallback((esoClass: EsoClass) => patch((s) => ({ ...s, esoClass })), [patch]);
-  const setRole = useCallback((role: CombatRole) => patch((s) => ({ ...s, role })), [patch]);
+  const setClass = useCallback(
+    (esoClass: EsoClass) =>
+      patch((s) => {
+        const next = { ...s, esoClass };
+        return s.customized ? next : applyArchetype(next);
+      }),
+    [patch],
+  );
+  const setRole = useCallback(
+    (role: CombatRole) =>
+      patch((s) => {
+        const next = { ...s, role };
+        return s.customized ? next : applyArchetype(next);
+      }),
+    [patch],
+  );
   const setFightDuration = useCallback(
     (seconds: number) =>
       patch((s) => ({ ...s, fightDurationSeconds: Math.max(1, Math.round(seconds)) })),
@@ -261,9 +332,17 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     (decisiveTwoHanded: boolean) => patch((s) => ({ ...s, decisiveTwoHanded })),
     [patch],
   );
+  // Hand-editing the source layer marks the build "customized" so a later
+  // context/role/class switch won't overwrite the user's choices. (Cost
+  // reductions also flow through toggleSource — toggling one is a real build
+  // change, so it counts as customizing too.)
   const toggleSource = useCallback(
     (id: string, enabled: boolean) =>
-      patch((s) => ({ ...s, enabledOverrides: { ...s.enabledOverrides, [id]: enabled } })),
+      patch((s) => ({
+        ...s,
+        enabledOverrides: { ...s.enabledOverrides, [id]: enabled },
+        customized: true,
+      })),
     [patch],
   );
   const setUptime = useCallback(
@@ -271,6 +350,7 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
       patch((s) => ({
         ...s,
         uptimeOverrides: { ...s.uptimeOverrides, [id]: Math.min(1, Math.max(0, uptime)) },
+        customized: true,
       })),
     [patch],
   );
@@ -307,6 +387,16 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
       })),
     [patch],
   );
+  // Re-apply the current archetype's typical source layer (keeps context, role,
+  // class and every scenario input). Backs both the "Apply typical {archetype}"
+  // nudge and the "Reset to typical {archetype}" button.
+  const applyActivePreset = useCallback(() => patch((s) => applyArchetype(s)), [patch]);
+
+  const activePreset = useMemo(
+    () => getArchetypePreset(state.context, state.role),
+    [state.context, state.role],
+  );
+
   const reset = useCallback(() => {
     setState(INITIAL_STATE);
     setDistribution(null);
@@ -315,6 +405,9 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
   return {
     state,
     selection,
+    activePreset,
+    customized: state.customized,
+    applyActivePreset,
     availableSourceEntries,
     availableReductionEntries,
     isEnabled,

--- a/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateCalculator.ts
@@ -332,16 +332,19 @@ export function useUltimateCalculator(): UltimateCalculatorResult {
     (decisiveTwoHanded: boolean) => patch((s) => ({ ...s, decisiveTwoHanded })),
     [patch],
   );
-  // Hand-editing the source layer marks the build "customized" so a later
-  // context/role/class switch won't overwrite the user's choices. (Cost
-  // reductions also flow through toggleSource — toggling one is a real build
-  // change, so it counts as customizing too.)
+  // Hand-editing a generation SOURCE marks the build "customized" so a later
+  // context/role/class switch won't overwrite the user's choices. Cost
+  // reductions also flow through toggleSource, but they're orthogonal to the
+  // archetype source layer (a preset never sets them, and applyArchetype
+  // preserves them), so toggling one must NOT freeze preset auto-apply —
+  // otherwise switching playstyle after, say, turning off Power Stone would
+  // leave stale source uptimes from the previous archetype.
   const toggleSource = useCallback(
     (id: string, enabled: boolean) =>
       patch((s) => ({
         ...s,
         enabledOverrides: { ...s.enabledOverrides, [id]: enabled },
-        customized: true,
+        customized: s.customized || !COST_REDUCTION_IDS.has(id),
       })),
     [patch],
   );

--- a/src/features/ultimate-simulator/shared/constants/__tests__/presets.test.ts
+++ b/src/features/ultimate-simulator/shared/constants/__tests__/presets.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Data-integrity tests for the archetype preset matrix.
+ *
+ * These guard the two ways a preset can silently rot: (1) listing a source whose
+ * context/role gate excludes the archetype (it would be dropped by
+ * `compileSources`, under-populating the "typical" build with no error), and
+ * (2) enabling both Minor and Major Heroism in one archetype (they are the same
+ * non-stacking buff at two tiers). Plus the basic shape + resolution behavior.
+ */
+
+import { isSourceAvailable } from '../../../application/compileCatalog';
+import { ESO_CLASSES, type EsoClass } from '../../types/catalog';
+import { ULTIMATE_SOURCE_CATALOG } from '../catalog';
+import {
+  ALL_ARCHETYPE_PRESETS,
+  ARCHETYPE_PRESETS,
+  CLASS_PRIMARY_PROC_ID,
+  classPrimaryProcId,
+  getArchetypePreset,
+  resolvePresetOverrides,
+} from '../presets';
+
+const sourceById = (id: string) => ULTIMATE_SOURCE_CATALOG.find((s) => s.id === id);
+
+describe('ARCHETYPE_PRESETS data integrity', () => {
+  it('has exactly the 9 (context × role) archetypes with matching ids', () => {
+    expect(ALL_ARCHETYPE_PRESETS).toHaveLength(9);
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      expect(preset.id).toBe(`${preset.context}-${preset.role}`);
+      expect(getArchetypePreset(preset.context, preset.role)).toBe(preset);
+    }
+  });
+
+  it('only references source ids that exist in the catalog', () => {
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      for (const id of preset.enabledSourceIds) {
+        expect(sourceById(id)).toBeDefined();
+      }
+      for (const id of Object.keys(preset.uptimeOverrides)) {
+        expect(sourceById(id)).toBeDefined();
+      }
+    }
+  });
+
+  it('every enabled source is gate-valid for its archetype (context + role, all classes)', () => {
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      for (const id of preset.enabledSourceIds) {
+        const source = sourceById(id)!;
+        for (const esoClass of ESO_CLASSES) {
+          expect(
+            isSourceAvailable(source, {
+              context: preset.context,
+              esoClass,
+              role: preset.role,
+            }),
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('never enables both Minor and Major Heroism in the same archetype (non-stacking)', () => {
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      const ids = new Set(preset.enabledSourceIds);
+      expect(ids.has('minor-heroism') && ids.has('major-heroism')).toBe(false);
+    }
+  });
+
+  it('keeps every uptime override within [0, 1]', () => {
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      expect(preset.baseUptime).toBeGreaterThanOrEqual(0);
+      expect(preset.baseUptime).toBeLessThanOrEqual(1);
+      for (const v of Object.values(preset.uptimeOverrides)) {
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('carries a non-empty summary and assumptions for each archetype', () => {
+    for (const preset of ALL_ARCHETYPE_PRESETS) {
+      expect(preset.summary.length).toBeGreaterThan(0);
+      expect(preset.assumptions.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
+describe('classPrimaryProcId', () => {
+  it('resolves each generation-passive class to a real, class-gated catalog source', () => {
+    for (const esoClass of ESO_CLASSES) {
+      const procId = classPrimaryProcId(esoClass);
+      if (procId == null) continue;
+      const source = sourceById(procId);
+      expect(source).toBeDefined();
+      // The proc must be gated to (at least) this class.
+      expect(source!.classes).toContain(esoClass);
+    }
+  });
+
+  it('has no native ult-gen passive for Sorcerer or Warden', () => {
+    expect(CLASS_PRIMARY_PROC_ID.sorcerer).toBeNull();
+    expect(CLASS_PRIMARY_PROC_ID.warden).toBeNull();
+  });
+});
+
+describe('resolvePresetOverrides', () => {
+  it('enables base income + the class proc + the archetype sources, and nothing else', () => {
+    const preset = ARCHETYPE_PRESETS.groupPve.dps;
+    const { enabledOverrides, uptimeOverrides } = resolvePresetOverrides(preset, 'arcanist');
+
+    // Always-on base + arcanist proc + the two archetype sources.
+    expect(enabledOverrides['base-light-attack']).toBe(true);
+    expect(enabledOverrides['arcanist-implacable-outcome']).toBe(true);
+    expect(enabledOverrides['minor-heroism']).toBe(true);
+    expect(enabledOverrides['arkasis-genius-external']).toBe(true);
+    // Not in the preset → explicitly off (deterministic, no stale carry-over).
+    expect(enabledOverrides['major-heroism']).toBe(false);
+    expect(enabledOverrides['bloodspawn']).toBe(false);
+
+    // Base uptime + the preset's per-source uptime land in the override map.
+    expect(uptimeOverrides['base-light-attack']).toBe(preset.baseUptime);
+    expect(uptimeOverrides['minor-heroism']).toBe(0.6);
+  });
+
+  it('sets an explicit boolean for every catalog source (deterministic apply)', () => {
+    const { enabledOverrides } = resolvePresetOverrides(ARCHETYPE_PRESETS.soloPve.dps, 'sorcerer');
+    for (const source of ULTIMATE_SOURCE_CATALOG) {
+      expect(typeof enabledOverrides[source.id]).toBe('boolean');
+    }
+  });
+
+  it('omits a class proc for a class that has none (Sorcerer/Warden)', () => {
+    const classesWithoutProc: EsoClass[] = ['sorcerer', 'warden'];
+    for (const esoClass of classesWithoutProc) {
+      const { enabledOverrides } = resolvePresetOverrides(ARCHETYPE_PRESETS.groupPve.dps, esoClass);
+      // None of the class procs should be enabled for these classes.
+      for (const procId of Object.values(CLASS_PRIMARY_PROC_ID)) {
+        if (procId) expect(enabledOverrides[procId]).toBe(false);
+      }
+    }
+  });
+});

--- a/src/features/ultimate-simulator/shared/constants/presets.ts
+++ b/src/features/ultimate-simulator/shared/constants/presets.ts
@@ -1,0 +1,287 @@
+/**
+ * Archetype PRESETS — what a typical build of each (context × role) actually runs.
+ *
+ * The Solo/Group/PvP context and the DPS/Healer/Tank role used to be inert: every
+ * context- and role-specific catalog source is `defaultEnabled: false`, so all
+ * nine (context × role) combinations produced an identical headline number. These
+ * presets fix that — picking a context + role seeds a realistic set of enabled
+ * sources at realistic uptimes, so the result is meaningful out of the box and
+ * visibly changes as you switch.
+ *
+ * Nothing here invents new numbers. A preset only *selects* which catalog sources
+ * a typical build of that archetype runs and at what uptime — every per-source
+ * rate and its provenance still live in `catalog.ts`. The uptime overrides stay
+ * within the ranges those sourced catalog notes already justify (e.g. Minor
+ * Heroism from a 45s-cooldown Essence of Heroism potion ≈ 33% uptime, not the
+ * catalog's optimistic 90% set-maintained default).
+ *
+ * Design (verified by an adversarial ESO-theorycraft review):
+ *  - A preset touches ONLY the source layer (which sources are enabled + their
+ *    uptime). It never sets Decisive, fight length, the chosen ultimate, starting
+ *    ultimate, or the Pillager's wearer cost — those are the user's scenario.
+ *  - `enableClassProc` turns on the current class's primary ultimate-generation
+ *    passive (resolved per-class below); Sorcerer and Warden have none.
+ *  - Minor and Major Heroism never appear together (they are the same buff at two
+ *    tiers — Major overrides Minor, they do not stack).
+ *  - Every `enabledSourceIds` entry is gated-valid for its archetype (a source
+ *    whose `availableIn`/`roles` excludes the archetype would be silently dropped
+ *    by `compileSources`; the preset data-integrity test guards against that).
+ */
+
+import type { CombatContext, CombatRole, EsoClass } from '../types/catalog';
+
+import { ULTIMATE_SOURCE_CATALOG } from './catalog';
+
+/**
+ * A typical-build preset for one (context × role) archetype.
+ *
+ * `enabledSourceIds` lists the archetype-specific sources to enable *on top of*
+ * the always-on base income and (when `enableClassProc`) the class proc.
+ */
+export interface ArchetypePreset {
+  /** Stable id, `${context}-${role}` (e.g. 'groupPve-dps'). */
+  readonly id: string;
+  readonly context: CombatContext;
+  readonly role: CombatRole;
+  /** Enable the current class's primary ult-gen passive (Sorc/Warden: no-op). */
+  readonly enableClassProc: boolean;
+  /** Light/heavy-attack (base income) uptime for this archetype. */
+  readonly baseUptime: number;
+  /** Archetype-specific source ids to enable (besides base + class proc). */
+  readonly enabledSourceIds: readonly string[];
+  /** Per-source uptime overrides; sources omitted keep their catalog default. */
+  readonly uptimeOverrides: Readonly<Record<string, number>>;
+  /** One-line, player-facing description of the build this models. */
+  readonly summary: string;
+  /** 2–4 short caveats explaining what the numbers assume. */
+  readonly assumptions: readonly string[];
+}
+
+/**
+ * The current class's primary ultimate-GENERATION passive id (the one a typical
+ * build of that class runs). Sorcerer (Power Stone is a cost *reduction*) and
+ * Warden (no native ult-gen passive in U50) resolve to null — they intentionally
+ * read as structurally lower, which the explainer copy calls out.
+ */
+export const CLASS_PRIMARY_PROC_ID: Record<EsoClass, string | null> = {
+  arcanist: 'arcanist-implacable-outcome',
+  dragonknight: 'dragonknight-mountains-blessing',
+  necromancer: 'necromancer-corpse-consumption',
+  nightblade: 'nightblade-catalyst',
+  sorcerer: null,
+  templar: 'templar-prism',
+  warden: null,
+};
+
+export const classPrimaryProcId = (esoClass: EsoClass): string | null =>
+  CLASS_PRIMARY_PROC_ID[esoClass];
+
+/**
+ * The 9-archetype matrix. Indexed `[context][role]`. Each enables the realistic
+ * set of sources for that archetype, grounded in the catalog's sourced rates.
+ */
+export const ARCHETYPE_PRESETS: Record<CombatContext, Record<CombatRole, ArchetypePreset>> = {
+  soloPve: {
+    dps: {
+      id: 'soloPve-dps',
+      context: 'soloPve',
+      role: 'dps',
+      enableClassProc: true,
+      baseUptime: 0.97,
+      enabledSourceIds: ['minor-heroism'],
+      uptimeOverrides: { 'minor-heroism': 0.33 },
+      summary:
+        'Self-sufficient parse: near-full weaving, your class proc, Heroism from potions only.',
+      assumptions: [
+        'No group buffs available solo — only self-sourced income.',
+        'Minor Heroism from Essence of Heroism potions (~33% uptime over the 45s potion cooldown).',
+        'Class ult-gen proc assumes its trigger is in your rotation; Sorcerer & Warden have none.',
+        'A solo DK can hold Major Heroism via Basalt-Blooded Warrior — toggle Major (it overrides Minor) if you run it.',
+      ],
+    },
+    healer: {
+      id: 'soloPve-healer',
+      context: 'soloPve',
+      role: 'healer',
+      enableClassProc: true,
+      baseUptime: 0.9,
+      enabledSourceIds: ['minor-heroism'],
+      uptimeOverrides: { 'minor-heroism': 0.33 },
+      summary:
+        'Solo self-healer weaving between heals, with Heroism from potions and your class proc.',
+      assumptions: [
+        'No group buffs solo — you self-DPS and weave between heals (slightly lower LA uptime than a pure parse).',
+        'Minor Heroism from Essence of Heroism potions (~33% uptime).',
+        'Class proc assumes its trigger is slotted; Sorcerer & Warden have none.',
+      ],
+    },
+    tank: {
+      id: 'soloPve-tank',
+      context: 'soloPve',
+      role: 'tank',
+      enableClassProc: true,
+      baseUptime: 0.8,
+      enabledSourceIds: ['bloodspawn', 'minor-heroism'],
+      uptimeOverrides: { bloodspawn: 0.6, 'minor-heroism': 0.33 },
+      summary:
+        'Self-tank: Bloodspawn procs from incoming hits, plus Heroism potions and your class proc.',
+      assumptions: [
+        "Bloodspawn uptime assumes you're actively soaking damage (~0.7 ult/s when constantly hit).",
+        'Block-heavy play lowers light-attack uptime versus a DPS parse.',
+        'Minor Heroism from potions only; class proc assumes its trigger is slotted (Sorcerer & Warden have none).',
+      ],
+    },
+  },
+  groupPve: {
+    dps: {
+      id: 'groupPve-dps',
+      context: 'groupPve',
+      role: 'dps',
+      enableClassProc: true,
+      baseUptime: 0.97,
+      enabledSourceIds: ['minor-heroism', 'arkasis-genius-external'],
+      uptimeOverrides: { 'minor-heroism': 0.6 },
+      summary:
+        'Optimized raid parse: full weaving, set/support Minor Heroism, and Arkasis ult batteries from a support.',
+      assumptions: [
+        'Minor Heroism is the realistic class-agnostic group buff (Heroism set, scribing, or battery) — swap to Major if a Warden scrip / Drake’s Rush support provides it.',
+        "Assumes a support wears Arkasis's Genius and pots on cooldown (~1 ult/s, the strongest group-exclusive income).",
+        'Class ult-gen proc assumes its rotation trigger is present; Sorcerer & Warden have none.',
+        "Kraglen's Howl synergy is optional — toggle it on for add-heavy pulls (near-zero on clean single-target).",
+      ],
+    },
+    healer: {
+      id: 'groupPve-healer',
+      context: 'groupPve',
+      role: 'healer',
+      enableClassProc: true,
+      baseUptime: 0.85,
+      enabledSourceIds: ['major-heroism', 'arkasis-genius-external'],
+      uptimeOverrides: { 'major-heroism': 0.55 },
+      summary: 'Support healer: holds Major Heroism for the group and receives Arkasis batteries.',
+      assumptions: [
+        'Major Heroism assumes a Warden / scribed source maintaining it; if not, switch to Minor and lower its uptime.',
+        "You're usually the Pillager's Profit WEARER (you grant it, you don't receive it) — so it's not in this default; a second support's Arkasis is the realistic incoming source.",
+        'Lower light-attack uptime than DPS — time spent purging, shielding and casting heals.',
+        'Class proc assumes its trigger is slotted; Sorcerer & Warden have none.',
+      ],
+    },
+    tank: {
+      id: 'groupPve-tank',
+      context: 'groupPve',
+      role: 'tank',
+      enableClassProc: true,
+      baseUptime: 0.8,
+      enabledSourceIds: [
+        'major-heroism',
+        'bloodspawn',
+        'pillagers-profit-external',
+        'arkasis-genius-external',
+      ],
+      uptimeOverrides: { 'major-heroism': 0.5, bloodspawn: 0.6 },
+      summary:
+        'Raid tank: Bloodspawn from incoming hits, Major Heroism, and group ult batteries (Pillager’s + Arkasis).',
+      assumptions: [
+        "Bloodspawn (tank-only) assumes you're actively soaking damage (~0.7 ult/s).",
+        'Major Heroism from DK Basalt-Blooded or a support buff (~50%); drop to Minor if your build can’t hold it.',
+        "Pillager's Profit: set the WEARER's (healer's) ult cost below — a ~250 ult ≈ 0.55 ult/s.",
+        'Assumes a support wears Arkasis and pots on cooldown; block-heavy play lowers light-attack uptime.',
+      ],
+    },
+  },
+  pvp: {
+    dps: {
+      id: 'pvp-dps',
+      context: 'pvp',
+      role: 'dps',
+      enableClassProc: true,
+      baseUptime: 0.6,
+      enabledSourceIds: ['minor-heroism', 'colovian-highlands-general-external'],
+      uptimeOverrides: { 'minor-heroism': 0.4 },
+      summary:
+        'PvP pressure build: intermittent weaving, Minor Heroism from sets/potions, ult from allied kills.',
+      assumptions: [
+        'PvP light-attack uptime is low — lots of blocking, breaking free, dodge-rolling and repositioning.',
+        'Minor Heroism more reliably slotted in PvP (sets/potions, ~40%); swap to Major only in organized groups.',
+        'Colovian Highlands General is bursty (allied player kills) — averages ~0.2 ult/s, spikes in active fights.',
+        'Class proc assumes its trigger is slotted; Sorcerer & Warden have none.',
+      ],
+    },
+    healer: {
+      id: 'pvp-healer',
+      context: 'pvp',
+      role: 'healer',
+      enableClassProc: true,
+      baseUptime: 0.5,
+      enabledSourceIds: ['minor-heroism', 'arkays-charity-external'],
+      uptimeOverrides: { 'minor-heroism': 0.4 },
+      summary:
+        'PvP support healer: low weaving uptime, Minor Heroism, and ult from being cleansed by allies.',
+      assumptions: [
+        'Very low light-attack uptime — busy purging, shielding and holding line-of-sight.',
+        'Minor Heroism from sets/potions (~40%).',
+        "Arkay's Charity is situational (only when an ally cleanses a debuff off you) — modeled at 25%, near-zero with no debuffs.",
+        'Class proc assumes its trigger is slotted; Sorcerer & Warden have none.',
+      ],
+    },
+    tank: {
+      id: 'pvp-tank',
+      context: 'pvp',
+      role: 'tank',
+      enableClassProc: true,
+      baseUptime: 0.55,
+      enabledSourceIds: ['bloodspawn', 'minor-heroism', 'colovian-highlands-general-external'],
+      uptimeOverrides: { bloodspawn: 0.5, 'minor-heroism': 0.4 },
+      summary:
+        'PvP brawler: Bloodspawn from constant incoming hits, Minor Heroism, and ult from allied kills.',
+      assumptions: [
+        'Heavy block uptime suppresses light attacks — low weaving uptime.',
+        'Bloodspawn (tank-only) thrives on a brawler taking constant damage (~50%).',
+        'Minor Heroism from sets/potions (~40%); Colovian Highlands General is bursty from allied kills.',
+        'Class proc assumes its trigger is slotted; Sorcerer & Warden have none.',
+      ],
+    },
+  },
+};
+
+/** The preset for a given archetype. */
+export const getArchetypePreset = (context: CombatContext, role: CombatRole): ArchetypePreset =>
+  ARCHETYPE_PRESETS[context][role];
+
+/** Flat list of all presets (for data-integrity tests + iteration). */
+export const ALL_ARCHETYPE_PRESETS: readonly ArchetypePreset[] = Object.values(
+  ARCHETYPE_PRESETS,
+).flatMap((byRole) => Object.values(byRole));
+
+/**
+ * Resolve a preset into concrete engine override maps for a given class.
+ *
+ * Returns an `enabledOverrides` that sets an explicit boolean for EVERY catalog
+ * generation source (so applying a preset is deterministic — no stale source is
+ * left enabled from a previous archetype) plus a `uptimeOverrides` carrying the
+ * base-income uptime and the preset's per-source uptimes. Cost-reduction toggles
+ * are intentionally NOT included here — a preset never changes a class's ultimate
+ * cost reduction; the hook preserves those separately.
+ */
+export function resolvePresetOverrides(
+  preset: ArchetypePreset,
+  esoClass: EsoClass,
+): { enabledOverrides: Record<string, boolean>; uptimeOverrides: Record<string, number> } {
+  const enabledIds = new Set<string>(['base-light-attack', ...preset.enabledSourceIds]);
+  if (preset.enableClassProc) {
+    const proc = classPrimaryProcId(esoClass);
+    if (proc) enabledIds.add(proc);
+  }
+
+  const enabledOverrides: Record<string, boolean> = {};
+  for (const source of ULTIMATE_SOURCE_CATALOG) {
+    enabledOverrides[source.id] = enabledIds.has(source.id);
+  }
+
+  const uptimeOverrides: Record<string, number> = {
+    'base-light-attack': preset.baseUptime,
+    ...preset.uptimeOverrides,
+  };
+
+  return { enabledOverrides, uptimeOverrides };
+}


### PR DESCRIPTION
## Why

In the recently-merged Ultimate Calculator, the **Solo / Group / PvP** context selector and the **DPS / Healer / Tank** role selector were effectively **inert**. Every context- and role-specific catalog source is `defaultEnabled: false`, and the only default-on sources are available in all contexts with no role gate — so all nine (context × role) combinations rendered the **identical** headline ult/s number. Confirmed live: switching Solo↔Group↔PvP or DPS↔Healer↔Tank left the total unchanged at `656.2` in every combination. The two most prominent controls in the build form did nothing.

## What

Picking a context + role now seeds a realistic, transparent **archetype preset** — the calculator's answer becomes meaningful out of the box and visibly tracks how you play.

**Headline now moves with the playstyle** (Arcanist, default scenario):

| Archetype | ult over 180s |
|---|---|
| Group · DPS (default) | **935.8** |
| Solo · DPS | 718.5 |
| PvP · DPS | 548.6 |
| Group · Tank | 1,166.6 |

### Changes
- **`presets.ts` (new):** `ARCHETYPE_PRESETS[context][role]` — for each of the 9 archetypes, which sources a typical build runs, at what uptime, plus a one-line summary and `assumptions`. Also `classPrimaryProcId()` and `resolvePresetOverrides()`. **Grounded entirely in the existing catalog's sourced rates — no new numbers are invented** (uptimes stay within the ranges the catalog's provenance notes justify, e.g. Minor Heroism from a 45s-cooldown potion ≈ 33%, not the optimistic 90% set default). The matrix was refined by an adversarial ESO-theorycraft review (e.g. Group DPS uses Minor Heroism + an Arkasis battery rather than assuming a Major-Heroism support; the Group Healer drops Pillager's because the healer is usually the *wearer*).
- **`useUltimateCalculator`:** opens on the typical **Group · DPS** build. While the build is *pristine*, switching context / role / class auto-applies the matching preset so the number changes immediately. Once you hand-edit a source, your edits are preserved and an explicit **"Apply typical {archetype}"** appears instead. A preset only ever touches the **source layer** — never Decisive, fight length, the chosen ultimate, starting ultimate, or the Pillager's wearer cost.
- **`UltimateCalculator.tsx`:** an explainer card under the controls with the archetype summary, an expandable **"What this assumes"**, a live **"N sources on"** count, and the customized-build nudge. "Reset to defaults" → **"Reset to typical {archetype}"**.

## Testing
- `tsc`, `eslint`, `prettier` clean.
- **99 jest tests pass** (8 suites), including new preset **data-integrity** tests (every enabled source is gate-valid for its archetype; Minor/Major Heroism are never co-enabled; resolver behaviour) and component tests proving the selectors change the headline and the customized → switch → re-apply flow.
- **Live-verified** in Chrome on the dev server, **both light and dark themes**: the numbers above, the explainer card, the assumptions expander, and the full customized/preserve/re-apply flow.
- Adversarial code review (3 lenses + verify) returned **ship**; the two low a11y findings it surfaced (`aria-controls` on the assumptions toggle; un-hiding the count pill from screen readers) are fixed in this PR.

## Notes / known modelling assumptions
- `enableClassProc` turns on the class's primary ult-gen passive at its catalog default uptime; for a loadout that doesn't slot the trigger (e.g. a Templar tank not casting Dawn's Wrath) this can be optimistic — the explainer's assumptions call this out and the uptime is user-tunable. Sorcerer and Warden have no native ult-gen passive, so they read structurally lower by design (also disclosed in the copy).
- Presets deliberately leave class **cost-reduction** toggles (Sorc Power Stone / Templar Restoring Spirit) untouched, since those are class mechanics rather than archetype choices.
