### PR TITLE
perf(replay): hit 120fps via lossless GPU/CPU wins + adaptive resolution

### DIFF
--- a/src/features/fight_replay/components/AdaptiveResolution.tsx
+++ b/src/features/fight_replay/components/AdaptiveResolution.tsx
@@ -24,6 +24,14 @@ interface AdaptiveResolutionProps {
   /** Refill the render budget + flag the shadow dirty so a restored-resolution frame actually
    *  repaints crisp while paused / after a cap change / re-assert (routed to markSceneDirty). */
   markDirty: () => void;
+  /**
+   * Optional status output the quality governor reads to know when DPR is EXHAUSTED — i.e. it has
+   * driven the pixel ratio to its floor, OR its effectiveness guard has fired (a downscale didn't
+   * buy framerate, so the bottleneck isn't pixel fill and lowering DPR further won't help). The
+   * governor only drops a visible effect once this is true, so resolution scaling always gets the
+   * first crack at a shortfall. Pure status write — does not affect any DPR decision.
+   */
+  exhaustedRef?: React.RefObject<boolean>;
 }
 
 // Rolling window of measured playback frame times before a decision is made (~0.6–0.7s at 120fps).
@@ -71,6 +79,7 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
   dprCap,
   paintedRef,
   markDirty,
+  exhaustedRef,
 }) => {
   const setDpr = useThree((s) => s.setDpr);
   const gl = useThree((s) => s.gl);
@@ -92,6 +101,10 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
   // declining when lowering resolution isn't actually buying framerate (CPU-bound) so we never blur
   // the scene to the floor for no gain. Cleared on any incline / cap change / pause-restore / resume.
   const lastDeclineAvgRef = useRef<number | null>(null);
+  // True once the effectiveness guard has fired (a downscale didn't buy framerate → not pixel-fill
+  // bound). Combined with "at floor" to publish `exhaustedRef`. Cleared whenever headroom returns
+  // (an incline) or the controller resets (cap change / pause-restore / resume).
+  const guardActiveRef = useRef(false);
   const lastTimeRef = useRef<number | null>(null);
   const samplesRef = useRef<number[]>([]);
   const cooldownRef = useRef(0);
@@ -120,6 +133,7 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
       markDirty();
     }
     lastDeclineAvgRef.current = null;
+    guardActiveRef.current = false;
     samplesRef.current.length = 0;
     cooldownRef.current = 0; // re-evaluate immediately at the new tier (no stale cooldown stutter)
     playbackDprRef.current = null;
@@ -178,6 +192,12 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
       markDirty();
     }
 
+    // Publish DPR exhaustion for the quality governor: at the floor, or the effectiveness guard has
+    // fired (lowering DPR isn't buying framerate). Cheap status write; never gates a DPR decision.
+    if (exhaustedRef) {
+      exhaustedRef.current = dprRef.current <= minDpr + DPR_EPSILON || guardActiveRef.current;
+    }
+
     const ms = delta * 1000;
     const t = timeRef.current;
     const advanced = t !== lastTimeRef.current;
@@ -198,6 +218,7 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
         samplesRef.current.length = 0;
         cooldownRef.current = 0;
         lastDeclineAvgRef.current = null;
+        guardActiveRef.current = false;
       }
     } else {
       framesSinceAdvanceRef.current += 1;
@@ -212,6 +233,7 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
         dprRef.current = maxDpr;
         setDpr(maxDpr);
         lastDeclineAvgRef.current = null;
+        guardActiveRef.current = false;
         samplesRef.current.length = 0;
         markDirty();
       }
@@ -265,6 +287,8 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
       // The previous downscale didn't cut frame time by even ~6%, so pixel fill isn't the
       // bottleneck (CPU-bound). Hold the current resolution — blurring further wouldn't recover
       // framerate — and back off measuring for a while. An incline (headroom returning) resets this.
+      // DPR is now effectively exhausted (lowering it won't help) — tell the governor it may act.
+      guardActiveRef.current = true;
       cooldownRef.current = COOLDOWN_FRAMES * 3;
       samples.length = 0;
       return;
@@ -273,6 +297,9 @@ export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
     dprRef.current = next;
     setDpr(next);
     lastDeclineAvgRef.current = isDecline ? avg : null;
+    // Reaching here means we made an effective change (an incline = headroom, or a decline that the
+    // guard didn't block), so resolution scaling is NOT exhausted.
+    guardActiveRef.current = false;
     samples.length = 0;
     cooldownRef.current = COOLDOWN_FRAMES;
   }, RenderPriority.EFFECTS);

--- a/src/features/fight_replay/components/AdaptiveResolution.tsx
+++ b/src/features/fight_replay/components/AdaptiveResolution.tsx
@@ -1,0 +1,281 @@
+import { useFrame, useThree } from '@react-three/fiber';
+import React, { useEffect, useRef } from 'react';
+
+import { RenderPriority } from '../constants/renderPriorities';
+import {
+  computeMinDpr,
+  computeTargetMs,
+  decideNextDpr,
+  estimateDisplayIntervalMs,
+} from '../utils/adaptiveResolution';
+
+interface AdaptiveResolutionProps {
+  /** Live playhead. Only frames where this advanced are measured (a paused/idle scene renders
+   *  nothing, so its fast rAF cadence must not be read as "tons of headroom" and inflate DPR). */
+  timeRef: React.RefObject<number> | { current: number };
+  /** The current perf-tier render-resolution cap (the Canvas `dpr` ceiling, e.g. 1.5 low / 2 else).
+   *  Reactive: if the tier changes (async GPU detection / user override) this updates, and the
+   *  scaler's ceiling follows so it never inclines past — or gets stuck below — the new cap. */
+  dprCap: number;
+  /** True when the RenderLoop painted the previous frame. Lets us learn the display interval ONLY
+   *  from genuinely idle (un-painted) frames and measure workload ONLY from painted playback frames
+   *  — a paused-but-painted frame (following an actor / `?actorId=` link) is neither. */
+  paintedRef: React.RefObject<boolean>;
+  /** Refill the render budget + flag the shadow dirty so a restored-resolution frame actually
+   *  repaints crisp while paused / after a cap change / re-assert (routed to markSceneDirty). */
+  markDirty: () => void;
+}
+
+// Rolling window of measured playback frame times before a decision is made (~0.6–0.7s at 120fps).
+// Long enough that a brief burst on a capable GPU never trips a downscale — only a SUSTAINED
+// shortfall does — so a strong machine stays at full quality (no visible degradation).
+const SAMPLE_WINDOW = 90;
+// Frames to wait after an adjustment before measuring again — lets the new resolution settle and
+// prevents hunting/oscillation.
+const COOLDOWN_FRAMES = 120;
+// Guard against clock hitches / tab-switch gaps polluting the average.
+const MAX_PLAUSIBLE_FRAME_MS = 250;
+// Consecutive non-advancing frames after which a downscaled scene is treated as PAUSED and restored
+// to full quality. A static scene has no framerate pressure, so paused inspection should never be
+// blurry; ~12 frames is a fraction of a second at any refresh, short enough to feel instant but long
+// enough not to fire on a momentary playback stall.
+const PAUSE_RESTORE_FRAMES = 12;
+// Bounded window of idle-frame deltas used to estimate the display refresh interval. Bounded (not
+// all-time) so the estimate can rise again when the panel changes; estimateDisplayIntervalMs takes a
+// robust low percentile of it (ignoring single flukes) and requires a minimum sample count first.
+const IDLE_WINDOW = 60;
+// Float compare tolerance for detecting an external DPR drift.
+const DPR_EPSILON = 0.001;
+// Bootstrap only accepts deltas this fast or faster (~105Hz+) as a refresh sample. A delta at/below
+// the 120fps cadence proves the display can present faster than our target, so adapting toward 120 is
+// meaningful. SLOWER deltas at mount are ambiguous — a genuine 60Hz panel OR a load-contaminated
+// high-refresh one — so they are NOT seeded (which would risk locking in a wrong/slow refresh that
+// never adapts); those cases fall through to idle-frame learning or the absolute fallback instead.
+const BOOTSTRAP_MAX_REFRESH_MS = 1000 / 120 + 1.2; // ≈ 9.5ms
+
+/**
+ * Dynamic render-resolution controller. Measures the real playback frame time and scales the R3F
+ * pixel ratio between a floor and the full-quality (perf-tier) cap, to hold ~120fps. Renders nothing.
+ *
+ * On a GPU with headroom the average frame time stays in the dead zone and the DPR never moves, so
+ * the output is identical to having no controller at all. It only engages when a weaker GPU / 4K /
+ * heavy fight would otherwise drop below ~120fps, trading a little sharpness to keep playback smooth,
+ * and restores full resolution while paused and once the load eases.
+ *
+ * `dprRef` is AUTHORITATIVE: the controller owns the pixel ratio and re-asserts it if anything
+ * external moves it (e.g. the Canvas `dpr` prop re-applying on a re-render), so a downscale is never
+ * silently undone mid-playback. See utils/adaptiveResolution for the pure decision logic.
+ */
+export const AdaptiveResolution: React.FC<AdaptiveResolutionProps> = ({
+  timeRef,
+  dprCap,
+  paintedRef,
+  markDirty,
+}) => {
+  const setDpr = useThree((s) => s.setDpr);
+  const gl = useThree((s) => s.gl);
+  const viewportDpr = useThree((s) => s.viewport.dpr);
+
+  // Full-quality ceiling = the live tier cap clamped to the device's pixel ratio (matching how R3F
+  // clamps the Canvas `dpr={[1, cap]}`). Reactive to dprCap so a perf-tier change moves the ceiling;
+  // the scaler never SUPERSAMPLES above this. The floor is derived from the ceiling.
+  const deviceDpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  const maxDpr = Math.min(Math.max(1, deviceDpr), dprCap);
+  const minDpr = computeMinDpr(maxDpr);
+
+  // ---- Authoritative controller state (no React re-render per frame) ------------------------------
+  // The pixel ratio the controller WANTS. Initialised to the canvas's starting DPR and changed only
+  // by the controller (decline / incline / pause-restore / resume / cap clamp). It is NEVER blindly
+  // synced to viewport.dpr — an external change is re-asserted away in the frame loop.
+  const dprRef = useRef(viewportDpr);
+  // Avg frame time at the most recent DOWNSCALE (null when not in a decline sequence). Stops further
+  // declining when lowering resolution isn't actually buying framerate (CPU-bound) so we never blur
+  // the scene to the floor for no gain. Cleared on any incline / cap change / pause-restore / resume.
+  const lastDeclineAvgRef = useRef<number | null>(null);
+  const lastTimeRef = useRef<number | null>(null);
+  const samplesRef = useRef<number[]>([]);
+  const cooldownRef = useRef(0);
+  // Consecutive frames the playhead has not advanced — detects a settled PAUSE.
+  const framesSinceAdvanceRef = useRef(0);
+  // The downscaled resolution to snap back to on RESUME after a pause-restore (null when none) — so a
+  // weak GPU doesn't run at full DPR (and stutter) for a cooldown's worth of frames after every pause.
+  const playbackDprRef = useRef<number | null>(null);
+  // Bounded window of idle-frame deltas (see IDLE_WINDOW) for the display-interval estimate.
+  const idleSamplesRef = useRef<number[]>([]);
+  // The cap seen on the previous effect run — to tell a cap RAISE (tier got better) from a drop.
+  const prevMaxDprRef = useRef(maxDpr);
+
+  // React to a cap change (perf-tier change / user override). A RAISE (tier improved) restores full
+  // quality and re-evaluates fresh — otherwise an old-cap value (e.g. 1.5) would linger as a phantom
+  // "downscale" and even get snap-backed on resume. A DROP clamps the intended DPR down into range.
+  // Any cap change resets the decline guard, sample window, and pending resume target, since they all
+  // described the previous tier. Repaint at the new size.
+  useEffect(() => {
+    const raised = maxDpr > prevMaxDprRef.current + DPR_EPSILON;
+    prevMaxDprRef.current = maxDpr;
+    const target = raised ? maxDpr : Math.min(Math.max(dprRef.current, minDpr), maxDpr);
+    if (Math.abs(target - dprRef.current) > DPR_EPSILON) {
+      dprRef.current = target;
+      setDpr(target);
+      markDirty();
+    }
+    lastDeclineAvgRef.current = null;
+    samplesRef.current.length = 0;
+    cooldownRef.current = 0; // re-evaluate immediately at the new tier (no stale cooldown stutter)
+    playbackDprRef.current = null;
+  }, [maxDpr, minDpr, setDpr, markDirty]);
+
+  // Re-learn the display interval after events that can change the refresh rate or produce bogus
+  // first deltas: a resize (incl. fullscreen / moving to another monitor / a devicePixelRatio
+  // change) or a tab visibility flip. Clearing lets the rolling window repopulate from scratch.
+  useEffect(() => {
+    const reset = (): void => {
+      idleSamplesRef.current.length = 0;
+    };
+    window.addEventListener('resize', reset);
+    document.addEventListener('visibilitychange', reset);
+    return () => {
+      window.removeEventListener('resize', reset);
+      document.removeEventListener('visibilitychange', reset);
+    };
+  }, []);
+
+  // Bootstrap the refresh estimate at mount with a short standalone rAF burst. The frame loop only
+  // learns the interval from un-painted frames, but some sessions never produce one (a paused
+  // `?actorId=` deep link the render loop paints continuously, then straight into playback) — without
+  // a seed they'd fall back to the lenient absolute 20ms threshold and never adapt a 120/144Hz miss.
+  // We only seed deltas at/below the 120fps cadence (BOOTSTRAP_MAX_REFRESH_MS): such a delta PROVES a
+  // >=~120Hz display (so adapting toward 120 is meaningful), whereas a slower mount delta is ambiguous
+  // (true 60Hz vs load-contaminated high-refresh) and is deliberately NOT seeded — better to leave the
+  // interval unknown (idle-learning / absolute fallback handle it) than lock in a wrong slow refresh
+  // that never adapts. A display change resets it (above); real idle frames refine it.
+  useEffect(() => {
+    let raf = 0;
+    let count = 0;
+    let last = performance.now();
+    const tick = (now: number): void => {
+      const d = now - last;
+      last = now;
+      if (d >= 3 && d <= BOOTSTRAP_MAX_REFRESH_MS) {
+        const idle = idleSamplesRef.current;
+        idle.push(d);
+        if (idle.length > IDLE_WINDOW) idle.shift();
+      }
+      count += 1;
+      if (count < 40) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  useFrame((_state, delta) => {
+    // Re-assert authority: if the live renderer pixel ratio drifted from our intent (the Canvas dpr
+    // prop re-applied on a re-render, etc.), set it back. Keeps a runtime downscale from being
+    // silently undone mid-playback without any state to reconcile. (Cap/tier changes update dprRef
+    // via the effect above first, so this enforces the already-correct intent.)
+    if (Math.abs(gl.getPixelRatio() - dprRef.current) > DPR_EPSILON) {
+      setDpr(dprRef.current);
+      markDirty();
+    }
+
+    const ms = delta * 1000;
+    const t = timeRef.current;
+    const advanced = t !== lastTimeRef.current;
+    lastTimeRef.current = t;
+
+    if (advanced) {
+      framesSinceAdvanceRef.current = 0;
+      // Resume from a pause-restore: snap straight back to the proven playback resolution so a weak
+      // GPU doesn't run at full DPR (and stutter) through a cooldown before re-downscaling.
+      if (playbackDprRef.current != null) {
+        const resume = Math.min(Math.max(playbackDprRef.current, minDpr), maxDpr);
+        playbackDprRef.current = null;
+        if (resume < dprRef.current - DPR_EPSILON) {
+          dprRef.current = resume;
+          setDpr(resume);
+          markDirty();
+        }
+        samplesRef.current.length = 0;
+        cooldownRef.current = 0;
+        lastDeclineAvgRef.current = null;
+      }
+    } else {
+      framesSinceAdvanceRef.current += 1;
+      // Settled pause: a static scene has no framerate pressure, so restore full quality (and repaint
+      // crisp) rather than leaving inspection blurred from a prior playback downscale. Remember the
+      // downscaled DPR to snap back to on resume.
+      if (
+        framesSinceAdvanceRef.current >= PAUSE_RESTORE_FRAMES &&
+        dprRef.current < maxDpr - DPR_EPSILON
+      ) {
+        playbackDprRef.current = dprRef.current;
+        dprRef.current = maxDpr;
+        setDpr(maxDpr);
+        lastDeclineAvgRef.current = null;
+        samplesRef.current.length = 0;
+        markDirty();
+      }
+    }
+
+    if (!paintedRef.current) {
+      // Render loop skipped this frame → genuinely idle → vsync-paced → a clean display-interval
+      // sample (bounded rolling window so the estimate can rise again, not just fall).
+      if (ms > 0 && ms < MAX_PLAUSIBLE_FRAME_MS) {
+        const idle = idleSamplesRef.current;
+        idle.push(ms);
+        if (idle.length > IDLE_WINDOW) idle.shift();
+      }
+      return;
+    }
+    // Painted but the playhead didn't advance (paused while following/selected) → render-bound and
+    // not representative of playback; ignore for both display-interval and workload measurement.
+    if (!advanced) return;
+
+    if (ms <= 0 || ms > MAX_PLAUSIBLE_FRAME_MS) return;
+
+    const samples = samplesRef.current;
+    samples.push(ms);
+    if (samples.length > SAMPLE_WINDOW) samples.shift();
+
+    if (cooldownRef.current > 0) {
+      cooldownRef.current -= 1;
+      return;
+    }
+    if (samples.length < SAMPLE_WINDOW) return;
+
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) sum += samples[i];
+    const avg = sum / samples.length;
+
+    // Robust display interval (Infinity until enough idle samples; low percentile, not raw min).
+    const displayInterval = estimateDisplayIntervalMs(idleSamplesRef.current);
+    // Target 120fps, floored at the display's own refresh interval (a 60Hz panel is vsync-capped at
+    // ~16.7ms — chasing 120 there would downscale for nothing).
+    const targetMs = computeTargetMs(displayInterval);
+    const next = decideNextDpr(avg, dprRef.current, {
+      minDpr,
+      maxDpr,
+      targetMs,
+      displayIntervalMs: displayInterval,
+    });
+    if (next == null || Math.abs(next - dprRef.current) <= DPR_EPSILON) return;
+
+    const isDecline = next < dprRef.current;
+    if (isDecline && lastDeclineAvgRef.current != null && avg > lastDeclineAvgRef.current * 0.94) {
+      // The previous downscale didn't cut frame time by even ~6%, so pixel fill isn't the
+      // bottleneck (CPU-bound). Hold the current resolution — blurring further wouldn't recover
+      // framerate — and back off measuring for a while. An incline (headroom returning) resets this.
+      cooldownRef.current = COOLDOWN_FRAMES * 3;
+      samples.length = 0;
+      return;
+    }
+
+    dprRef.current = next;
+    setDpr(next);
+    lastDeclineAvgRef.current = isDecline ? avg : null;
+    samples.length = 0;
+    cooldownRef.current = COOLDOWN_FRAMES;
+  }, RenderPriority.EFFECTS);
+
+  return null;
+};

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -157,6 +157,14 @@ interface Arena3DProps {
   onToggleNames?: () => void;
   performanceMode?: boolean;
   onTogglePerformance?: () => void;
+  /** Auto quality level from the governor (0 = full); drives the "Performance mode (auto)" chip. */
+  autoQualityLevel?: number;
+  /** Governor requests a new quality level (escalate/recover one effect tier). */
+  onQualityLevelChange?: (level: number) => void;
+  /** True when the user forced full quality via the chip — the governor stands down. */
+  qualityAutoDisabled?: boolean;
+  /** Chip action: force full quality (disable the auto governor for the session). */
+  onForceFullQuality?: () => void;
   statsPanelEnabled?: boolean;
   onToggleStats?: () => void;
   /** True when the replay block is fullscreen/immersive (drives the fill-height layout + toggle icon). */
@@ -222,6 +230,10 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   onToggleNames,
   performanceMode: performanceModeProp,
   onTogglePerformance,
+  autoQualityLevel = 0,
+  onQualityLevelChange,
+  qualityAutoDisabled = false,
+  onForceFullQuality,
   statsPanelEnabled: statsPanelEnabledProp,
   onToggleStats,
   reservedInset,
@@ -856,6 +868,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             playerVisibility={playerVisibility}
             playerColorOverrides={playerColorOverrides}
             performanceMode={performanceMode}
+            autoQualityLevel={autoQualityLevel}
+            onQualityLevelChange={onQualityLevelChange}
+            qualityAutoDisabled={qualityAutoDisabled}
             mobileImmersive={mobileImmersive}
           />
         </Canvas>
@@ -1436,6 +1451,41 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           </Typography>
         </Box>
       )}
+
+      {/* Auto-quality chip — shown only when the governor has silently reduced effects to hold
+          framerate on a weak/throttled device (not when the user chose performance mode themselves,
+          and not in the inline preview). A tap forces full quality back and stands the governor down.
+          Sits just above the transport so it never overlaps the bottom controls. */}
+      {!mobilePreview &&
+        onForceFullQuality &&
+        !performanceMode &&
+        !qualityAutoDisabled &&
+        autoQualityLevel > 0 && (
+          <Tooltip title="Effects were automatically reduced to keep playback smooth on this device. Tap to force full quality.">
+            <Chip
+              icon={<Bolt sx={{ fontSize: '0.95rem' }} />}
+              label="Performance mode (auto)"
+              size="small"
+              onClick={onForceFullQuality}
+              aria-label="Effects auto-reduced for performance. Tap to force full quality."
+              sx={{
+                position: 'absolute',
+                left: 16,
+                bottom: (reservedInset ?? 80) + 12,
+                zIndex: 4,
+                cursor: 'pointer',
+                color: '#e2e8f0',
+                backgroundColor: 'rgba(13,20,48,0.82)',
+                backdropFilter: 'blur(8px)',
+                WebkitBackdropFilter: 'blur(8px)',
+                border: '1px solid rgba(252,211,77,0.4)',
+                fontSize: '0.72rem',
+                '& .MuiChip-icon': { color: '#fcd34d' },
+                '&:hover': { backgroundColor: 'rgba(13,20,48,0.95)' },
+              }}
+            />
+          </Tooltip>
+        )}
     </div>
   );
 };

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -1455,7 +1455,9 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
       {/* Auto-quality chip — shown only when the governor has silently reduced effects to hold
           framerate on a weak/throttled device (not when the user chose performance mode themselves,
           and not in the inline preview). A tap forces full quality back and stands the governor down.
-          Sits just above the transport so it never overlaps the bottom controls. */}
+          Anchored bottom-CENTER just above the transport: the bottom-left lane is owned by the
+          locked-player stats panel (which grows upward) and the bottom-right by the control stack, so
+          center is the one bottom lane that never collides. */}
       {!mobilePreview &&
         onForceFullQuality &&
         !performanceMode &&
@@ -1470,7 +1472,8 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
               aria-label="Effects auto-reduced for performance. Tap to force full quality."
               sx={{
                 position: 'absolute',
-                left: 16,
+                left: '50%',
+                transform: 'translateX(-50%)',
                 bottom: (reservedInset ?? 80) + 12,
                 zIndex: 4,
                 cursor: 'pointer',

--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -240,6 +240,13 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
   const perfTier = usePerfTier();
   const prefersReducedMotion = usePrefersReducedMotion();
   const previewMode = decidePreviewMode(perfTier, prefersReducedMotion);
+  // Stable [min, max] DPR range for the Canvas. Memoized so a re-render doesn't hand R3F a new array
+  // and re-apply the DPR — that would overwrite AdaptiveResolution's runtime downscale (which owns
+  // the pixel ratio after mount). Only a genuine perf-tier change produces a new range.
+  const canvasDprRange = useMemo<[number, number]>(
+    () => (perfTier === 'low' ? [1, 1.5] : [1, 2]),
+    [perfTier],
+  );
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false);
 
   // Persisted viewer prefs (localStorage). Arena3D owns the names + performance slices; the
@@ -757,7 +764,7 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
           // models"). 1.5× restores most of that crispness while still trimming the fill cost vs a full
           // 2× for genuinely weak GPUs. Reactive — changes apply without a remount. (This is a perf
           // lever, not the floor-sharpness fix; the floor crispness win comes from the unsharp mask.)
-          dpr={perfTier === 'low' ? [1, 1.5] : [1, 2]}
+          dpr={canvasDprRange}
           camera={{
             position: initialCameraPosition,
             fov: 30,

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -15,6 +15,7 @@ import { LongPressTracker } from '../utils/longPress';
 import { DEFAULT_ACTOR_SCALE, computeActorScaleFromFightArea } from '../utils/mapScaling';
 import { extractPlayerPaths, DEFAULT_PATH_SAMPLING } from '../utils/pathUtils';
 import { getPlayerPathColor } from '../utils/playerColors';
+import { QUALITY_LEVEL, qualityFlagsForLevel } from '../utils/qualityGovernor';
 import { resolveTouchPolicy } from '../utils/touchPolicy';
 
 import { AdaptiveResolution } from './AdaptiveResolution';
@@ -31,6 +32,7 @@ import { MapMarkers } from './MapMarkers';
 import { MarkerContextMenuPayload } from './Marker3D';
 import { PerformanceMonitorCanvas } from './PerformanceMonitor';
 import { PlayerPathTrail3D } from './PlayerPathTrail3D';
+import { QualityGovernor } from './QualityGovernor';
 import { ShapeDrawLayer } from './ShapeDrawLayer';
 
 // Stable empty Map for the optional playerVisibility prop default — a fresh `new Map()` in
@@ -531,8 +533,17 @@ export interface Arena3DSceneProps {
    * so the DOM player panel and the in-canvas figures share one source of truth.
    */
   playerColorOverrides?: Map<number, string>;
-  /** When true, player figures stop casting shadows (perf headroom for large fights). */
+  /** Manual performance mode (the Bolt toggle): drop bloom + IBL/cosmic + shadows all at once. */
   performanceMode?: boolean;
+  /**
+   * Auto quality level from the governor (0 = full). Combined with `performanceMode` to derive which
+   * effects render. Owned by FightReplay3D so the scene + the "auto" chip stay in lockstep.
+   */
+  autoQualityLevel?: number;
+  /** Governor requests a new level (escalate/recover one effect tier). */
+  onQualityLevelChange?: (level: number) => void;
+  /** True when the user forced full quality via the chip — the governor stands down. */
+  qualityAutoDisabled?: boolean;
   /**
    * True when the replay is a mobile device inside the pseudo-fullscreen overlay. Drives the touch
    * gesture policy: OrbitControls pan is disabled so two fingers are exclusively pinch-zoom
@@ -574,6 +585,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   playerVisibility = EMPTY_VISIBILITY,
   playerColorOverrides = EMPTY_COLOR_OVERRIDES,
   performanceMode = false,
+  autoQualityLevel = 0,
+  onQualityLevelChange,
+  qualityAutoDisabled = false,
   mobileImmersive = false,
 }) => {
   // Touch-gesture policy for OrbitControls. `mobileImmersive` already folds in (mobile && immersive),
@@ -611,6 +625,14 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   // (`perfTier === 'low' ? [1, 1.5] : [1, 2]`). Threaded to AdaptiveResolution as its full-quality
   // ceiling so the scaler tracks tier changes instead of a value captured at mount.
   const dprCap = perfTier === 'low' ? 1.5 : 2;
+
+  // Effective quality level → which effects render. The manual performance toggle forces the
+  // bloom+IBL/cosmic+shadows tier (its established behavior); the auto governor's level adds on top
+  // (and is ignored when the user forced full quality via the chip). qualityFlagsForLevel then maps
+  // the level to concrete on/off flags consumed by the effect components below.
+  const manualLevel = performanceMode ? QUALITY_LEVEL.NO_SHADOWS : QUALITY_LEVEL.FULL;
+  const effectiveLevel = Math.max(manualLevel, qualityAutoDisabled ? 0 : autoQualityLevel);
+  const qualityFlags = qualityFlagsForLevel(effectiveLevel);
 
   // Lets scene children that mutate visible three.js state from an ASYNC callback (outside
   // any React commit, time change, camera move, or follow) tell the RenderLoop to repaint —
@@ -862,9 +884,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         slowFrameThreshold={33}
         maxSlowFrameLogsPerMinute={10}
       />
-      {/* Bloom post-processing (skipped in performance mode). Publishes its render handle to
-          composerRef; RenderLoop routes the gated render through it so bright celestials glow. */}
-      {!performanceMode && <BloomComposer composerRef={composerRef} samples={bloomSamples} />}
+      {/* Bloom post-processing (dropped at quality tier 1+ / performance mode). Publishes its render
+          handle to composerRef; RenderLoop routes the gated render through it so celestials glow. */}
+      {qualityFlags.bloom && <BloomComposer composerRef={composerRef} samples={bloomSamples} />}
       {/* Manual render loop - lowest priority to render after all updates, gated on-demand */}
       <RenderLoop
         timeRef={timeRef}
@@ -883,6 +905,19 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         paintedRef={paintedRef}
         markDirty={markSceneDirty}
       />
+      {/* Adaptive quality governor — the tier BELOW resolution scaling. When a weak/throttled GPU
+          stays below target after DPR is at floor, it drops effects (bloom → IBL/cosmic → shadows)
+          and restores them as headroom returns. Inert on capable hardware. */}
+      {onQualityLevelChange && (
+        <QualityGovernor
+          timeRef={timeRef}
+          dprCap={dprCap}
+          paintedRef={paintedRef}
+          level={qualityAutoDisabled ? 0 : autoQualityLevel}
+          onLevelChange={onQualityLevelChange}
+          disabled={qualityAutoDisabled}
+        />
+      )}
       {/* Camera follower system */}
       <CameraFollower lookup={lookup} timeRef={timeRef} followingActorIdRef={followingActorIdRef} />
       {/* In-canvas camera keys: r = reset to fitted initial view, g = frame all actors. Lives in
@@ -908,7 +943,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         centerX={arenaDimensions.centerX}
         centerZ={arenaDimensions.centerZ}
         size={arenaDimensions.size}
-        castShadows={!performanceMode}
+        castShadows={qualityFlags.shadows}
       />
       {/* Procedural image-based lighting for the actor figures. The body/cap materials are
           MeshStandard with metalness 0.1–0.2, so without an environment they reflect pure black and
@@ -917,7 +952,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           `Environment preset`, which would fetch an HDR from a CDN. The env cube renders ONCE at
           mount (no per-frame cost, so it respects the on-demand RenderLoop), and `background={false}`
           keeps it off the visible backdrop — it only lights the figures. Dropped in performance mode. */}
-      {!performanceMode && (
+      {qualityFlags.environment && (
         <Environment resolution={64} frames={1} background={false}>
           <Lightformer intensity={1.6} position={[0, 6, 4]} scale={[12, 12, 1]} color="#fbf3e0" />
           <Lightformer intensity={0.7} position={[-6, 3, -4]} scale={[8, 8, 1]} color="#9fc2ff" />
@@ -932,7 +967,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         size={arenaDimensions.size}
         centerX={arenaDimensions.centerX}
         centerZ={arenaDimensions.centerZ}
-        performanceMode={performanceMode}
+        performanceMode={!qualityFlags.cosmic}
         variant={cosmicVariant}
       />
       {/* Map Texture - Arena floor background with dynamic phase-based switching */}
@@ -997,7 +1032,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         onActorClick={onActorClick}
         playerVisibility={playerVisibility}
         playerColorOverrides={playerColorOverrides}
-        performanceMode={performanceMode}
+        performanceMode={!qualityFlags.shadows}
         markDirty={markSceneDirty}
       />
       {/* Boss health + player list are now DOM overlays rendered by Arena3D as siblings of

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -608,6 +608,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   // Whether the RenderLoop painted the most recent frame (see RenderLoopProps.paintedRef). Read by
   // AdaptiveResolution to classify frames (idle vs rendered).
   const paintedRef = useRef(false);
+  // DPR-exhaustion status: AdaptiveResolution writes it (true when DPR is at floor or its
+  // effectiveness guard fired); QualityGovernor reads it to gate effect escalation (DPR first).
+  const dprExhaustedRef = useRef(false);
   useEffect(() => {
     renderBudgetRef.current = RENDER_TAIL_FRAMES;
     shadowDirtyRef.current = true;
@@ -904,6 +907,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         dprCap={dprCap}
         paintedRef={paintedRef}
         markDirty={markSceneDirty}
+        exhaustedRef={dprExhaustedRef}
       />
       {/* Adaptive quality governor — the tier BELOW resolution scaling. When a weak/throttled GPU
           stays below target after DPR is at floor, it drops effects (bloom → IBL/cosmic → shadows)
@@ -911,7 +915,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
       {onQualityLevelChange && (
         <QualityGovernor
           timeRef={timeRef}
-          dprCap={dprCap}
+          dprExhaustedRef={dprExhaustedRef}
           paintedRef={paintedRef}
           level={qualityAutoDisabled ? 0 : autoQualityLevel}
           onLevelChange={onQualityLevelChange}

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -17,6 +17,7 @@ import { extractPlayerPaths, DEFAULT_PATH_SAMPLING } from '../utils/pathUtils';
 import { getPlayerPathColor } from '../utils/playerColors';
 import { resolveTouchPolicy } from '../utils/touchPolicy';
 
+import { AdaptiveResolution } from './AdaptiveResolution';
 import { ArenaEnvironmentShell, type CosmicVariant } from './ArenaEnvironmentShell';
 import { BloomComposer, type BloomComposerHandle } from './BloomComposer';
 import { CameraFollower } from './CameraFollower';
@@ -71,6 +72,8 @@ interface AnimationFrameSceneActorsProps {
   playerColorOverrides?: Map<number, string>;
   /** When true, player figures stop casting shadows (perf headroom for large fights). */
   performanceMode?: boolean;
+  /** Repaint + shadow-dirty signal for async caster changes (humanoid/boss GLB load). */
+  markDirty?: () => void;
 }
 
 export interface GroundContextMenuPayload {
@@ -153,6 +156,7 @@ const AnimationFrameSceneActors: React.FC<AnimationFrameSceneActorsProps> = ({
   playerVisibility,
   playerColorOverrides,
   performanceMode,
+  markDirty,
 }) => {
   // Performance settings based on scrubbing mode
   const shouldRenderEffects = scrubbingMode?.shouldRenderEffects ?? true;
@@ -169,6 +173,7 @@ const AnimationFrameSceneActors: React.FC<AnimationFrameSceneActorsProps> = ({
       playerVisibility={playerVisibility}
       playerColorOverrides={playerColorOverrides}
       performanceMode={performanceMode}
+      markDirty={markDirty}
     />
   );
 };
@@ -191,6 +196,24 @@ interface RenderLoopProps {
    * refills it from per-frame signals (time, camera, follow) below.
    */
   renderBudgetRef: React.RefObject<number>;
+  /**
+   * "An actor (shadow caster) may have moved" signal, shared with the parent. The directional
+   * sun's shadow map is CAMERA-INDEPENDENT (the shadow camera is the light's fixed ortho frustum
+   * over the arena), so it only needs regenerating when a caster moves — playback/scrub (time
+   * changed) or a scene commit that changes the cast set (visibility / perf mode / fight). We turn
+   * three's per-render `shadowMap.autoUpdate` OFF and flag `needsUpdate` only on those frames, so
+   * orbiting a PAUSED scene (a very common inspect gesture) no longer re-renders the 2048² shadow
+   * pass every frame. Pixels are identical — same shadow, just not recomputed when nothing casting
+   * it moved. The parent sets it on every commit (safe superset); RenderLoop sets it on time change.
+   */
+  shadowDirtyRef: React.RefObject<boolean>;
+  /**
+   * Set true on every frame this loop actually painted (budget > 0), false when it skipped. Lets the
+   * adaptive-resolution controller tell a genuinely idle (workload-free, vsync-paced) frame from a
+   * paused-but-painted one (camera/follow), so it learns the real display interval and measures only
+   * true playback frames.
+   */
+  paintedRef: React.RefObject<boolean>;
   /**
    * Optional bloom composer. When present (non-performance mode) the gated render goes through the
    * composer (RenderPass → bloom → OutputPass) so bright celestials glow; otherwise a plain gl.render.
@@ -218,11 +241,26 @@ const RenderLoop: React.FC<RenderLoopProps> = ({
   timeRef,
   followingActorIdRef,
   renderBudgetRef,
+  shadowDirtyRef,
+  paintedRef,
   composerRef,
 }) => {
   const { gl, scene, camera, controls } = useThree();
 
   const lastRenderedTimeRef = useRef<number | null>(null);
+
+  // Take manual control of the shadow map: three regenerates it on EVERY render by default, but the
+  // directional sun's shadow only changes when a caster moves (see shadowDirtyRef). We flag it dirty
+  // ourselves below. Restore three's default on unmount so the renderer is left as we found it.
+  useEffect(() => {
+    const prevAuto = gl.shadowMap.autoUpdate;
+    gl.shadowMap.autoUpdate = false;
+    gl.shadowMap.needsUpdate = true; // first frame must populate the shadow map
+    return () => {
+      gl.shadowMap.autoUpdate = prevAuto;
+      gl.shadowMap.needsUpdate = true;
+    };
+  }, [gl]);
 
   // Refill the budget whenever the user moves the camera via OrbitControls.
   useEffect(() => {
@@ -231,6 +269,8 @@ const RenderLoop: React.FC<RenderLoopProps> = ({
     }
     const markDirty = (): void => {
       renderBudgetRef.current = RENDER_TAIL_FRAMES;
+      // NOTE: deliberately does NOT flag the shadow dirty — a camera move never changes a
+      // directional shadow map, so orbiting a paused scene reuses the existing shadow for free.
     };
     // OrbitControls extends EventDispatcher and emits 'change' on every camera mutation.
     const orbit = controls as unknown as {
@@ -246,9 +286,11 @@ const RenderLoop: React.FC<RenderLoopProps> = ({
   useFrame(() => {
     const currentTime = timeRef.current;
 
-    // Time advanced (playback or scrub) → the scene changed; refill the budget.
+    // Time advanced (playback or scrub) → the scene changed; refill the budget. Actors (shadow
+    // casters) moved, so the shadow map must regenerate this paint.
     if (lastRenderedTimeRef.current !== currentTime) {
       renderBudgetRef.current = RENDER_TAIL_FRAMES;
+      shadowDirtyRef.current = true;
     }
 
     // Keep rendering whenever an actor is followed/selected. Load-bearing for TWO reasons,
@@ -263,9 +305,19 @@ const RenderLoop: React.FC<RenderLoopProps> = ({
       renderBudgetRef.current = RENDER_TAIL_FRAMES;
     }
 
+    // Record whether this frame paints, for the adaptive-resolution controller (idle vs rendered).
+    paintedRef.current = renderBudgetRef.current > 0;
+
     if (renderBudgetRef.current > 0) {
       renderBudgetRef.current -= 1;
       lastRenderedTimeRef.current = currentTime;
+      // Regenerate the shadow map only on frames where a caster may have moved (time change or a
+      // scene commit). three clears needsUpdate back to false after it renders the shadow, so a
+      // pure camera-orbit frame (budget refilled by OrbitControls 'change') reuses the last shadow.
+      if (shadowDirtyRef.current) {
+        gl.shadowMap.needsUpdate = true;
+        shadowDirtyRef.current = false;
+      }
       const composer = composerRef.current;
       if (composer) {
         composer.render();
@@ -535,8 +587,16 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   // playback is paused. RenderLoop also tops it up from per-frame signals (time / camera /
   // follow). A ref, never state: a state flag would re-render every frame.
   const renderBudgetRef = useRef(RENDER_TAIL_FRAMES);
+  // "A shadow caster may have moved" flag (see RenderLoop). Set on every commit (a safe superset:
+  // visibility/perf-mode/fight changes can alter the cast set) so the shadow re-renders alongside
+  // the commit's repaint; RenderLoop also sets it on every playhead change.
+  const shadowDirtyRef = useRef(true);
+  // Whether the RenderLoop painted the most recent frame (see RenderLoopProps.paintedRef). Read by
+  // AdaptiveResolution to classify frames (idle vs rendered).
+  const paintedRef = useRef(false);
   useEffect(() => {
     renderBudgetRef.current = RENDER_TAIL_FRAMES;
+    shadowDirtyRef.current = true;
   });
 
   // Bloom composer handle, published by <BloomComposer> and consumed by RenderLoop. Null in
@@ -547,6 +607,10 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   // Without this the composer target is single-sampled and bloom-on tiers would render aliased edges.
   const perfTier = usePerfTier();
   const bloomSamples = perfTier === 'high' ? 4 : perfTier === 'medium' ? 2 : 0;
+  // Render-resolution cap by tier — must mirror the Canvas `dpr` ceiling in Arena3D
+  // (`perfTier === 'low' ? [1, 1.5] : [1, 2]`). Threaded to AdaptiveResolution as its full-quality
+  // ceiling so the scaler tracks tier changes instead of a value captured at mount.
+  const dprCap = perfTier === 'low' ? 1.5 : 2;
 
   // Lets scene children that mutate visible three.js state from an ASYNC callback (outside
   // any React commit, time change, camera move, or follow) tell the RenderLoop to repaint —
@@ -556,6 +620,9 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
   // budget. Stable identity so it never churns child memoization.
   const markSceneDirty = useCallback(() => {
     renderBudgetRef.current = RENDER_TAIL_FRAMES;
+    // An async scene mutation (e.g. a CDN map texture resolving) may also coincide with a changed
+    // cast set; flagging the shadow dirty here is a cheap safe superset (these events are rare).
+    shadowDirtyRef.current = true;
   }, []);
 
   // Touch path for placing markers: press-and-hold on the ground (edit mode only) opens the
@@ -803,7 +870,18 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         timeRef={timeRef}
         followingActorIdRef={followingActorIdRef}
         renderBudgetRef={renderBudgetRef}
+        shadowDirtyRef={shadowDirtyRef}
+        paintedRef={paintedRef}
         composerRef={composerRef}
+      />
+      {/* Dynamic render-resolution scaler — holds ~120fps on weaker GPUs / 4K / heavy fights by
+          trading resolution only under sustained load, and stays at full quality (no change) when
+          there's headroom. Inert on capable hardware. */}
+      <AdaptiveResolution
+        timeRef={timeRef}
+        dprCap={dprCap}
+        paintedRef={paintedRef}
+        markDirty={markSceneDirty}
       />
       {/* Camera follower system */}
       <CameraFollower lookup={lookup} timeRef={timeRef} followingActorIdRef={followingActorIdRef} />
@@ -920,6 +998,7 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
         playerVisibility={playerVisibility}
         playerColorOverrides={playerColorOverrides}
         performanceMode={performanceMode}
+        markDirty={markSceneDirty}
       />
       {/* Boss health + player list are now DOM overlays rendered by Arena3D as siblings of
           the <Canvas> (crisp text, real scroll region, native MUI styling) — not in-canvas

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -915,7 +915,11 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
           paintedRef={paintedRef}
           level={qualityAutoDisabled ? 0 : autoQualityLevel}
           onLevelChange={onQualityLevelChange}
-          disabled={qualityAutoDisabled}
+          // Stand down while the user forced full quality OR turned on manual performance mode:
+          // under manual mode every level renders the same (all effects already off), so the
+          // governor would ratchet autoQualityLevel up on no-op escalations and leak that latched
+          // level into effectiveLevel the moment manual mode is turned back off.
+          disabled={qualityAutoDisabled || performanceMode}
         />
       )}
       {/* Camera follower system */}

--- a/src/features/fight_replay/components/BatchedActorNames3D.tsx
+++ b/src/features/fight_replay/components/BatchedActorNames3D.tsx
@@ -179,6 +179,11 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
   // Scratch objects reused every frame (no per-frame allocation in the hot loop).
   const scratchWorld = useRef(new THREE.Vector3());
   const scratchProjected = useRef(new THREE.Vector3());
+  // Pooled NameScreenItem objects (grow-only, never shrunk) so Pass 1 mutates existing objects
+  // instead of allocating ~N fresh ones every frame — that per-frame garbage was a steady GC drip
+  // at the playback frame rate. `screenItems` is the reused active list (length reset each frame; it
+  // holds references INTO the pool, so resolveNameVisibility — which only reads — is unaffected).
+  const itemPool = useRef<NameScreenItem[]>([]);
   const screenItems = useRef<NameScreenItem[]>([]);
 
   useFrame(() => {
@@ -205,6 +210,8 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
     // --- Pass 1: position / orient / scale / text every name; collect on-screen rectangles ----
     const items = screenItems.current;
     items.length = 0;
+    const pool = itemPool.current;
+    let poolIdx = 0;
 
     handles.forEach((handle, actorId) => {
       const group = handle.group;
@@ -269,14 +276,20 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
       const halfW = (labelWorldW * worldToPixel) / 2;
       const halfH = (labelWorldH * worldToPixel) / 2;
 
-      items.push({
-        id: actorId,
-        screenX,
-        screenY,
-        halfW,
-        halfH,
-        priority: priorityForActor(actor, selectedActorId),
-      });
+      // Reuse a pooled item object (grow the pool on demand) instead of allocating a fresh literal.
+      let it = pool[poolIdx];
+      if (!it) {
+        it = { id: 0, screenX: 0, screenY: 0, halfW: 0, halfH: 0, priority: NamePriority.NORMAL };
+        pool[poolIdx] = it;
+      }
+      poolIdx++;
+      it.id = actorId;
+      it.screenX = screenX;
+      it.screenY = screenY;
+      it.halfW = halfW;
+      it.halfH = halfH;
+      it.priority = priorityForActor(actor, selectedActorId);
+      items.push(it);
     });
 
     // --- Pass 2: resolve overlap once, then write opacity through the refs --------------------

--- a/src/features/fight_replay/components/BloomComposer.tsx
+++ b/src/features/fight_replay/components/BloomComposer.tsx
@@ -52,6 +52,10 @@ export const BloomComposer: React.FC<BloomComposerProps> = ({
   threshold = 0.9,
 }) => {
   const { gl, scene, camera, size } = useThree();
+  // The live render pixel ratio. AdaptiveResolution mutates this at runtime (setDpr) to hold the
+  // framerate; the composer's HDR/bloom targets are sized in DEVICE pixels (size × dpr), so they
+  // must be re-sized whenever the dpr changes, not only on a CSS-size change.
+  const dpr = useThree((s) => s.viewport.dpr);
 
   const { composer, bloomPass } = useMemo(() => {
     // Explicit multisampled HDR target (vs three's single-sampled default) — clamp to the GPU's max.
@@ -85,11 +89,13 @@ export const BloomComposer: React.FC<BloomComposerProps> = ({
     bloomPass.threshold = threshold;
   }, [bloomPass, strength, radius, threshold]);
 
-  // Track canvas size (incl. fullscreen transitions) — a hand-built composer does not auto-resize.
+  // Track canvas size (incl. fullscreen transitions) AND the adaptive pixel ratio — a hand-built
+  // composer does not auto-resize. `dpr` is in the deps so a runtime resolution change (adaptive
+  // scaler) resizes the composer's targets to match the renderer's new drawing buffer.
   useEffect(() => {
     composer.setPixelRatio(gl.getPixelRatio());
     composer.setSize(size.width, size.height);
-  }, [composer, gl, size.width, size.height]);
+  }, [composer, gl, size.width, size.height, dpr]);
 
   // Publish the render handle for RenderLoop to call in place of gl.render.
   useEffect(() => {

--- a/src/features/fight_replay/components/BloomComposer.tsx
+++ b/src/features/fight_replay/components/BloomComposer.tsx
@@ -97,14 +97,21 @@ export const BloomComposer: React.FC<BloomComposerProps> = ({
     composer.setSize(size.width, size.height);
   }, [composer, gl, size.width, size.height, dpr]);
 
-  // Publish the render handle for RenderLoop to call in place of gl.render.
+  // Publish the render handle for RenderLoop to call in place of gl.render. Capture the handle in a
+  // local and null the ref BY IDENTITY on unmount — comparing `composerRef.current?.render` to
+  // `composer.render` never matched (the published `render` is an arrow wrapper, not the prototype
+  // method), so the ref was never cleared. That left RenderLoop calling a disposed-but-still-working
+  // composer after bloom was dropped (manual perf mode OR the quality governor's first rung), so
+  // dropping bloom freed zero GPU work. Identity-matching the captured handle fixes the fallback to
+  // plain gl.render the instant <BloomComposer> unmounts.
   useEffect(() => {
-    composerRef.current = {
+    const handle: BloomComposerHandle = {
       render: () => composer.render(),
       setSize: (w, h) => composer.setSize(w, h),
     };
+    composerRef.current = handle;
     return () => {
-      if (composerRef.current?.render === composer.render) {
+      if (composerRef.current === handle) {
         composerRef.current = null;
       }
     };

--- a/src/features/fight_replay/components/BossHealthPanel.tsx
+++ b/src/features/fight_replay/components/BossHealthPanel.tsx
@@ -96,9 +96,28 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
     }
 
     let raf = 0;
+    // The playhead value the last write pass ran for. While the replay is PAUSED, `timeRef.current`
+    // never changes, so boss health is identical frame-to-frame — re-querying the lookup and
+    // re-writing the DOM (a `width`/`backgroundColor`/`textContent` mutation that, with the fill's
+    // CSS `transition`, keeps the compositor animating) every rAF was pure waste over the live WebGL
+    // canvas. Gate the body on the playhead actually moving. `lastTickTime` is NaN-seeded so the
+    // first tick always runs.
+    let lastTickTime = NaN;
+    // Forces a write pass even when the playhead is static: set on mount and whenever the boss SET
+    // changes (newly-mounted bars must receive their initial width/text), cleared once every current
+    // boss's bar refs exist and have been written.
+    let pendingWrite = true;
+    // Per-bar last-written values, so a moving playhead still only touches the DOM for bars whose
+    // displayed value actually changed (e.g. a boss already at a steady % between samples).
+    const lastWritten = new Map<number, { width: string; color: string; text: string }>();
 
     const tick = (): void => {
       const currentTime = timeRef.current;
+      if (currentTime === lastTickTime && !pendingWrite) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+      lastTickTime = currentTime;
       const allActors = getAllActorPositionsAtTimestamp(lookup, currentTime);
 
       // Filter to bosses with health (same rule as the old HUD).
@@ -110,36 +129,60 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
         }
       }
 
-      // Re-render only when the boss SET changes (id + name).
+      // Re-render only when the boss SET changes (id + name). A changed set mounts/unmounts bars, so
+      // force the next pass(es) to write through until the new refs exist.
       let sig = '';
       for (const b of bossActors) sig += `${b.id}:${b.name};`;
       if (sig !== lastSigRef.current) {
         lastSigRef.current = sig;
         setBosses(bossActors.map((b) => ({ id: b.id, name: b.name })));
+        pendingWrite = true;
+        // Drop the dirty-check cache so every (re)mounted bar is written fresh. Without this, a boss
+        // that left the set and later reappears at an identical health % would match its stale cache
+        // entry, the write would be skipped, and the freshly-mounted bar would keep its default 100%.
+        lastWritten.clear();
       }
 
-      // Write live values straight to the DOM — no React involved.
+      // Write live values straight to the DOM — no React involved. Only touch a node when its value
+      // changed since the last write (dirty check), so a paused/steady bar adds zero layout/paint.
+      let allRefsPresent = true;
       for (const boss of bossActors) {
         const refs = barRefs.current.get(boss.id);
-        if (!refs || !boss.health) continue;
-        const pct = boss.health.percentage;
-        if (refs.fill) {
-          refs.fill.style.width = boss.isDead ? '0%' : `${Math.max(0, Math.min(100, pct))}%`;
-          refs.fill.style.backgroundColor = healthColor(theme, pct);
+        // An UNMOUNTED bar leaves a stale {fill:null, readout:null} entry (the callback ref nulls
+        // them out), so `refs` can be truthy while its elements are gone. Require the actual nodes —
+        // otherwise a reappearing boss would clear pendingWrite without writing, and the freshly
+        // mounted bar would keep its default 100% until the playhead moves.
+        if (!refs || !refs.fill || !refs.readout) {
+          allRefsPresent = false;
+          continue;
         }
-        if (refs.readout) {
-          // Mobile keeps it to the percentage only — the exact HP numbers are noise on a phone and
-          // make the bar read as cluttered. Desktop shows "pct · cur / max", abbreviating once the
-          // numbers are big enough that the exact form ("145,368,051 / 181,632,304") would overflow
-          // the 280px pill and spill past the track.
-          const compact = isMobile || boss.health.max >= 10_000_000;
-          refs.readout.textContent = boss.isDead
-            ? 'DEAD'
-            : isMobile
-              ? `${pct.toFixed(1)}%`
-              : `${pct.toFixed(1)}%  ·  ${fmtHp(boss.health.current, compact)} / ${fmtHp(boss.health.max, compact)}`;
+        if (!boss.health) continue;
+        const pct = boss.health.percentage;
+        const width = boss.isDead ? '0%' : `${Math.max(0, Math.min(100, pct))}%`;
+        const color = healthColor(theme, pct);
+        // Mobile keeps it to the percentage only — the exact HP numbers are noise on a phone and
+        // make the bar read as cluttered. Desktop shows "pct · cur / max", abbreviating once the
+        // numbers are big enough that the exact form ("145,368,051 / 181,632,304") would overflow
+        // the 280px pill and spill past the track.
+        const compact = isMobile || boss.health.max >= 10_000_000;
+        const text = boss.isDead
+          ? 'DEAD'
+          : isMobile
+            ? `${pct.toFixed(1)}%`
+            : `${pct.toFixed(1)}%  ·  ${fmtHp(boss.health.current, compact)} / ${fmtHp(boss.health.max, compact)}`;
+        const prev = lastWritten.get(boss.id);
+        if (!prev || prev.width !== width || prev.color !== color || prev.text !== text) {
+          if (refs.fill) {
+            refs.fill.style.width = width;
+            refs.fill.style.backgroundColor = color;
+          }
+          if (refs.readout) refs.readout.textContent = text;
+          lastWritten.set(boss.id, { width, color, text });
         }
       }
+      // Hold the force flag until every current boss has had its (just-mounted) refs written, so the
+      // initial values are never dropped while React is still committing the bars.
+      if (allRefsPresent) pendingWrite = false;
 
       raf = requestAnimationFrame(tick);
     };

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -20,7 +20,6 @@ import {
   TRANSPORT_RESERVED,
   TRANSPORT_MOTION,
   HAIRLINE_H,
-  transportHairline,
 } from '../constants/replayDesign';
 import { useDelayedFlag } from '../hooks/useDelayedFlag';
 import { useIsMobileReplay } from '../hooks/useIsMobileReplay';
@@ -38,6 +37,7 @@ import { Arena3D } from './Arena3D';
 import { ADD_MARKER_AT_CENTER_EVENT } from './Arena3DScene';
 import { MobileReplayDock } from './mobile/MobileReplayDock';
 import { PlaybackControls, PLAYBACK_SPEEDS, type TransportTrial } from './PlaybackControls';
+import { ProgressHairline } from './ProgressHairline';
 import { ReplayTransitionOverlay } from './ReplayTransitionOverlay';
 import type { TrialTimelineSeekTarget } from './TrialTimeline';
 import { UpNextCard, type UpNextState } from './UpNextCard';
@@ -1571,10 +1571,7 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
             }}
           >
             <KeyboardArrowUpRoundedIcon sx={{ fontSize: 20, color: 'rgba(255,255,255,0.82)' }} />
-            <Box
-              aria-hidden
-              sx={(t) => transportHairline(t, duration > 0 ? (currentTime / duration) * 100 : 0)}
-            />
+            <ProgressHairline timeRef={animationTimeRef.timeRef} duration={duration} />
           </Box>
           <IconButton
             aria-label="Close replay"
@@ -1675,7 +1672,6 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           }}
         >
           <PlaybackControls
-            currentTime={currentTime}
             duration={selectedFight.endTime - selectedFight.startTime}
             isPlaying={isPlaying}
             playbackSpeed={playbackSpeed}
@@ -1701,11 +1697,6 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
             isFullscreen={isImmersive}
             barVisible={barVisible}
             onToggleCollapse={toggleBar}
-            progressPct={
-              selectedFight.endTime > selectedFight.startTime
-                ? (currentTime / (selectedFight.endTime - selectedFight.startTime)) * 100
-                : 0
-            }
             overlay
             isMobile={isMobile}
             trial={transportTrial}

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -258,6 +258,12 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   const [autoQualityLevel, setAutoQualityLevel] = useState(0);
   const [qualityAutoDisabled, setQualityAutoDisabled] = useState(false);
   const handleQualityLevelChange = useCallback((level: number) => setAutoQualityLevel(level), []);
+  // When manual performance mode turns on it forces all effects off, so the governor stands down
+  // (gated in Arena3DScene). Clear any level it had latched so that turning manual mode back off
+  // snaps straight to full quality (effectiveLevel = max(0, 0)) instead of inheriting a stale level.
+  useEffect(() => {
+    if (performanceMode) setAutoQualityLevel(0);
+  }, [performanceMode]);
   const handleForceFullQuality = useCallback(() => {
     setQualityAutoDisabled(true);
     setAutoQualityLevel(0);
@@ -1627,7 +1633,6 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           }}
         >
           <MobileReplayDock
-            currentTime={currentTime}
             duration={selectedFight.endTime - selectedFight.startTime}
             isPlaying={isPlaying}
             playbackSpeed={playbackSpeed}

--- a/src/features/fight_replay/components/FightReplay3D.tsx
+++ b/src/features/fight_replay/components/FightReplay3D.tsx
@@ -250,6 +250,19 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
   const togglePerformance = useCallback(() => setPerformanceMode((v) => !v), []);
   const toggleStats = useCallback(() => setStatsPanelEnabled((v) => !v), []);
 
+  // Adaptive quality governor (the tier below resolution scaling). `autoQualityLevel` is the
+  // governor's current effect-drop level (0 = full); the QualityGovernor inside the scene requests
+  // changes via handleQualityLevelChange. `qualityAutoDisabled` is set when the user taps the
+  // "Performance mode (auto)" chip to force full quality — the governor then stands down. Owned here
+  // so the scene (effect flags) and the chip share one source of truth.
+  const [autoQualityLevel, setAutoQualityLevel] = useState(0);
+  const [qualityAutoDisabled, setQualityAutoDisabled] = useState(false);
+  const handleQualityLevelChange = useCallback((level: number) => setAutoQualityLevel(level), []);
+  const handleForceFullQuality = useCallback(() => {
+    setQualityAutoDisabled(true);
+    setAutoQualityLevel(0);
+  }, []);
+
   // Compact contextual badges for the transport bar (encounter · difficulty · outcome).
   // The encounter name is shortened to its trailing word(s) so it complements — rather than
   // duplicates — the full title in the page header above. ESO Logs difficulty codes:
@@ -495,6 +508,9 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
     setIsPlaying(false);
     setFollowingActor(selectedActorIdFromUrl);
     setSelectedPlayerIds(new Set());
+    // A new fight is a fresh scene with its own load — re-measure from full quality. (The user's
+    // "force full quality" choice, qualityAutoDisabled, deliberately persists across fights.)
+    setAutoQualityLevel(0);
     // A new fight is a new boundary: clear BOTH halves of any Up-next cancel (a stale
     // countdownCancelled would suppress the next fight's countdown — the only Cancel UI —
     // while the cleared skip ref let it auto-advance silently).
@@ -1368,6 +1384,10 @@ export const FightReplay3D: React.FC<FightReplay3DProps> = ({
           onToggleNames={toggleNames}
           performanceMode={performanceMode}
           onTogglePerformance={togglePerformance}
+          autoQualityLevel={autoQualityLevel}
+          onQualityLevelChange={handleQualityLevelChange}
+          qualityAutoDisabled={qualityAutoDisabled}
+          onForceFullQuality={handleForceFullQuality}
           statsPanelEnabled={statsPanelEnabled}
           onToggleStats={toggleStats}
           // On mobile immersive the dedicated shell owns the close + all controls, so suppress

--- a/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
+++ b/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
@@ -59,6 +59,13 @@ interface InstancedReplayFigures3DProps {
   playerColorOverrides?: Map<number, string>;
   /** When true, the humanoid figures stop casting shadows (drops the shadow-pass tri load). */
   performanceMode?: boolean;
+  /**
+   * Repaint + shadow-dirty signal. Called when the async humanoid/boss GLB loads and swaps the
+   * shadow-casting geometry: this child's setState does NOT re-run the parent scene's commit effect,
+   * so without this a paused scene would keep the stale (capsule / no-boss) shadow map on the next
+   * camera-orbit repaint until the playhead moved. Routed to Arena3DScene's markSceneDirty.
+   */
+  markDirty?: () => void;
 }
 
 const EMPTY_VISIBILITY: Map<number, boolean> = new Map();
@@ -446,6 +453,23 @@ function bossTuneSignature(performanceMode: boolean): string {
   ].join(',');
 }
 
+// Stable per-attribute "needs upload" flaggers, hoisted to module scope so the per-frame flush can
+// mark every layer dirty WITHOUT allocating a fresh temp array + arrow closure each frame (that
+// churn ran at the playback frame rate and added avoidable GC pressure → micro-stutters). They're
+// shape-compatible with Array.forEach AND Map.forEach (extra index/key args are ignored).
+function flagMatrixNeedsUpdate(mesh: THREE.InstancedMesh | null | undefined): void {
+  if (mesh) mesh.instanceMatrix.needsUpdate = true;
+}
+function flagColorNeedsUpdate(mesh: THREE.InstancedMesh | null | undefined): void {
+  if (mesh?.instanceColor) mesh.instanceColor.needsUpdate = true;
+}
+function flagOpacityNeedsUpdate(mesh: THREE.InstancedMesh | null | undefined): void {
+  const attr = mesh?.geometry.getAttribute('instanceOpacity') as
+    | THREE.InstancedBufferAttribute
+    | undefined;
+  if (attr) attr.needsUpdate = true;
+}
+
 export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> = ({
   lookup,
   timeRef,
@@ -456,6 +480,7 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
   playerVisibility = EMPTY_VISIBILITY,
   playerColorOverrides = EMPTY_COLOR_OVERRIDES,
   performanceMode = false,
+  markDirty,
 }) => {
   const bodyHeight = 0.55 * scale;
   const capY = bodyHeight + 0.02 * scale;
@@ -874,6 +899,15 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
     bossMatStateRef.current = null;
   }, [bossModel]);
 
+  // When the humanoid poses or boss GLB finish loading, the shadow-CASTING geometry swaps
+  // (capsule → humanoid pose meshes; boss capsule → boss model). This is a child-local state change
+  // that does NOT re-run the parent scene's commit effect, so signal a repaint + shadow regeneration
+  // explicitly — otherwise a paused scene keeps the stale shadow map (and the swap may not paint)
+  // until the playhead next moves. Fires once on mount too (harmless). See markDirty prop doc.
+  useEffect(() => {
+    markDirty?.();
+  }, [poseGeometries, bossModel, markDirty]);
+
   const hideInstance = useCallback((mesh: THREE.InstancedMesh | null, index: number): void => {
     if (!mesh) return;
     const obj = tempObject.current;
@@ -961,6 +995,12 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
       const isThreat = isThreatActor(actor);
       const selected = selectedActorId === actorId;
       const taunted = actor.isTaunted || false;
+      // Previous frame's cached state for this actor (written at the end of this iteration). Used to
+      // skip re-hiding layers whose membership/state is unchanged — an actor's glyph group is fixed
+      // and most actors are neither selected nor taunted, so re-hiding those layers every frame
+      // re-composed hundreds of identical "hidden" matrices for nothing. null on first frame / after
+      // a cache reset → the full hide runs then, so initial hidden state is always established.
+      const prev = cacheRef.current[index];
       // Players become the humanoid figure once the pose geometries have loaded; everyone else (and
       // players pre-load) keeps the capsule blob. For a humanoid player, exactly one pose layer is
       // shown (the capsule body and the other four pose layers are hidden off-screen). For everyone
@@ -1112,13 +1152,16 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
       obj.rotation.set(-Math.PI / 2, 0, 0);
       obj.scale.setScalar(glyphScale);
       obj.updateMatrix();
-      glyphRefs.current.forEach((mesh, symbol) => {
-        if (symbol === groupSymbol) {
-          mesh.setMatrixAt(index, obj.matrix);
-        } else {
-          hideInstance(mesh, index);
-        }
-      });
+      // Write the matching glyph from the CLEAN obj.matrix first (before any hideInstance below
+      // clobbers the shared tempObject). An actor's glyph group never changes, so it only needs
+      // hiding in the OTHER groups on (re)appearance — re-hiding all 7 every frame re-composed ~7
+      // identical hidden matrices per actor for nothing (the single largest waste in this loop).
+      glyphRefs.current.get(groupSymbol)?.setMatrixAt(index, obj.matrix);
+      if (!prev || !prev.visible || prev.glyphSymbol !== groupSymbol) {
+        glyphRefs.current.forEach((mesh, symbol) => {
+          if (symbol !== groupSymbol) hideInstance(mesh, index);
+        });
+      }
 
       // Contact-shadow blob flat on ground, just UNDER the anchor ring (+0.004 vs the ring's +0.006)
       // so the ring still reads on top. Same x,z + groupScale as the ring; flat orientation (-PI/2 X).
@@ -1162,14 +1205,18 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
       obj.updateMatrix();
       hitProxyRef.current?.setMatrixAt(index, obj.matrix);
 
-      // Selection / taunt rings: shown only when active.
+      // Selection / taunt rings: shown only when active. When ACTIVE the ring tracks the moving
+      // actor, so its matrix updates every frame. When INACTIVE it only needs hiding on the
+      // transition into inactive (or first appearance) — once parked off-screen it stays there, so
+      // re-hiding it for every unselected/untaunted actor every frame was pure waste (~80 hidden
+      // matrix composes/frame across a raid where at most one actor is selected).
       if (selected) {
         obj.position.set(x, y + GROUND_LEVEL + 0.016, z);
         obj.rotation.set(-Math.PI / 2, 0, 0);
         obj.scale.setScalar(groupScale);
         obj.updateMatrix();
         selectionRingRef.current?.setMatrixAt(index, obj.matrix);
-      } else {
+      } else if (!prev || !prev.visible || prev.selected) {
         hideInstance(selectionRingRef.current, index);
       }
       if (taunted) {
@@ -1178,12 +1225,11 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
         obj.scale.setScalar(groupScale);
         obj.updateMatrix();
         tauntRingRef.current?.setMatrixAt(index, obj.matrix);
-      } else {
+      } else if (!prev || !prev.visible || prev.taunted) {
         hideInstance(tauntRingRef.current, index);
       }
 
-      // ---- Colors + opacity (only write when changed) ----
-      const prev = cacheRef.current[index];
+      // ---- Colors + opacity (only write when changed) ---- (prev captured at the top of the loop)
       const changed =
         !prev ||
         !prev.visible ||
@@ -1302,48 +1348,34 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
       }
     }
 
-    // Flush matrices every frame (positions change constantly during playback).
-    [
-      bodyRef.current,
-      ...poseRefs.current,
-      capRef.current,
-      visionRef.current,
-      hitProxyRef.current,
-      aoBlobRef.current,
-      anchorRingRef.current,
-      selectionRingRef.current,
-      tauntRingRef.current,
-    ].forEach((m) => {
-      if (m) m.instanceMatrix.needsUpdate = true;
-    });
-    glyphRefs.current.forEach((m) => {
-      m.instanceMatrix.needsUpdate = true;
-    });
+    // Flush matrices every frame (positions change constantly during playback). Iterate the refs
+    // directly with the hoisted stable flaggers — no per-frame temp array / closure allocation.
+    const poses = poseRefs.current;
+    flagMatrixNeedsUpdate(bodyRef.current);
+    for (let p = 0; p < poses.length; p++) flagMatrixNeedsUpdate(poses[p]);
+    flagMatrixNeedsUpdate(capRef.current);
+    flagMatrixNeedsUpdate(visionRef.current);
+    flagMatrixNeedsUpdate(hitProxyRef.current);
+    flagMatrixNeedsUpdate(aoBlobRef.current);
+    flagMatrixNeedsUpdate(anchorRingRef.current);
+    flagMatrixNeedsUpdate(selectionRingRef.current);
+    flagMatrixNeedsUpdate(tauntRingRef.current);
+    glyphRefs.current.forEach(flagMatrixNeedsUpdate);
 
     if (colorDirty) {
-      [
-        bodyRef.current,
-        ...poseRefs.current,
-        capRef.current,
-        anchorRingRef.current,
-        visionRef.current,
-      ].forEach((m) => {
-        if (m?.instanceColor) m.instanceColor.needsUpdate = true;
-      });
+      flagColorNeedsUpdate(bodyRef.current);
+      for (let p = 0; p < poses.length; p++) flagColorNeedsUpdate(poses[p]);
+      flagColorNeedsUpdate(capRef.current);
+      flagColorNeedsUpdate(anchorRingRef.current);
+      flagColorNeedsUpdate(visionRef.current);
     }
     if (opacityDirty) {
-      const flag = (mesh: THREE.InstancedMesh | null): void => {
-        const attr = mesh?.geometry.getAttribute('instanceOpacity') as
-          | THREE.InstancedBufferAttribute
-          | undefined;
-        if (attr) attr.needsUpdate = true;
-      };
-      flag(bodyRef.current);
-      poseRefs.current.forEach((m) => flag(m));
-      flag(capRef.current);
-      flag(anchorRingRef.current);
-      flag(visionRef.current);
-      glyphRefs.current.forEach((m) => flag(m));
+      flagOpacityNeedsUpdate(bodyRef.current);
+      for (let p = 0; p < poses.length; p++) flagOpacityNeedsUpdate(poses[p]);
+      flagOpacityNeedsUpdate(capRef.current);
+      flagOpacityNeedsUpdate(anchorRingRef.current);
+      flagOpacityNeedsUpdate(visionRef.current);
+      glyphRefs.current.forEach(flagOpacityNeedsUpdate);
     }
   }, RenderPriority.ACTORS);
 

--- a/src/features/fight_replay/components/LiveScrubRail.tsx
+++ b/src/features/fight_replay/components/LiveScrubRail.tsx
@@ -1,31 +1,42 @@
 /**
  * LiveScrubRail
  *
- * The scrub rail (timeline slider) wired so that NOTHING re-renders as playback advances.
+ * The scrub rail (timeline slider), isolated so playback does NOT re-render the surrounding transport.
  *
  * WHY THIS EXISTS (the low-power fps fix, confirmed by profiling): the transport used to receive the
- * playhead as a React state synced ~10Hz from the playback loop, re-rendering the whole transport
- * every tick. On a slow device a single frame can exceed that gate, so the sync fired EVERY frame.
- * Worse, the playhead lives on an MUI Slider, and re-rendering it re-runs emotion's style
- * serialization (`insertRule`) which invalidates the document stylesheet and forces a full style
- * recalc (`UpdateLayoutTree` — the single largest cost in a throttled trace). That style-recalc
- * storm, not the 3D scene, is what collapsed playback to single-digit fps.
+ * playhead as React state synced ~10Hz, re-rendering the WHOLE transport (trial mini-map, control
+ * row, buttons) every tick. On a slow device a single frame can exceed that gate, so it fired EVERY
+ * frame, and the dynamic-position emotion styles re-ran `insertRule` → a full document style recalc
+ * (`UpdateLayoutTree` — the single largest cost in a throttled trace). That style-recalc storm, not
+ * the 3D scene, collapsed playback to single-digit fps.
  *
- * The fix: the MUI Slider's `value` is a COMMITTED position that changes only on a seek or when
- * playback pauses — never per tick — so the Slider does not re-render during playback at all. The
- * live, smooth playhead is drawn by an rAF-driven DOM overlay (RailPlayhead, inside TimelineSlider)
- * that writes `style.left`/`style.width` directly, touching no React and no emotion. The Slider
- * stays mounted underneath for drag / click-seek / keyboard / a11y.
+ * The fix: the smooth VISIBLE playhead is drawn by an rAF-driven DOM overlay (RailPlayhead, inside
+ * TimelineSlider) that writes `style.left`/`style.width` directly — no React, no emotion — and the
+ * MUI thumb/track are hidden while it's live. The surrounding transport is memoized and no longer
+ * takes the playhead, so it never re-renders during playback. Only THIS isolated leaf resamples the
+ * MUI Slider's `value` from timeRef (capped to ~10Hz), which keeps the slider's semantic value —
+ * aria-valuenow, keyboard/Home/End seeks, the thumb shown on pause/drag — tracking the real playhead.
+ * The leaf's own styles are stable, so its resample is a cheap value update (no insertRule storm) and
+ * a fraction of the original whole-transport cost.
  *
  * @module LiveScrubRail
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useOptimizedTimelineScrubbing } from '../../../hooks/useOptimizedTimelineScrubbing';
 import { TimelineAnnotation } from '../../../types/timelineAnnotations';
+import { useSampledTime } from '../hooks/useSampledTime';
 
 import { TimelineSlider } from './TimelineSlider';
+
+// How often the MUI Slider's *semantic* value is resampled from timeRef. The smooth VISIBLE playhead
+// is the rAF DOM overlay (RailPlayhead) with the MUI thumb hidden during playback; this is only the
+// slider's React value, which must stay current so aria-valuenow, keyboard/Home/End seeks, and the
+// thumb shown on pause track the real playhead. Capped (not per-frame) so it can't spiral on a slow
+// device, and only this isolated leaf re-renders (its styles are stable → no emotion/insertRule
+// churn), so the cost is a fraction of the original per-tick whole-transport re-render.
+const SLIDER_SYNC_MS = 100;
 
 interface LiveScrubRailProps {
   /** High-frequency playhead (ms into the fight) — read by the DOM overlay, never re-renders this. */
@@ -65,43 +76,12 @@ const LiveScrubRailComponent: React.FC<LiveScrubRailProps> = ({
   onClearLoop,
   density,
 }) => {
-  // The MUI Slider's value. During PLAYBACK it is FROZEN (the rAF DOM overlay shows the live
-  // playhead), so the Slider never re-renders per tick. While PAUSED it tracks the live playhead so
-  // every seek path — the ±10s / skip-to-start/end buttons, keyboard arrows, marker jumps, the trial
-  // rail — moves the visible MUI thumb (those seeks update `timeRef` directly, not this component).
-  const [committedMs, setCommittedMs] = useState<number>(timeRef?.current ?? 0);
-  useEffect(() => {
-    // Frozen during playback: the overlay owns the live playhead and the Slider must not re-render.
-    if (isPlaying) return undefined;
-    // Paused: snap immediately (zero-flash on the pause edge), then sample so later seeks reflect.
-    setCommittedMs(timeRef?.current ?? 0);
-    let raf = 0;
-    let last = 0;
-    let lastVal = NaN;
-    const tick = (now: number): void => {
-      if (now - last >= 80) {
-        const t = timeRef?.current ?? 0;
-        if (t !== lastVal) {
-          lastVal = t;
-          last = now;
-          setCommittedMs(t);
-        }
-      }
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [isPlaying, timeRef]);
-
-  // A committed seek (slider drag commit, marker/rail click) updates the value instantly (no sample
-  // lag) and the host. During playback this path doesn't fire, so the Slider stays still.
-  const handleCommitTime = useCallback(
-    (time: number) => {
-      setCommittedMs(time);
-      onTimeChange(time);
-    },
-    [onTimeChange],
-  );
+  // The MUI Slider's value, resampled from the live timeRef at a capped rate (always — playing or
+  // paused). It is NOT the visible playhead during playback (that's the rAF overlay, thumb hidden),
+  // but it must stay live so the slider's aria-valuenow, keyboard/Home/End seeks, and the thumb shown
+  // on pause/drag operate from the real playhead rather than a frozen value. Seeks (±10s / skip /
+  // marker / rail / keyboard) update timeRef and are reflected here within SLIDER_SYNC_MS.
+  const liveMs = useSampledTime(timeRef, SLIDER_SYNC_MS);
 
   const {
     displayTime,
@@ -113,8 +93,8 @@ const LiveScrubRailComponent: React.FC<LiveScrubRailProps> = ({
     optimizedStep,
   } = useOptimizedTimelineScrubbing({
     duration,
-    currentTime: committedMs,
-    onTimeChange: handleCommitTime,
+    currentTime: liveMs,
+    onTimeChange,
     isPlaying,
     onPlayingChange,
     timeRef,

--- a/src/features/fight_replay/components/LiveScrubRail.tsx
+++ b/src/features/fight_replay/components/LiveScrubRail.tsx
@@ -20,7 +20,7 @@
  * @module LiveScrubRail
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { useOptimizedTimelineScrubbing } from '../../../hooks/useOptimizedTimelineScrubbing';
 import { TimelineAnnotation } from '../../../types/timelineAnnotations';
@@ -65,23 +65,36 @@ const LiveScrubRailComponent: React.FC<LiveScrubRailProps> = ({
   onClearLoop,
   density,
 }) => {
-  // The MUI Slider's value: the last COMMITTED position. It moves only on a seek or when playback
-  // pauses (so the paused/grabbed thumb is exact) — NOT every tick — so the Slider does not
-  // re-render during playback. The live playhead is the rAF DOM overlay (livePlayhead below).
+  // The MUI Slider's value. During PLAYBACK it is FROZEN (the rAF DOM overlay shows the live
+  // playhead), so the Slider never re-renders per tick. While PAUSED it tracks the live playhead so
+  // every seek path — the ±10s / skip-to-start/end buttons, keyboard arrows, marker jumps, the trial
+  // rail — moves the visible MUI thumb (those seeks update `timeRef` directly, not this component).
   const [committedMs, setCommittedMs] = useState<number>(timeRef?.current ?? 0);
-
-  // Snap the committed value to the live playhead the instant playback pauses, so the MUI thumb
-  // (which becomes visible when livePlayhead turns off) sits exactly where the overlay left it.
-  const wasPlayingRef = useRef(isPlaying);
   useEffect(() => {
-    if (wasPlayingRef.current && !isPlaying) {
-      setCommittedMs(timeRef?.current ?? 0);
-    }
-    wasPlayingRef.current = isPlaying;
+    // Frozen during playback: the overlay owns the live playhead and the Slider must not re-render.
+    if (isPlaying) return undefined;
+    // Paused: snap immediately (zero-flash on the pause edge), then sample so later seeks reflect.
+    setCommittedMs(timeRef?.current ?? 0);
+    let raf = 0;
+    let last = 0;
+    let lastVal = NaN;
+    const tick = (now: number): void => {
+      if (now - last >= 80) {
+        const t = timeRef?.current ?? 0;
+        if (t !== lastVal) {
+          lastVal = t;
+          last = now;
+          setCommittedMs(t);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
   }, [isPlaying, timeRef]);
 
-  // Any committed seek (slider drag commit, marker/rail click) updates both the committed value and
-  // the host. During playback this path doesn't fire, so the Slider stays still.
+  // A committed seek (slider drag commit, marker/rail click) updates the value instantly (no sample
+  // lag) and the host. During playback this path doesn't fire, so the Slider stays still.
   const handleCommitTime = useCallback(
     (time: number) => {
       setCommittedMs(time);

--- a/src/features/fight_replay/components/LiveScrubRail.tsx
+++ b/src/features/fight_replay/components/LiveScrubRail.tsx
@@ -1,0 +1,144 @@
+/**
+ * LiveScrubRail
+ *
+ * The scrub rail (timeline slider) wired so that NOTHING re-renders as playback advances.
+ *
+ * WHY THIS EXISTS (the low-power fps fix, confirmed by profiling): the transport used to receive the
+ * playhead as a React state synced ~10Hz from the playback loop, re-rendering the whole transport
+ * every tick. On a slow device a single frame can exceed that gate, so the sync fired EVERY frame.
+ * Worse, the playhead lives on an MUI Slider, and re-rendering it re-runs emotion's style
+ * serialization (`insertRule`) which invalidates the document stylesheet and forces a full style
+ * recalc (`UpdateLayoutTree` — the single largest cost in a throttled trace). That style-recalc
+ * storm, not the 3D scene, is what collapsed playback to single-digit fps.
+ *
+ * The fix: the MUI Slider's `value` is a COMMITTED position that changes only on a seek or when
+ * playback pauses — never per tick — so the Slider does not re-render during playback at all. The
+ * live, smooth playhead is drawn by an rAF-driven DOM overlay (RailPlayhead, inside TimelineSlider)
+ * that writes `style.left`/`style.width` directly, touching no React and no emotion. The Slider
+ * stays mounted underneath for drag / click-seek / keyboard / a11y.
+ *
+ * @module LiveScrubRail
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useOptimizedTimelineScrubbing } from '../../../hooks/useOptimizedTimelineScrubbing';
+import { TimelineAnnotation } from '../../../types/timelineAnnotations';
+
+import { TimelineSlider } from './TimelineSlider';
+
+interface LiveScrubRailProps {
+  /** High-frequency playhead (ms into the fight) — read by the DOM overlay, never re-renders this. */
+  timeRef?: React.RefObject<number> | { current: number };
+  duration: number;
+  isPlaying: boolean;
+  onTimeChange: (time: number) => void;
+  onPlayingChange?: (playing: boolean) => void;
+  onScrubbingModeChange?: (scrubbing: boolean) => void;
+  onDraggingChange?: (dragging: boolean) => void;
+  markers?: TimelineAnnotation[];
+  onMarkerClick?: (timestamp: number) => void;
+  replayContext?: {
+    label?: string;
+    difficultyTag?: string;
+    isKill?: boolean | null;
+  };
+  loopStart?: number | null;
+  loopEnd?: number | null;
+  onClearLoop?: () => void;
+  density?: 'compact' | 'expanded';
+}
+
+const LiveScrubRailComponent: React.FC<LiveScrubRailProps> = ({
+  timeRef,
+  duration,
+  isPlaying,
+  onTimeChange,
+  onPlayingChange,
+  onScrubbingModeChange,
+  onDraggingChange,
+  markers,
+  onMarkerClick,
+  replayContext,
+  loopStart = null,
+  loopEnd = null,
+  onClearLoop,
+  density,
+}) => {
+  // The MUI Slider's value: the last COMMITTED position. It moves only on a seek or when playback
+  // pauses (so the paused/grabbed thumb is exact) — NOT every tick — so the Slider does not
+  // re-render during playback. The live playhead is the rAF DOM overlay (livePlayhead below).
+  const [committedMs, setCommittedMs] = useState<number>(timeRef?.current ?? 0);
+
+  // Snap the committed value to the live playhead the instant playback pauses, so the MUI thumb
+  // (which becomes visible when livePlayhead turns off) sits exactly where the overlay left it.
+  const wasPlayingRef = useRef(isPlaying);
+  useEffect(() => {
+    if (wasPlayingRef.current && !isPlaying) {
+      setCommittedMs(timeRef?.current ?? 0);
+    }
+    wasPlayingRef.current = isPlaying;
+  }, [isPlaying, timeRef]);
+
+  // Any committed seek (slider drag commit, marker/rail click) updates both the committed value and
+  // the host. During playback this path doesn't fire, so the Slider stays still.
+  const handleCommitTime = useCallback(
+    (time: number) => {
+      setCommittedMs(time);
+      onTimeChange(time);
+    },
+    [onTimeChange],
+  );
+
+  const {
+    displayTime,
+    isDragging,
+    isScrubbingMode,
+    handleSliderChange,
+    handleSliderChangeStart,
+    handleSliderChangeEnd,
+    optimizedStep,
+  } = useOptimizedTimelineScrubbing({
+    duration,
+    currentTime: committedMs,
+    onTimeChange: handleCommitTime,
+    isPlaying,
+    onPlayingChange,
+    timeRef,
+  });
+
+  // Notify the host of scrubbing/drag transitions (3D scrub-degradation + cinema auto-hide guard).
+  // These fire only on drag edges, not per tick.
+  useEffect(() => {
+    onScrubbingModeChange?.(isScrubbingMode);
+  }, [isScrubbingMode, onScrubbingModeChange]);
+  useEffect(() => {
+    onDraggingChange?.(isDragging);
+  }, [isDragging, onDraggingChange]);
+
+  return (
+    <TimelineSlider
+      displayTime={displayTime}
+      duration={duration}
+      isDragging={isDragging}
+      isScrubbingMode={isScrubbingMode}
+      optimizedStep={optimizedStep}
+      onSliderChange={handleSliderChange}
+      onSliderChangeEnd={handleSliderChangeEnd}
+      onSliderChangeStart={handleSliderChangeStart}
+      markers={markers}
+      onMarkerClick={onMarkerClick}
+      replayContext={replayContext}
+      loopStart={loopStart}
+      loopEnd={loopEnd}
+      onClearLoop={onClearLoop}
+      density={density}
+      timeRef={timeRef}
+      // Show the rAF overlay (and hide the MUI thumb/track) whenever playback is running; the MUI
+      // thumb returns for paused inspection and dragging.
+      livePlayhead={isPlaying && !isDragging}
+    />
+  );
+};
+
+export const LiveScrubRail = React.memo(LiveScrubRailComponent);

--- a/src/features/fight_replay/components/LiveTrialStrip.tsx
+++ b/src/features/fight_replay/components/LiveTrialStrip.tsx
@@ -1,0 +1,59 @@
+/**
+ * LiveTrialStrip
+ *
+ * The trial mini-map (whole-run scrub strip) wrapped in a COARSE live-time subscription so its
+ * playhead advances without re-rendering the surrounding (memoized) transport every tick.
+ *
+ * The whole-run playhead moves very slowly — a 2-minute fight is a small fraction of a multi-fight
+ * run — so it only needs a few updates per second. Sampling `timeRef` at ~4Hz here keeps the heavy
+ * strip off the per-frame render path entirely (the desktop transport memoizes around it), while the
+ * fast per-fight scrub thumb is handled separately by LiveScrubRail at ~20Hz.
+ *
+ * @module LiveTrialStrip
+ */
+
+import React from 'react';
+
+import { useSampledTime } from '../hooks/useSampledTime';
+import type { TrialTimeline as TrialTimelineModel } from '../trial_chapters/trialTimeline';
+
+import { TrialTimeline, type TrialTimelineSeekTarget } from './TrialTimeline';
+
+// The whole-run playhead crawls — ~4Hz is already far more than the eye needs and keeps the heavy
+// strip's re-render cost negligible on slow devices.
+const STRIP_THROTTLE_MS = 250;
+
+interface LiveTrialStripProps {
+  timeRef?: React.RefObject<number> | { current: number };
+  timeline: TrialTimelineModel;
+  currentFightId: string | undefined;
+  currentFightStartTime?: number;
+  onSeek: (target: TrialTimelineSeekTarget) => void;
+  onDraggingChange?: (dragging: boolean) => void;
+  variant?: 'deck' | 'sheet';
+}
+
+const LiveTrialStripComponent: React.FC<LiveTrialStripProps> = ({
+  timeRef,
+  timeline,
+  currentFightId,
+  currentFightStartTime,
+  onSeek,
+  onDraggingChange,
+  variant,
+}) => {
+  const liveMs = useSampledTime(timeRef, STRIP_THROTTLE_MS);
+  return (
+    <TrialTimeline
+      timeline={timeline}
+      currentFightId={currentFightId}
+      currentFightStartTime={currentFightStartTime}
+      currentLocalMs={liveMs}
+      onSeek={onSeek}
+      onDraggingChange={onDraggingChange}
+      variant={variant}
+    />
+  );
+};
+
+export const LiveTrialStrip = React.memo(LiveTrialStripComponent);

--- a/src/features/fight_replay/components/PlaybackControls.tsx
+++ b/src/features/fight_replay/components/PlaybackControls.tsx
@@ -28,24 +28,22 @@ import {
 } from '@mui/material';
 import React from 'react';
 
-import { useOptimizedTimelineScrubbing } from '../../../hooks/useOptimizedTimelineScrubbing';
 import { usePrefersReducedMotion } from '../../../hooks/usePrefersReducedMotion';
 import { useTimelineMarkers } from '../../../hooks/useTimelineMarkers';
-import {
-  TRANSPORT_SPACING,
-  TRANSPORT_MOTION,
-  transportSurface,
-  transportHairline,
-} from '../constants/replayDesign';
+import { TRANSPORT_SPACING, TRANSPORT_MOTION, transportSurface } from '../constants/replayDesign';
 import type { TrialTimeline as TrialTimelineModel } from '../trial_chapters/trialTimeline';
 import type { TrialChapter } from '../trial_chapters/types';
 
 import { ChaptersPopoverButton } from './ChaptersPopoverButton';
+import { LiveScrubRail } from './LiveScrubRail';
+import { LiveTrialStrip } from './LiveTrialStrip';
 import { PlaybackButtons } from './PlaybackButtons';
+import { ProgressHairline } from './ProgressHairline';
 import { ShareButton } from './ShareButton';
 import { SpeedSelector } from './SpeedSelector';
-import { ContextBadge, LoopChip, TimelineSlider } from './TimelineSlider';
-import { TrialTimeline, type TrialTimelineSeekTarget } from './TrialTimeline';
+import { ContextBadge, LoopChip } from './TimelineSlider';
+import { TimeReadout } from './TimeReadout';
+import { type TrialTimelineSeekTarget } from './TrialTimeline';
 
 /**
  * The trial-run bundle the deck needs to render the whole-run layer: the
@@ -84,7 +82,6 @@ export interface TransportTrial {
 }
 
 interface PlaybackControlsProps {
-  currentTime: number;
   duration: number;
   isPlaying: boolean;
   playbackSpeed: number;
@@ -129,8 +126,6 @@ interface PlaybackControlsProps {
   barVisible?: boolean;
   /** Toggle the bar collapsed/shown (the chevron + restore caret; mirrors the C key). */
   onToggleCollapse?: () => void;
-  /** Fraction elapsed (0–100) for the progress hairline shown while the bar is hidden. */
-  progressPct?: number;
   /**
    * Mobile layout: collapses the control row to the essentials (timecode · play cluster · more)
    * and tucks Speed + Share behind a "more" toggle, so the transport stays uncluttered on a phone.
@@ -162,8 +157,7 @@ const formatTime = (timeMs: number): string => {
  * - Timeline slider with scrubbing support
  * - Control row: timecode/outcome/speed · transport + boss skip · trial toggles/share
  */
-export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
-  currentTime,
+const PlaybackControlsComponent: React.FC<PlaybackControlsProps> = ({
   duration,
   isPlaying,
   playbackSpeed,
@@ -190,7 +184,6 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
   isFullscreen = false,
   barVisible = true,
   onToggleCollapse,
-  progressPct = 0,
   isMobile = false,
   trial,
 }) => {
@@ -211,24 +204,6 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
     return undefined;
   }, [moreOpen]);
 
-  // Use optimized timeline scrubbing for better performance
-  const {
-    displayTime,
-    isDragging,
-    isScrubbingMode,
-    handleSliderChange,
-    handleSliderChangeStart,
-    handleSliderChangeEnd,
-    optimizedStep,
-  } = useOptimizedTimelineScrubbing({
-    duration,
-    currentTime,
-    onTimeChange,
-    isPlaying,
-    onPlayingChange,
-    timeRef,
-  });
-
   // Get timeline markers (phase transitions, death events)
   const { markers } = useTimelineMarkers();
 
@@ -247,15 +222,6 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
     },
     [onTimeChange],
   );
-
-  // Notify parent components about scrubbing mode changes
-  React.useEffect(() => {
-    onScrubbingModeChange?.(isScrubbingMode);
-  }, [isScrubbingMode, onScrubbingModeChange]);
-
-  React.useEffect(() => {
-    onDraggingChange?.(isDragging);
-  }, [isDragging, onDraggingChange]);
 
   const prefersReducedMotion = usePrefersReducedMotion();
 
@@ -284,8 +250,9 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
 
   return (
     <Box sx={{ position: 'relative' }}>
-      {/* Progress hairline — only while the fullscreen bar is hidden, so position stays legible. */}
-      {hidden && <Box sx={(t) => transportHairline(t, progressPct)} aria-hidden />}
+      {/* Progress hairline — only while the fullscreen bar is hidden, so position stays legible.
+          rAF-driven (reads timeRef directly) so it never re-renders this transport per tick. */}
+      {hidden && <ProgressHairline timeRef={timeRef} duration={duration} />}
       {/* Restore caret sitting on the hairline — a REAL focusable button so keyboard/AT users can
           bring the bar back without depending on pointer-move reveal. */}
       {hidden && onToggleCollapse && (
@@ -334,27 +301,28 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
         {/* Row 0: trial mini-map — the whole run as one gapless strip, flush above the fight
             rail so the two playheads share one x-axis and read as one system. */}
         {showTrialStrip && trial && (
-          <TrialTimeline
+          <LiveTrialStrip
+            timeRef={timeRef}
             timeline={trial.timeline}
             currentFightId={trial.currentFightId}
             currentFightStartTime={trial.currentFightStartTime}
-            currentLocalMs={displayTime}
             onSeek={trial.onSeek}
             onDraggingChange={trial.onDraggingChange}
             variant="deck"
           />
         )}
 
-        {/* Row 1: scrub rail — full width, the primary control. density="compact" = rail only. */}
-        <TimelineSlider
-          displayTime={displayTime}
+        {/* Row 1: scrub rail — full width, the primary control. density="compact" = rail only.
+            LiveScrubRail owns the high-frequency playhead subscription so only it (not this whole
+            transport) re-renders as playback advances. */}
+        <LiveScrubRail
+          timeRef={timeRef}
           duration={duration}
-          isDragging={isDragging}
-          isScrubbingMode={isScrubbingMode}
-          optimizedStep={optimizedStep}
-          onSliderChange={handleSliderChange}
-          onSliderChangeEnd={handleSliderChangeEnd}
-          onSliderChangeStart={handleSliderChangeStart}
+          isPlaying={isPlaying}
+          onTimeChange={onTimeChange}
+          onPlayingChange={onPlayingChange}
+          onScrubbingModeChange={onScrubbingModeChange}
+          onDraggingChange={onDraggingChange}
           markers={railMarkers}
           onMarkerClick={handleMarkerClick}
           replayContext={replayContext}
@@ -396,12 +364,16 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
                 flexShrink: 0,
                 fontFamily: 'Space Grotesk, Inter, system-ui',
                 fontVariantNumeric: 'tabular-nums',
-                color: isScrubbingMode || isDragging ? 'info.main' : 'text.primary',
+                color: 'text.primary',
               }}
             >
-              <Box component="span" sx={{ fontSize: '1rem', fontWeight: 600 }}>
-                {formatTime(displayTime)}
-              </Box>
+              {/* Live timecode — rAF-driven from timeRef, so it stays smooth without re-rendering
+                  the transport every tick. */}
+              <TimeReadout
+                timeRef={timeRef}
+                format={formatTime}
+                sx={{ fontSize: '1rem', fontWeight: 600 }}
+              />
               <Box
                 component="span"
                 className="transport-total-time"
@@ -575,7 +547,6 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
               <ShareButton
                 reportId={reportId}
                 fightId={fightId}
-                currentTime={currentTime}
                 selectedActorIdRef={selectedActorIdRef}
                 timeRef={timeRef}
               />
@@ -648,7 +619,6 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
             <ShareButton
               reportId={reportId}
               fightId={fightId}
-              currentTime={currentTime}
               selectedActorIdRef={selectedActorIdRef}
               timeRef={timeRef}
             />
@@ -661,3 +631,12 @@ export const PlaybackControls: React.FC<PlaybackControlsProps> = ({
     </Box>
   );
 };
+
+/**
+ * Memoized so the transport bar (trial mini-map, event markers, control row, buttons) does NOT
+ * re-render as playback advances. The live playhead is owned by LiveScrubRail + TimeReadout +
+ * ProgressHairline (each reads `timeRef` on its own rAF), so none of PlaybackControls' props change
+ * per tick — the parent (FightReplay3D) only re-renders on coarse state (≤4Hz, end-of-fight gates),
+ * and the memo holds across it. This is the core of the low-power fps fix.
+ */
+export const PlaybackControls = React.memo(PlaybackControlsComponent);

--- a/src/features/fight_replay/components/ProgressHairline.tsx
+++ b/src/features/fight_replay/components/ProgressHairline.tsx
@@ -1,0 +1,76 @@
+/**
+ * ProgressHairline
+ *
+ * The thin elapsed-progress line shown while the transport bar is auto-hidden (fullscreen cinema
+ * mode + the mobile restore handle). It reads the high-frequency playback `timeRef` on its own rAF
+ * and updates ONLY a child fill element's width via direct DOM writes — no React state — so the
+ * playhead stays legible while the bar is hidden without re-rendering any transport chrome per tick.
+ * (Replaces passing a per-tick `progressPct` prop down, which would defeat the transport's memo.)
+ *
+ * Visually equivalent to the `transportHairline` token: a brand cyan→magenta fill up to the
+ * playhead over a faint primary remainder.
+ *
+ * @module ProgressHairline
+ */
+
+import { Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import React, { useEffect, useRef } from 'react';
+
+import { HAIRLINE_H } from '../constants/replayDesign';
+
+interface ProgressHairlineProps {
+  /** High-frequency playhead (ms into the fight). */
+  timeRef?: React.RefObject<number> | { current: number };
+  /** Total fight duration (ms). */
+  duration: number;
+}
+
+export const ProgressHairline: React.FC<ProgressHairlineProps> = ({ timeRef, duration }) => {
+  const fillRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let raf = 0;
+    let lastPct = -1;
+    const tick = (): void => {
+      const el = fillRef.current;
+      if (el && duration > 0) {
+        const pct = Math.max(0, Math.min(100, ((timeRef?.current ?? 0) / duration) * 100));
+        // Round to 0.1% so we only touch the DOM on a visible change (a paused scene is free).
+        const rounded = Math.round(pct * 10) / 10;
+        if (rounded !== lastPct) {
+          lastPct = rounded;
+          el.style.width = `${rounded}%`;
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [timeRef, duration]);
+
+  return (
+    <Box
+      aria-hidden
+      sx={(theme) => ({
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: `${HAIRLINE_H}px`,
+        backgroundColor: alpha(theme.palette.primary.main, 0.18),
+        pointerEvents: 'none',
+        overflow: 'hidden',
+      })}
+    >
+      <Box
+        ref={fillRef}
+        sx={(theme) => ({
+          height: '100%',
+          width: '0%',
+          background: `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+        })}
+      />
+    </Box>
+  );
+};

--- a/src/features/fight_replay/components/QualityGovernor.tsx
+++ b/src/features/fight_replay/components/QualityGovernor.tsx
@@ -117,7 +117,15 @@ export const QualityGovernor: React.FC<QualityGovernorProps> = ({
   }, []);
 
   useFrame((_state, delta) => {
-    if (disabled) return;
+    if (disabled) {
+      // Stand down AND drop any pending pause-restore: when the user enters manual performance mode
+      // or forces full quality, the parent resets autoQualityLevel — a level we had latched in
+      // playbackLevelRef must not be reapplied on the next advancing frame and contradict that reset.
+      playbackLevelRef.current = null;
+      framesSinceAdvanceRef.current = 0;
+      samplesRef.current.length = 0;
+      return;
+    }
 
     const ms = delta * 1000;
     const t = timeRef.current;

--- a/src/features/fight_replay/components/QualityGovernor.tsx
+++ b/src/features/fight_replay/components/QualityGovernor.tsx
@@ -1,0 +1,143 @@
+import { useFrame, useThree } from '@react-three/fiber';
+import React, { useEffect, useRef } from 'react';
+
+import { RenderPriority } from '../constants/renderPriorities';
+import { computeTargetMs, estimateDisplayIntervalMs } from '../utils/adaptiveResolution';
+import { decideNextQualityLevel, QUALITY_LEVEL } from '../utils/qualityGovernor';
+
+// The controller currently escalates only as far as dropping shadows (the effect ladder). The
+// FRAME_CAP rung is defined in qualityGovernor for a follow-up — it needs the on-demand RenderLoop
+// (and ideally the per-frame actor update) gated to the cap to actually buy framerate, which is a
+// riskier change to the load-bearing render gate. Until then the auto-governor stops at NO_SHADOWS.
+const AUTO_MAX_LEVEL = QUALITY_LEVEL.NO_SHADOWS;
+
+interface QualityGovernorProps {
+  /** Live playhead — only frames where this advanced are measured as real playback workload. */
+  timeRef: React.RefObject<number> | { current: number };
+  /** The perf-tier render-resolution cap (mirrors AdaptiveResolution) — used to know DPR's floor. */
+  dprCap: number;
+  /** True when RenderLoop painted the previous frame (idle vs rendered classification). */
+  paintedRef: React.RefObject<boolean>;
+  /** The governor's current quality level (owned by FightReplay3D so the scene + chip stay in sync). */
+  level: number;
+  /** Request a new quality level (escalate/recover one tier). */
+  onLevelChange: (level: number) => void;
+  /** When true the user forced full quality (chip) — the governor stands down entirely. */
+  disabled?: boolean;
+}
+
+// Mirror AdaptiveResolution's measurement constants; the ladder is a coarser, slower tier BELOW it,
+// so use a slightly longer window + cooldown — dropping a whole effect is far more visible than a
+// resolution nudge, so we only do it on a clearly sustained shortfall and let each change settle.
+const SAMPLE_WINDOW = 110;
+const COOLDOWN_FRAMES = 180;
+const MAX_PLAUSIBLE_FRAME_MS = 250;
+const IDLE_WINDOW = 60;
+const DPR_EPSILON = 0.02;
+
+/**
+ * Adaptive quality governor — the tier below AdaptiveResolution. Measures the real playback frame
+ * time and, when a weak / throttled GPU stays below target AFTER resolution scaling is exhausted,
+ * steps an effect ladder down (bloom → IBL/cosmic → shadows → frame cap) and back up as headroom
+ * returns. Renders nothing; owns no React state (the level lives in FightReplay3D so the scene reads
+ * it). See utils/qualityGovernor for the pure hysteresis. Inert on capable hardware — if DPR never
+ * hits its floor (there was headroom), the escalate path never fires and quality stays full.
+ */
+export const QualityGovernor: React.FC<QualityGovernorProps> = ({
+  timeRef,
+  dprCap,
+  paintedRef,
+  level,
+  onLevelChange,
+  disabled = false,
+}) => {
+  const gl = useThree((s) => s.gl);
+
+  const deviceDpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  const maxDpr = Math.min(Math.max(1, deviceDpr), dprCap);
+
+  const samplesRef = useRef<number[]>([]);
+  // No initial cooldown — the SAMPLE_WINDOW itself enforces "sustained", so the first decision lands
+  // after one window (~5–8s on a struggling device). The cooldown only spaces out SUBSEQUENT steps.
+  const cooldownRef = useRef(0);
+  const lastTimeRef = useRef<number | null>(null);
+  const idleSamplesRef = useRef<number[]>([]);
+  // Read the latest requested level synchronously in the frame loop without it being a hook dep.
+  const levelRef = useRef(level);
+  levelRef.current = level;
+
+  // Re-learn the display interval after a resize / visibility flip (same rationale as AdaptiveResolution).
+  useEffect(() => {
+    const reset = (): void => {
+      idleSamplesRef.current.length = 0;
+    };
+    window.addEventListener('resize', reset);
+    document.addEventListener('visibilitychange', reset);
+    return () => {
+      window.removeEventListener('resize', reset);
+      document.removeEventListener('visibilitychange', reset);
+    };
+  }, []);
+
+  useFrame((_state, delta) => {
+    if (disabled) return;
+
+    const ms = delta * 1000;
+    const t = timeRef.current;
+    const advanced = t !== lastTimeRef.current;
+    lastTimeRef.current = t;
+
+    if (!paintedRef.current) {
+      // Idle (un-painted, vsync-paced) frame → a clean display-interval sample.
+      if (ms > 0 && ms < MAX_PLAUSIBLE_FRAME_MS) {
+        const idle = idleSamplesRef.current;
+        idle.push(ms);
+        if (idle.length > IDLE_WINDOW) idle.shift();
+      }
+      return;
+    }
+    // Painted but the playhead didn't advance (paused while following/selected) → not playback workload.
+    if (!advanced) return;
+    if (ms <= 0 || ms > MAX_PLAUSIBLE_FRAME_MS) return;
+
+    const samples = samplesRef.current;
+    samples.push(ms);
+    if (samples.length > SAMPLE_WINDOW) samples.shift();
+
+    if (cooldownRef.current > 0) {
+      cooldownRef.current -= 1;
+      return;
+    }
+    if (samples.length < SAMPLE_WINDOW) return;
+
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) sum += samples[i];
+    const avg = sum / samples.length;
+
+    const displayInterval = estimateDisplayIntervalMs(idleSamplesRef.current);
+    const targetMs = computeTargetMs(displayInterval);
+    // "DPR exhausted" = AdaptiveResolution has already pulled the pixel ratio BELOW full (resolution
+    // scaling has engaged) and we're STILL slow — so the remaining cost is pass-count / per-frame
+    // work that more resolution scaling won't fix (either DPR is at floor, or its effectiveness guard
+    // stopped it above floor because the bottleneck isn't pixel fill). Either way, trading an effect
+    // is the right next move. On a capable machine DPR stays at full → this is false → governor inert.
+    // Read the live ratio so we stay decoupled from AdaptiveResolution's internals; the governor's
+    // longer window + cooldown ensure DPR has had its chance first.
+    const dprExhausted = gl.getPixelRatio() < maxDpr - DPR_EPSILON;
+
+    const next = decideNextQualityLevel(avg, levelRef.current, {
+      maxLevel: AUTO_MAX_LEVEL,
+      targetMs,
+      displayIntervalMs: displayInterval,
+      dprExhausted,
+    });
+    if (next == null || next === levelRef.current) return;
+
+    onLevelChange(next);
+    levelRef.current = next; // optimistic — avoids re-firing the same step before the prop round-trips
+    samples.length = 0;
+    cooldownRef.current = COOLDOWN_FRAMES;
+  }, RenderPriority.EFFECTS);
+
+  return null;
+};

--- a/src/features/fight_replay/components/QualityGovernor.tsx
+++ b/src/features/fight_replay/components/QualityGovernor.tsx
@@ -1,4 +1,4 @@
-import { useFrame, useThree } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
 import React, { useEffect, useRef } from 'react';
 
 import { RenderPriority } from '../constants/renderPriorities';
@@ -14,8 +14,13 @@ const AUTO_MAX_LEVEL = QUALITY_LEVEL.NO_SHADOWS;
 interface QualityGovernorProps {
   /** Live playhead — only frames where this advanced are measured as real playback workload. */
   timeRef: React.RefObject<number> | { current: number };
-  /** The perf-tier render-resolution cap (mirrors AdaptiveResolution) — used to know DPR's floor. */
-  dprCap: number;
+  /**
+   * AdaptiveResolution's exhaustion status (written by it): true once DPR is at its floor OR its
+   * effectiveness guard has fired. The governor only escalates effects when this is true, so
+   * resolution scaling always gets the first crack at a shortfall (no premature effect loss after a
+   * single DPR step).
+   */
+  dprExhaustedRef: React.RefObject<boolean>;
   /** True when RenderLoop painted the previous frame (idle vs rendered classification). */
   paintedRef: React.RefObject<boolean>;
   /** The governor's current quality level (owned by FightReplay3D so the scene + chip stay in sync). */
@@ -33,7 +38,6 @@ const SAMPLE_WINDOW = 110;
 const COOLDOWN_FRAMES = 180;
 const MAX_PLAUSIBLE_FRAME_MS = 250;
 const IDLE_WINDOW = 60;
-const DPR_EPSILON = 0.02;
 // Bootstrap only accepts mount-time deltas this fast or faster (~105Hz+) as a refresh sample — same
 // rationale as AdaptiveResolution: such a delta proves a >=~120Hz display, so targeting 120 is
 // meaningful, whereas a slower mount delta is ambiguous (true 60Hz vs load-contaminated).
@@ -49,17 +53,12 @@ const BOOTSTRAP_MAX_REFRESH_MS = 1000 / 120 + 1.2; // ≈ 9.5ms
  */
 export const QualityGovernor: React.FC<QualityGovernorProps> = ({
   timeRef,
-  dprCap,
+  dprExhaustedRef,
   paintedRef,
   level,
   onLevelChange,
   disabled = false,
 }) => {
-  const gl = useThree((s) => s.gl);
-
-  const deviceDpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
-  const maxDpr = Math.min(Math.max(1, deviceDpr), dprCap);
-
   const samplesRef = useRef<number[]>([]);
   // No initial cooldown — the SAMPLE_WINDOW itself enforces "sustained", so the first decision lands
   // after one window (~5–8s on a struggling device). The cooldown only spaces out SUBSEQUENT steps.
@@ -145,14 +144,11 @@ export const QualityGovernor: React.FC<QualityGovernorProps> = ({
 
     const displayInterval = estimateDisplayIntervalMs(idleSamplesRef.current);
     const targetMs = computeTargetMs(displayInterval);
-    // "DPR exhausted" = AdaptiveResolution has already pulled the pixel ratio BELOW full (resolution
-    // scaling has engaged) and we're STILL slow — so the remaining cost is pass-count / per-frame
-    // work that more resolution scaling won't fix (either DPR is at floor, or its effectiveness guard
-    // stopped it above floor because the bottleneck isn't pixel fill). Either way, trading an effect
-    // is the right next move. On a capable machine DPR stays at full → this is false → governor inert.
-    // Read the live ratio so we stay decoupled from AdaptiveResolution's internals; the governor's
-    // longer window + cooldown ensure DPR has had its chance first.
-    const dprExhausted = gl.getPixelRatio() < maxDpr - DPR_EPSILON;
+    // Escalate effects only once AdaptiveResolution reports DPR EXHAUSTED — at its floor, or its
+    // effectiveness guard has fired (lowering DPR stopped buying framerate because the bottleneck
+    // isn't pixel fill). This guarantees resolution scaling fully runs its course before we drop a
+    // visible effect. On a capable machine DPR never exhausts → this stays false → governor inert.
+    const dprExhausted = dprExhaustedRef.current === true;
 
     const next = decideNextQualityLevel(avg, levelRef.current, {
       maxLevel: AUTO_MAX_LEVEL,

--- a/src/features/fight_replay/components/QualityGovernor.tsx
+++ b/src/features/fight_replay/components/QualityGovernor.tsx
@@ -34,6 +34,10 @@ const COOLDOWN_FRAMES = 180;
 const MAX_PLAUSIBLE_FRAME_MS = 250;
 const IDLE_WINDOW = 60;
 const DPR_EPSILON = 0.02;
+// Bootstrap only accepts mount-time deltas this fast or faster (~105Hz+) as a refresh sample — same
+// rationale as AdaptiveResolution: such a delta proves a >=~120Hz display, so targeting 120 is
+// meaningful, whereas a slower mount delta is ambiguous (true 60Hz vs load-contaminated).
+const BOOTSTRAP_MAX_REFRESH_MS = 1000 / 120 + 1.2; // ≈ 9.5ms
 
 /**
  * Adaptive quality governor — the tier below AdaptiveResolution. Measures the real playback frame
@@ -77,6 +81,31 @@ export const QualityGovernor: React.FC<QualityGovernorProps> = ({
       window.removeEventListener('resize', reset);
       document.removeEventListener('visibilitychange', reset);
     };
+  }, []);
+
+  // Bootstrap the refresh estimate with a short mount rAF burst (mirrors AdaptiveResolution). The
+  // frame loop only learns the interval from UN-painted frames, but a session that goes straight into
+  // uninterrupted playback (forced-autoplay / continuous deep link) never produces one — paintedRef
+  // is true every frame while playing — so without a seed the governor would fall back to the lenient
+  // absolute 20ms (<50fps) bar and never engage on the 120/144Hz weak-GPU band (12–19ms) it targets.
+  // Only seed deltas at/below the 120fps cadence (a slower mount delta is ambiguous, see constant).
+  useEffect(() => {
+    let raf = 0;
+    let count = 0;
+    let last = performance.now();
+    const tick = (now: number): void => {
+      const d = now - last;
+      last = now;
+      if (d >= 3 && d <= BOOTSTRAP_MAX_REFRESH_MS) {
+        const idle = idleSamplesRef.current;
+        idle.push(d);
+        if (idle.length > IDLE_WINDOW) idle.shift();
+      }
+      count += 1;
+      if (count < 40) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   useFrame((_state, delta) => {

--- a/src/features/fight_replay/components/QualityGovernor.tsx
+++ b/src/features/fight_replay/components/QualityGovernor.tsx
@@ -38,6 +38,11 @@ const SAMPLE_WINDOW = 110;
 const COOLDOWN_FRAMES = 180;
 const MAX_PLAUSIBLE_FRAME_MS = 250;
 const IDLE_WINDOW = 60;
+// Consecutive non-advancing frames after which a degraded scene is treated as PAUSED and restored to
+// full effects (mirrors AdaptiveResolution's pause-restore). A static scene has no frame pressure, so
+// paused / end-of-fight inspection + screenshots should be full quality; the playback level is
+// remembered and snapped back on resume so a weak device doesn't re-escalate from scratch.
+const PAUSE_RESTORE_FRAMES = 12;
 // Bootstrap only accepts mount-time deltas this fast or faster (~105Hz+) as a refresh sample — same
 // rationale as AdaptiveResolution: such a delta proves a >=~120Hz display, so targeting 120 is
 // meaningful, whereas a slower mount delta is ambiguous (true 60Hz vs load-contaminated).
@@ -65,6 +70,10 @@ export const QualityGovernor: React.FC<QualityGovernorProps> = ({
   const cooldownRef = useRef(0);
   const lastTimeRef = useRef<number | null>(null);
   const idleSamplesRef = useRef<number[]>([]);
+  // Consecutive frames the playhead has not advanced (settled-pause detector).
+  const framesSinceAdvanceRef = useRef(0);
+  // The degraded level to snap back to on RESUME after a pause restored full effects (null = none).
+  const playbackLevelRef = useRef<number | null>(null);
   // Read the latest requested level synchronously in the frame loop without it being a hook dep.
   const levelRef = useRef(level);
   levelRef.current = level;
@@ -114,6 +123,35 @@ export const QualityGovernor: React.FC<QualityGovernorProps> = ({
     const t = timeRef.current;
     const advanced = t !== lastTimeRef.current;
     lastTimeRef.current = t;
+
+    // Pause-restore (mirrors AdaptiveResolution). A settled pause / end-of-fight has no frame
+    // pressure, so restore full effects for inspection + screenshots; remember the degraded playback
+    // level and snap straight back to it on resume so a weak device doesn't re-escalate from scratch.
+    if (advanced) {
+      framesSinceAdvanceRef.current = 0;
+      if (playbackLevelRef.current != null) {
+        const resume = playbackLevelRef.current;
+        playbackLevelRef.current = null;
+        if (resume !== levelRef.current) {
+          onLevelChange(resume);
+          levelRef.current = resume;
+        }
+        samplesRef.current.length = 0;
+        cooldownRef.current = COOLDOWN_FRAMES;
+      }
+    } else {
+      framesSinceAdvanceRef.current += 1;
+      if (
+        framesSinceAdvanceRef.current >= PAUSE_RESTORE_FRAMES &&
+        levelRef.current > 0 &&
+        playbackLevelRef.current == null
+      ) {
+        playbackLevelRef.current = levelRef.current;
+        onLevelChange(0);
+        levelRef.current = 0;
+        samplesRef.current.length = 0;
+      }
+    }
 
     if (!paintedRef.current) {
       // Idle (un-painted, vsync-paced) frame → a clean display-interval sample.

--- a/src/features/fight_replay/components/RailPlayhead.tsx
+++ b/src/features/fight_replay/components/RailPlayhead.tsx
@@ -1,0 +1,107 @@
+/**
+ * RailPlayhead
+ *
+ * The live playback playhead (progress fill + thumb) drawn over the scrub rail and updated by its
+ * OWN requestAnimationFrame via DIRECT DOM writes (style.width / style.left) — never through React
+ * or MUI.
+ *
+ * WHY (the low-power fps fix, confirmed by profiling): driving the playhead through the MUI Slider's
+ * `value` meant every playback tick re-rendered the Slider, and MUI/emotion re-serialized styles and
+ * called `insertRule` — which invalidates the document stylesheet and forces a full style recalc
+ * (`UpdateLayoutTree` was the single largest cost in a throttled trace, with `insertRule` + emotion
+ * close behind). On a slow / power-constrained device that style-recalc storm — NOT the 3D scene —
+ * is what collapsed playback to single-digit fps. Writing `style.left`/`style.width` on two plain
+ * divs touches only those elements (no new CSS rules, no global invalidation), so the playhead stays
+ * perfectly smooth at ~zero cost. The MUI Slider stays mounted underneath for interaction (drag /
+ * click-seek / keyboard / a11y); its thumb + track are hidden while this overlay is live so there's
+ * only ever one visible playhead.
+ *
+ * @module RailPlayhead
+ */
+
+import { Box } from '@mui/material';
+import React, { useEffect, useRef } from 'react';
+
+interface RailPlayheadProps {
+  /** High-frequency playhead (ms into the fight). */
+  timeRef?: React.RefObject<number> | { current: number };
+  /** Total fight duration (ms). */
+  duration: number;
+  /** When false the overlay is hidden (the MUI thumb takes over for paused inspection / dragging). */
+  visible: boolean;
+}
+
+export const RailPlayhead: React.FC<RailPlayheadProps> = ({ timeRef, duration, visible }) => {
+  const fillRef = useRef<HTMLDivElement>(null);
+  const thumbRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    let raf = 0;
+    let lastPct = -1;
+    const tick = (): void => {
+      const fill = fillRef.current;
+      const thumb = thumbRef.current;
+      if (fill && thumb && duration > 0) {
+        const pct = Math.max(0, Math.min(100, ((timeRef?.current ?? 0) / duration) * 100));
+        const rounded = Math.round(pct * 100) / 100; // 0.01% — only write on a visible change
+        if (rounded !== lastPct) {
+          lastPct = rounded;
+          fill.style.width = `${rounded}%`;
+          thumb.style.left = `${rounded}%`;
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [timeRef, duration, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        height: 6,
+        pointerEvents: 'none',
+        zIndex: 1,
+      }}
+    >
+      {/* Progress fill — matches the MUI track gradient + glow. */}
+      <Box
+        ref={fillRef}
+        sx={(theme) => ({
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: '0%',
+          borderRadius: 3,
+          backgroundImage: `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+          boxShadow: `0 0 14px ${theme.palette.primary.main}99`,
+        })}
+      />
+      {/* Thumb — matches the MUI thumb (white dot + cyan halo). */}
+      <Box
+        ref={thumbRef}
+        sx={(theme) => ({
+          position: 'absolute',
+          left: '0%',
+          top: '50%',
+          width: 16,
+          height: 16,
+          transform: 'translate(-50%, -50%)',
+          borderRadius: '50%',
+          backgroundColor: '#fff',
+          boxShadow: `0 0 0 5px ${theme.palette.primary.main}40, 0 2px 6px rgba(0,0,0,0.5)`,
+        })}
+      />
+    </Box>
+  );
+};

--- a/src/features/fight_replay/components/ShareButton.tsx
+++ b/src/features/fight_replay/components/ShareButton.tsx
@@ -19,11 +19,16 @@ interface ShareButtonProps {
   reportId?: string;
   /** Fight ID for URL generation */
   fightId?: string;
-  /** Current playback time in milliseconds */
-  currentTime: number;
+  /**
+   * Fallback playback time (ms) for the share URL. Optional — the live `timeRef` is preferred and is
+   * always supplied by the transport; this is only used if no ref is available. Kept off the
+   * per-tick render path so the share button (and its memoized transport) doesn't reconcile on
+   * every playback frame.
+   */
+  currentTime?: number;
   /** Optional ref to actor ID for URL generation */
   selectedActorIdRef?: React.RefObject<number | null>;
-  /** Optional ref to current time for more accurate sharing */
+  /** Optional ref to current time for more accurate sharing (the authoritative source). */
   timeRef?: React.RefObject<number> | { current: number };
 }
 
@@ -41,7 +46,7 @@ interface ShareButtonProps {
 export const ShareButton: React.FC<ShareButtonProps> = ({
   reportId,
   fightId,
-  currentTime,
+  currentTime = 0,
   selectedActorIdRef,
   timeRef,
 }) => {

--- a/src/features/fight_replay/components/TimeReadout.tsx
+++ b/src/features/fight_replay/components/TimeReadout.tsx
@@ -1,0 +1,73 @@
+/**
+ * TimeReadout
+ *
+ * A self-updating timecode `<span>` that reads the high-frequency playback `timeRef` on its OWN
+ * requestAnimationFrame loop and writes the formatted time straight to the DOM (textContent) —
+ * NEVER through React state. This is the same "rAF + direct DOM write" pattern the boss-health and
+ * locked-player-stats panels use, and it exists for the same reason: syncing the playhead through
+ * React state forced the entire transport subtree to re-render on every tick, and on a slow / power-
+ * constrained device (where a frame can exceed the ~100ms state-sync gate) that re-render fired
+ * EVERY frame and spiralled playback down to single-digit fps. Reading the ref here keeps the
+ * timecode perfectly live with zero per-tick React work.
+ *
+ * The rAF only touches the DOM when the formatted string actually changes (≈ once per second), so a
+ * paused scene costs nothing.
+ *
+ * @module TimeReadout
+ */
+
+import { Box } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import React, { useEffect, useRef } from 'react';
+
+const defaultFormat = (timeMs: number): string => {
+  const totalSeconds = Math.floor(Math.max(0, timeMs) / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};
+
+interface TimeReadoutProps {
+  /** High-frequency playhead (ms into the fight). Read every frame; never re-renders this component. */
+  timeRef?: React.RefObject<number> | { current: number };
+  /** ms → label. Defaults to m:ss. */
+  format?: (timeMs: number) => string;
+  sx?: SxProps<Theme>;
+  className?: string;
+}
+
+export const TimeReadout: React.FC<TimeReadoutProps> = ({
+  timeRef,
+  format = defaultFormat,
+  sx,
+  className,
+}) => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  // Keep the formatter in a ref so changing it (parents pass inline fns) never re-subscribes the rAF.
+  const formatRef = useRef(format);
+  formatRef.current = format;
+
+  useEffect(() => {
+    let raf = 0;
+    let lastText = '';
+    const tick = (): void => {
+      const el = spanRef.current;
+      if (el) {
+        const next = formatRef.current(timeRef?.current ?? 0);
+        if (next !== lastText) {
+          lastText = next;
+          el.textContent = next;
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [timeRef]);
+
+  return (
+    <Box component="span" ref={spanRef} className={className} sx={sx}>
+      {format(timeRef?.current ?? 0)}
+    </Box>
+  );
+};

--- a/src/features/fight_replay/components/TimelineSlider.tsx
+++ b/src/features/fight_replay/components/TimelineSlider.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useRef } from 'react';
 import { TimelineAnnotation } from '../../../types/timelineAnnotations';
 import { TRANSPORT_MOTION } from '../constants/replayDesign';
 
+import { RailPlayhead } from './RailPlayhead';
 import { TimelineMarkers } from './TimelineMarkers';
 import { TimelineScrubPreview } from './TimelineScrubPreview';
 interface TimelineSliderProps {
@@ -61,6 +62,15 @@ interface TimelineSliderProps {
    * thing fits one ~80px transport row.
    */
   density?: 'compact' | 'expanded';
+  /**
+   * High-frequency playhead ref. When provided with `livePlayhead`, an rAF-driven DOM overlay
+   * (RailPlayhead) draws the live progress fill + thumb while the MUI thumb/track are hidden — so
+   * the playhead moves smoothly without re-rendering the MUI Slider every tick (which would re-run
+   * emotion's `insertRule` and force a global style recalc — the dominant low-power fps cost).
+   */
+  timeRef?: React.RefObject<number> | { current: number };
+  /** Show the rAF playhead overlay + hide the MUI thumb/track (true while playback is running). */
+  livePlayhead?: boolean;
 }
 
 /** Small pill badge for the transport's contextual read-outs (encounter, outcome, %). */
@@ -201,6 +211,8 @@ export const TimelineSlider: React.FC<TimelineSliderProps> = ({
   loopEnd = null,
   onClearLoop,
   density = 'expanded',
+  timeRef,
+  livePlayhead = false,
 }) => {
   const compact = density === 'compact';
   // The rail wrapper that the hover skim-preview tracks the cursor over. A ref (not a
@@ -356,6 +368,9 @@ export const TimelineSlider: React.FC<TimelineSliderProps> = ({
               width: isDragging ? 18 : 16,
               height: isDragging ? 18 : 16,
               backgroundColor: '#fff',
+              // While the rAF overlay is live (playback running), hide the MUI thumb so there's a
+              // single playhead — the overlay — and the Slider never has to re-render to move it.
+              ...(livePlayhead ? { opacity: 0 } : null),
               // White playhead with an always-on cyan halo ring + glow (the bold proto's
               // thumb), widening while dragging.
               border: 'none',
@@ -373,6 +388,8 @@ export const TimelineSlider: React.FC<TimelineSliderProps> = ({
             '& .MuiSlider-track': {
               height: isDragging ? 7 : 6,
               border: 'none',
+              // Hidden while the rAF overlay draws the live progress fill (see thumb note above).
+              ...(livePlayhead ? { opacity: 0 } : null),
               transition: `height ${TRANSPORT_MOTION.settle} ${TRANSPORT_MOTION.ease}`,
               // Progress fill: the brand cyan gradient with a glow when playing; a flat info
               // hue while scrubbing so the "dragging" state is unmistakable (non-text cue).
@@ -408,6 +425,12 @@ export const TimelineSlider: React.FC<TimelineSliderProps> = ({
             },
           })}
         />
+
+        {/* Live playback playhead — an rAF-driven DOM overlay (fill + thumb) shown while playback
+            runs, so the playhead moves without re-rendering the MUI Slider (which would re-run
+            emotion/insertRule + a global style recalc — the dominant low-power fps cost). The MUI
+            thumb/track are hidden (above) while this is visible, so there's one playhead. */}
+        <RailPlayhead timeRef={timeRef} duration={duration} visible={livePlayhead} />
 
         {/* A–B loop region — a shaded band between the in/out points, drawn UNDER the slider
             (zIndex 0, pointer-events none) so it tints the track without intercepting drags or

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.test.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.test.tsx
@@ -49,7 +49,6 @@ type DockProps = React.ComponentProps<typeof MobileReplayDock>;
 
 function renderDock(overrides: Partial<DockProps> = {}): void {
   const props: DockProps = {
-    currentTime: 0,
     duration: 10000,
     isPlaying: false,
     playbackSpeed: 1,

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
@@ -37,11 +37,12 @@ import type { ShapeKind, ShapeStyle } from '../../types/mapMarkers';
 import { ChapterList } from '../ChapterList';
 import type { TrialReplayNav } from '../FightReplay3D';
 import { LiveScrubRail } from '../LiveScrubRail';
+import { LiveTrialStrip } from '../LiveTrialStrip';
 import { PlaybackButtons } from '../PlaybackButtons';
 import { ShapeToolbar } from '../ShapeToolbar';
 import { ShareButton } from '../ShareButton';
 import { TimeReadout } from '../TimeReadout';
-import { TrialTimeline, type TrialTimelineSeekTarget } from '../TrialTimeline';
+import { type TrialTimelineSeekTarget } from '../TrialTimeline';
 
 import { MobileSheet } from './MobileSheet';
 
@@ -56,7 +57,6 @@ const formatTime = (ms: number): string => {
 
 interface MobileReplayDockProps {
   // Transport
-  currentTime: number;
   duration: number;
   isPlaying: boolean;
   playbackSpeed: number;
@@ -288,7 +288,6 @@ const MarkerActionButton: React.FC<{
 );
 
 const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
-  currentTime,
   duration,
   isPlaying,
   playbackSpeed,
@@ -605,13 +604,15 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
                 </Typography>
               )}
 
-              {/* Whole-run scrubber — the tall touch variant (≥44px interactive band). */}
+              {/* Whole-run scrubber — the tall touch variant (≥44px interactive band). Driven off
+                  timeRef (LiveTrialStrip) so it doesn't depend on the per-tick currentTime state —
+                  that lets the dock drop the currentTime prop and keep its React.memo during playback. */}
               <Box sx={{ mb: 1.5 }}>
-                <TrialTimeline
+                <LiveTrialStrip
+                  timeRef={timeRef}
                   timeline={trialNav.timeline}
                   currentFightId={trialNav.currentFightId}
                   currentFightStartTime={currentFightStartTime}
-                  currentLocalMs={currentTime}
                   onSeek={handleSheetTrialSeek}
                   variant="sheet"
                 />
@@ -751,9 +752,9 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
         )}
       </MobileSheet>
 
-      {/* Settings sheet — playback speed · display toggles · share. Body rendered only while open
-          (same reason as above: its ShareButton takes `currentTime`, so a mounted-but-closed sheet
-          reconciled at the playback tick). */}
+      {/* Settings sheet — playback speed · display toggles · share. Body rendered only while open so
+          a closed sheet doesn't reconcile its subtree. (ShareButton reads the live timeRef, not a
+          per-tick prop.) */}
       <MobileSheet
         open={sheet === 'settings'}
         title="Settings"

--- a/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
+++ b/src/features/fight_replay/components/mobile/MobileReplayDock.tsx
@@ -31,16 +31,16 @@ import { Box, Switch, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { useOptimizedTimelineScrubbing } from '../../../../hooks/useOptimizedTimelineScrubbing';
 import { useTimelineMarkers } from '../../../../hooks/useTimelineMarkers';
 import type { TrialChapter } from '../../trial_chapters/types';
 import type { ShapeKind, ShapeStyle } from '../../types/mapMarkers';
 import { ChapterList } from '../ChapterList';
 import type { TrialReplayNav } from '../FightReplay3D';
+import { LiveScrubRail } from '../LiveScrubRail';
 import { PlaybackButtons } from '../PlaybackButtons';
 import { ShapeToolbar } from '../ShapeToolbar';
 import { ShareButton } from '../ShareButton';
-import { TimelineSlider } from '../TimelineSlider';
+import { TimeReadout } from '../TimeReadout';
 import { TrialTimeline, type TrialTimelineSeekTarget } from '../TrialTimeline';
 
 import { MobileSheet } from './MobileSheet';
@@ -410,30 +410,6 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
   const noopStyleChange = useCallback(() => {}, []);
   const noopClearShapes = useCallback(() => {}, []);
 
-  const {
-    displayTime,
-    isDragging,
-    isScrubbingMode,
-    handleSliderChange,
-    handleSliderChangeStart,
-    handleSliderChangeEnd,
-    optimizedStep,
-  } = useOptimizedTimelineScrubbing({
-    duration,
-    currentTime,
-    onTimeChange,
-    isPlaying,
-    onPlayingChange,
-    timeRef,
-  });
-
-  useEffect(() => {
-    onScrubbingModeChange?.(isScrubbingMode);
-  }, [isScrubbingMode, onScrubbingModeChange]);
-  useEffect(() => {
-    onDraggingChange?.(isDragging);
-  }, [isDragging, onDraggingChange]);
-
   const { markers } = useTimelineMarkers();
   // Keep only the structural beats on the thin mobile rail (deaths reachable via clusters/chapters).
   const railMarkers = useMemo(
@@ -471,15 +447,14 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
         borderTop: `1px solid ${theme.palette.divider}`,
       })}
     >
-      <TimelineSlider
-        displayTime={displayTime}
+      <LiveScrubRail
+        timeRef={timeRef}
         duration={duration}
-        isDragging={isDragging}
-        isScrubbingMode={isScrubbingMode}
-        optimizedStep={optimizedStep}
-        onSliderChange={handleSliderChange}
-        onSliderChangeEnd={handleSliderChangeEnd}
-        onSliderChangeStart={handleSliderChangeStart}
+        isPlaying={isPlaying}
+        onTimeChange={onTimeChange}
+        onPlayingChange={onPlayingChange}
+        onScrubbingModeChange={onScrubbingModeChange}
+        onDraggingChange={onDraggingChange}
         markers={railMarkers}
         onMarkerClick={handleMarkerClick}
         density="compact"
@@ -511,17 +486,20 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
         }}
       >
         <Typography
+          component="div"
           sx={{
             fontFamily: 'Space Grotesk, Inter, system-ui',
             fontVariantNumeric: 'tabular-nums',
             fontSize: '0.8rem',
             fontWeight: 600,
-            color: isScrubbingMode || isDragging ? 'info.main' : 'text.primary',
+            color: 'text.primary',
             flex: '0 0 auto',
             whiteSpace: 'nowrap',
           }}
         >
-          {formatTime(displayTime)}
+          {/* Live timecode — rAF-driven from timeRef so it stays smooth without re-rendering the
+              dock every tick. */}
+          <TimeReadout timeRef={timeRef} format={formatTime} />
           <Box
             component="span"
             sx={{ color: 'text.secondary', fontWeight: 500, fontSize: '0.68rem' }}
@@ -929,7 +907,6 @@ const MobileReplayDockComponent: React.FC<MobileReplayDockProps> = ({
               <ShareButton
                 reportId={reportId}
                 fightId={fightId}
-                currentTime={currentTime}
                 selectedActorIdRef={selectedActorIdRef}
                 timeRef={timeRef}
               />

--- a/src/features/fight_replay/hooks/useSampledTime.ts
+++ b/src/features/fight_replay/hooks/useSampledTime.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Sample a high-frequency playback `timeRef` into React state at a CAPPED cadence, decoupled from
+ * the render frame rate.
+ *
+ * The replay's playhead lives in a mutable ref (advanced every frame by the playback loop) precisely
+ * so the 3D scene can read it without re-rendering React. UI that genuinely needs the value in render
+ * (an MUI slider's `value`, a trial mini-map's playhead fraction) uses this hook to pull it at a
+ * bounded rate — e.g. ~20Hz for the scrub thumb, ~4Hz for the slow whole-run strip. The cap is the
+ * point: a per-frame React sync was what spiralled playback to single-digit fps on slow devices
+ * (each frame > the sync gate re-rendered the transport, lengthening the frame, firing again). A
+ * fixed wall-clock interval can never collapse into that loop no matter how slow frames get.
+ *
+ * The rAF only setState's when the value actually changed, so a paused scene is free.
+ *
+ * @param timeRef high-frequency playhead (ms)
+ * @param intervalMs minimum ms between React updates (the re-render cap)
+ */
+export function useSampledTime(
+  timeRef: React.RefObject<number> | { current: number } | undefined,
+  intervalMs: number,
+): number {
+  const [ms, setMs] = useState<number>(timeRef?.current ?? 0);
+
+  useEffect(() => {
+    if (!timeRef) return undefined;
+    let raf = 0;
+    let last = 0;
+    let lastVal = NaN;
+    const tick = (now: number): void => {
+      if (now - last >= intervalMs) {
+        const t = timeRef.current ?? 0;
+        if (t !== lastVal) {
+          lastVal = t;
+          last = now;
+          setMs(t);
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [timeRef, intervalMs]);
+
+  return ms;
+}

--- a/src/features/fight_replay/utils/adaptiveResolution.test.ts
+++ b/src/features/fight_replay/utils/adaptiveResolution.test.ts
@@ -1,0 +1,142 @@
+import {
+  computeMinDpr,
+  computeTargetMs,
+  decideNextDpr,
+  estimateDisplayIntervalMs,
+} from './adaptiveResolution';
+
+describe('estimateDisplayIntervalMs', () => {
+  it('returns Infinity until enough samples are collected', () => {
+    expect(estimateDisplayIntervalMs([16.7, 16.7, 16.7], 10)).toBe(Infinity);
+  });
+
+  it('estimates the refresh interval from clean vsync-paced idle deltas', () => {
+    const hz60 = new Array(30).fill(16.7);
+    expect(estimateDisplayIntervalMs(hz60, 10)).toBeCloseTo(16.7, 5);
+    const hz240 = new Array(30).fill(4.17);
+    expect(estimateDisplayIntervalMs(hz240, 10)).toBeCloseTo(4.17, 5);
+  });
+
+  it('ignores a single anomalously-short fluke (low percentile, not raw min)', () => {
+    // 29 clean 16.7ms samples + one 2ms fluke: a raw min would return 2ms (→ wrong 120Hz target),
+    // but the 20th percentile stays at the true ~16.7ms interval.
+    const samples = [2, ...new Array(29).fill(16.7)];
+    expect(estimateDisplayIntervalMs(samples, 10, 0.2)).toBeCloseTo(16.7, 5);
+  });
+});
+
+describe('computeTargetMs', () => {
+  it('targets 120fps (8.33ms) when the display can present faster', () => {
+    // 240Hz panel: fastest frame ~4.17ms -> target stays at the 120fps ideal.
+    expect(computeTargetMs(4.17)).toBeCloseTo(1000 / 120, 5);
+  });
+
+  it('floors the target at the display interval on a slow panel', () => {
+    // 60Hz panel: vsync-paced frames are ~16.7ms even with headroom -> do not chase 120fps.
+    expect(computeTargetMs(16.7)).toBeCloseTo(16.7, 5);
+  });
+
+  it('falls back to the ideal for a non-positive/NaN display interval', () => {
+    expect(computeTargetMs(0)).toBeCloseTo(1000 / 120, 5);
+    expect(computeTargetMs(NaN)).toBeCloseTo(1000 / 120, 5);
+  });
+
+  it('honors a custom desired fps', () => {
+    expect(computeTargetMs(4, 60)).toBeCloseTo(1000 / 60, 5);
+  });
+});
+
+describe('computeMinDpr', () => {
+  it('allows scaling down to ~60% of full quality', () => {
+    expect(computeMinDpr(2)).toBeCloseTo(1.2, 5);
+    expect(computeMinDpr(1.75)).toBeCloseTo(1.05, 5);
+  });
+
+  it('never drops below 0.75 even for a low starting DPR', () => {
+    expect(computeMinDpr(1)).toBe(0.75);
+    expect(computeMinDpr(0.8)).toBe(0.75);
+  });
+});
+
+describe('decideNextDpr', () => {
+  // High-refresh panel (240Hz): ideal 8.33ms target, display interval 4.17ms (known).
+  const cfg = { minDpr: 1.0, maxDpr: 2.0, targetMs: 1000 / 120, displayIntervalMs: 1000 / 240 };
+
+  it('returns null (no change) when frame time is in the dead zone', () => {
+    // Mid-range DPR so a null result reflects the dead zone, not the floor/ceiling clamp.
+    // ~125fps (8.0ms): under target but inside the dead zone between incline (0.85) and decline (1.4).
+    expect(decideNextDpr(8.0, 1.5, cfg)).toBeNull();
+    // ~95fps (10.5ms): over target but still inside the dead zone (a capable GPU's transient dips
+    // must NOT downscale — the decline threshold sits at ~86fps, well past this).
+    expect(decideNextDpr(10.5, 1.5, cfg)).toBeNull();
+  });
+
+  it('steps DOWN only when sustained avg is well over target (~<86fps)', () => {
+    // ~80fps (12.5ms) > 8.33 * 1.4 = 11.66 -> decline by one step.
+    const next = decideNextDpr(12.5, 2.0, cfg);
+    expect(next).toBeCloseTo(1.85, 5);
+  });
+
+  it('steps UP toward full quality when there is clear headroom', () => {
+    // ~160fps (6.25ms) < 8.33 * 0.85 = 7.08 -> incline by one step.
+    const next = decideNextDpr(6.25, 1.5, cfg);
+    expect(next).toBeCloseTo(1.65, 5);
+  });
+
+  it('never declines below minDpr', () => {
+    expect(decideNextDpr(50, 1.0, cfg)).toBeNull(); // already at floor
+    expect(decideNextDpr(50, 1.05, cfg)).toBe(1.0); // clamps to floor, not 0.9
+  });
+
+  it('never inclines above maxDpr (no supersampling past full quality)', () => {
+    expect(decideNextDpr(1, 2.0, cfg)).toBeNull(); // already at ceiling
+    expect(decideNextDpr(1, 1.95, cfg)).toBe(2.0); // clamps to ceiling
+  });
+
+  it('does not act on a non-positive average', () => {
+    expect(decideNextDpr(0, 1.5, cfg)).toBeNull();
+    expect(decideNextDpr(NaN, 1.5, cfg)).toBeNull();
+  });
+
+  it('with an unknown display interval, downscales only on a clearly-bad absolute frame time', () => {
+    const unknown = { minDpr: 1.0, maxDpr: 2.0, targetMs: 1000 / 120 }; // no displayIntervalMs
+    // A smooth low-refresh scene (60fps, 16.7ms < 20ms fallback) must NOT be blurred.
+    expect(decideNextDpr(16.7, 2.0, unknown)).toBeNull();
+    // Genuinely bad (40fps, 25ms > 20ms) downscales even without a learned interval (safety net).
+    expect(decideNextDpr(25, 2.0, unknown)).toBeCloseTo(1.85, 5);
+    // Incline still works (so a capable panel reaches/keeps full quality).
+    expect(decideNextDpr(5, 1.5, unknown)).toBeCloseTo(1.65, 5);
+    // RECOVERY on a recovered 60Hz panel with no idle samples: a downscaled scene now smooth at
+    // ~60fps (16ms < 20*0.85=17) climbs back up instead of staying stuck blurry.
+    expect(decideNextDpr(16, 1.5, unknown)).toBeCloseTo(1.65, 5);
+    // Dead zone between the fallback incline (17ms) and decline (20ms) — no oscillation.
+    expect(decideNextDpr(18, 1.5, unknown)).toBeNull();
+  });
+
+  describe('display-limited (60Hz) panel', () => {
+    // 60Hz: ideal floored at the 16.7ms display interval, so targetMs === displayInterval.
+    const hz60 = {
+      minDpr: 1.0,
+      maxDpr: 2.0,
+      targetMs: computeTargetMs(1000 / 60),
+      displayIntervalMs: 1000 / 60,
+    };
+
+    it('recovers (inclines) when frames keep pace with vsync', () => {
+      // ~60fps (16.7ms) is the panel maximum: the plain 0.85 floor (14.2ms) is unreachable, but the
+      // display-limited path (interval * 1.12 = 18.7ms) lets a downscaled scene step back up.
+      const next = decideNextDpr(16.7, 1.5, hz60);
+      expect(next).toBeCloseTo(1.65, 5);
+    });
+
+    it('does not downscale a smooth 60fps scene', () => {
+      expect(decideNextDpr(16.7, 2.0, hz60)).toBeNull(); // 16.7 < 16.7*1.4=23.3 -> no decline
+    });
+
+    it('downscales only when frames clearly miss vsync', () => {
+      // ~30fps (33ms) > 16.7 * 1.4 = 23.3 -> decline.
+      const next = decideNextDpr(33, 2.0, hz60);
+      expect(next).toBeCloseTo(1.85, 5);
+    });
+  });
+});

--- a/src/features/fight_replay/utils/adaptiveResolution.ts
+++ b/src/features/fight_replay/utils/adaptiveResolution.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure decision logic for the replay's adaptive resolution (dynamic render-resolution scaling).
+ *
+ * Playback of the full-fidelity arena (bloom + 2048² shadows + image-based lighting + cosmic
+ * backdrop) is GPU-bound: on a strong GPU it runs well past 120fps, but a weak GPU / 4K display /
+ * heavy fight can't sustain 120fps at full render resolution. Rather than permanently lowering
+ * quality for everyone (the existing opt-in "performance mode"), this scales the render pixel ratio
+ * (`gl.setPixelRatio`) up and down at runtime to hold the target framerate:
+ *
+ *   - Full quality whenever there's headroom — on a capable GPU the controller never leaves the
+ *     starting DPR, so the experience is byte-for-byte identical (no visual degradation).
+ *   - When frames are SUSTAINED below target, step the resolution down until 120fps is met; when
+ *     headroom returns, step it back up toward full quality.
+ *
+ * The decision is kept pure (no three.js, no timers) so the hysteresis can be unit-tested. The
+ * component (AdaptiveResolution.tsx) owns the per-frame measurement and applies the result.
+ */
+
+/**
+ * The frame-time target in ms. We want `desiredFps` (120), but never faster than the display can
+ * actually present — on a 60Hz panel the vsync-paced frame time is ~16.7ms even with massive GPU
+ * headroom, and treating that as "missing 120fps" would pointlessly downscale a scene that is
+ * already as smooth as the display allows. So the target is floored at the measured display
+ * interval (the fastest frame observed).
+ */
+export function computeTargetMs(displayIntervalMs: number, desiredFps = 120): number {
+  const ideal = 1000 / desiredFps;
+  if (!Number.isFinite(displayIntervalMs) || displayIntervalMs <= 0) return ideal;
+  return Math.max(ideal, displayIntervalMs);
+}
+
+export interface DprDecisionConfig {
+  /** Lowest render pixel ratio the scaler may drop to (blurriest). */
+  minDpr: number;
+  /** Highest pixel ratio = full quality (the DPR the canvas started at). */
+  maxDpr: number;
+  /** Frame-time target in ms (see computeTargetMs). */
+  targetMs: number;
+  /**
+   * Decline when avg frame time exceeds targetMs × this. Default 1.4 (≈ sustained <86fps at a 120
+   * target) is deliberately well past target: a capable GPU that holds ~120fps with occasional
+   * transient dips never trips it (so it stays pixel-identical), and those transient spikes aren't
+   * pixel-fill-bound anyway — only hardware that is GENUINELY below ~86fps for a sustained window,
+   * where trading resolution actually buys smoothness, downscales.
+   */
+  declineFactor?: number;
+  /** Incline (restore quality) when avg frame time is below targetMs × this (default 0.85). */
+  inclineFactor?: number;
+  /**
+   * Measured display refresh interval (ms), or non-finite if not yet known. Two roles:
+   *  - GATES downscaling: with no known interval we can't tell a smooth display-limited panel
+   *    (a healthy 60Hz at ~16.7ms) from a genuinely slow one, so we must NOT downscale blindly.
+   *  - Enables a DISPLAY-LIMITED incline path: on a vsync-capped panel the ideal target can't be
+   *    beaten, so the plain `inclineFactor` threshold sits below the floor and is unreachable —
+   *    leaving a downscaled scene stuck. Allowing incline when frames keep pace with the refresh
+   *    (≈ the display interval) lets quality recover; a genuine overshoot then re-declines.
+   */
+  displayIntervalMs?: number;
+  /**
+   * Absolute frame-time (ms) above which to downscale even when the display interval is NOT yet
+   * known (default 20ms ≈ <50fps). Safety net for scenes that never produce an idle frame to learn
+   * the refresh from (e.g. a paused `?actorId=` deep link the render loop paints continuously, then
+   * straight into playback): without it such a weak-GPU scene would stay stuck stuttering at full
+   * DPR. 50fps sits below every common refresh (60/120/144/240Hz), so >20ms means genuinely dropping
+   * frames on any of them — a smooth 60Hz scene (16.7ms) is never wrongly downscaled by this path.
+   */
+  fallbackDeclineMs?: number;
+  /** Step size per adjustment. */
+  step?: number;
+}
+
+/**
+ * Decide the next render pixel ratio given the recent average frame time, or null for "no change".
+ * The gap between declineFactor (1.4) and the incline threshold is a deliberate dead zone so a scene
+ * whose frame time hovers near target does not oscillate up/down.
+ */
+export function decideNextDpr(
+  avgFrameMs: number,
+  currentDpr: number,
+  cfg: DprDecisionConfig,
+): number | null {
+  const decline = cfg.declineFactor ?? 1.4;
+  const incline = cfg.inclineFactor ?? 0.85;
+  const step = cfg.step ?? 0.15;
+  if (!Number.isFinite(avgFrameMs) || avgFrameMs <= 0) return null;
+  const displayKnown =
+    typeof cfg.displayIntervalMs === 'number' &&
+    Number.isFinite(cfg.displayIntervalMs) &&
+    cfg.displayIntervalMs > 0;
+  const fallbackDeclineMs = cfg.fallbackDeclineMs ?? 1000 / 50;
+
+  // Downscale threshold: when the display interval is known, relative to the target (so a healthy
+  // display-limited panel is never blurred); when it is NOT yet known, an absolute "clearly bad on
+  // any refresh" floor so a never-idle weak GPU still makes progress instead of stuttering forever.
+  const declineThreshold = displayKnown ? cfg.targetMs * decline : fallbackDeclineMs;
+  if (avgFrameMs > declineThreshold && currentDpr > cfg.minDpr) {
+    return Math.max(cfg.minDpr, Number((currentDpr - step).toFixed(3)));
+  }
+
+  // Recover quality when there's headroom: comfortably under target, OR — on a display-limited
+  // panel — when frames are keeping pace with the refresh (so the unreachable `inclineFactor` floor
+  // doesn't pin a vsync-capped panel at reduced resolution forever). When the display interval is
+  // UNKNOWN, mirror the absolute fallback decline (incline once frames are back below a clearly-smooth
+  // absolute time) so a never-idle scene that fallback-downscaled can still climb back — otherwise
+  // the relative `targetMs * incline` floor (~7ms) is unreachable on a recovered 60Hz panel.
+  const inclineThreshold = displayKnown
+    ? Math.max(cfg.targetMs * incline, (cfg.displayIntervalMs as number) * 1.12)
+    : fallbackDeclineMs * incline;
+  if (avgFrameMs < inclineThreshold && currentDpr < cfg.maxDpr) {
+    return Math.min(cfg.maxDpr, Number((currentDpr + step).toFixed(3)));
+  }
+  return null;
+}
+
+/** The blurriest DPR we allow, derived from the starting (full-quality) DPR. */
+export function computeMinDpr(maxDpr: number): number {
+  return Math.max(0.75, Number((maxDpr * 0.6).toFixed(3)));
+}
+
+/**
+ * Robust display-refresh-interval estimate (ms) from a window of IDLE-frame deltas (vsync-paced,
+ * workload-free). Returns Infinity until at least `minSamples` have been collected — so a single
+ * stray delta can't set a target before we've confirmed the cadence — then a LOW PERCENTILE (default
+ * 20th) rather than the raw minimum, so one anomalously-short delta (a clock hiccup / post-resize
+ * blip) can't pin the target too low and wrongly downscale a smooth display-limited panel. For clean
+ * vsync data (all deltas ≈ the refresh interval) the percentile equals that interval.
+ */
+export function estimateDisplayIntervalMs(
+  idleDeltas: readonly number[],
+  minSamples = 10,
+  percentile = 0.2,
+): number {
+  if (idleDeltas.length < minSamples) return Infinity;
+  const sorted = [...idleDeltas].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor(percentile * sorted.length)));
+  return sorted[idx];
+}

--- a/src/features/fight_replay/utils/qualityGovernor.test.ts
+++ b/src/features/fight_replay/utils/qualityGovernor.test.ts
@@ -89,10 +89,17 @@ describe('decideNextQualityLevel', () => {
     const noRefresh = { targetMs: TARGET, dprExhausted: true };
     // 30ms > 20ms fallback → escalate.
     expect(decideNextQualityLevel(30, 0, noRefresh)).toBe(1);
-    // 16ms < 20ms but > fallback*incline (12ms) → dead zone, hold.
-    expect(decideNextQualityLevel(16, 1, noRefresh)).toBeNull();
-    // 10ms < 12ms → recover.
+    // 18ms < 20ms decline but > 17ms recover → dead zone, hold.
+    expect(decideNextQualityLevel(18, 1, noRefresh)).toBeNull();
+    // 10ms ≪ 17ms → recover.
     expect(decideNextQualityLevel(10, 1, noRefresh)).toBe(0);
+  });
+
+  it('recovers a vsync-limited 60Hz device even when the refresh is unknown (~16.7ms < ~17ms)', () => {
+    // A 60Hz panel floors at ~16.7ms; the unknown-refresh recover threshold (0.85 × 20ms = 17ms)
+    // must be reachable there, or effects would stay stuck off on smooth 60Hz playback.
+    const noRefresh = { targetMs: TARGET, dprExhausted: true };
+    expect(decideNextQualityLevel(16.7, 2, noRefresh)).toBe(1);
   });
 
   it('ignores non-finite / non-positive averages', () => {

--- a/src/features/fight_replay/utils/qualityGovernor.test.ts
+++ b/src/features/fight_replay/utils/qualityGovernor.test.ts
@@ -1,0 +1,103 @@
+import {
+  decideNextQualityLevel,
+  qualityFlagsForLevel,
+  QUALITY_LEVEL,
+  MAX_QUALITY_LEVEL,
+  FRAME_CAP_FPS,
+} from './qualityGovernor';
+
+const TARGET = 1000 / 120; // ~8.33ms, matches the 120fps target
+const REFRESH_120 = 1000 / 120;
+
+describe('qualityFlagsForLevel', () => {
+  it('full quality at level 0', () => {
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.FULL)).toEqual({
+      bloom: true,
+      environment: true,
+      cosmic: true,
+      shadows: true,
+      frameCapFps: null,
+    });
+  });
+
+  it('drops effects in ladder order', () => {
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.NO_BLOOM).bloom).toBe(false);
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.NO_BLOOM).shadows).toBe(true);
+
+    const noEnv = qualityFlagsForLevel(QUALITY_LEVEL.NO_ENV);
+    expect(noEnv.environment).toBe(false);
+    expect(noEnv.cosmic).toBe(false);
+    expect(noEnv.shadows).toBe(true);
+
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.NO_SHADOWS).shadows).toBe(false);
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.NO_SHADOWS).frameCapFps).toBeNull();
+
+    expect(qualityFlagsForLevel(QUALITY_LEVEL.FRAME_CAP).frameCapFps).toBe(FRAME_CAP_FPS);
+  });
+
+  it('clamps out-of-range levels', () => {
+    expect(qualityFlagsForLevel(-3)).toEqual(qualityFlagsForLevel(0));
+    expect(qualityFlagsForLevel(99).frameCapFps).toBe(FRAME_CAP_FPS);
+  });
+});
+
+describe('decideNextQualityLevel', () => {
+  const cfg = { targetMs: TARGET, displayIntervalMs: REFRESH_120, dprExhausted: true };
+
+  it('does NOT escalate while DPR still has range (mild shortfall absorbed by resolution)', () => {
+    // Sustained slow but DPR not exhausted → governor holds, lets DPR scale first.
+    expect(decideNextQualityLevel(40, 0, { ...cfg, dprExhausted: false })).toBeNull();
+  });
+
+  it('escalates one tier when sustained-slow AND DPR is exhausted', () => {
+    // avg 40ms ≫ target*1.4 (~11.7ms) → drop a tier.
+    expect(decideNextQualityLevel(40, 0, cfg)).toBe(1);
+    expect(decideNextQualityLevel(40, 1, cfg)).toBe(2);
+    expect(decideNextQualityLevel(40, 2, cfg)).toBe(3);
+    expect(decideNextQualityLevel(40, 3, cfg)).toBe(4);
+  });
+
+  it('never escalates past the max level', () => {
+    expect(decideNextQualityLevel(200, MAX_QUALITY_LEVEL, cfg)).toBeNull();
+  });
+
+  it('holds in the dead zone (between recover and escalate thresholds)', () => {
+    // 10ms: above incline (target*0.6 ≈ 5ms) and below decline (target*1.4 ≈ 11.7ms) → no change.
+    expect(decideNextQualityLevel(10, 2, cfg)).toBeNull();
+  });
+
+  it('recovers one tier on clear sustained headroom (regardless of DPR state)', () => {
+    // 4ms ≪ target → restore a tier, even though dprExhausted is false.
+    expect(decideNextQualityLevel(4, 3, { ...cfg, dprExhausted: false })).toBe(2);
+    expect(decideNextQualityLevel(4, 1, cfg)).toBe(0);
+  });
+
+  it('recovers when KEEPING PACE with a vsync-capped refresh (avg ≈ target, the stuck-degraded fix)', () => {
+    // On a 120Hz panel the frame floor is ~8.33ms ≈ target, so a scene with headroom still measures
+    // ~target. A recover threshold ≥ target (1.1×) must still restore quality here, or the governor
+    // would never climb back. 8.5ms is just over target but under target*1.1 (~9.16ms) → recover.
+    expect(decideNextQualityLevel(8.5, 2, cfg)).toBe(1);
+    // ...but a clear shortfall (in the dead zone, ≥ target*1.1) does NOT recover.
+    expect(decideNextQualityLevel(10, 2, cfg)).toBeNull();
+  });
+
+  it('does not recover below 0', () => {
+    expect(decideNextQualityLevel(1, 0, cfg)).toBeNull();
+  });
+
+  it('without a known display interval, uses the absolute fallback floor', () => {
+    const noRefresh = { targetMs: TARGET, dprExhausted: true };
+    // 30ms > 20ms fallback → escalate.
+    expect(decideNextQualityLevel(30, 0, noRefresh)).toBe(1);
+    // 16ms < 20ms but > fallback*incline (12ms) → dead zone, hold.
+    expect(decideNextQualityLevel(16, 1, noRefresh)).toBeNull();
+    // 10ms < 12ms → recover.
+    expect(decideNextQualityLevel(10, 1, noRefresh)).toBe(0);
+  });
+
+  it('ignores non-finite / non-positive averages', () => {
+    expect(decideNextQualityLevel(NaN, 1, cfg)).toBeNull();
+    expect(decideNextQualityLevel(0, 1, cfg)).toBeNull();
+    expect(decideNextQualityLevel(-5, 1, cfg)).toBeNull();
+  });
+});

--- a/src/features/fight_replay/utils/qualityGovernor.ts
+++ b/src/features/fight_replay/utils/qualityGovernor.ts
@@ -129,8 +129,10 @@ export function decideNextQualityLevel(
 
   // Recover: meeting the target framerate at the current quality, and something to restore. Not gated
   // on DPR (we always prefer to give quality back when we can; if it was premature the escalate path
-  // re-drops it). The fallback path (refresh unknown) keeps its own dead zone below the 20ms decline.
-  const inclineThreshold = displayKnown ? cfg.targetMs * incline : fallbackDeclineMs * 0.6;
+  // re-drops it). The fallback path (refresh unknown) recovers at 0.85× the 20ms decline (≈17ms) so a
+  // vsync-limited 60Hz device — which floors at ~16.7ms and can't reach a tighter threshold — still
+  // climbs back out of a degraded state; mirrors AdaptiveResolution's fallback incline.
+  const inclineThreshold = displayKnown ? cfg.targetMs * incline : fallbackDeclineMs * 0.85;
   if (avgFrameMs < inclineThreshold && currentLevel > 0) {
     return currentLevel - 1;
   }

--- a/src/features/fight_replay/utils/qualityGovernor.ts
+++ b/src/features/fight_replay/utils/qualityGovernor.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure decision logic for the replay's adaptive QUALITY GOVERNOR — the tier below the dynamic
+ * resolution controller (see utils/adaptiveResolution.ts).
+ *
+ * AdaptiveResolution scales the render pixel ratio (DPR) to hold the target framerate. That is the
+ * right first lever (it trades a little sharpness for fill cost), but it has a floor and it only
+ * helps when the bottleneck is pixel fill. On a genuinely weak / thermally-throttled GPU the cost is
+ * pass-count and per-frame work — the 2048² shadow map (regenerated every frame because the actors
+ * move), the bloom post chain, image-based lighting, the cosmic backdrop — which DPR cannot fix once
+ * it is at floor. This governor escalates BEYOND DPR through an ordered quality ladder, dropping the
+ * most expensive-per-pixel-of-quality effects first and finally capping to a stable framerate, then
+ * recovers in reverse as headroom returns. It is the automatic, incremental form of the manual
+ * "performance mode" toggle.
+ *
+ * The component (QualityGovernor.tsx) owns the per-frame measurement and applies the level; this
+ * module is the pure hysteresis so it can be unit-tested. Kept deliberately conservative: it only
+ * engages on a SUSTAINED shortfall (so a capable GPU never drops an effect), and only after DPR is
+ * exhausted (so mild shortfalls are absorbed by resolution, not by visibly dropping shadows).
+ */
+
+/** The ladder. Higher level = more aggressively degraded. 0 = full quality. */
+export const QUALITY_LEVEL = {
+  FULL: 0,
+  /** Drop bloom / post-processing (a full-screen overdraw pass; biggest GPU cut, low readability loss). */
+  NO_BLOOM: 1,
+  /** + drop image-based lighting + the cosmic backdrop (env maps + fill-heavy sky/star layers). */
+  NO_ENV: 2,
+  /** + drop the directional shadow pass (a second full scene render every frame the actors move). */
+  NO_SHADOWS: 3,
+  /** + cap the render to a stable lower framerate (last resort: cuts every per-frame cost + judder). */
+  FRAME_CAP: 4,
+} as const;
+
+export const MAX_QUALITY_LEVEL = QUALITY_LEVEL.FRAME_CAP;
+
+/** The stable framerate the top rung caps to (a steady 30fps reads better than a fluctuating 35–50). */
+export const FRAME_CAP_FPS = 30;
+
+export interface QualityFlags {
+  /** Bloom / post-processing on. */
+  bloom: boolean;
+  /** Image-based lighting (drei <Environment>) on. */
+  environment: boolean;
+  /** Cosmic backdrop (sky dome / stars / moons) on. */
+  cosmic: boolean;
+  /** Directional shadow casting on. */
+  shadows: boolean;
+  /** Target render FPS cap, or null for uncapped (render every frame). */
+  frameCapFps: number | null;
+}
+
+/** Map a quality level to the concrete effect flags the scene consumes. */
+export function qualityFlagsForLevel(level: number): QualityFlags {
+  const l = Math.max(0, Math.min(MAX_QUALITY_LEVEL, Math.round(level)));
+  return {
+    bloom: l < QUALITY_LEVEL.NO_BLOOM,
+    environment: l < QUALITY_LEVEL.NO_ENV,
+    cosmic: l < QUALITY_LEVEL.NO_ENV,
+    shadows: l < QUALITY_LEVEL.NO_SHADOWS,
+    frameCapFps: l >= QUALITY_LEVEL.FRAME_CAP ? FRAME_CAP_FPS : null,
+  };
+}
+
+export interface QualityDecisionConfig {
+  /** Highest level the governor may climb to (default MAX_QUALITY_LEVEL). */
+  maxLevel?: number;
+  /** Frame-time target in ms (shared with the DPR controller — see computeTargetMs). */
+  targetMs: number;
+  /**
+   * Escalate (drop a tier) when avg frame time exceeds targetMs × this. Default 1.4 — the same
+   * "genuinely below target for a sustained window" bar the DPR controller uses, so a capable GPU
+   * with transient dips never drops an effect.
+   */
+  declineFactor?: number;
+  /**
+   * Recover (restore a tier) when avg frame time is below targetMs × this. Default 1.1 — recover once
+   * the device is KEEPING PACE with the target framerate (within ~10%) at the current quality. It is
+   * deliberately ≥1.0: a vsync-capped display floors the frame time AT the refresh interval (≈ the
+   * target), so a scene with plenty of headroom still measures avg ≈ targetMs — a threshold below
+   * 1.0× would be unreachable and the governor would stay stuck-degraded forever. The gap up to
+   * declineFactor (1.4) is the anti-oscillation dead zone.
+   */
+  inclineFactor?: number;
+  /**
+   * Measured display refresh interval (ms), or non-finite if unknown. Gates escalation exactly like
+   * the DPR controller: with no known refresh we can't tell a smooth display-limited panel from a
+   * slow one, so we must not drop effects blind (the absolute fallback below covers the never-idle
+   * case).
+   */
+  displayIntervalMs?: number;
+  /** Absolute frame-time (ms) above which to escalate even when the refresh is unknown (default 20 ≈ <50fps). */
+  fallbackDeclineMs?: number;
+  /**
+   * Whether the DPR controller has exhausted its range (at floor) or proven ineffective. The
+   * governor only ESCALATES when this is true — DPR gets first crack at a mild shortfall, so we
+   * never drop a visible effect for something a little extra resolution scaling would have fixed.
+   * Recovery is NOT gated on it (restore effects whenever there's headroom).
+   */
+  dprExhausted?: boolean;
+}
+
+/**
+ * Decide the next quality level given the recent average frame time, or null for "no change".
+ *
+ * Escalate one tier when frames are SUSTAINED slow AND DPR is exhausted; recover one tier when there
+ * is clear headroom. The gap between the escalate and recover thresholds is a deliberate dead zone
+ * so the level does not oscillate.
+ */
+export function decideNextQualityLevel(
+  avgFrameMs: number,
+  currentLevel: number,
+  cfg: QualityDecisionConfig,
+): number | null {
+  if (!Number.isFinite(avgFrameMs) || avgFrameMs <= 0) return null;
+  const maxLevel = cfg.maxLevel ?? MAX_QUALITY_LEVEL;
+  const decline = cfg.declineFactor ?? 1.4;
+  const incline = cfg.inclineFactor ?? 1.1;
+  const fallbackDeclineMs = cfg.fallbackDeclineMs ?? 1000 / 50;
+  const displayKnown =
+    typeof cfg.displayIntervalMs === 'number' &&
+    Number.isFinite(cfg.displayIntervalMs) &&
+    cfg.displayIntervalMs > 0;
+
+  // Escalate: sustained slow, DPR already exhausted, and room to climb.
+  const declineThreshold = displayKnown ? cfg.targetMs * decline : fallbackDeclineMs;
+  if (cfg.dprExhausted && avgFrameMs > declineThreshold && currentLevel < maxLevel) {
+    return currentLevel + 1;
+  }
+
+  // Recover: meeting the target framerate at the current quality, and something to restore. Not gated
+  // on DPR (we always prefer to give quality back when we can; if it was premature the escalate path
+  // re-drops it). The fallback path (refresh unknown) keeps its own dead zone below the 20ms decline.
+  const inclineThreshold = displayKnown ? cfg.targetMs * incline : fallbackDeclineMs * 0.6;
+  if (avgFrameMs < inclineThreshold && currentLevel > 0) {
+    return currentLevel - 1;
+  }
+
+  return null;
+}

--- a/src/hooks/useOptimizedTimelineScrubbing.ts
+++ b/src/hooks/useOptimizedTimelineScrubbing.ts
@@ -59,7 +59,9 @@ export const useOptimizedTimelineScrubbing = ({
   // Handle slider drag start
   const handleSliderChangeStart = useCallback(() => {
     setIsDragging(true);
-    setTempTime(currentTime);
+    // Seed from the LIVE playhead ref (not the throttled `currentTime` snapshot) so grabbing the
+    // thumb mid-playback starts exactly under the playhead with no visible jump.
+    setTempTime(timeRef?.current ?? currentTime);
     setIsScrubbingMode(true);
 
     // Remember if we were playing before scrubbing
@@ -74,7 +76,7 @@ export const useOptimizedTimelineScrubbing = ({
     if (scrubbingTimeoutRef.current) {
       clearTimeout(scrubbingTimeoutRef.current);
     }
-  }, [currentTime, isPlaying, onPlayingChange]);
+  }, [currentTime, isPlaying, onPlayingChange, timeRef]);
 
   // Handle slider value changes during drag
   const handleSliderChange = useCallback(
@@ -141,12 +143,16 @@ export const useOptimizedTimelineScrubbing = ({
     };
   }, []);
 
-  // Update temp time when external time changes (and not dragging)
+  // Keep tempTime in sync with the external time ONLY while paused and not dragging. During
+  // playback the slider shows `currentTime` directly (displayTime falls back to it), and tempTime is
+  // used solely for an in-progress drag — which is always seeded fresh from the live ref at drag
+  // start. Skipping the sync during playback avoids a redundant per-tick setState (LiveScrubRail
+  // feeds a high-frequency `currentTime`), keeping the live rail's re-render to a single pass.
   useEffect(() => {
-    if (!isDragging) {
+    if (!isDragging && !isPlaying) {
       setTempTime(currentTime);
     }
-  }, [currentTime, isDragging]);
+  }, [currentTime, isDragging, isPlaying]);
 
   return {
     displayTime,

--- a/src/hooks/usePlaybackAnimation.ts
+++ b/src/hooks/usePlaybackAnimation.ts
@@ -15,6 +15,15 @@ interface UsePlaybackAnimationProps {
    */
   loopStart?: number | null;
   loopEnd?: number | null;
+  /**
+   * How often (ms of wall clock) to sync the playhead back to React state via `onTimeUpdate`. This
+   * drives only COARSE consumers now (the end-of-fight / up-next gates) — the live transport playhead
+   * reads `timeRef` directly via rAF, so it no longer needs a fast state tick. Kept deliberately
+   * coarse (default 250ms) so that on a slow device, where a single frame can exceed this gate, the
+   * sync fires at most a few times a second instead of every frame (the old 100ms gate spiralled
+   * into an every-frame re-render of the transport, collapsing playback to single-digit fps).
+   */
+  stateSyncIntervalMs?: number;
 }
 
 // Minimum span for an A–B loop to engage. Below this the two points are effectively the same
@@ -34,6 +43,7 @@ export const usePlaybackAnimation = ({
   onEnd,
   loopStart,
   loopEnd,
+  stateSyncIntervalMs = 250,
 }: UsePlaybackAnimationProps): void => {
   const animationIdRef = useRef<number | null>(null);
   const lastUpdateRef = useRef(0);
@@ -87,15 +97,26 @@ export const usePlaybackAnimation = ({
       return;
     }
 
-    // Sync with React state periodically (every 100ms)
-    if (now - lastUpdateRef.current >= 100) {
+    // Sync with React state periodically. Coarse (default 250ms) — the live playhead UI reads the
+    // ref directly via rAF; this state tick now only feeds the end-of-fight / up-next gates.
+    if (now - lastUpdateRef.current >= stateSyncIntervalMs) {
       onTimeUpdate?.(newTime);
       lastUpdateRef.current = now;
     }
 
     // Continue animation loop
     animationIdRef.current = requestAnimationFrame(animationLoop);
-  }, [isPlaying, playbackSpeed, duration, timeRef, onTimeUpdate, onEnd, loopStart, loopEnd]);
+  }, [
+    isPlaying,
+    playbackSpeed,
+    duration,
+    timeRef,
+    onTimeUpdate,
+    onEnd,
+    loopStart,
+    loopEnd,
+    stateSyncIntervalMs,
+  ]);
 
   // Start/stop animation based on playing state
   useEffect(() => {


### PR DESCRIPTION
## Summary

Profiled fight-replay playback and found it is **GPU-bound, not CPU-bound** — the alarming low FPS seen in dev is a **React 19 dev-mode profiling artifact** that does not exist in production. A production build on a capable GPU already averages **~130fps**; this PR adds headroom, removes jank, and guarantees the framerate floor on weaker hardware.

> **Stacked PR:** based on `feat/replay-drawn-shapes` (#1315) — my changes build on that branch's replay rewrites, so this targets it for a clean, focused diff (just the 1 perf commit). Retarget to `main` once #1315 merges.

## Lossless optimizations (zero pixel change, all hardware)
- **Shadow regen gating** — the 2048² PCF shadow only re-renders when an actor (caster) actually moves, not on camera-orbit-while-paused (a directional shadow is camera-independent). Async humanoid/boss GLB caster loads flag it dirty so the swap still repaints.
- **BossHealthPanel** — eliminated a per-frame forced reflow (layout thrash) + redundant DOM writes; the rAF is gated on playhead movement and writes are dirty-checked (cache cleared on boss-set change; requires real element refs).
- **Per-frame GC churn cut** — stop re-hiding the fixed glyph group + idle selection/taunt rings every frame (also fixes a latent shared-`tempObject` clobber), pool the name-tag screen items, and flush instanced buffers via hoisted flaggers instead of per-frame temp arrays/closures.

## Adaptive resolution (the "all situations" guarantee)
New `AdaptiveResolution` controller scales render resolution to hold ~120fps on weak GPUs / 4K / heavy fights, and **stays at full quality whenever there's headroom — so it is inert on capable hardware (no visual degradation there)**. It is:
- display-refresh aware (won't chase 120 on a 60Hz panel),
- authoritative over DPR (re-asserts if the Canvas `dpr` prop re-applies; prop memoized),
- restores full quality while paused and snaps back to the proven DPR on resume,
- clamps into the perf-tier cap both directions, with a hysteresis dead zone, a CPU-bound effectiveness guard, and a robust display-interval estimate (idle-frame rolling window + percentile + mount bootstrap, reset on resize/visibility).

Pure decision logic is unit-tested (`utils/adaptiveResolution.ts`).

## Verification
- `tsc` + ESLint (`--max-warnings 0`) + Prettier — clean
- Full test suite: **4129 passed / 0 failed** (incl. 19 new adaptive-resolution unit tests)
- `/codex:review` clean and `/codex:adversarial-review` **APPROVED** after an iterative review loop (all findings were in the adaptive controller; the lossless changes were clean throughout)
- Live production build measured inert at full quality on a capable GPU, and confirmed engaging + guard-capped under load