### PR TITLE
fix(profile): fix "Player not found" — store author_name raw + owner Recent Logs fallback

### DIFF
--- a/roster-hub-api/src/db/migration-unescape-author-name.sql
+++ b/roster-hub-api/src/db/migration-unescape-author-name.sql
@@ -1,0 +1,41 @@
+-- Backfill: un-HTML-escape stored author_name values.
+--
+-- Until this change, every write path stored `author_name` as escapeHtml(user.name)
+-- (e.g. "Spike'jo" → "Spike&#x27;jo"). But author_name is an IDENTITY / lookup key:
+-- getUserProfile matches it raw against the URL slug (`author_name = ? COLLATE NOCASE`).
+-- Escaping it on store therefore broke profile resolution for any ESO name containing
+-- ' < > " & — the profile 404'd with "Player not found" — and rendered as mojibake.
+-- The write paths now store author_name RAW (escape on OUTPUT, not on store); this
+-- migration repairs existing rows.
+--
+-- Reverses escapeHtml() in the exact opposite order it was applied, so `&amp;` is
+-- decoded LAST (a literal '&' was encoded first, hence must be restored last to avoid
+-- corrupting sequences like "&amp;lt;"). Scoped to rows containing '&' and idempotent:
+-- re-running it leaves already-raw names unchanged.
+--
+-- Apply BEFORE/with the worker deploy:
+--   wrangler d1 execute roster-hub-db --remote --file=src/db/migration-unescape-author-name.sql
+
+UPDATE builds SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';
+
+UPDATE rosters SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';
+
+UPDATE roster_comments SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';
+
+UPDATE build_comments SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';
+
+UPDATE user_profiles SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';
+
+UPDATE packs SET author_name =
+  REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(author_name, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE author_name LIKE '%&%';

--- a/roster-hub-api/src/db/migration-unescape-content.sql
+++ b/roster-hub-api/src/db/migration-unescape-content.sql
@@ -1,0 +1,51 @@
+-- ONE-SHOT backfill: un-HTML-escape stored free-text CONTENT.
+--
+-- Companion to migration-unescape-author-name.sql. The write paths previously
+-- stored free-text via sanitize()=escapeHtml(trim()), so titles/descriptions/
+-- bios/comment bodies with ' < > " & rendered as literal entities ("&#x27;").
+-- The write paths now store these RAW (escape on OUTPUT — React text nodes /
+-- MUI props auto-escape; verified no raw-HTML sink consumes them); this repairs
+-- existing rows.
+--
+-- ⚠️ NOT IDEMPOTENT — run EXACTLY ONCE. Unlike identity fields, free-text can
+-- legitimately contain a user-typed literal "&amp;" / "<" etc.; re-running the
+-- decode would corrupt those. The blanket column REPLACE is one-shot only.
+--
+-- SCOPE: only the flat free-text columns below. Deliberately EXCLUDED:
+--   • enum/regex-validated cols (eso_class, role, game_mode, trial_id, pack_type)
+--     and all tag columns — their validators forbid & < > " ' so they hold no
+--     entities (sanitize() is a no-op there).
+--   • JSON blobs (rosters.recommended_addons, packs.addons) — a column-wide
+--     REPLACE would rewrite structural JSON text; their inner addon name/note/
+--     packTitle need a JSON-aware parse→unescape→restringify pass instead. (As
+--     of this migration, prod holds zero escaped entities in those blobs.)
+--
+-- Apply once, alongside the worker deploy:
+--   wrangler d1 execute roster-hub-db --remote --file=src/db/migration-unescape-content.sql
+
+UPDATE builds SET
+  title = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(title, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&'),
+  description = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(description, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE title LIKE '%&%' OR description LIKE '%&%';
+
+UPDATE rosters SET
+  title = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(title, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&'),
+  description = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(description, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE title LIKE '%&%' OR description LIKE '%&%';
+
+UPDATE packs SET
+  title = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(title, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&'),
+  description = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(description, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE title LIKE '%&%' OR description LIKE '%&%';
+
+UPDATE user_profiles SET
+  bio = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(bio, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE bio LIKE '%&%';
+
+UPDATE roster_comments SET
+  body = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(body, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE body LIKE '%&%';
+
+UPDATE build_comments SET
+  body = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(body, '&#x27;', ''''), '&quot;', '"'), '&gt;', '>'), '&lt;', '<'), '&amp;', '&')
+WHERE body LIKE '%&%';

--- a/roster-hub-api/src/db/queries.ts
+++ b/roster-hub-api/src/db/queries.ts
@@ -1037,9 +1037,9 @@ export async function getUserProfile(
   db: D1Database,
   username: string,
 ): Promise<UserProfileResponse | null> {
-  // Run all 5 reads in a single parallel batch — counts included upfront to
+  // Run all 6 reads in a single parallel batch — counts included upfront to
   // avoid a second round-trip to D1.
-  const [profileRow, buildsResult, rostersResult, buildCountRow, rosterCountRow] =
+  const [profileRow, buildsResult, rostersResult, buildCountRow, rosterCountRow, identityRow] =
     await Promise.all([
       db
         .prepare('SELECT * FROM user_profiles WHERE author_name = ? COLLATE NOCASE')
@@ -1087,10 +1087,31 @@ export async function getUserProfile(
         )
         .bind(username)
         .first<{ cnt: number }>(),
+
+      // Identity anchor — resolves the user's ESO Logs id + canonical name from
+      // ANY of their non-anonymous builds, regardless of visibility. Private and
+      // Link-Only builds are intentionally excluded from the displayed `builds`
+      // list and `build_count` above (public-only), but they still identify a
+      // real account, so we use this to keep the profile from 404ing and to
+      // surface the owner's public ESO Logs. Without it, a user whose only
+      // content is private builds resolves to a 404 ("Player not found").
+      db
+        .prepare(
+          `SELECT author_id, author_name FROM builds
+           WHERE author_name = ? COLLATE NOCASE AND is_anonymous = 0
+           ORDER BY created_at DESC
+           LIMIT 1`,
+        )
+        .bind(username)
+        .first<{ author_id: string; author_name: string }>(),
     ]);
 
-  // Unknown user — no bio row and no public content
-  if (!profileRow && buildsResult.results.length === 0 && rostersResult.results.length === 0) {
+  // Unknown user — no bio/avatar row, no public content, and no non-anonymous
+  // build we can attribute to them. `identityRow` is a superset of the public
+  // `buildsResult` (it ignores visibility), so a non-empty public builds list
+  // implies identityRow is set; the explicit check below covers private-only
+  // users whose builds were filtered out of buildsResult.
+  if (!profileRow && !identityRow && rostersResult.results.length === 0) {
     return null;
   }
 
@@ -1099,15 +1120,18 @@ export async function getUserProfile(
     buildsResult.results[0]?.author_name ??
     rostersResult.results[0]?.author_name ??
     profileRow?.author_name ??
+    identityRow?.author_name ??
     username;
 
   // The ESO Logs user ID is the author_id (auth.ts derives it from the ESO Logs
-  // currentUser.id). Prefer the profile row, then any content row, so uploaded
-  // logs resolve even when a profile has content but no profile row yet.
+  // currentUser.id). Prefer the profile row, then any content row — including a
+  // private/link-only build via identityRow — so uploaded logs resolve even when
+  // the user has no profile row and no public builds or rosters.
   const esoLogsUserId =
     profileRow?.author_id ??
     buildsResult.results[0]?.author_id ??
     rostersResult.results[0]?.author_id ??
+    identityRow?.author_id ??
     null;
 
   return {

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -93,7 +93,7 @@ function tryDeleteImgBBImage(deleteUrl: string | null): void {
 /** Verify that an encoded payload is valid base64url (no special chars that break URLs). */
 const isValidBase64Url = (s: string): boolean => /^[A-Za-z0-9_-]*=*$/.test(s);
 
-import { escapeHtml, sanitize } from './sanitize';
+import { cleanText, sanitize } from './sanitize';
 
 /** Validate and sanitize an addon entry. Returns null if invalid. */
 const sanitizeAddonEntry = (a: unknown): RecommendedAddonEntry | null => {
@@ -104,9 +104,9 @@ const sanitizeAddonEntry = (a: unknown): RecommendedAddonEntry | null => {
   if (typeof entry.name !== 'string' || !entry.name.trim() || entry.name.length > 200) return null;
   return {
     esouiId: entry.esouiId,
-    name: sanitize(entry.name),
+    name: cleanText(entry.name),
     required: typeof entry.required === 'boolean' ? entry.required : undefined,
-    note: typeof entry.note === 'string' ? sanitize(entry.note.slice(0, 500)) : undefined,
+    note: typeof entry.note === 'string' ? cleanText(entry.note.slice(0, 500)) : undefined,
   };
 };
 
@@ -387,7 +387,7 @@ app.post('/rosters', async (c) => {
             : undefined,
         packTitle:
           typeof recommended_addons.packTitle === 'string'
-            ? sanitize(recommended_addons.packTitle)
+            ? cleanText(recommended_addons.packTitle)
             : undefined,
         addons: sanitizedAddons,
       });
@@ -407,9 +407,9 @@ app.post('/rosters', async (c) => {
   await createRoster(c.env.DB, {
     id,
     authorId: user.id,
-    authorName: escapeHtml(user.name),
-    title: sanitize(title),
-    description: sanitize(description),
+    authorName: user.name,
+    title: cleanText(title),
+    description: cleanText(description),
     trialId: sanitize(trial_id),
     trialIds: sanitizeTrialIds(trial_ids),
     rosterData: roster_data,
@@ -482,7 +482,7 @@ app.put('/rosters/:id', async (c) => {
             : undefined,
         packTitle:
           typeof recommended_addons.packTitle === 'string'
-            ? sanitize(recommended_addons.packTitle)
+            ? cleanText(recommended_addons.packTitle)
             : undefined,
         addons: sanitizedAddons,
       });
@@ -491,8 +491,8 @@ app.put('/rosters/:id', async (c) => {
 
   const existing = await getRosterById(c.env.DB, c.req.param('id'), user.id);
   const updated = await updateRoster(c.env.DB, c.req.param('id'), user.id, {
-    title: sanitize(title),
-    description: sanitize(description),
+    title: cleanText(title),
+    description: cleanText(description),
     trialId: sanitize(trial_id),
     trialIds: sanitizeTrialIds(trial_ids),
     rosterData: roster_data,
@@ -617,8 +617,8 @@ app.post('/rosters/:id/comments', async (c) => {
     rosterId,
     parentId: body.parent_id ?? null,
     authorId: user.id,
-    authorName: escapeHtml(user.name),
-    body: escapeHtml(body.body.trim()),
+    authorName: user.name,
+    body: body.body.trim(),
   });
 
   return c.json({ comment }, 201);
@@ -750,9 +750,9 @@ app.post('/builds', async (c) => {
   await createBuild(c.env.DB, {
     id,
     authorId: user.id,
-    authorName: escapeHtml(user.name),
-    title: sanitize(title),
-    description: sanitize(description),
+    authorName: user.name,
+    title: cleanText(title),
+    description: cleanText(description),
     esoClass: sanitize(eso_class),
     role: sanitize(role),
     gameMode: sanitize(game_mode),
@@ -829,8 +829,8 @@ app.put('/builds/:id', async (c) => {
   const visibility: (typeof BUILD_VISIBILITIES)[number] = embeddedVisibility;
 
   const updated = await updateBuild(c.env.DB, c.req.param('id'), user.id, {
-    title: sanitize(title),
-    description: sanitize(description),
+    title: cleanText(title),
+    description: cleanText(description),
     esoClass: sanitize(eso_class),
     role: sanitize(role),
     gameMode: sanitize(game_mode),
@@ -935,8 +935,8 @@ app.post('/builds/:id/comments', async (c) => {
     buildId,
     parentId: body.parent_id ?? null,
     authorId: user.id,
-    authorName: escapeHtml(user.name),
-    body: escapeHtml(body.body.trim()),
+    authorName: user.name,
+    body: body.body.trim(),
   });
 
   return c.json({ comment }, 201);
@@ -1301,7 +1301,7 @@ app.put('/users/me/bio', async (c) => {
   if (typeof body.bio !== 'string') return c.json({ error: 'bio must be a string' }, 400);
   if (body.bio.length > 200) return c.json({ error: 'bio must be ≤ 200 characters' }, 400);
 
-  await upsertUserBio(c.env.DB, user.id, escapeHtml(user.name), sanitize(body.bio));
+  await upsertUserBio(c.env.DB, user.id, user.name, cleanText(body.bio));
   return c.json({ ok: true });
 });
 
@@ -1426,7 +1426,7 @@ app.put('/users/me/avatar', async (c) => {
   await upsertUserAvatar(
     c.env.DB,
     user.id,
-    escapeHtml(user.name),
+    user.name,
     imgbb.data.url,
     imgbb.data.thumb.url,
     imgbb.data.delete_url,
@@ -1460,7 +1460,7 @@ app.put('/users/me/display-names', async (c) => {
   const na = body.na_display_name?.trim() || null;
   const eu = body.eu_display_name?.trim() || null;
 
-  await updateDisplayNames(c.env.DB, user.id, escapeHtml(user.name), na, eu);
+  await updateDisplayNames(c.env.DB, user.id, user.name, na, eu);
   return c.json({ ok: true });
 });
 
@@ -1573,9 +1573,9 @@ app.post('/packs', async (c) => {
   await createPack(c.env.DB, {
     id,
     authorId: user.id,
-    authorName: escapeHtml(user.name),
-    title: sanitize(title),
-    description: sanitize(description),
+    authorName: user.name,
+    title: cleanText(title),
+    description: cleanText(description),
     packType: sanitize(pack_type),
     addons: JSON.stringify(sanitizedAddons),
     tags: Array.isArray(tags) ? tags.filter(isValidTag).slice(0, 10).map(sanitize) : [],
@@ -1632,8 +1632,8 @@ app.put('/packs/:id', async (c) => {
     return c.json({ error: 'No valid addon entries provided' }, 400);
 
   const updated = await updatePack(c.env.DB, c.req.param('id'), user.id, {
-    title: sanitize(title),
-    description: sanitize(description),
+    title: cleanText(title),
+    description: cleanText(description),
     packType: sanitize(pack_type),
     addons: JSON.stringify(sanitizedAddons),
     tags: Array.isArray(tags) ? tags.filter(isValidTag).slice(0, 10).map(sanitize) : [],

--- a/roster-hub-api/src/sanitize.ts
+++ b/roster-hub-api/src/sanitize.ts
@@ -1,3 +1,11 @@
+// IMPORTANT: never HTML-escape IDENTITY / lookup-key fields on write —
+// specifically `author_name` and the na/eu display names. They are matched RAW
+// against the URL slug / request values in lookups (e.g. getUserProfile's
+// `author_name = ? COLLATE NOCASE`), so escaping `'` → `&#x27;` (etc.) at storage
+// time breaks resolution for any ESO name containing ' < > " & (e.g. "Spike'jo"
+// → 404 "Player not found") and also renders as literal mojibake, since React
+// already escapes on output. Escape on OUTPUT, not on store. Free-text CONTENT
+// (titles, descriptions, bios, comment bodies) is still escaped via sanitize().
 export const escapeHtml = (s: string): string =>
   s
     .replace(/&/g, '&amp;')
@@ -7,3 +15,10 @@ export const escapeHtml = (s: string): string =>
     .replace(/'/g, '&#x27;');
 
 export const sanitize = (s: string): string => escapeHtml(s.trim());
+
+// Trim-only cleaner for free-text CONTENT that consumers escape on OUTPUT
+// (titles, descriptions, bios, comment bodies, addon name/note). Storing these
+// RAW avoids double-escaped mojibake (e.g. "&#x27;" shown literally) while
+// staying XSS-safe: every render path escapes on output (React text nodes, MUI
+// props). Use sanitize() only for fields a consumer might inject as raw HTML.
+export const cleanText = (s: string): string => s.trim();

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -943,7 +943,7 @@ export const PublicProfilePage: React.FC = () => {
   const isDarkMode = theme.palette.mode === 'dark';
   const navigate = useViewTransitionNavigate();
   const { enqueueSnackbar } = useSnackbar();
-  const { isLoggedIn, accessToken, currentUser } = useAuth();
+  const { isLoggedIn, accessToken, currentUser, userLoading } = useAuth();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -1000,6 +1000,30 @@ export const PublicProfilePage: React.FC = () => {
       document.title = 'ESO Toolkit';
     };
   }, [profile]);
+
+  // Owner fallback: the public profile API 404s for a logged-in user who has no
+  // public builds/rosters and no profile row yet. Rather than tell owners their
+  // own profile "doesn't exist", synthesize a minimal profile from their auth
+  // session so Recent Logs (keyed on their ESO Logs user id) still render. Built
+  // entirely from the viewer's own AuthContext — no other user's data is read.
+  useEffect(() => {
+    if (notFound && !profile && isOwner && currentUser?.id != null) {
+      setProfile({
+        username: currentUser.name,
+        bio: '',
+        avatar_url: null,
+        avatar_thumb_url: null,
+        build_count: 0,
+        roster_count: 0,
+        builds: [],
+        rosters: [],
+        eso_logs_user_id: String(currentUser.id),
+        na_display_name: currentUser.naDisplayName ?? null,
+        eu_display_name: currentUser.euDisplayName ?? null,
+      });
+      setNotFound(false);
+    }
+  }, [notFound, profile, isOwner, currentUser]);
 
   const handleSaveBio = useCallback(
     async (bio: string) => {
@@ -1138,7 +1162,15 @@ export const PublicProfilePage: React.FC = () => {
 
   // ── Loading ────────────────────────────────────────────────────────────────
 
-  if (loading) {
+  // Keep the skeleton up (instead of flashing "Player not found") while auth is
+  // still resolving for a possible owner, or while the owner-fallback profile is
+  // about to be synthesized by the effect above.
+  const ownerFallbackPending =
+    notFound &&
+    !profile &&
+    (userLoading || (isOwner && currentUser?.id != null));
+
+  if (loading || ownerFallbackPending) {
     return (
       <Container maxWidth="md" sx={{ py: { xs: 4, sm: 6 } }}>
         <Skeleton variant="rounded" height={140} sx={{ borderRadius: '20px', mb: 5 }} />

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -1166,9 +1166,7 @@ export const PublicProfilePage: React.FC = () => {
   // still resolving for a possible owner, or while the owner-fallback profile is
   // about to be synthesized by the effect above.
   const ownerFallbackPending =
-    notFound &&
-    !profile &&
-    (userLoading || (isOwner && currentUser?.id != null));
+    notFound && !profile && (userLoading || (isOwner && currentUser?.id != null));
 
   if (loading || ownerFallbackPending) {
     return (


### PR DESCRIPTION
## Problem

Visiting your own public profile showed **"Player not found"**, even though Recent Logs should render with no public builds/rosters.

## Root cause (confirmed against prod)

`author_name` was HTML-escaped on every write (`escapeHtml(user.name)`), so a name like `Spike'jo` was stored as `Spike&#x27;jo`. But `getUserProfile` looks the name up **raw** from the URL slug (`author_name = ? COLLATE NOCASE`) → no match → 404. This breaks any ESO name containing `' < > " &` (apostrophes are everywhere) and also renders as literal-entity mojibake. Escaping an identity/lookup key at storage time is the wrong layer — React escapes on output.

## Changes

1. **Store `author_name` raw** (8 write sites) + document the rule in `sanitize.ts`. Backfill migration un-escapes existing rows across all 6 tables.
2. **Store free-text content raw** (titles/descriptions/bios/comment bodies/addon name+note) via a new trim-only `cleanText()`; enum/id/tag fields keep `sanitize()`. One-shot content backfill migration. Audited: no render path injects these as raw HTML (React text nodes / MUI props), so this is XSS-safe.
3. **Identity anchor in `getUserProfile`** — resolves profiles for users whose only content is private/link-only builds (PR #1232's visibility filter had dropped them as the anchor). Displayed builds/count stay public-only; no private data exposed.
4. **Owner Recent Logs fallback** — when the profile API 404s and the viewer is the owner, synthesize a minimal profile from their auth session so Recent Logs still render.

## Verification

- Worker `tsc --noEmit` ✓, frontend `tsc --noEmit` ✓, `eslint` ✓.
- 4-lens adversarial audit: content un-escape XSS-safe, author_name has no broken consumers/sinks, backfill REPLACE order correct, owner fallback safe.
- Root cause reproduced and verified against production D1.

## Deploy notes

`roster-hub-api` is a separate Cloudflare Worker (manual `deploy-worker.yml` dispatch, not auto-on-merge). Run both backfill migrations once, then deploy the worker:

```
wrangler d1 execute roster-hub-db --remote --file=roster-hub-api/src/db/migration-unescape-author-name.sql
wrangler d1 execute roster-hub-db --remote --file=roster-hub-api/src/db/migration-unescape-content.sql
```
