### PR TITLE
Add Discord roster bot operator guide page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,12 @@ const DiscordSetupPage = React.lazy(() =>
   })),
 );
 
+const RosterBotDocsPage = React.lazy(() =>
+  import('./pages/RosterBotDocsPage').then((module) => ({
+    default: module.RosterBotDocsPage,
+  })),
+);
+
 const MyRostersPage = React.lazy(() =>
   import('./pages/MyRostersPage').then((module) => ({ default: module.MyRostersPage })),
 );
@@ -698,6 +704,16 @@ const AppRoutes: React.FC = () => {
                 <ErrorBoundary>
                   <Suspense fallback={<LoadingFallback />}>
                     <CalculationKnowledgeBasePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/docs/discord-roster-bot"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <RosterBotDocsPage />
                   </Suspense>
                 </ErrorBoundary>
               }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -62,6 +62,8 @@ export const Footer: React.FC = React.memo(() => {
 
       { label: 'Calculation Knowledge Base', href: '/docs/calculations' },
 
+      { label: 'Discord Bot Guide', href: '/docs/discord-roster-bot' },
+
       { label: "What's New", href: '/whats-new' },
 
       { label: 'About', href: '/about' },

--- a/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
+++ b/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
@@ -232,11 +232,16 @@ export const DiscordAdminGuideContent: React.FC<DiscordAdminGuideContentProps> =
               px: 2.5,
               py: 0.9,
               textTransform: 'none',
+              // Force white text + shadow so the label keeps AA contrast on the
+              // blurple gradient regardless of the active theme's contrastText.
+              color: '#fff',
+              textShadow: '0 1px 2px rgba(0,0,0,0.35)',
               background: 'linear-gradient(135deg, #5865F2 0%, #4752C4 100%)',
-              boxShadow: '0 4px 16px rgba(88,101,242,0.3)',
+              boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
               '&:hover': {
-                background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)',
-                boxShadow: '0 6px 20px rgba(88,101,242,0.4)',
+                color: '#fff',
+                background: 'linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)',
+                boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
               },
             }}
           >

--- a/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
+++ b/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
@@ -278,8 +278,9 @@ export const DiscordAdminGuideContent: React.FC<DiscordAdminGuideContentProps> =
           </Tooltip>
         </Stack>
 
-        {/* Let admins read what the bot actually does before they install. Opens
-            in a new tab so an in-progress publish (modal context) is preserved. */}
+        {/* Let admins read what the bot actually does before they install.
+            Navigates in-SPA (no target=_blank) so it gets the smooth view
+            transition instead of cold-loading the app in a new tab. */}
         <Typography
           variant="caption"
           sx={{ display: 'block', mt: 1.5, color: 'text.secondary', fontSize: '0.78rem' }}
@@ -288,8 +289,6 @@ export const DiscordAdminGuideContent: React.FC<DiscordAdminGuideContentProps> =
           <Box
             component={RouterLink}
             to="/docs/discord-roster-bot"
-            target="_blank"
-            rel="noopener noreferrer"
             sx={{
               // Deliberately NOT blurple — the invite CTAs above are blurple, so a
               // matching link colour blends into them. Use a muted, underlined

--- a/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
+++ b/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
@@ -291,10 +291,14 @@ export const DiscordAdminGuideContent: React.FC<DiscordAdminGuideContentProps> =
             target="_blank"
             rel="noopener noreferrer"
             sx={{
-              color: '#5865F2',
+              // Deliberately NOT blurple — the invite CTAs above are blurple, so a
+              // matching link colour blends into them. Use a muted, underlined
+              // link that reads as secondary next to the primary actions.
+              color: 'text.secondary',
               fontWeight: 600,
-              textDecoration: 'none',
-              '&:hover': { textDecoration: 'underline' },
+              textDecoration: 'underline',
+              textUnderlineOffset: '2px',
+              '&:hover': { color: 'text.primary' },
             }}
           >
             See what it does and how to operate it →

--- a/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
+++ b/src/features/roster-hub/components/DiscordAdminGuideContent.tsx
@@ -31,6 +31,7 @@ import {
   useTheme,
 } from '@mui/material';
 import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 
 import discordIcon from '../../../assets/discord-icon.svg';
 import { getBotInviteUrl } from '../../auth/discord-auth';
@@ -276,6 +277,29 @@ export const DiscordAdminGuideContent: React.FC<DiscordAdminGuideContentProps> =
             </Button>
           </Tooltip>
         </Stack>
+
+        {/* Let admins read what the bot actually does before they install. Opens
+            in a new tab so an in-progress publish (modal context) is preserved. */}
+        <Typography
+          variant="caption"
+          sx={{ display: 'block', mt: 1.5, color: 'text.secondary', fontSize: '0.78rem' }}
+        >
+          New to the bot?{' '}
+          <Box
+            component={RouterLink}
+            to="/docs/discord-roster-bot"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              color: '#5865F2',
+              fontWeight: 600,
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            See what it does and how to operate it →
+          </Box>
+        </Typography>
       </Box>
 
       {/* Permissions disclosure */}

--- a/src/features/roster-hub/components/ServerPickerDialog.tsx
+++ b/src/features/roster-hub/components/ServerPickerDialog.tsx
@@ -790,11 +790,14 @@ export const ServerPickerDialog: React.FC<ServerPickerDialogProps> = ({
                   fontSize: '0.85rem',
                   px: 3,
                   textTransform: 'none',
+                  color: '#fff',
+                  textShadow: '0 1px 2px rgba(0,0,0,0.35)',
                   background: 'linear-gradient(135deg, #5865F2 0%, #4752C4 100%)',
-                  boxShadow: '0 4px 16px rgba(88,101,242,0.3)',
+                  boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
                   '&:hover': {
-                    background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)',
-                    boxShadow: '0 6px 20px rgba(88,101,242,0.4)',
+                    color: '#fff',
+                    background: 'linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)',
+                    boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
                   },
                 }}
               >
@@ -1092,11 +1095,14 @@ export const ServerPickerDialog: React.FC<ServerPickerDialogProps> = ({
                         fontSize: '0.82rem',
                         py: 0.9,
                         textTransform: 'none',
+                        color: '#fff',
+                        textShadow: '0 1px 2px rgba(0,0,0,0.35)',
                         background: 'linear-gradient(135deg, #5865F2 0%, #4752C4 100%)',
-                        boxShadow: '0 4px 16px rgba(88,101,242,0.28)',
+                        boxShadow: '0 4px 16px rgba(88,101,242,0.32)',
                         '&:hover': {
-                          background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)',
-                          boxShadow: '0 6px 20px rgba(88,101,242,0.36)',
+                          color: '#fff',
+                          background: 'linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)',
+                          boxShadow: '0 6px 22px rgba(88,101,242,0.45)',
                         },
                       }}
                     >
@@ -2230,11 +2236,14 @@ export const ServerPickerDialog: React.FC<ServerPickerDialogProps> = ({
                     fontWeight: 600,
                     fontSize: '0.85rem',
                     px: 3,
+                    color: '#fff',
+                    textShadow: '0 1px 2px rgba(0,0,0,0.35)',
                     background: 'linear-gradient(135deg, #5865F2 0%, #4752C4 100%)',
-                    boxShadow: '0 4px 16px rgba(88,101,242,0.3)',
+                    boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
                     '&:hover': {
-                      background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)',
-                      boxShadow: '0 6px 20px rgba(88,101,242,0.4)',
+                      color: '#fff',
+                      background: 'linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)',
+                      boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
                     },
                   }}
                 >
@@ -2345,11 +2354,14 @@ export const ServerPickerDialog: React.FC<ServerPickerDialogProps> = ({
                   fontWeight: 600,
                   fontSize: '0.82rem',
                   px: 2.5,
+                  color: '#fff',
+                  textShadow: '0 1px 2px rgba(0,0,0,0.35)',
                   background: `linear-gradient(135deg, ${accent} 0%, #4752C4 100%)`,
-                  boxShadow: `0 4px 12px ${alpha(accent, 0.2)}`,
+                  boxShadow: `0 4px 12px ${alpha(accent, 0.28)}`,
                   '&:hover': {
-                    background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)',
-                    boxShadow: `0 6px 16px ${alpha(accent, 0.3)}`,
+                    color: '#fff',
+                    background: `linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)`,
+                    boxShadow: `0 6px 16px ${alpha(accent, 0.4)}`,
                   },
                   '&.Mui-disabled': {
                     background: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',

--- a/src/pages/DiscordServerConfigPage.tsx
+++ b/src/pages/DiscordServerConfigPage.tsx
@@ -630,6 +630,29 @@ export const DiscordServerConfigPage: React.FC = () => {
           >
             Connect Discord
           </Button>
+          <Typography variant="body2" sx={{ mt: 2.5, color: 'text.secondary' }}>
+            New to the bot?{' '}
+            <Box
+              component="span"
+              onClick={() => navigate('/docs/discord-roster-bot')}
+              role="link"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  navigate('/docs/discord-roster-bot');
+                }
+              }}
+              sx={{
+                color: '#5865F2',
+                fontWeight: 600,
+                cursor: 'pointer',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              Read the roster bot guide
+            </Box>
+          </Typography>
         </Paper>
       </Container>
     );

--- a/src/pages/DiscordServerConfigPage.tsx
+++ b/src/pages/DiscordServerConfigPage.tsx
@@ -622,8 +622,15 @@ export const DiscordServerConfigPage: React.FC = () => {
               />
             }
             sx={{
+              color: '#fff',
+              textShadow: '0 1px 2px rgba(0,0,0,0.35)',
               background: 'linear-gradient(135deg, #5865F2 0%, #4752C4 100%)',
-              '&:hover': { background: 'linear-gradient(135deg, #6973F5 0%, #5865F2 100%)' },
+              boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
+              '&:hover': {
+                color: '#fff',
+                background: 'linear-gradient(135deg, #4752C4 0%, #3a44a8 100%)',
+                boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
+              },
               px: 4,
               py: 1.2,
             }}

--- a/src/pages/RosterBotDocsPage.tsx
+++ b/src/pages/RosterBotDocsPage.tsx
@@ -114,7 +114,7 @@ const COMMAND_GROUPS: ReadonlyArray<CommandGroup> = [
         command: '/roster link',
         summary:
           'Link an ESO Toolkit roster to this server and publish it in one step. Paste the roster URL or its ID.',
-        access: 'Publisher role or Manage Server',
+        access: 'Publisher role (or admins until one is set)',
         args: [
           {
             name: 'roster',
@@ -127,7 +127,7 @@ const COMMAND_GROUPS: ReadonlyArray<CommandGroup> = [
         command: '/roster publish',
         summary:
           'Publish a roster to a fresh Discord channel by ID. Optionally override the channel name or the category it lands in.',
-        access: 'Publisher role or Manage Server',
+        access: 'Publisher role (or admins until one is set)',
         args: [
           { name: 'roster-id', required: true, desc: 'ESO Toolkit roster ID' },
           {
@@ -142,7 +142,7 @@ const COMMAND_GROUPS: ReadonlyArray<CommandGroup> = [
         command: '/roster refresh',
         summary:
           'Re-sync the roster in the current channel from ESO Toolkit. Run it after editing the roster on the website. The 🔄 Refresh button on the post does the same thing.',
-        access: 'Publisher role or Manage Server',
+        access: 'Publisher role (or admins until one is set)',
       },
     ],
   },
@@ -174,7 +174,7 @@ const COMMAND_GROUPS: ReadonlyArray<CommandGroup> = [
       {
         command: '/roster config set-role',
         summary:
-          'Set the role allowed to publish and refresh rosters (replaces any existing allowed roles). Without this, only Manage Server admins can publish.',
+          'Set the role allowed to publish and refresh rosters (replaces any existing allowed roles). Once a role is set it is required for publishing — even Manage Server admins must hold it. With no role configured, only Manage Server admins can publish.',
         access: 'Manage Server',
         args: [{ name: 'role', required: true, desc: 'Role to allow' }],
       },
@@ -481,7 +481,8 @@ export const RosterBotDocsPage: React.FC = () => {
                   <Box component="code" sx={codeChipSx}>
                     /roster config set-role @RaidLead
                   </Box>{' '}
-                  so your leads can post rosters. Without it, only Manage Server admins can publish.
+                  so your leads can post rosters. Once a role is set, publishing requires it — even
+                  admins. With no role configured, only Manage Server admins can publish.
                 </>
               ),
             },
@@ -736,7 +737,7 @@ export const RosterBotDocsPage: React.FC = () => {
         <Stack spacing={1.5}>
           <PermRow
             role="Server admins (Manage Server)"
-            can="Everything — invite the bot, run all /roster config commands, publish, and refresh."
+            can="Invite the bot and run every /roster config command. They can also publish and refresh — but once a publisher role is configured, an admin needs that role too."
           />
           <PermRow
             role="Publisher role (set via set-role / add-role)"

--- a/src/pages/RosterBotDocsPage.tsx
+++ b/src/pages/RosterBotDocsPage.tsx
@@ -1,0 +1,883 @@
+/**
+ * Operator guide for the ESO Toolkit Discord roster bot.
+ *
+ * A standalone, link-friendly docs page (route: /docs/discord-roster-bot) that
+ * teaches raid leads and server admins how to operate the bot end-to-end:
+ * inviting it, configuring access, publishing rosters, member sign-ups, and
+ * keeping a posted roster in sync.
+ *
+ * This is hand-built rather than markdown-rendered (cf. CalculationKnowledgeBasePage)
+ * so the command reference can offer copy-to-clipboard, the Discord brand styling
+ * matches DiscordAdminGuideContent, and the page works unauthenticated — a teammate
+ * can DM it to whoever holds "Manage Server".
+ */
+
+import {
+  ArrowForward,
+  AutoMode,
+  Bolt,
+  Campaign,
+  Check as CheckIcon,
+  ContentCopy,
+  ExpandMore,
+  HelpOutlined,
+  Login as LoginIcon,
+  Publish as PublishIcon,
+  Settings as SettingsIcon,
+  Shield,
+  Tag as TagIcon,
+} from '@mui/icons-material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  Container,
+  Divider,
+  Stack,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+
+import discordIcon from '../assets/discord-icon.svg';
+import { getBotInviteUrl } from '../features/auth/discord-auth';
+
+const DISCORD_BLURPLE = '#5865F2';
+const DISCORD_BLURPLE_DARK = '#4752C4';
+const DISCORD_GREEN = '#57F287';
+
+// ── Reusable copy-to-clipboard for slash commands ───────────────────────────
+
+const CopyButton: React.FC<{ value: string; label?: string }> = ({ value, label }) => {
+  const [copied, setCopied] = React.useState(false);
+  const copy = React.useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      /* clipboard denied — fail silently */
+    }
+  }, [value]);
+
+  return (
+    <Tooltip title={copied ? 'Copied!' : (label ?? 'Copy command')} arrow>
+      <Button
+        size="small"
+        onClick={() => void copy()}
+        aria-label={copied ? 'Command copied' : `Copy ${value}`}
+        sx={{
+          minWidth: 0,
+          px: 0.75,
+          py: 0.25,
+          color: copied ? DISCORD_GREEN : 'text.secondary',
+          '&:hover': { color: copied ? DISCORD_GREEN : DISCORD_BLURPLE, background: 'transparent' },
+        }}
+      >
+        {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopy sx={{ fontSize: 16 }} />}
+      </Button>
+    </Tooltip>
+  );
+};
+
+// ── Command reference data ──────────────────────────────────────────────────
+
+interface CommandSpec {
+  command: string;
+  summary: string;
+  /** Argument hints, exactly as registered with Discord. */
+  args?: ReadonlyArray<{ name: string; required: boolean; desc: string }>;
+  /** Who can run it. */
+  access: string;
+}
+
+interface CommandGroup {
+  title: string;
+  blurb: string;
+  icon: React.ReactNode;
+  commands: ReadonlyArray<CommandSpec>;
+}
+
+const COMMAND_GROUPS: ReadonlyArray<CommandGroup> = [
+  {
+    title: 'Publishing & syncing',
+    blurb:
+      'The day-to-day commands a raid lead uses to get a roster into Discord and keep it current.',
+    icon: <PublishIcon sx={{ fontSize: 18 }} />,
+    commands: [
+      {
+        command: '/roster link',
+        summary:
+          'Link an ESO Toolkit roster to this server and publish it in one step. Paste the roster URL or its ID.',
+        access: 'Publisher role or Manage Server',
+        args: [
+          {
+            name: 'roster',
+            required: true,
+            desc: 'Roster URL or ID, e.g. https://esotk.com/roster-hub/ABC123',
+          },
+        ],
+      },
+      {
+        command: '/roster publish',
+        summary:
+          'Publish a roster to a fresh Discord channel by ID. Optionally override the channel name or the category it lands in.',
+        access: 'Publisher role or Manage Server',
+        args: [
+          { name: 'roster-id', required: true, desc: 'ESO Toolkit roster ID' },
+          {
+            name: 'channel-name',
+            required: false,
+            desc: 'Override the auto-generated channel name',
+          },
+          { name: 'category', required: false, desc: 'Category to create the channel in' },
+        ],
+      },
+      {
+        command: '/roster refresh',
+        summary:
+          'Re-sync the roster in the current channel from ESO Toolkit. Run it after editing the roster on the website. The 🔄 Refresh button on the post does the same thing.',
+        access: 'Publisher role or Manage Server',
+      },
+    ],
+  },
+  {
+    title: 'Getting started',
+    blurb: 'Run these once when you first add the bot to a server.',
+    icon: <Bolt sx={{ fontSize: 18 }} />,
+    commands: [
+      {
+        command: '/roster setup',
+        summary:
+          'Show an interactive getting-started checklist with the exact config commands for your server.',
+        access: 'Manage Server',
+      },
+      {
+        command: '/roster config list',
+        summary:
+          'Show the current configuration: allowed roles, name pattern, default category, and role pings.',
+        access: 'Manage Server',
+      },
+    ],
+  },
+  {
+    title: 'Configuration',
+    blurb:
+      'Tune who can publish, where channels are created, how they are named, and which roles get pinged.',
+    icon: <SettingsIcon sx={{ fontSize: 18 }} />,
+    commands: [
+      {
+        command: '/roster config set-role',
+        summary:
+          'Set the role allowed to publish and refresh rosters (replaces any existing allowed roles). Without this, only Manage Server admins can publish.',
+        access: 'Manage Server',
+        args: [{ name: 'role', required: true, desc: 'Role to allow' }],
+      },
+      {
+        command: '/roster config add-role',
+        summary: 'Add another allowed publisher role, keeping the existing ones.',
+        access: 'Manage Server',
+        args: [{ name: 'role', required: true, desc: 'Role to add' }],
+      },
+      {
+        command: '/roster config remove-role',
+        summary: 'Remove a role from the allowed publisher list.',
+        access: 'Manage Server',
+        args: [{ name: 'role', required: true, desc: 'Role to remove' }],
+      },
+      {
+        command: '/roster config set-default-category',
+        summary: 'Choose the category new roster channels are created under.',
+        access: 'Manage Server',
+        args: [{ name: 'category', required: true, desc: 'Category channel' }],
+      },
+      {
+        command: '/roster config set-name-pattern',
+        summary:
+          'Set the template used to name auto-created roster channels. Default: {day-short}-{time}-{trial}.',
+        access: 'Manage Server',
+        args: [{ name: 'pattern', required: true, desc: 'Naming template using the tokens below' }],
+      },
+      {
+        command: '/roster config set-role-pings',
+        summary:
+          'Pick the roles to ping when a published roster needs tanks, healers, or DDs. Use the clear-* options to stop pinging a role.',
+        access: 'Manage Server',
+        args: [
+          { name: 'tank-role', required: false, desc: 'Tank role to ping' },
+          { name: 'healer-role', required: false, desc: 'Healer role to ping' },
+          { name: 'dd-role', required: false, desc: 'DD role to ping' },
+          {
+            name: 'clear-tank / clear-healer / clear-dd',
+            required: false,
+            desc: 'Stop pinging that role',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// ── Channel name tokens ─────────────────────────────────────────────────────
+
+const NAME_TOKENS: ReadonlyArray<{ token: string; example: string; desc: string }> = [
+  { token: '{day-short}', example: 'sun', desc: 'Three-letter day of the run' },
+  { token: '{day-full}', example: 'sunday', desc: 'Full day name' },
+  { token: '{time}', example: '8pm', desc: '12-hour start time' },
+  {
+    token: '{trial}',
+    example: 'vlc',
+    desc: 'Trial abbreviation with difficulty prefix (v = vet, n = normal)',
+  },
+  { token: '{difficulty}', example: 'vet', desc: '“vet” or “norm”' },
+];
+
+// ── Member-facing buttons on a published roster ─────────────────────────────
+
+const ROSTER_BUTTONS: ReadonlyArray<{ emoji: string; label: string; desc: string }> = [
+  {
+    emoji: '🛡️',
+    label: 'Tank',
+    desc: 'Posts that you’re interested in tanking so a raid lead can confirm your slot.',
+  },
+  {
+    emoji: '💚',
+    label: 'Healer',
+    desc: 'Flags your interest in a healer slot.',
+  },
+  {
+    emoji: '⚔️',
+    label: 'DD',
+    desc: 'Flags your interest in a damage slot.',
+  },
+  {
+    emoji: '🔗',
+    label: 'View on ESO Toolkit',
+    desc: 'Opens the full interactive roster (gear, scripts, notes) on the website.',
+  },
+  {
+    emoji: '🔄',
+    label: 'Refresh',
+    desc: 'Re-pulls the latest roster from ESO Toolkit. Restricted to publishers.',
+  },
+];
+
+// ── Page ────────────────────────────────────────────────────────────────────
+
+export const RosterBotDocsPage: React.FC = () => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  React.useEffect(() => {
+    document.title = 'Discord Roster Bot Guide | ESO Toolkit';
+  }, []);
+
+  const cardSx = {
+    borderRadius: '16px',
+    p: { xs: 2.5, md: 3 },
+    border: isDark ? '1px solid rgba(255,255,255,0.07)' : '1px solid rgba(0,0,0,0.07)',
+    background: isDark ? 'rgba(255,255,255,0.025)' : 'rgba(255,255,255,0.6)',
+    backdropFilter: 'blur(8px)',
+  } as const;
+
+  const codeChipSx = {
+    fontFamily: "Consolas, Monaco, 'Fira Code', monospace",
+    fontWeight: 600,
+    fontSize: '0.92rem',
+    color: isDark ? '#c7d2fe' : DISCORD_BLURPLE_DARK,
+    background: isDark ? 'rgba(88,101,242,0.16)' : 'rgba(88,101,242,0.10)',
+    borderRadius: '8px',
+    px: 1,
+    py: 0.4,
+    display: 'inline-block',
+    whiteSpace: 'nowrap',
+  } as const;
+
+  return (
+    <Container maxWidth="lg" sx={{ py: { xs: 4, md: 6 } }}>
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: '20px',
+          px: { xs: 3, md: 5 },
+          py: { xs: 4, md: 5 },
+          mb: 4,
+          background: isDark
+            ? 'linear-gradient(135deg, rgba(88,101,242,0.22) 0%, rgba(87,242,135,0.06) 100%)'
+            : 'linear-gradient(135deg, rgba(88,101,242,0.12) 0%, rgba(87,242,135,0.05) 100%)',
+          border: isDark ? '1px solid rgba(88,101,242,0.28)' : '1px solid rgba(88,101,242,0.18)',
+        }}
+      >
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center', mb: 2 }}>
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: '16px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
+              boxShadow: '0 8px 24px rgba(88,101,242,0.35)',
+            }}
+          >
+            <img
+              src={discordIcon}
+              alt=""
+              style={{ width: 28, height: 28, filter: 'brightness(10)' }}
+            />
+          </Box>
+          <Box>
+            <Typography
+              variant="h3"
+              component="h1"
+              sx={{ fontWeight: 800, fontSize: { xs: '1.7rem', md: '2.4rem' }, lineHeight: 1.1 }}
+            >
+              Discord Roster Bot
+            </Typography>
+            <Typography variant="subtitle1" sx={{ color: 'text.secondary', mt: 0.5 }}>
+              Publish ESO Toolkit rosters straight into your Discord, take sign-ups, and keep
+              everything in sync.
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ mt: 3 }}>
+          <Button
+            variant="contained"
+            href={getBotInviteUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            startIcon={
+              <img
+                src={discordIcon}
+                alt=""
+                style={{ width: 16, height: 16, filter: 'brightness(10)' }}
+              />
+            }
+            sx={{
+              borderRadius: '10px',
+              fontWeight: 700,
+              textTransform: 'none',
+              px: 3,
+              py: 1,
+              background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
+              boxShadow: '0 4px 16px rgba(88,101,242,0.3)',
+              '&:hover': {
+                background: `linear-gradient(135deg, #6973F5 0%, ${DISCORD_BLURPLE} 100%)`,
+                boxShadow: '0 6px 20px rgba(88,101,242,0.4)',
+              },
+            }}
+          >
+            Invite the bot
+          </Button>
+          <Button
+            variant="outlined"
+            component={RouterLink}
+            to="/discord-server-config"
+            startIcon={<SettingsIcon />}
+            sx={{
+              borderRadius: '10px',
+              fontWeight: 600,
+              textTransform: 'none',
+              px: 3,
+              py: 1,
+              borderColor: 'rgba(88,101,242,0.4)',
+              color: isDark ? '#c7d2fe' : DISCORD_BLURPLE,
+              '&:hover': { borderColor: DISCORD_BLURPLE, background: 'rgba(88,101,242,0.06)' },
+            }}
+          >
+            Configure on the web
+          </Button>
+          <Button
+            variant="text"
+            component={RouterLink}
+            to="/discord-setup"
+            sx={{
+              borderRadius: '10px',
+              fontWeight: 600,
+              textTransform: 'none',
+              color: 'text.secondary',
+            }}
+          >
+            Install guide →
+          </Button>
+        </Stack>
+      </Box>
+
+      {/* ── What it does ─────────────────────────────────────────────── */}
+      <SectionHeading icon={<Campaign sx={{ color: DISCORD_BLURPLE }} />} title="What it does" />
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' },
+          mb: 5,
+        }}
+      >
+        {[
+          {
+            icon: <PublishIcon sx={{ color: DISCORD_BLURPLE }} />,
+            title: 'Publish rosters',
+            body: 'Turn any ESO Toolkit roster into a Discord channel with a formatted post — tanks, healers, DDs, gear, and notes.',
+          },
+          {
+            icon: <Shield sx={{ color: DISCORD_BLURPLE }} />,
+            title: 'Take sign-ups',
+            body: 'Members tap Tank / Healer / DD to flag interest, and the right roles get pinged automatically when you publish.',
+          },
+          {
+            icon: <AutoMode sx={{ color: DISCORD_BLURPLE }} />,
+            title: 'Stay in sync',
+            body: 'Edit the roster on the website, hit Refresh, and the Discord post updates in place — no re-posting.',
+          },
+        ].map((card) => (
+          <Box key={card.title} sx={cardSx}>
+            <Box sx={{ mb: 1 }}>{card.icon}</Box>
+            <Typography sx={{ fontWeight: 700, mb: 0.5 }}>{card.title}</Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.55 }}>
+              {card.body}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+
+      {/* ── Quick start ──────────────────────────────────────────────── */}
+      <SectionHeading icon={<Bolt sx={{ color: DISCORD_BLURPLE }} />} title="Quick start" />
+      <Box sx={{ ...cardSx, mb: 5 }}>
+        <Stack spacing={2.5} divider={<Divider flexItem />}>
+          {[
+            {
+              n: 1,
+              title: 'Invite the bot',
+              body: (
+                <>
+                  Use the <strong>Invite the bot</strong> button above. You’ll need{' '}
+                  <strong>Manage Server</strong> in Discord. Not the admin? Send them the{' '}
+                  <RouterLink
+                    to="/discord-setup"
+                    style={{ color: DISCORD_BLURPLE, fontWeight: 600 }}
+                  >
+                    install guide
+                  </RouterLink>
+                  .
+                </>
+              ),
+            },
+            {
+              n: 2,
+              title: 'Pick who can publish',
+              body: (
+                <>
+                  Run{' '}
+                  <Box component="code" sx={codeChipSx}>
+                    /roster config set-role @RaidLead
+                  </Box>{' '}
+                  so your leads can post rosters. Without it, only Manage Server admins can publish.
+                </>
+              ),
+            },
+            {
+              n: 3,
+              title: '(Optional) Set defaults',
+              body: (
+                <>
+                  Choose a category with{' '}
+                  <Box component="code" sx={codeChipSx}>
+                    /roster config set-default-category
+                  </Box>{' '}
+                  and customise channel names with{' '}
+                  <Box component="code" sx={codeChipSx}>
+                    /roster config set-name-pattern
+                  </Box>
+                  .
+                </>
+              ),
+            },
+            {
+              n: 4,
+              title: 'Publish your first roster',
+              body: (
+                <>
+                  Build a roster on the site, copy its link, then run{' '}
+                  <Box component="code" sx={codeChipSx}>
+                    /roster link &lt;url&gt;
+                  </Box>
+                  . The bot creates the channel, posts the roster, and pings the roles you
+                  configured.
+                </>
+              ),
+            },
+          ].map((step) => (
+            <Stack key={step.n} direction="row" spacing={2} sx={{ alignItems: 'flex-start' }}>
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  width: 30,
+                  height: 30,
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 700,
+                  fontSize: '0.9rem',
+                  color: '#fff',
+                  background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
+                }}
+              >
+                {step.n}
+              </Box>
+              <Box>
+                <Typography sx={{ fontWeight: 700, mb: 0.25 }}>{step.title}</Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.6 }}>
+                  {step.body}
+                </Typography>
+              </Box>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+
+      {/* ── Command reference ────────────────────────────────────────── */}
+      <SectionHeading
+        icon={<TagIcon sx={{ color: DISCORD_BLURPLE }} />}
+        title="Command reference"
+      />
+      <Stack spacing={3} sx={{ mb: 5 }}>
+        {COMMAND_GROUPS.map((group) => (
+          <Box key={group.title}>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: 'center', mb: 0.5, color: DISCORD_BLURPLE }}
+            >
+              {group.icon}
+              <Typography sx={{ fontWeight: 700, fontSize: '1.05rem', color: 'text.primary' }}>
+                {group.title}
+              </Typography>
+            </Stack>
+            <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1.5 }}>
+              {group.blurb}
+            </Typography>
+            <Stack spacing={1.5}>
+              {group.commands.map((cmd) => (
+                <Box key={cmd.command} sx={cardSx}>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 0.75 }}
+                  >
+                    <Box component="code" sx={{ ...codeChipSx, fontSize: '1rem' }}>
+                      {cmd.command}
+                    </Box>
+                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                      <Chip
+                        label={cmd.access}
+                        size="small"
+                        sx={{
+                          height: 22,
+                          fontSize: '0.68rem',
+                          fontWeight: 600,
+                          color: 'text.secondary',
+                          background: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
+                        }}
+                      />
+                      <CopyButton value={cmd.command} />
+                    </Stack>
+                  </Stack>
+                  <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.55 }}>
+                    {cmd.summary}
+                  </Typography>
+                  {cmd.args && cmd.args.length > 0 && (
+                    <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2.5 }}>
+                      {cmd.args.map((arg) => (
+                        <Box component="li" key={arg.name} sx={{ mb: 0.25 }}>
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                            <Box
+                              component="code"
+                              sx={{
+                                fontFamily: "Consolas, Monaco, 'Fira Code', monospace",
+                                fontWeight: 600,
+                                color: 'text.primary',
+                              }}
+                            >
+                              {arg.name}
+                            </Box>{' '}
+                            {arg.required ? (
+                              <Box
+                                component="span"
+                                sx={{ color: DISCORD_BLURPLE, fontWeight: 600 }}
+                              >
+                                (required)
+                              </Box>
+                            ) : (
+                              <Box component="span" sx={{ opacity: 0.7 }}>
+                                (optional)
+                              </Box>
+                            )}{' '}
+                            — {arg.desc}
+                          </Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+
+      {/* ── Sign-ups ─────────────────────────────────────────────────── */}
+      <SectionHeading
+        icon={<Shield sx={{ color: DISCORD_BLURPLE }} />}
+        title="How members sign up"
+      />
+      <Box sx={{ ...cardSx, mb: 5 }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2, lineHeight: 1.6 }}>
+          Every published roster carries a row of buttons. Sign-up buttons post a public message
+          flagging interest — a raid lead still confirms the slot, so nothing is locked in
+          automatically.
+        </Typography>
+        <Stack spacing={1.25}>
+          {ROSTER_BUTTONS.map((b) => (
+            <Stack key={b.label} direction="row" spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  minWidth: 40,
+                  height: 28,
+                  px: 1,
+                  borderRadius: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '0.85rem',
+                  fontWeight: 600,
+                  color: isDark ? '#c7d2fe' : DISCORD_BLURPLE_DARK,
+                  background: isDark ? 'rgba(88,101,242,0.16)' : 'rgba(88,101,242,0.1)',
+                }}
+              >
+                {b.emoji}
+              </Box>
+              <Typography variant="body2" sx={{ lineHeight: 1.55 }}>
+                <Box component="span" sx={{ fontWeight: 700 }}>
+                  {b.label}
+                </Box>{' '}
+                <Box component="span" sx={{ color: 'text.secondary' }}>
+                  — {b.desc}
+                </Box>
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+
+      {/* ── Channel naming ───────────────────────────────────────────── */}
+      <SectionHeading
+        icon={<TagIcon sx={{ color: DISCORD_BLURPLE }} />}
+        title="Channel name tokens"
+      />
+      <Box sx={{ ...cardSx, mb: 5 }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2, lineHeight: 1.6 }}>
+          Set a template with{' '}
+          <Box component="code" sx={codeChipSx}>
+            /roster config set-name-pattern
+          </Box>
+          . The default{' '}
+          <Box component="code" sx={codeChipSx}>
+            {'{day-short}-{time}-{trial}'}
+          </Box>{' '}
+          produces channels like{' '}
+          <Box component="code" sx={codeChipSx}>
+            sun-8pm-vlc
+          </Box>
+          .
+        </Typography>
+        <Stack spacing={1} divider={<Divider flexItem />}>
+          {NAME_TOKENS.map((t) => (
+            <Stack
+              key={t.token}
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={{ xs: 0.25, sm: 2 }}
+              sx={{ alignItems: { xs: 'flex-start', sm: 'center' } }}
+            >
+              <Box component="code" sx={{ ...codeChipSx, minWidth: 120 }}>
+                {t.token}
+              </Box>
+              <Box
+                component="code"
+                sx={{ ...codeChipSx, minWidth: 70, fontSize: '0.82rem', opacity: 0.85 }}
+              >
+                {t.example}
+              </Box>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {t.desc}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+
+      {/* ── Permissions ──────────────────────────────────────────────── */}
+      <SectionHeading
+        icon={<LoginIcon sx={{ color: DISCORD_BLURPLE }} />}
+        title="Who can do what"
+      />
+      <Box sx={{ ...cardSx, mb: 5 }}>
+        <Stack spacing={1.5}>
+          <PermRow
+            role="Server admins (Manage Server)"
+            can="Everything — invite the bot, run all /roster config commands, publish, and refresh."
+          />
+          <PermRow
+            role="Publisher role (set via set-role / add-role)"
+            can="Publish, link, and refresh rosters. Cannot change configuration."
+          />
+          <PermRow
+            role="Everyone else"
+            can="Tap the Tank / Healer / DD sign-up buttons and open the roster on ESO Toolkit."
+          />
+        </Stack>
+      </Box>
+
+      {/* ── Troubleshooting ──────────────────────────────────────────── */}
+      <SectionHeading icon={<HelpOutlined sx={{ color: '#FEB900' }} />} title="Troubleshooting" />
+      <Stack spacing={1.25} sx={{ mb: 5 }}>
+        {[
+          {
+            q: '“You do not have permission to publish rosters.”',
+            a: 'Ask an admin to grant your role with /roster config set-role, or have someone with Manage Server publish.',
+          },
+          {
+            q: '“No roster is linked to this channel.”',
+            a: 'Run /roster refresh inside a channel the bot created with /roster link or /roster publish. Use /roster link first if the roster was never posted here.',
+          },
+          {
+            q: 'The bot posts but can’t create a channel',
+            a: 'It needs Manage Channels plus View Channel, Send Messages, and Embed Links — check for channel- or category-level permission overrides that deny the bot.',
+          },
+          {
+            q: 'Refresh says it can’t find the post',
+            a: 'The roster message was deleted. Re-publish it with /roster link or /roster publish.',
+          },
+          {
+            q: 'Slash commands don’t appear',
+            a: 'Give Discord a minute after inviting the bot, then fully reload your client. Make sure the bot was added with the applications.commands scope (the Invite button includes it).',
+          },
+        ].map((item) => (
+          <Accordion
+            key={item.q}
+            disableGutters
+            elevation={0}
+            sx={{
+              borderRadius: '12px !important',
+              border: isDark ? '1px solid rgba(255,255,255,0.07)' : '1px solid rgba(0,0,0,0.07)',
+              background: isDark ? 'rgba(255,255,255,0.025)' : 'rgba(255,255,255,0.6)',
+              '&:before': { display: 'none' },
+              overflow: 'hidden',
+            }}
+          >
+            <AccordionSummary expandIcon={<ExpandMore />} sx={{ px: 2 }}>
+              <Typography sx={{ fontWeight: 600, fontSize: '0.92rem' }}>{item.q}</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ px: 2, pt: 0, pb: 2 }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.6 }}>
+                {item.a}
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Stack>
+
+      {/* ── Footer CTA ───────────────────────────────────────────────── */}
+      <Box
+        sx={{
+          ...cardSx,
+          textAlign: 'center',
+          background: isDark
+            ? 'linear-gradient(135deg, rgba(88,101,242,0.16) 0%, rgba(87,242,135,0.05) 100%)'
+            : 'linear-gradient(135deg, rgba(88,101,242,0.1) 0%, rgba(87,242,135,0.04) 100%)',
+        }}
+      >
+        <Typography sx={{ fontWeight: 700, fontSize: '1.1rem', mb: 0.5 }}>
+          Ready to roll?
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+          Build a roster, then publish it to your server in seconds.
+        </Typography>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1.5}
+          sx={{ justifyContent: 'center' }}
+        >
+          <Button
+            variant="contained"
+            component={RouterLink}
+            to="/roster-builder"
+            endIcon={<ArrowForward />}
+            sx={{
+              borderRadius: '10px',
+              fontWeight: 700,
+              textTransform: 'none',
+              px: 3,
+              background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
+              '&:hover': {
+                background: `linear-gradient(135deg, #6973F5 0%, ${DISCORD_BLURPLE} 100%)`,
+              },
+            }}
+          >
+            Build a roster
+          </Button>
+          <Button
+            variant="outlined"
+            href="https://discord.gg/mMjwcQYFdc"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              borderRadius: '10px',
+              fontWeight: 600,
+              textTransform: 'none',
+              px: 3,
+              borderColor: 'rgba(88,101,242,0.4)',
+              color: isDark ? '#c7d2fe' : DISCORD_BLURPLE,
+              '&:hover': { borderColor: DISCORD_BLURPLE, background: 'rgba(88,101,242,0.06)' },
+            }}
+          >
+            Need help? Join our Discord
+          </Button>
+        </Stack>
+      </Box>
+    </Container>
+  );
+};
+
+// ── Small presentational helpers ────────────────────────────────────────────
+
+const SectionHeading: React.FC<{ icon: React.ReactNode; title: string }> = ({ icon, title }) => (
+  <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', mb: 2 }}>
+    {icon}
+    <Typography variant="h5" component="h2" sx={{ fontWeight: 700 }}>
+      {title}
+    </Typography>
+  </Stack>
+);
+
+const PermRow: React.FC<{ role: string; can: string }> = ({ role, can }) => (
+  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 0.25, sm: 2 }}>
+    <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', minWidth: { sm: 260 } }}>
+      {role}
+    </Typography>
+    <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.55 }}>
+      {can}
+    </Typography>
+  </Stack>
+);

--- a/src/pages/RosterBotDocsPage.tsx
+++ b/src/pages/RosterBotDocsPage.tsx
@@ -33,7 +33,6 @@ import {
   AccordionSummary,
   Box,
   Button,
-  Chip,
   Container,
   Divider,
   Stack,
@@ -295,7 +294,11 @@ export const RosterBotDocsPage: React.FC = () => {
     px: 1,
     py: 0.4,
     display: 'inline-block',
-    whiteSpace: 'nowrap',
+    maxWidth: '100%',
+    // Long slash commands (e.g. /roster config set-default-category) must wrap
+    // rather than force horizontal overflow on narrow mobile viewports.
+    whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
   } as const;
 
   return (
@@ -369,11 +372,16 @@ export const RosterBotDocsPage: React.FC = () => {
               textTransform: 'none',
               px: 3,
               py: 1,
+              // Force white text + shadow so the label keeps AA contrast on the
+              // blurple gradient regardless of the active theme's contrastText.
+              color: '#fff',
+              textShadow: '0 1px 2px rgba(0,0,0,0.35)',
               background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
-              boxShadow: '0 4px 16px rgba(88,101,242,0.3)',
+              boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
               '&:hover': {
-                background: `linear-gradient(135deg, #6973F5 0%, ${DISCORD_BLURPLE} 100%)`,
-                boxShadow: '0 6px 20px rgba(88,101,242,0.4)',
+                color: '#fff',
+                background: `linear-gradient(135deg, ${DISCORD_BLURPLE_DARK} 0%, #3a44a8 100%)`,
+                boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
               },
             }}
           >
@@ -574,25 +582,27 @@ export const RosterBotDocsPage: React.FC = () => {
                   <Stack
                     direction="row"
                     spacing={1}
-                    sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 0.75 }}
+                    sx={{ alignItems: 'flex-start', justifyContent: 'space-between', mb: 0.5 }}
                   >
-                    <Box component="code" sx={{ ...codeChipSx, fontSize: '1rem' }}>
+                    <Box
+                      component="code"
+                      sx={{ ...codeChipSx, fontSize: '1rem', minWidth: 0, flexShrink: 1 }}
+                    >
                       {cmd.command}
                     </Box>
-                    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                      <Chip
-                        label={cmd.access}
-                        size="small"
-                        sx={{
-                          height: 22,
-                          fontSize: '0.68rem',
-                          fontWeight: 600,
-                          color: 'text.secondary',
-                          background: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
-                        }}
-                      />
+                    <Box sx={{ flexShrink: 0 }}>
                       <CopyButton value={cmd.command} />
-                    </Stack>
+                    </Box>
+                  </Stack>
+                  <Stack
+                    direction="row"
+                    spacing={0.5}
+                    sx={{ alignItems: 'center', mb: 0.75, color: 'text.secondary' }}
+                  >
+                    <Shield sx={{ fontSize: 14, flexShrink: 0 }} />
+                    <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                      {cmd.access}
+                    </Typography>
                   </Stack>
                   <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.55 }}>
                     {cmd.summary}
@@ -601,7 +611,10 @@ export const RosterBotDocsPage: React.FC = () => {
                     <Box component="ul" sx={{ mt: 1, mb: 0, pl: 2.5 }}>
                       {cmd.args.map((arg) => (
                         <Box component="li" key={arg.name} sx={{ mb: 0.25 }}>
-                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                          <Typography
+                            variant="caption"
+                            sx={{ color: 'text.secondary', overflowWrap: 'anywhere' }}
+                          >
                             <Box
                               component="code"
                               sx={{
@@ -830,9 +843,14 @@ export const RosterBotDocsPage: React.FC = () => {
               fontWeight: 700,
               textTransform: 'none',
               px: 3,
+              color: '#fff',
+              textShadow: '0 1px 2px rgba(0,0,0,0.35)',
               background: `linear-gradient(135deg, ${DISCORD_BLURPLE} 0%, ${DISCORD_BLURPLE_DARK} 100%)`,
+              boxShadow: '0 4px 16px rgba(88,101,242,0.35)',
               '&:hover': {
-                background: `linear-gradient(135deg, #6973F5 0%, ${DISCORD_BLURPLE} 100%)`,
+                color: '#fff',
+                background: `linear-gradient(135deg, ${DISCORD_BLURPLE_DARK} 0%, #3a44a8 100%)`,
+                boxShadow: '0 6px 22px rgba(88,101,242,0.5)',
               },
             }}
           >

--- a/src/pages/__tests__/RosterBotDocsPage.test.tsx
+++ b/src/pages/__tests__/RosterBotDocsPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import { RosterBotDocsPage } from '../RosterBotDocsPage';
+
+const renderPage = (): ReturnType<typeof render> =>
+  render(
+    <MemoryRouter>
+      <RosterBotDocsPage />
+    </MemoryRouter>,
+  );
+
+describe('RosterBotDocsPage', () => {
+  it('renders the hero and core calls to action', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Discord Roster Bot/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Invite the bot/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Configure on the web/i })).toBeInTheDocument();
+  });
+
+  it('documents the key roster commands', () => {
+    renderPage();
+
+    expect(screen.getByText('/roster link')).toBeInTheDocument();
+    expect(screen.getByText('/roster publish')).toBeInTheDocument();
+    expect(screen.getByText('/roster refresh')).toBeInTheDocument();
+    expect(screen.getByText('/roster config set-role')).toBeInTheDocument();
+  });
+
+  it('explains the member sign-up buttons', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: /How members sign up/i })).toBeInTheDocument();
+    expect(screen.getByText(/A raid lead still confirms the slot/i)).toBeInTheDocument();
+  });
+
+  it('sets the document title', () => {
+    renderPage();
+    expect(document.title).toBe('Discord Roster Bot Guide | ESO Toolkit');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an in-app documentation page at **`/docs/discord-roster-bot`** so raid leads and server admins know how to operate the Discord roster bot.

The site is a React SPA with an existing in-app docs pattern (`/docs/calculations`, `/docs/loadout/food-selector`). Rather than rendering a markdown file, this page is hand-built so it can offer **copy-to-clipboard command chips** and match the Discord brand styling already used in `DiscordAdminGuideContent`. It works **unauthenticated**, so it can be DM'd to whoever holds *Manage Server*.

## What the page covers

- **Hero** with one-click *Invite the bot*, *Configure on the web*, and *Install guide* CTAs
- **What it does** — publish rosters, take sign-ups, stay in sync
- **Quick start** — 4-step admin onboarding
- **Command reference** — every `/roster` command grouped by purpose (publishing, getting started, configuration), with exact arguments, who can run each, and copy buttons. Command/option names verified against `discord-bot/scripts/register-commands.js`.
- **How members sign up** — the Tank / Healer / DD / View / Refresh buttons, and the fact that sign-ups flag interest (a raid lead confirms)
- **Channel name tokens** — `{day-short}`, `{time}`, `{trial}`, etc. with the default `{day-short}-{time}-{trial}`
- **Who can do what** — admins vs. publisher role vs. everyone
- **Troubleshooting** accordion

## Integration

- Lazy route registered in `App.tsx`
- "Discord Bot Guide" added to the footer Quick Links
- Guide linked from the Discord server-config login screen
- Render tests added (`src/pages/__tests__/RosterBotDocsPage.test.tsx`)

## Validation

- `npm run typecheck` — passes
- `eslint` on changed source files — clean
- `prettier --check` — clean
- `jest` for the new page — 4/4 passing

> Note: browser screenshots weren't possible in this environment (no Chrome binary), so visual confirmation relies on the jsdom render test plus typecheck/lint/format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTNStWLArMYaL4juhtULN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTNStWLArMYaL4juhtULN1)_