### PR TITLE
feat(loadout↔build bridge): close the Phase-1 gate — export weapon slots to Wizard's Wardrobe

### DIFF
--- a/src/features/build-editor/utils/__tests__/buildLoadoutBridge.test.ts
+++ b/src/features/build-editor/utils/__tests__/buildLoadoutBridge.test.ts
@@ -1,0 +1,114 @@
+import type { BuildSetup } from '../../types/build.types';
+import {
+  buildChampionPointsToFlat,
+  buildSetupToLoadoutSetup,
+  buildSetupToWWTransfer,
+} from '../buildLoadoutBridge';
+
+function makeBuildSetup(overrides: Partial<BuildSetup> = {}): BuildSetup {
+  return {
+    id: 's1',
+    name: 'My DPS',
+    attributes: { magicka: 64, health: 0, stamina: 0 },
+    curse: 'none',
+    mundusStone: '',
+    gear: {},
+    skills: { 0: {}, 1: {} },
+    cp: {
+      warfare: { slots: [], passives: {} },
+      fitness: { slots: [], passives: {} },
+      craft: { slots: [], passives: {} },
+    },
+    consumables: { potions: [], food: {} },
+    passives: [],
+    screenshots: [],
+    ...overrides,
+  };
+}
+
+describe('buildChampionPointsToFlat', () => {
+  it('flattens the three trees into slots 1-12 (craft 1-4, warfare 5-8, fitness 9-12)', () => {
+    const flat = buildChampionPointsToFlat({
+      craft: { slots: [1001, 1002], passives: {} },
+      warfare: { slots: [2001], passives: {} },
+      fitness: { slots: [null, 3001], passives: {} },
+    });
+    expect(flat).toEqual({ 1: 1001, 2: 1002, 5: 2001, 10: 3001 });
+  });
+
+  it('skips null/zero perks and ignores anything past the 4th slot in a tree', () => {
+    const flat = buildChampionPointsToFlat({
+      craft: { slots: [0, null, 1003, 1004, 9999 /* 5th, ignored */], passives: {} },
+      warfare: { slots: [], passives: {} },
+      fitness: { slots: [], passives: {} },
+    });
+    expect(flat).toEqual({ 3: 1003, 4: 1004 });
+  });
+});
+
+describe('buildSetupToLoadoutSetup', () => {
+  it('copies shared gear/skills, flattens CP, reduces food, drops editor-only fields', () => {
+    const loadout = buildSetupToLoadoutSetup(
+      makeBuildSetup({
+        name: '  Stamblade  ',
+        skills: { 0: { 3: 111, 8: 999 }, 1: { 3: 222 } },
+        gear: { 0: { id: 'x', trait: 'divines' }, 2: { id: 'y' } },
+        cp: {
+          craft: { slots: [1001], passives: {} },
+          warfare: { slots: [2001, 2002], passives: {} },
+          fitness: { slots: [], passives: {} },
+        },
+        consumables: { potions: [], food: { id: 84720, name: 'Dubious' } },
+      }),
+    );
+
+    expect(loadout.name).toBe('Stamblade');
+    expect(loadout.disabled).toBe(false);
+    expect(loadout.condition).toEqual({});
+    expect(loadout.skills).toEqual({ 0: { 3: 111, 8: 999 }, 1: { 3: 222 } });
+    expect(loadout.gear).toEqual({ 0: { id: 'x', trait: 'divines' }, 2: { id: 'y' } });
+    expect(loadout.cp).toEqual({ 1: 1001, 5: 2001, 6: 2002 });
+    expect(loadout.food).toEqual({ id: 84720 });
+    // Editor-only concepts have no representation on the loadout.
+    expect(loadout).not.toHaveProperty('attributes');
+    expect(loadout).not.toHaveProperty('mundusStone');
+  });
+
+  it('falls back to a default name and empty food', () => {
+    const loadout = buildSetupToLoadoutSetup(makeBuildSetup({ name: '   ' }));
+    expect(loadout.name).toBe('Build');
+    expect(loadout.food).toEqual({});
+  });
+});
+
+describe('buildSetupToWWTransfer (end-to-end: build → loadout → WW code)', () => {
+  it('carries skills/CP/food through and applies the same gear-safety omission', () => {
+    const result = buildSetupToWWTransfer(
+      makeBuildSetup({
+        name: 'Trial DPS',
+        skills: { 0: { 3: 111, 4: 222, 8: 999 }, 1: { 3: 333 } },
+        cp: {
+          craft: { slots: [1001], passives: {} },
+          warfare: { slots: [2001], passives: {} },
+          fitness: { slots: [3001], passives: {} },
+        },
+        consumables: { potions: [], food: { id: 84720 } },
+        // A weapon slot (omitted) and an unidentifiable armor slot (omitted).
+        gear: { 4: { link: '|H0:item:54321:0:0:0|h|h' }, 0: { id: 'not-an-id' } },
+      }),
+    );
+
+    expect(result.data.name).toBe('Trial DPS');
+    expect(result.data.skills['0']).toEqual({ 3: 111, 4: 222, 8: 999 });
+    expect(result.data.skills['1']).toEqual({ 3: 333 });
+    expect(result.data.cp).toEqual({ 1: 1001, 5: 2001, 9: 3001 });
+    expect(result.data.food).toBe(84720);
+
+    // Gear that can't be safely encoded is omitted, never guessed.
+    expect(Object.keys(result.data.gear)).toHaveLength(0);
+    expect(result.unresolvedSlots.map((u) => u.slot).sort((a, b) => a - b)).toEqual([0, 4]);
+
+    // Produces parseable JSON for the in-game paste box.
+    expect(JSON.parse(result.json)).toEqual(result.data);
+  });
+});

--- a/src/features/build-editor/utils/buildLoadoutBridge.ts
+++ b/src/features/build-editor/utils/buildLoadoutBridge.ts
@@ -1,0 +1,77 @@
+/**
+ * Build Editor → Loadout Manager bridge.
+ *
+ * The Build Editor and the Loadout Manager describe the same ESO build with
+ * different shapes: the editor uses a flat, class-centric `BuildSetup` (champion
+ * points as three trees), while the loadout manager uses a leaner `LoadoutSetup`
+ * (champion points as a flat 1-12 slot map) geared toward in-game addon export.
+ * They already share the gear and skill types, so the only real transform is the
+ * champion-point model and dropping editor-only metadata (class/race/mundus/etc.,
+ * which Wizard's Wardrobe does not carry anyway).
+ *
+ * This is the seam that lets a build authored in the editor flow into the loadout
+ * surface and out to Wizard's Wardrobe as a paste-in import code, without
+ * re-entering anything.
+ *
+ * Lives in `build-editor` (not `loadout-manager`) to preserve the existing
+ * one-way feature dependency build-editor → loadout-manager and avoid a cycle.
+ */
+
+import type { LoadoutSetup, ChampionPointsConfig } from '../../loadout-manager/types/loadout.types';
+import {
+  loadoutSetupToWWTransfer,
+  type WWTransferResult,
+} from '../../loadout-manager/utils/wizardWardrobeTransfer';
+import type { BuildSetup } from '../types/build.types';
+
+/**
+ * Flatten the editor's three champion-point trees into the loadout manager's
+ * 1-12 slot map. Matches the loadout manager's own import convention
+ * (`wizardWardrobeConverter`): craft → slots 1-4, warfare → 5-8, fitness → 9-12.
+ * Only slotted (non-null, positive) perks are carried — passive star
+ * allocations are not part of the slotted-CP model.
+ */
+export function buildChampionPointsToFlat(cp: BuildSetup['cp']): ChampionPointsConfig {
+  const flat: ChampionPointsConfig = {};
+  const trees: Array<{ slots: Array<number | null>; offset: number }> = [
+    { slots: cp?.craft?.slots ?? [], offset: 0 },
+    { slots: cp?.warfare?.slots ?? [], offset: 4 },
+    { slots: cp?.fitness?.slots ?? [], offset: 8 },
+  ];
+  for (const { slots, offset } of trees) {
+    slots.forEach((abilityId, index) => {
+      if (index < 4 && typeof abilityId === 'number' && abilityId > 0) {
+        flat[offset + index + 1] = abilityId;
+      }
+    });
+  }
+  return flat;
+}
+
+/**
+ * Convert a Build Editor `BuildSetup` into a Loadout Manager `LoadoutSetup`.
+ * Gear and skills are shared types (copied as-is); champion points are flattened;
+ * food is reduced to its item id. Editor-only fields (attributes, mundus, curse,
+ * passives, screenshots) are intentionally dropped — they have no place in the
+ * loadout / Wizard's Wardrobe model.
+ */
+export function buildSetupToLoadoutSetup(setup: BuildSetup): LoadoutSetup {
+  return {
+    name: setup.name?.trim() || 'Build',
+    disabled: false,
+    condition: {},
+    skills: setup.skills ?? { 0: {}, 1: {} },
+    cp: buildChampionPointsToFlat(setup.cp),
+    food: typeof setup.consumables?.food?.id === 'number' ? { id: setup.consumables.food.id } : {},
+    gear: setup.gear ?? {},
+  };
+}
+
+/**
+ * Encode a Build Editor `BuildSetup` directly as a Wizard's Wardrobe import code,
+ * by bridging to a `LoadoutSetup` and reusing the loadout manager's WW Transfer
+ * encoder. This is the end-to-end "plan a build, paste it into the game" path.
+ */
+export function buildSetupToWWTransfer(setup: BuildSetup): WWTransferResult {
+  return loadoutSetupToWWTransfer(buildSetupToLoadoutSetup(setup));
+}

--- a/src/features/loadout-manager/components/ExportDialog.tsx
+++ b/src/features/loadout-manager/components/ExportDialog.tsx
@@ -29,12 +29,13 @@ import { useLogger } from '@/hooks/useLogger';
 
 import { TRIALS } from '../data/trialConfigs';
 import { selectCurrentTrial, selectCurrentSetups, selectLoadoutState } from '../store/selectors';
-import type { WizardWardrobeExport } from '../types/loadout.types';
 import {
   convertLoadoutStateToAlphaGear,
   serializeAlphaGearToLua,
 } from '../utils/alphaGearConverter';
 import { validateGearConfig } from '../utils/itemSlotValidator';
+
+import { WizardWardrobeTransferPanel } from './WizardWardrobeTransferPanel';
 
 interface ExportDialogProps {
   open: boolean;
@@ -111,32 +112,16 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ open, onClose }) => 
     return serializeAlphaGearToLua(agData);
   };
 
-  const generateWizardWardrobe = (): string => {
-    // Convert to Wizard's Wardrobe format
-    const wizardData: WizardWardrobeExport = {
-      version: 1,
-      selectedZoneTag: currentTrialId || '',
-      setups: {
-        [currentTrialId || 'default']: setups.map((setup, index) => ({
-          [index + 1]: setup,
-        })),
-      },
-      pages: {
-        [currentTrialId || 'default']: [{ selected: 1 }],
-      },
-    };
-    return JSON.stringify(wizardData, null, 2);
-  };
-
+  // Wizard's Wardrobe uses a paste-in import code per setup (handled by
+  // WizardWardrobeTransferPanel), so it is not part of the file/clipboard export
+  // path below — that path serves the JSON and AlphaGear (Lua file) formats.
   const getExportData = (): string => {
     if (exportFormat === 'alphagear') return generateAlphaGear();
-    if (exportFormat === 'wizard') return generateWizardWardrobe();
     return generateJSON();
   };
 
   const getExportFilename = (): string => {
     if (exportFormat === 'alphagear') return `AlphaGear.lua`;
-    if (exportFormat === 'wizard') return `wizard-wardrobe-${currentTrialId}-${Date.now()}.json`;
     return `loadout-${currentTrialId}-${Date.now()}.json`;
   };
 
@@ -290,7 +275,7 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ open, onClose }) => 
                 <Stack>
                   <Typography variant="body1">Wizard&apos;s Wardrobe (ESO Addon)</Typography>
                   <Typography variant="caption" color="text.secondary">
-                    Compatible with in-game addon
+                    Paste-in import code — no file needed
                   </Typography>
                 </Stack>
               </MenuItem>
@@ -305,56 +290,62 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ open, onClose }) => 
             </Select>
           </FormControl>
 
-          {/* Preview */}
-          <Paper
-            elevation={0}
-            sx={{
-              p: 2,
-              backgroundColor: isDarkMode ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.04)',
-              border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)'}`,
-            }}
-          >
-            <Typography variant="caption" color="text.secondary" gutterBottom>
-              Preview:
-            </Typography>
-            <TextField
-              multiline
-              fullWidth
-              rows={12}
-              value={getPreview()}
-              slotProps={{
-                input: {
-                  readOnly: true,
-                  sx: {
-                    fontFamily: 'monospace',
-                    fontSize: '0.75rem',
-                    bgcolor: 'background.paper',
-                  },
-                },
-              }}
-            />
-          </Paper>
+          {exportFormat === 'wizard' ? (
+            <WizardWardrobeTransferPanel setups={setups} />
+          ) : (
+            <>
+              {/* Preview */}
+              <Paper
+                elevation={0}
+                sx={{
+                  p: 2,
+                  backgroundColor: isDarkMode ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.04)',
+                  border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)'}`,
+                }}
+              >
+                <Typography variant="caption" color="text.secondary" gutterBottom>
+                  Preview:
+                </Typography>
+                <TextField
+                  multiline
+                  fullWidth
+                  rows={12}
+                  value={getPreview()}
+                  slotProps={{
+                    input: {
+                      readOnly: true,
+                      sx: {
+                        fontFamily: 'monospace',
+                        fontSize: '0.75rem',
+                        bgcolor: 'background.paper',
+                      },
+                    },
+                  }}
+                />
+              </Paper>
 
-          {copied && (
-            <Alert severity="success" onClose={() => setCopied(false)}>
-              Copied to clipboard!
-            </Alert>
-          )}
+              {copied && (
+                <Alert severity="success" onClose={() => setCopied(false)}>
+                  Copied to clipboard!
+                </Alert>
+              )}
 
-          {/* Help text for Wizard's Wardrobe and AlphaGear formats */}
-          {(exportFormat === 'wizard' || exportFormat === 'alphagear') && (
-            <Alert severity="info">
-              <Typography variant="caption" component="div">
-                <strong>To use in-game:</strong> Save this file to your ESO folder at:
-                <br />
-                <code style={{ fontSize: '0.85em', display: 'block', marginTop: '4px' }}>
-                  {getESOSavedVarsPath()}
-                  {exportFormat === 'alphagear' ? 'AlphaGear.lua' : 'WizardWardrobe.lua'}
-                </code>
-                <br />
-                Then use <code>/reloadui</code> in-game to load your changes.
-              </Typography>
-            </Alert>
+              {/* Help text for the AlphaGear (Lua SavedVariables file) format */}
+              {exportFormat === 'alphagear' && (
+                <Alert severity="info">
+                  <Typography variant="caption" component="div">
+                    <strong>To use in-game:</strong> Save this file to your ESO folder at:
+                    <br />
+                    <code style={{ fontSize: '0.85em', display: 'block', marginTop: '4px' }}>
+                      {getESOSavedVarsPath()}
+                      AlphaGear.lua
+                    </code>
+                    <br />
+                    Then use <code>/reloadui</code> in-game to load your changes.
+                  </Typography>
+                </Alert>
+              )}
+            </>
           )}
         </Stack>
       </DialogContent>
@@ -366,35 +357,40 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ open, onClose }) => 
             </Typography>
           )}
         </Box>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          startIcon={<ContentCopy />}
-          onClick={handleCopy}
-          variant="outlined"
-          disabled={exportBlocked}
-          sx={{
-            borderRadius: '20px',
-            backgroundColor: isDarkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',
-            borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
-            '&:hover': {
-              backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
-              borderColor: isDarkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
-            },
-          }}
-        >
-          Copy to Clipboard
-        </Button>
-        <Button
-          startIcon={<Download />}
-          onClick={handleExport}
-          variant="contained"
-          disabled={exportBlocked}
-          sx={{
-            borderRadius: '20px',
-          }}
-        >
-          Download File
-        </Button>
+        <Button onClick={onClose}>{exportFormat === 'wizard' ? 'Close' : 'Cancel'}</Button>
+        {/* Wizard's Wardrobe uses per-setup copy buttons in the panel above. */}
+        {exportFormat !== 'wizard' && (
+          <>
+            <Button
+              startIcon={<ContentCopy />}
+              onClick={handleCopy}
+              variant="outlined"
+              disabled={exportBlocked}
+              sx={{
+                borderRadius: '20px',
+                backgroundColor: isDarkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',
+                borderColor: isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+                '&:hover': {
+                  backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.04)',
+                  borderColor: isDarkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
+                },
+              }}
+            >
+              Copy to Clipboard
+            </Button>
+            <Button
+              startIcon={<Download />}
+              onClick={handleExport}
+              variant="contained"
+              disabled={exportBlocked}
+              sx={{
+                borderRadius: '20px',
+              }}
+            >
+              Download File
+            </Button>
+          </>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/features/loadout-manager/components/ExportDialog.tsx
+++ b/src/features/loadout-manager/components/ExportDialog.tsx
@@ -291,7 +291,7 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ open, onClose }) => 
           </FormControl>
 
           {exportFormat === 'wizard' ? (
-            <WizardWardrobeTransferPanel setups={setups} />
+            <WizardWardrobeTransferPanel setups={setups} disabled={exportBlocked} />
           ) : (
             <>
               {/* Preview */}

--- a/src/features/loadout-manager/components/WizardWardrobeTransferPanel.tsx
+++ b/src/features/loadout-manager/components/WizardWardrobeTransferPanel.tsx
@@ -1,0 +1,188 @@
+/**
+ * Wizard's Wardrobe import-code panel.
+ *
+ * Renders one paste-in import code per setup (WW imports a single setup into a
+ * single slot), each with a copy button, a character-count chip against the
+ * in-game 1000-char limit, and a note for any gear slots that couldn't be encoded
+ * (weapon slots / unknown sets) so the user knows to set those manually.
+ */
+
+import { ContentCopy, CheckCircleOutlined, WarningAmberOutlined } from '@mui/icons-material';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React, { useState } from 'react';
+
+import { useLogger } from '@/hooks/useLogger';
+
+import type { LoadoutSetup } from '../types/loadout.types';
+import {
+  loadoutSetupToWWTransfer,
+  WW_TRANSFER_CHAR_LIMIT,
+  type WWTransferResult,
+} from '../utils/wizardWardrobeTransfer';
+
+interface WizardWardrobeTransferPanelProps {
+  setups: LoadoutSetup[];
+}
+
+const SLOT_NAMES: Record<number, string> = {
+  0: 'Head',
+  1: 'Necklace',
+  2: 'Chest',
+  3: 'Shoulders',
+  4: 'Main Hand',
+  5: 'Off Hand',
+  6: 'Waist',
+  8: 'Legs',
+  9: 'Feet',
+  11: 'Ring 1',
+  12: 'Ring 2',
+  16: 'Hands',
+  20: 'Backup Main Hand',
+  21: 'Backup Off Hand',
+};
+
+export const WizardWardrobeTransferPanel: React.FC<WizardWardrobeTransferPanelProps> = ({
+  setups,
+}) => {
+  const logger = useLogger('WizardWardrobeTransferPanel');
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const encoded: WWTransferResult[] = React.useMemo(
+    () => setups.map((setup) => loadoutSetupToWWTransfer(setup)),
+    [setups],
+  );
+
+  const handleCopy = async (index: number, json: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(json);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex((current) => (current === index ? null : current)), 2000);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error('Failed to copy Wizard’s Wardrobe import code', err);
+    }
+  };
+
+  if (setups.length === 0) {
+    return (
+      <Alert severity="info" sx={{ borderRadius: '12px' }}>
+        No setups to export. Add a setup first.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Alert severity="info" sx={{ borderRadius: '12px' }}>
+        <Typography variant="caption" component="div">
+          <strong>In-game:</strong> open Wizard&apos;s Wardrobe, right-click a setup slot &rarr;{' '}
+          <strong>Import</strong> &rarr; paste the code &rarr; <strong>Import</strong>. No file or{' '}
+          <code>/reloadui</code> needed. WW equips items you already own that match each set and
+          trait.
+        </Typography>
+      </Alert>
+
+      {encoded.map((result, index) => {
+        const setupName = setups[index]?.name?.trim() || `Setup ${index + 1}`;
+        const unresolvedTitle = result.unresolvedSlots
+          .map((u) => `${SLOT_NAMES[u.slot] ?? `Slot ${u.slot}`}: ${u.reason}`)
+          .join('\n');
+        return (
+          <Paper
+            key={index}
+            elevation={0}
+            sx={{
+              p: 2,
+              borderRadius: '12px',
+              backgroundColor: isDarkMode ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
+              border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+            }}
+          >
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: 'center', justifyContent: 'space-between' }}
+            >
+              <Typography variant="subtitle2" sx={{ fontWeight: 700 }} noWrap>
+                {setupName}
+              </Typography>
+              <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                <Chip
+                  size="small"
+                  label={`${result.charCount} / ${WW_TRANSFER_CHAR_LIMIT}`}
+                  color={result.overCharLimit ? 'error' : 'default'}
+                  variant="outlined"
+                />
+                <Button
+                  size="small"
+                  startIcon={copiedIndex === index ? <CheckCircleOutlined /> : <ContentCopy />}
+                  onClick={() => void handleCopy(index, result.json)}
+                  variant="outlined"
+                  color={copiedIndex === index ? 'success' : 'primary'}
+                  sx={{ borderRadius: '16px', minWidth: 96 }}
+                >
+                  {copiedIndex === index ? 'Copied' : 'Copy'}
+                </Button>
+              </Stack>
+            </Stack>
+
+            <TextField
+              multiline
+              fullWidth
+              maxRows={4}
+              value={result.json}
+              slotProps={{
+                input: {
+                  readOnly: true,
+                  sx: { fontFamily: 'monospace', fontSize: '0.7rem', mt: 1 },
+                },
+              }}
+            />
+
+            {result.overCharLimit && (
+              <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
+                This code exceeds the 1000-character in-game paste limit. Reduce the setup (fewer
+                gear pieces or a shorter name) or set part of it manually.
+              </Typography>
+            )}
+
+            {result.unresolvedSlots.length > 0 && (
+              <Tooltip title={<Box sx={{ whiteSpace: 'pre-line' }}>{unresolvedTitle}</Box>}>
+                <Stack
+                  direction="row"
+                  spacing={0.5}
+                  sx={{
+                    mt: 1,
+                    color: 'warning.main',
+                    cursor: 'help',
+                    width: 'fit-content',
+                    alignItems: 'center',
+                  }}
+                >
+                  <WarningAmberOutlined fontSize="small" />
+                  <Typography variant="caption">
+                    {result.unresolvedSlots.length} slot
+                    {result.unresolvedSlots.length === 1 ? '' : 's'} to set manually in-game
+                  </Typography>
+                </Stack>
+              </Tooltip>
+            )}
+          </Paper>
+        );
+      })}
+    </Stack>
+  );
+};

--- a/src/features/loadout-manager/components/WizardWardrobeTransferPanel.tsx
+++ b/src/features/loadout-manager/components/WizardWardrobeTransferPanel.tsx
@@ -16,7 +16,6 @@ import {
   Paper,
   Stack,
   TextField,
-  Tooltip,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -33,6 +32,12 @@ import {
 
 interface WizardWardrobeTransferPanelProps {
   setups: LoadoutSetup[];
+  /**
+   * When true, gear validation has blocking errors, so import codes are withheld
+   * (the parent dialog shows the specific errors). Mirrors the JSON/AlphaGear
+   * export gate so an invalid setup can't be copied out of the Wizard path.
+   */
+  disabled?: boolean;
 }
 
 const SLOT_NAMES: Record<number, string> = {
@@ -54,6 +59,7 @@ const SLOT_NAMES: Record<number, string> = {
 
 export const WizardWardrobeTransferPanel: React.FC<WizardWardrobeTransferPanelProps> = ({
   setups,
+  disabled = false,
 }) => {
   const logger = useLogger('WizardWardrobeTransferPanel');
   const theme = useTheme();
@@ -84,6 +90,14 @@ export const WizardWardrobeTransferPanel: React.FC<WizardWardrobeTransferPanelPr
     );
   }
 
+  if (disabled) {
+    return (
+      <Alert severity="error" sx={{ borderRadius: '12px' }}>
+        Resolve the gear slot issues above to generate Wizard&apos;s Wardrobe import codes.
+      </Alert>
+    );
+  }
+
   return (
     <Stack spacing={2}>
       <Alert severity="info" sx={{ borderRadius: '12px' }}>
@@ -97,9 +111,6 @@ export const WizardWardrobeTransferPanel: React.FC<WizardWardrobeTransferPanelPr
 
       {encoded.map((result, index) => {
         const setupName = setups[index]?.name?.trim() || `Setup ${index + 1}`;
-        const unresolvedTitle = result.unresolvedSlots
-          .map((u) => `${SLOT_NAMES[u.slot] ?? `Slot ${u.slot}`}: ${u.reason}`)
-          .join('\n');
         return (
           <Paper
             key={index}
@@ -160,25 +171,23 @@ export const WizardWardrobeTransferPanel: React.FC<WizardWardrobeTransferPanelPr
             )}
 
             {result.unresolvedSlots.length > 0 && (
-              <Tooltip title={<Box sx={{ whiteSpace: 'pre-line' }}>{unresolvedTitle}</Box>}>
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{
-                    mt: 1,
-                    color: 'warning.main',
-                    cursor: 'help',
-                    width: 'fit-content',
-                    alignItems: 'center',
-                  }}
-                >
-                  <WarningAmberOutlined fontSize="small" />
-                  <Typography variant="caption">
-                    {result.unresolvedSlots.length} slot
-                    {result.unresolvedSlots.length === 1 ? '' : 's'} to set manually in-game
-                  </Typography>
-                </Stack>
-              </Tooltip>
+              <Alert
+                severity="warning"
+                icon={<WarningAmberOutlined fontSize="small" />}
+                sx={{ mt: 1, borderRadius: '10px', py: 0.5 }}
+              >
+                <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }}>
+                  {result.unresolvedSlots.length} slot
+                  {result.unresolvedSlots.length === 1 ? '' : 's'} to set manually in-game:
+                </Typography>
+                <Box component="ul" sx={{ pl: 2, my: 0.5 }}>
+                  {result.unresolvedSlots.map((u) => (
+                    <Typography key={u.slot} component="li" variant="caption">
+                      <strong>{SLOT_NAMES[u.slot] ?? `Slot ${u.slot}`}:</strong> {u.reason}
+                    </Typography>
+                  ))}
+                </Box>
+              </Alert>
             )}
           </Paper>
         );

--- a/src/features/loadout-manager/data/esoEquipmentEnums.ts
+++ b/src/features/loadout-manager/data/esoEquipmentEnums.ts
@@ -95,13 +95,52 @@ export const SLOT_TO_EQUIP_TYPE: Readonly<Record<number, number>> = {
   [EQUIP_SLOT.RING2]: EQUIP_TYPE.RING,
 };
 
-/** Weapon gear-slot indices (equipType is weapon-type-dependent — omit if unknown). */
+/** Weapon gear-slot indices (equipType is weapon-type-dependent — derive per item). */
 export const WEAPON_SLOTS: ReadonlySet<number> = new Set([
   EQUIP_SLOT.MAIN_HAND,
   EQUIP_SLOT.OFF_HAND,
   EQUIP_SLOT.BACKUP_MAIN,
   EQUIP_SLOT.BACKUP_OFF,
 ]);
+
+/**
+ * ESO weapon-type label → `EQUIP_TYPE` int. The labels are exactly the values
+ * produced by `getWeaponTypeLabel` (itemIconResolver). equipType is intrinsic to
+ * the weapon (not the slot it sits in): every one-handed weapon equips as
+ * ONE_HAND even in the off-hand slot, a shield equips as OFF_HAND, and every
+ * two-handed weapon (greatsword / battle axe / maul / bow / all staves) equips as
+ * TWO_HAND. The generic "Staff" label (element unknown) is still unambiguously
+ * TWO_HAND, so it resolves here even though its element doesn't.
+ */
+export const WEAPON_LABEL_TO_EQUIP_TYPE: Readonly<Record<string, number>> = {
+  // One-handed weapons
+  Sword: EQUIP_TYPE.ONE_HAND,
+  Axe: EQUIP_TYPE.ONE_HAND,
+  Mace: EQUIP_TYPE.ONE_HAND,
+  Dagger: EQUIP_TYPE.ONE_HAND,
+  // Off-hand
+  Shield: EQUIP_TYPE.OFF_HAND,
+  // Two-handed weapons
+  Greatsword: EQUIP_TYPE.TWO_HAND,
+  'Battle Axe': EQUIP_TYPE.TWO_HAND,
+  Maul: EQUIP_TYPE.TWO_HAND,
+  Bow: EQUIP_TYPE.TWO_HAND,
+  Staff: EQUIP_TYPE.TWO_HAND,
+  'Inferno Staff': EQUIP_TYPE.TWO_HAND,
+  'Ice Staff': EQUIP_TYPE.TWO_HAND,
+  'Lightning Staff': EQUIP_TYPE.TWO_HAND,
+  'Restoration Staff': EQUIP_TYPE.TWO_HAND,
+};
+
+/**
+ * Resolve a weapon-type label (e.g. "Dagger", "Greatsword", "Inferno Staff") to
+ * its `EQUIP_TYPE` int. Returns undefined for non-weapon / unrecognized labels so
+ * callers can omit the slot rather than emit a wrong (hard-matched) equipType.
+ */
+export function weaponLabelToEquipType(label: string | null | undefined): number | undefined {
+  if (!label) return undefined;
+  return WEAPON_LABEL_TO_EQUIP_TYPE[label.trim()];
+}
 
 /** Internal gear-slot index → trait category (for resolving the trait int). */
 export function slotTraitCategory(slot: number): GearTraitCategory {

--- a/src/features/loadout-manager/data/esoEquipmentEnums.ts
+++ b/src/features/loadout-manager/data/esoEquipmentEnums.ts
@@ -1,0 +1,164 @@
+/**
+ * Canonical ESO (Elder Scrolls Online) equipment/trait enum values.
+ *
+ * These integers are the values returned by the live ESO Lua API
+ * (`GetItemLinkEquipType`, `GetItemLinkTraitInfo`, the `EQUIP_SLOT_*` globals).
+ * They are needed to encode a Wizard's Wardrobe "Transfer" import code, whose
+ * gear tuple is `[equipType, setId, traitType]` keyed by `String(EQUIP_SLOT)`.
+ *
+ * Values cross-verified (2026-06) against two independent sources and the
+ * addon source itself:
+ *  - esoui globals dump: Baertram/IntelliJ_ESOUI_AutoCompletion `eso-api_globals.lua`
+ *  - trait cross-check:  Baertram/LibResearch `LibResearch.lua`
+ *  - name set:           esoui/esoui `ESOUIDocumentation.txt` (API 101050)
+ *  - transfer format:    nicokimmel/wizardswardrobe `WizardsWardrobeTransfer.lua`
+ *
+ * traitType is a SOFT field for WW import (it prefers the requested trait, else
+ * any matching item), so an unmapped trait safely degrades to 0 ("any"). equipType
+ * and setId are HARD-matched, so callers must omit a slot rather than emit a guess.
+ */
+
+/** `EQUIP_TYPE_*` — the value returned by `GetItemLinkEquipType(link)`. */
+export const EQUIP_TYPE = {
+  INVALID: 0,
+  HEAD: 1,
+  NECK: 2,
+  CHEST: 3,
+  SHOULDERS: 4,
+  ONE_HAND: 5,
+  TWO_HAND: 6,
+  OFF_HAND: 7,
+  WAIST: 8,
+  LEGS: 9,
+  FEET: 10,
+  COSTUME: 11,
+  RING: 12,
+  HAND: 13,
+  MAIN_HAND: 14,
+  POISON: 15,
+} as const;
+
+/**
+ * `EQUIP_SLOT_*` — the equipment slot ids. The app's internal gear slot indices
+ * (see `loadout.types.ts` GearConfig) already match these ESO constants, and WW's
+ * Transfer `gear` map is keyed by `String(EQUIP_SLOT)`.
+ */
+export const EQUIP_SLOT = {
+  HEAD: 0,
+  NECK: 1,
+  CHEST: 2,
+  SHOULDERS: 3,
+  MAIN_HAND: 4,
+  OFF_HAND: 5,
+  WAIST: 6,
+  WRIST: 7,
+  LEGS: 8,
+  FEET: 9,
+  COSTUME: 10,
+  RING1: 11,
+  RING2: 12,
+  POISON: 13,
+  BACKUP_POISON: 14,
+  RANGED: 15,
+  HAND: 16,
+  BACKUP_MAIN: 20,
+  BACKUP_OFF: 21,
+} as const;
+
+/** Slots WW's Transfer export deliberately skips (`WizardsWardrobeTransfer.lua`). */
+export const WW_EXCLUDED_SLOTS: ReadonlySet<number> = new Set([
+  EQUIP_SLOT.COSTUME,
+  EQUIP_SLOT.POISON,
+  EQUIP_SLOT.BACKUP_POISON,
+  EQUIP_SLOT.WRIST, // deprecated/unused
+  EQUIP_SLOT.RANGED, // unused
+]);
+
+export type GearTraitCategory = 'armor' | 'weapon' | 'jewelry';
+
+/**
+ * Internal gear-slot index → `EQUIP_TYPE` for the deterministic (armor + jewelry)
+ * slots. Weapon slots (main/off/backup) are intentionally absent: their equipType
+ * (ONE_HAND / TWO_HAND / OFF_HAND) depends on the weapon's type, which the loadout
+ * gear model does not store — callers must omit those slots, not guess.
+ */
+export const SLOT_TO_EQUIP_TYPE: Readonly<Record<number, number>> = {
+  [EQUIP_SLOT.HEAD]: EQUIP_TYPE.HEAD,
+  [EQUIP_SLOT.NECK]: EQUIP_TYPE.NECK,
+  [EQUIP_SLOT.CHEST]: EQUIP_TYPE.CHEST,
+  [EQUIP_SLOT.SHOULDERS]: EQUIP_TYPE.SHOULDERS,
+  [EQUIP_SLOT.WAIST]: EQUIP_TYPE.WAIST,
+  [EQUIP_SLOT.LEGS]: EQUIP_TYPE.LEGS,
+  [EQUIP_SLOT.FEET]: EQUIP_TYPE.FEET,
+  [EQUIP_SLOT.HAND]: EQUIP_TYPE.HAND,
+  [EQUIP_SLOT.RING1]: EQUIP_TYPE.RING,
+  [EQUIP_SLOT.RING2]: EQUIP_TYPE.RING,
+};
+
+/** Weapon gear-slot indices (equipType is weapon-type-dependent — omit if unknown). */
+export const WEAPON_SLOTS: ReadonlySet<number> = new Set([
+  EQUIP_SLOT.MAIN_HAND,
+  EQUIP_SLOT.OFF_HAND,
+  EQUIP_SLOT.BACKUP_MAIN,
+  EQUIP_SLOT.BACKUP_OFF,
+]);
+
+/** Internal gear-slot index → trait category (for resolving the trait int). */
+export function slotTraitCategory(slot: number): GearTraitCategory {
+  if (slot === EQUIP_SLOT.NECK || slot === EQUIP_SLOT.RING1 || slot === EQUIP_SLOT.RING2) {
+    return 'jewelry';
+  }
+  if (WEAPON_SLOTS.has(slot)) return 'weapon';
+  return 'armor';
+}
+
+/**
+ * kebab-case trait id (as stored in `GearPiece.trait`, matching the ids in
+ * build-editor `gear-traits-enchants.ts`) → `ITEM_TRAIT_TYPE` int, keyed by gear
+ * category. `infused`/`training`/`nirnhoned` differ across categories, hence the
+ * nesting. Unmapped ids resolve to 0 ("any trait") — safe for WW import.
+ */
+export const TRAIT_ID_TO_TRAIT_TYPE: Record<GearTraitCategory, Record<string, number>> = {
+  armor: {
+    sturdy: 11,
+    impenetrable: 12,
+    reinforced: 13,
+    'well-fitted': 14,
+    training: 15,
+    infused: 16,
+    divines: 18,
+    nirnhoned: 25,
+    // 'invigorating' has no confirmed ITEM_TRAIT_TYPE constant — falls through to 0 (any).
+  },
+  weapon: {
+    powered: 1,
+    charged: 2,
+    precise: 3,
+    infused: 4,
+    defending: 5,
+    training: 6,
+    sharpened: 7,
+    decisive: 8,
+    nirnhoned: 26,
+  },
+  jewelry: {
+    healthy: 21,
+    arcane: 22,
+    robust: 23,
+    swift: 28,
+    harmony: 29,
+    triune: 30,
+    bloodthirsty: 31,
+    protective: 32,
+    infused: 33,
+  },
+};
+
+/** Resolve a kebab-case trait id to its `ITEM_TRAIT_TYPE` int (0 = none/any). */
+export function traitIdToTraitType(
+  category: GearTraitCategory,
+  traitId: string | undefined,
+): number {
+  if (!traitId) return 0;
+  return TRAIT_ID_TO_TRAIT_TYPE[category][traitId.toLowerCase().trim()] ?? 0;
+}

--- a/src/features/loadout-manager/data/esoEquipmentEnums.ts
+++ b/src/features/loadout-manager/data/esoEquipmentEnums.ts
@@ -13,9 +13,12 @@
  *  - name set:           esoui/esoui `ESOUIDocumentation.txt` (API 101050)
  *  - transfer format:    nicokimmel/wizardswardrobe `WizardsWardrobeTransfer.lua`
  *
- * traitType is a SOFT field for WW import (it prefers the requested trait, else
- * any matching item), so an unmapped trait safely degrades to 0 ("any"). equipType
- * and setId are HARD-matched, so callers must omit a slot rather than emit a guess.
+ * traitType, equipType, and setId are all HARD-matched on import: WW's
+ * `WWT.SearchItem` returns nil (leaving the slot unequipped) when any of them is
+ * 0. A non-zero traitType is a *preference* — WW falls back to any matching
+ * set+slot item if the player owns none with that trait — but 0 is rejected
+ * outright. So an unmapped/missing trait resolves to 0 here and the WW Transfer
+ * encoder must OMIT that slot rather than emit a tuple WW would silently skip.
  */
 
 /** `EQUIP_TYPE_*` — the value returned by `GetItemLinkEquipType(link)`. */
@@ -155,7 +158,8 @@ export function slotTraitCategory(slot: number): GearTraitCategory {
  * kebab-case trait id (as stored in `GearPiece.trait`, matching the ids in
  * build-editor `gear-traits-enchants.ts`) → `ITEM_TRAIT_TYPE` int, keyed by gear
  * category. `infused`/`training`/`nirnhoned` differ across categories, hence the
- * nesting. Unmapped ids resolve to 0 ("any trait") — safe for WW import.
+ * nesting. Unmapped/missing ids resolve to 0; since WW rejects a trait-0 tuple,
+ * the encoder must treat a 0 result as "unresolved" and omit the slot.
  */
 export const TRAIT_ID_TO_TRAIT_TYPE: Record<GearTraitCategory, Record<string, number>> = {
   armor: {
@@ -193,7 +197,7 @@ export const TRAIT_ID_TO_TRAIT_TYPE: Record<GearTraitCategory, Record<string, nu
   },
 };
 
-/** Resolve a kebab-case trait id to its `ITEM_TRAIT_TYPE` int (0 = none/any). */
+/** Resolve a kebab-case trait id to its `ITEM_TRAIT_TYPE` int (0 = none/unmapped — WW rejects it). */
 export function traitIdToTraitType(
   category: GearTraitCategory,
   traitId: string | undefined,

--- a/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { LoadoutSetup } from '../../types/loadout.types';
+import { traitIdToTraitType } from '../../data/esoEquipmentEnums';
+import { convertAllCharactersToLoadoutState } from '../wizardWardrobeConverter';
+import {
+  extractWizardWardrobeData,
+  parseWizardWardrobeSavedVariablesWithFallback,
+} from '../luaParser';
+
+import {
+  loadoutSetupToWWTransfer,
+  WW_TRANSFER_CHAR_LIMIT,
+  type WWGearTuple,
+} from '../wizardWardrobeTransfer';
+
+function makeSetup(overrides: Partial<LoadoutSetup> = {}): LoadoutSetup {
+  return {
+    name: 'Test Setup',
+    disabled: false,
+    condition: {},
+    skills: { 0: {}, 1: {} },
+    cp: {},
+    food: {},
+    gear: {},
+    ...overrides,
+  };
+}
+
+describe('traitIdToTraitType', () => {
+  it('maps category-specific armor / weapon / jewelry trait ids', () => {
+    expect(traitIdToTraitType('armor', 'divines')).toBe(18);
+    expect(traitIdToTraitType('armor', 'infused')).toBe(16);
+    expect(traitIdToTraitType('weapon', 'sharpened')).toBe(7);
+    expect(traitIdToTraitType('weapon', 'infused')).toBe(4); // different int than armor
+    expect(traitIdToTraitType('jewelry', 'bloodthirsty')).toBe(31);
+    expect(traitIdToTraitType('jewelry', 'infused')).toBe(33);
+  });
+
+  it('returns 0 (any) for unknown or missing traits — a SOFT field for WW', () => {
+    expect(traitIdToTraitType('armor', 'invigorating')).toBe(0); // no confirmed constant
+    expect(traitIdToTraitType('armor', undefined)).toBe(0);
+    expect(traitIdToTraitType('weapon', 'not-a-trait')).toBe(0);
+  });
+});
+
+describe('loadoutSetupToWWTransfer — non-gear fields', () => {
+  it('copies skill bars (slots 3-8 only) keyed by bar then slot', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({
+        skills: {
+          0: { 3: 111, 4: 222, 8: 999, 2: 1 /* out of range, dropped */ },
+          1: { 3: 333 },
+        },
+      }),
+    );
+    expect(result.data.skills['0']).toEqual({ 3: 111, 4: 222, 8: 999 });
+    expect(result.data.skills['1']).toEqual({ 3: 333 });
+  });
+
+  it('copies champion points (slots 1-12) and food item id', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({
+        cp: { 1: 1001, 12: 1012, 13: 9 /* out of range, dropped */ },
+        food: { id: 84720 },
+      }),
+    );
+    expect(result.data.cp).toEqual({ 1: 1001, 12: 1012 });
+    expect(result.data.food).toBe(84720);
+  });
+
+  it('omits the food key when no food is set', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup());
+    expect(result.data.food).toBeUndefined();
+    expect(JSON.parse(result.json)).not.toHaveProperty('food');
+  });
+
+  it('flags being over the 1000-char in-game paste limit', () => {
+    const small = loadoutSetupToWWTransfer(makeSetup());
+    expect(small.overCharLimit).toBe(false);
+    expect(small.charCount).toBe(small.json.length);
+
+    const huge = loadoutSetupToWWTransfer(
+      makeSetup({ name: 'x'.repeat(WW_TRANSFER_CHAR_LIMIT + 50) }),
+    );
+    expect(huge.overCharLimit).toBe(true);
+  });
+});
+
+describe('loadoutSetupToWWTransfer — gear safety (never emit a wrong tuple)', () => {
+  it('omits weapon slots and reports them as unresolved', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({ gear: { 4: { link: '|H0:item:54321:0:0:0|h|h' }, 20: { id: 12345 } } }),
+    );
+    expect(result.data.gear['4']).toBeUndefined();
+    expect(result.data.gear['20']).toBeUndefined();
+    expect(result.unresolvedSlots.map((u) => u.slot).sort((a, b) => a - b)).toEqual([4, 20]);
+  });
+
+  it('omits armor slots whose set cannot be identified (rather than guessing)', () => {
+    // A 14-digit value is an item uniqueId, not an itemId → cannot resolve a set.
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({ gear: { 0: { id: '99999999999999', trait: 'divines' } } }),
+    );
+    expect(result.data.gear['0']).toBeUndefined();
+    expect(result.unresolvedSlots.some((u) => u.slot === 0)).toBe(true);
+  });
+
+  it('silently skips excluded slots (costume / poison) with no warning', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup({ gear: { 10: { id: 5 }, 13: { id: 6 } } }));
+    expect(result.data.gear['10']).toBeUndefined();
+    expect(result.data.gear['13']).toBeUndefined();
+    expect(result.unresolvedSlots).toHaveLength(0);
+  });
+});
+
+describe("loadoutSetupToWWTransfer — real Wizard's Wardrobe fixture (end-to-end)", () => {
+  function firstSetup(): LoadoutSetup | undefined {
+    const samplePath = path.join(process.cwd(), 'tests', 'fixtures', 'wizards-wardrobe-sample.lua');
+    const luaContent = fs.readFileSync(samplePath, 'utf8');
+    const parsed = parseWizardWardrobeSavedVariablesWithFallback(luaContent);
+    const wizardData = extractWizardWardrobeData({ [parsed.tableName]: parsed.data });
+    if (!wizardData) return undefined;
+    const state = convertAllCharactersToLoadoutState(wizardData);
+    for (const trials of Object.values(state.pages)) {
+      for (const pages of Object.values(trials)) {
+        for (const page of pages) {
+          if (page.setups?.length) return page.setups[0];
+        }
+      }
+    }
+    return undefined;
+  }
+
+  it('encodes a real imported setup into valid WW Transfer JSON', () => {
+    const setup = firstSetup();
+    expect(setup).toBeDefined();
+
+    const result = loadoutSetupToWWTransfer(setup!);
+
+    // Structure
+    expect(typeof result.data.name).toBe('string');
+    expect(result.data.skills).toHaveProperty('0');
+    expect(result.data.skills).toHaveProperty('1');
+    expect(Array.isArray(result.unresolvedSlots)).toBe(true);
+
+    // Every emitted gear tuple is a hard-valid [equipType>0, setId>0, traitType>=0].
+    for (const [slot, tuple] of Object.entries(result.data.gear)) {
+      const t = tuple as WWGearTuple;
+      expect(t).toHaveLength(3);
+      expect(t[0]).toBeGreaterThan(0); // equipType
+      expect(t[1]).toBeGreaterThan(0); // setId
+      expect(t[2]).toBeGreaterThanOrEqual(0); // traitType (0 = any)
+      expect(Number(slot)).toBeGreaterThanOrEqual(0);
+    }
+
+    // JSON is the canonical serialization of `data`.
+    expect(JSON.parse(result.json)).toEqual(result.data);
+    expect(result.charCount).toBe(result.json.length);
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.weaponSlots.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.weaponSlots.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Weapon-slot equipType resolution for the Wizard's Wardrobe Transfer encoder.
+ *
+ * Weapon equipType (ONE_HAND / TWO_HAND / OFF_HAND) is HARD-matched on import, so
+ * it is derived from the item's resolved weapon type. These tests stub the item
+ * data, weapon-type, and set-catalog lookups so the encoder's branching is
+ * deterministic (the real lookups depend on async-loaded icon data).
+ */
+
+import type { LoadoutSetup } from '../../types/loadout.types';
+import { EQUIP_TYPE, weaponLabelToEquipType } from '../../data/esoEquipmentEnums';
+
+// itemId → controlled ItemInfo. `slot: 'weapon' | 'offhand'` marks slot-specific
+// weapons (resolvable); a generic set id (no slot field) must NOT resolve.
+jest.mock('../../data/itemIdMap', () => ({
+  getItemInfo: (itemId: number) =>
+    (
+      ({
+        // slot-specific weapons in a known set
+        201: { name: 'Test Set Sword', setName: 'Test Set', type: 'Gear', slot: 'weapon' },
+        202: { name: 'Test Set Greatsword', setName: 'Test Set', type: 'Gear', slot: 'weapon' },
+        203: { name: 'Test Set Shield', setName: 'Test Set', type: 'Gear', slot: 'offhand' },
+        204: {
+          name: 'Test Set Lightning Staff',
+          setName: 'Test Set',
+          type: 'Gear',
+          slot: 'weapon',
+        },
+        // generic set id with no slot field — collides with unrelated weapon icons
+        685: { name: "Bloodthorn's Touch Gear", setName: "Bloodthorn's Touch", type: 'Gear' },
+      }) as Record<number, unknown>
+    )[itemId],
+}));
+
+// Weapon-type label per item (what getItemIconUrl-based resolution would yield).
+jest.mock('../itemIconResolver', () => ({
+  getWeaponTypeLabel: (itemId: number) =>
+    (
+      ({
+        201: 'Sword',
+        202: 'Greatsword',
+        203: 'Shield',
+        204: 'Lightning Staff',
+        685: 'Staff', // a label IS derivable, but the slot guard must reject the generic id
+      }) as Record<number, string>
+    )[itemId] ?? null,
+}));
+
+// Any known set name resolves to a positive set id; unknowns resolve to 0/falsy.
+jest.mock('@/utils/setNameUtils', () => ({
+  findSetIdByName: (name: string | undefined) => (name === 'Test Set' ? 999 : 0),
+}));
+
+import { loadoutSetupToWWTransfer } from '../wizardWardrobeTransfer';
+
+function makeSetup(overrides: Partial<LoadoutSetup> = {}): LoadoutSetup {
+  return {
+    name: 'Weapon Test',
+    disabled: false,
+    condition: {},
+    skills: { 0: {}, 1: {} },
+    cp: {},
+    food: {},
+    gear: {},
+    ...overrides,
+  };
+}
+
+describe('weaponLabelToEquipType', () => {
+  it('maps one-handed weapons to ONE_HAND', () => {
+    for (const label of ['Sword', 'Axe', 'Mace', 'Dagger']) {
+      expect(weaponLabelToEquipType(label)).toBe(EQUIP_TYPE.ONE_HAND);
+    }
+  });
+
+  it('maps the shield to OFF_HAND', () => {
+    expect(weaponLabelToEquipType('Shield')).toBe(EQUIP_TYPE.OFF_HAND);
+  });
+
+  it('maps every two-handed weapon (incl. all staves) to TWO_HAND', () => {
+    for (const label of [
+      'Greatsword',
+      'Battle Axe',
+      'Maul',
+      'Bow',
+      'Staff',
+      'Inferno Staff',
+      'Ice Staff',
+      'Lightning Staff',
+      'Restoration Staff',
+    ]) {
+      expect(weaponLabelToEquipType(label)).toBe(EQUIP_TYPE.TWO_HAND);
+    }
+  });
+
+  it('returns undefined for non-weapon / unknown / missing labels', () => {
+    expect(weaponLabelToEquipType('Helmet')).toBeUndefined();
+    expect(weaponLabelToEquipType('')).toBeUndefined();
+    expect(weaponLabelToEquipType(null)).toBeUndefined();
+    expect(weaponLabelToEquipType(undefined)).toBeUndefined();
+  });
+});
+
+describe('loadoutSetupToWWTransfer — weapon slots', () => {
+  it('encodes the weapon equipType derived from the item type', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({
+        gear: {
+          4: { id: 201, trait: 'sharpened' }, // main hand → Sword → ONE_HAND
+          5: { id: 203 }, // off hand → Shield → OFF_HAND
+          20: { id: 202 }, // backup main → Greatsword → TWO_HAND
+          21: { id: 204 }, // backup off → Lightning Staff → TWO_HAND
+        },
+      }),
+    );
+
+    expect(result.data.gear['4']).toEqual([EQUIP_TYPE.ONE_HAND, 999, 7]); // sharpened (weapon) = 7
+    expect(result.data.gear['5']).toEqual([EQUIP_TYPE.OFF_HAND, 999, 0]);
+    expect(result.data.gear['20']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 0]);
+    expect(result.data.gear['21']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 0]);
+    expect(result.unresolvedSlots).toHaveLength(0);
+  });
+
+  it('omits a weapon slot whose item is a generic set id (slot-specificity guard)', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup({ gear: { 4: { id: 685 } } }));
+    expect(result.data.gear['4']).toBeUndefined();
+    expect(result.unresolvedSlots).toEqual([
+      expect.objectContaining({ slot: 4, reason: expect.stringContaining('Weapon type') }),
+    ]);
+  });
+
+  it('omits a weapon slot whose item cannot be identified at all', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup({ gear: { 4: { id: '99999999999999' } } }));
+    expect(result.data.gear['4']).toBeUndefined();
+    expect(result.unresolvedSlots).toEqual([
+      expect.objectContaining({
+        slot: 4,
+        reason: expect.stringContaining('couldn’t be identified'),
+      }),
+    ]);
+  });
+});

--- a/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.weaponSlots.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/wizardWardrobeTransfer.weaponSlots.test.ts
@@ -26,6 +26,8 @@ jest.mock('../../data/itemIdMap', () => ({
           type: 'Gear',
           slot: 'weapon',
         },
+        // an armor (head) piece in a known set — exercises the non-weapon path
+        301: { name: 'Test Set Head', setName: 'Test Set', type: 'Gear', slot: 'head' },
         // generic set id with no slot field — collides with unrelated weapon icons
         685: { name: "Bloodthorn's Touch Gear", setName: "Bloodthorn's Touch", type: 'Gear' },
       }) as Record<number, unknown>
@@ -102,23 +104,31 @@ describe('weaponLabelToEquipType', () => {
 });
 
 describe('loadoutSetupToWWTransfer — weapon slots', () => {
-  it('encodes the weapon equipType derived from the item type', () => {
+  it('encodes the weapon equipType derived from the item type (with a valid trait)', () => {
     const result = loadoutSetupToWWTransfer(
       makeSetup({
         gear: {
-          4: { id: 201, trait: 'sharpened' }, // main hand → Sword → ONE_HAND
-          5: { id: 203 }, // off hand → Shield → OFF_HAND
-          20: { id: 202 }, // backup main → Greatsword → TWO_HAND
-          21: { id: 204 }, // backup off → Lightning Staff → TWO_HAND
+          4: { id: 201, trait: 'sharpened' }, // main hand → Sword → ONE_HAND, sharpened=7
+          5: { id: 203, trait: 'infused' }, // off hand → Shield → OFF_HAND, weapon infused=4
+          20: { id: 202, trait: 'precise' }, // backup main → Greatsword → TWO_HAND, precise=3
+          21: { id: 204, trait: 'charged' }, // backup off → Lightning Staff → TWO_HAND, charged=2
         },
       }),
     );
 
-    expect(result.data.gear['4']).toEqual([EQUIP_TYPE.ONE_HAND, 999, 7]); // sharpened (weapon) = 7
-    expect(result.data.gear['5']).toEqual([EQUIP_TYPE.OFF_HAND, 999, 0]);
-    expect(result.data.gear['20']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 0]);
-    expect(result.data.gear['21']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 0]);
+    expect(result.data.gear['4']).toEqual([EQUIP_TYPE.ONE_HAND, 999, 7]);
+    expect(result.data.gear['5']).toEqual([EQUIP_TYPE.OFF_HAND, 999, 4]);
+    expect(result.data.gear['20']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 3]);
+    expect(result.data.gear['21']).toEqual([EQUIP_TYPE.TWO_HAND, 999, 2]);
     expect(result.unresolvedSlots).toHaveLength(0);
+  });
+
+  it('omits an otherwise-resolvable weapon that has no recorded trait (WW rejects trait 0)', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup({ gear: { 4: { id: 201 } } }));
+    expect(result.data.gear['4']).toBeUndefined();
+    expect(result.unresolvedSlots).toEqual([
+      expect.objectContaining({ slot: 4, reason: expect.stringContaining('No trait recorded') }),
+    ]);
   });
 
   it('omits a weapon slot whose item is a generic set id (slot-specificity guard)', () => {
@@ -137,6 +147,34 @@ describe('loadoutSetupToWWTransfer — weapon slots', () => {
         slot: 4,
         reason: expect.stringContaining('couldn’t be identified'),
       }),
+    ]);
+  });
+});
+
+describe('loadoutSetupToWWTransfer — trait is required (any slot)', () => {
+  it('encodes an armor slot when the trait maps to a non-zero ITEM_TRAIT_TYPE', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({ gear: { 0: { id: 301, trait: 'divines' } } }),
+    );
+    expect(result.data.gear['0']).toEqual([EQUIP_TYPE.HEAD, 999, 18]); // armor divines = 18
+    expect(result.unresolvedSlots).toHaveLength(0);
+  });
+
+  it('omits an otherwise-resolvable armor slot with no trait', () => {
+    const result = loadoutSetupToWWTransfer(makeSetup({ gear: { 0: { id: 301 } } }));
+    expect(result.data.gear['0']).toBeUndefined();
+    expect(result.unresolvedSlots).toEqual([
+      expect.objectContaining({ slot: 0, reason: expect.stringContaining('No trait recorded') }),
+    ]);
+  });
+
+  it('omits a slot whose trait id is unrecognized, naming the trait', () => {
+    const result = loadoutSetupToWWTransfer(
+      makeSetup({ gear: { 0: { id: 301, trait: 'bogus' } } }),
+    );
+    expect(result.data.gear['0']).toBeUndefined();
+    expect(result.unresolvedSlots).toEqual([
+      expect.objectContaining({ slot: 0, reason: expect.stringContaining('bogus') }),
     ]);
   });
 });

--- a/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
+++ b/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
@@ -21,8 +21,10 @@
  * the set + slot (preferring the requested trait). Because equipType and setId are
  * HARD-matched in-game, this generator OMITS any slot it cannot resolve with
  * confidence (rather than emit a wrong/zero value that would silently drop the
- * slot). Weapon slots are omitted because the loadout model does not record weapon
- * type (1H/2H/shield), which equipType depends on. Omitted slots are reported in
+ * slot). Weapon slots are exported too: the weapon's equipType (ONE_HAND /
+ * TWO_HAND / OFF_HAND) is derived from the item's resolved weapon type, and a slot
+ * is only omitted when that type can't be pinned down (e.g. a generic set itemId
+ * with no slot-specific weapon metadata). Omitted slots are reported in
  * `unresolvedSlots` so the UI can tell the user to set them manually.
  *
  * The in-game import box caps input at 1000 characters (`overCharLimit`).
@@ -36,10 +38,12 @@ import {
   WW_EXCLUDED_SLOTS,
   slotTraitCategory,
   traitIdToTraitType,
+  weaponLabelToEquipType,
 } from '../data/esoEquipmentEnums';
 import { getItemInfo } from '../data/itemIdMap';
 import type { LoadoutSetup, GearPiece } from '../types/loadout.types';
 
+import { getWeaponTypeLabel } from './itemIconResolver';
 import { getItemIdFromLink } from './itemLinkParser';
 
 /** WW input box hard limit (`SetMaxInputChars(1000)`). */
@@ -98,6 +102,21 @@ function resolveItemId(piece: GearPiece): number | undefined {
   return undefined;
 }
 
+/**
+ * Resolve the `EQUIP_TYPE` for a weapon-slot item from its weapon type.
+ *
+ * Applies the same slot-specificity guard as `isTwoHandedWeapon`: generic set
+ * itemIds (no `slot` field) collide with unrelated weapon icons in UESP's icon
+ * database, so a guess from one would silently equip the wrong weapon class.
+ * Only classify items whose own metadata says they are a slot-specific
+ * weapon/offhand item; otherwise return undefined so the caller omits the slot.
+ */
+function resolveWeaponEquipType(itemId: number): number | undefined {
+  const info = getItemInfo(itemId);
+  if (info?.slot !== 'weapon' && info?.slot !== 'offhand') return undefined;
+  return weaponLabelToEquipType(getWeaponTypeLabel(itemId));
+}
+
 function buildSkills(skills: LoadoutSetup['skills']): WWTransferSetup['skills'] {
   const out: WWTransferSetup['skills'] = { '0': {}, '1': {} };
   for (const bar of [0, 1] as const) {
@@ -151,18 +170,27 @@ export function loadoutSetupToWWTransfer(setup: LoadoutSetup): WWTransferResult 
     const piece = rawPiece as GearPiece;
     if (!piece || (!piece.link && piece.id == null)) continue; // empty slot
 
+    const itemId = resolveItemId(piece);
+
+    // equipType is HARD-matched on import. Weapon slots derive it from the
+    // weapon's type; armor/jewelry slots read it straight from the slot index.
+    let equipType: number | undefined;
     if (WEAPON_SLOTS.has(slot)) {
-      unresolvedSlots.push({
-        slot,
-        reason: 'Weapon slot — weapon type is not stored, so set it manually in Wizard’s Wardrobe.',
-      });
-      continue;
+      equipType = itemId ? resolveWeaponEquipType(itemId) : undefined;
+      if (!equipType) {
+        unresolvedSlots.push({
+          slot,
+          reason: itemId
+            ? 'Weapon type couldn’t be determined — set this slot manually in Wizard’s Wardrobe.'
+            : 'Weapon item couldn’t be identified — set this slot manually in Wizard’s Wardrobe.',
+        });
+        continue;
+      }
+    } else {
+      equipType = SLOT_TO_EQUIP_TYPE[slot];
+      if (!equipType) continue; // not an exportable armor/jewelry slot
     }
 
-    const equipType = SLOT_TO_EQUIP_TYPE[slot];
-    if (!equipType) continue; // not an exportable armor/jewelry slot
-
-    const itemId = resolveItemId(piece);
     const setName = itemId ? getItemInfo(itemId)?.setName : undefined;
     const setId = findSetIdByName(setName);
     if (!setId) {

--- a/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
+++ b/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
@@ -1,0 +1,200 @@
+/**
+ * Wizard's Wardrobe "Transfer" import-code generator.
+ *
+ * Wizard's Wardrobe (the in-game ESO addon) has a built-in Import/Export feature
+ * (`WizardsWardrobeTransfer.lua`): the player right-clicks a setup slot →
+ * Import → pastes a JSON string. This module turns one of the app's
+ * `LoadoutSetup`s into exactly that JSON, so a build planned on the web can be
+ * pasted into the game with no SavedVariables file editing.
+ *
+ * Transfer JSON shape (confirmed against the addon source):
+ *   {
+ *     name,
+ *     skills: { "0": { "3..8": abilityId }, "1": { ... } },   // 0 = front, 1 = back
+ *     gear:   { "<EQUIP_SLOT>": [equipType, setId, traitType] },
+ *     cp:     { "1".."12": championAbilityId },
+ *     food:   <foodItemId>
+ *   }
+ *
+ * Gear is encoded as the abstract triple `[equipType, setId, traitType]`, NOT an
+ * item instance — on import WW equips an item the player already owns that matches
+ * the set + slot (preferring the requested trait). Because equipType and setId are
+ * HARD-matched in-game, this generator OMITS any slot it cannot resolve with
+ * confidence (rather than emit a wrong/zero value that would silently drop the
+ * slot). Weapon slots are omitted because the loadout model does not record weapon
+ * type (1H/2H/shield), which equipType depends on. Omitted slots are reported in
+ * `unresolvedSlots` so the UI can tell the user to set them manually.
+ *
+ * The in-game import box caps input at 1000 characters (`overCharLimit`).
+ */
+
+import { findSetIdByName } from '@/utils/setNameUtils';
+
+import {
+  SLOT_TO_EQUIP_TYPE,
+  WEAPON_SLOTS,
+  WW_EXCLUDED_SLOTS,
+  slotTraitCategory,
+  traitIdToTraitType,
+} from '../data/esoEquipmentEnums';
+import { getItemInfo } from '../data/itemIdMap';
+import type { LoadoutSetup, GearPiece } from '../types/loadout.types';
+
+import { getItemIdFromLink } from './itemLinkParser';
+
+/** WW input box hard limit (`SetMaxInputChars(1000)`). */
+export const WW_TRANSFER_CHAR_LIMIT = 1000;
+
+/** `[equipType, setId, traitType]` — the WW gear tuple. */
+export type WWGearTuple = [number, number, number];
+
+/** A single setup encoded in WW Transfer JSON shape. */
+export interface WWTransferSetup {
+  name: string;
+  skills: { '0': Record<string, number>; '1': Record<string, number> };
+  gear: Record<string, WWGearTuple>;
+  cp: Record<string, number>;
+  food?: number;
+}
+
+/** A gear slot that could not be encoded, with a user-facing reason. */
+export interface UnresolvedSlot {
+  slot: number;
+  reason: string;
+}
+
+export interface WWTransferResult {
+  /** Minified JSON to paste into the Wizard's Wardrobe Import box. */
+  json: string;
+  /** The structured payload (handy for previews / tests). */
+  data: WWTransferSetup;
+  /** Gear slots intentionally left out (weapon slots, unknown sets). */
+  unresolvedSlots: UnresolvedSlot[];
+  /** Length of `json`. */
+  charCount: number;
+  /** True when `charCount` exceeds the in-game paste limit. */
+  overCharLimit: boolean;
+}
+
+/**
+ * Best-effort itemId for a gear piece. Prefers the item link (WW-imported pieces
+ * store an account-local `id` that is a uniqueId, not an itemId — the link is the
+ * portable source). Falls back to a numeric `id` only when it is plausibly an
+ * itemId (uniqueIds are 64-bit and far larger than any real itemId).
+ */
+function resolveItemId(piece: GearPiece): number | undefined {
+  if (piece.link) {
+    const fromLink = getItemIdFromLink(piece.link);
+    if (fromLink && fromLink > 0) return fromLink;
+  }
+  if (typeof piece.id === 'number' && Number.isFinite(piece.id) && piece.id > 0) {
+    return piece.id;
+  }
+  if (typeof piece.id === 'string' && /^\d+$/.test(piece.id.trim())) {
+    const n = Number(piece.id.trim());
+    // Real itemIds are < ~500k; anything larger is an item uniqueId, not an itemId.
+    if (Number.isFinite(n) && n > 0 && n < 500_000) return n;
+  }
+  return undefined;
+}
+
+function buildSkills(skills: LoadoutSetup['skills']): WWTransferSetup['skills'] {
+  const out: WWTransferSetup['skills'] = { '0': {}, '1': {} };
+  for (const bar of [0, 1] as const) {
+    const sourceBar = skills?.[bar];
+    if (!sourceBar) continue;
+    for (const [slotStr, abilityId] of Object.entries(sourceBar)) {
+      const slot = Number(slotStr);
+      // WW expects ability slots 3-7 plus the ultimate at slot 8.
+      if (slot >= 3 && slot <= 8 && typeof abilityId === 'number' && abilityId > 0) {
+        out[String(bar) as '0' | '1'][String(slot)] = abilityId;
+      }
+    }
+  }
+  return out;
+}
+
+function buildChampionPoints(cp: LoadoutSetup['cp']): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!cp) return out;
+  for (const [slotStr, abilityId] of Object.entries(cp)) {
+    const slot = Number(slotStr);
+    if (slot >= 1 && slot <= 12 && typeof abilityId === 'number' && abilityId > 0) {
+      out[String(slot)] = abilityId;
+    }
+  }
+  return out;
+}
+
+function resolveFoodItemId(food: LoadoutSetup['food']): number | undefined {
+  if (!food) return undefined;
+  if (typeof food.id === 'number' && Number.isFinite(food.id) && food.id > 0) return food.id;
+  if (food.link) {
+    const fromLink = getItemIdFromLink(food.link);
+    if (fromLink && fromLink > 0) return fromLink;
+  }
+  return undefined;
+}
+
+/**
+ * Encode a single `LoadoutSetup` as a Wizard's Wardrobe Transfer import code.
+ */
+export function loadoutSetupToWWTransfer(setup: LoadoutSetup): WWTransferResult {
+  const unresolvedSlots: UnresolvedSlot[] = [];
+  const gear: Record<string, WWGearTuple> = {};
+
+  for (const [slotStr, rawPiece] of Object.entries(setup.gear ?? {})) {
+    if (slotStr === 'mythic') continue; // GearConfig.mythic is a slot index, not a piece
+    const slot = Number(slotStr);
+    if (!Number.isInteger(slot) || WW_EXCLUDED_SLOTS.has(slot)) continue;
+
+    const piece = rawPiece as GearPiece;
+    if (!piece || (!piece.link && piece.id == null)) continue; // empty slot
+
+    if (WEAPON_SLOTS.has(slot)) {
+      unresolvedSlots.push({
+        slot,
+        reason: 'Weapon slot — weapon type is not stored, so set it manually in Wizard’s Wardrobe.',
+      });
+      continue;
+    }
+
+    const equipType = SLOT_TO_EQUIP_TYPE[slot];
+    if (!equipType) continue; // not an exportable armor/jewelry slot
+
+    const itemId = resolveItemId(piece);
+    const setName = itemId ? getItemInfo(itemId)?.setName : undefined;
+    const setId = findSetIdByName(setName);
+    if (!setId) {
+      unresolvedSlots.push({
+        slot,
+        reason: setName
+          ? `Set "${setName}" isn’t in the catalog yet — set this slot manually.`
+          : 'Item / set couldn’t be identified — set this slot manually.',
+      });
+      continue;
+    }
+
+    const traitType = traitIdToTraitType(slotTraitCategory(slot), piece.trait);
+    gear[String(slot)] = [equipType, setId, traitType];
+  }
+
+  const data: WWTransferSetup = {
+    name: setup.name?.trim() || 'Imported Setup',
+    skills: buildSkills(setup.skills),
+    gear,
+    cp: buildChampionPoints(setup.cp),
+  };
+
+  const food = resolveFoodItemId(setup.food);
+  if (food !== undefined) data.food = food;
+
+  const json = JSON.stringify(data);
+  return {
+    json,
+    data,
+    unresolvedSlots,
+    charCount: json.length,
+    overCharLimit: json.length > WW_TRANSFER_CHAR_LIMIT,
+  };
+}

--- a/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
+++ b/src/features/loadout-manager/utils/wizardWardrobeTransfer.ts
@@ -18,10 +18,14 @@
  *
  * Gear is encoded as the abstract triple `[equipType, setId, traitType]`, NOT an
  * item instance — on import WW equips an item the player already owns that matches
- * the set + slot (preferring the requested trait). Because equipType and setId are
- * HARD-matched in-game, this generator OMITS any slot it cannot resolve with
- * confidence (rather than emit a wrong/zero value that would silently drop the
- * slot). Weapon slots are exported too: the weapon's equipType (ONE_HAND /
+ * the set + slot (preferring the requested trait, else any item of that set+slot).
+ * All three fields are effectively HARD-matched: `WWT.SearchItem` bails out and
+ * leaves the slot unequipped when equipType, setId, OR traitType is 0. So this
+ * generator OMITS any slot it cannot resolve to a full, non-zero triple (rather
+ * than emit a value that would silently drop the slot in-game) and reports it in
+ * `unresolvedSlots`. In particular, a gear piece with no recorded / unrecognized
+ * trait is omitted — WW would skip a trait-0 tuple entirely.
+ * Weapon slots are exported too: the weapon's equipType (ONE_HAND /
  * TWO_HAND / OFF_HAND) is derived from the item's resolved weapon type, and a slot
  * is only omitted when that type can't be pinned down (e.g. a generic set itemId
  * with no slot-specific weapon metadata). Omitted slots are reported in
@@ -203,7 +207,21 @@ export function loadoutSetupToWWTransfer(setup: LoadoutSetup): WWTransferResult 
       continue;
     }
 
+    // traitType is REQUIRED by WW's importer: `WWT.SearchItem` returns nil (the
+    // slot is left unequipped) when prefTraitType is 0. A non-zero value is a
+    // preference — WW falls back to any matching set+slot item if the player owns
+    // none with that trait — but 0 is rejected outright. So a piece with no
+    // recorded / unrecognized trait can't be encoded; omit it and tell the user.
     const traitType = traitIdToTraitType(slotTraitCategory(slot), piece.trait);
+    if (traitType === 0) {
+      unresolvedSlots.push({
+        slot,
+        reason: piece.trait
+          ? `Trait “${piece.trait}” isn’t recognized — set this slot’s trait manually in Wizard’s Wardrobe.`
+          : 'No trait recorded — Wizard’s Wardrobe needs a trait to equip this item. Pick a trait, or set this slot manually in-game.',
+      });
+      continue;
+    }
     gear[String(slot)] = [equipType, setId, traitType];
   }
 


### PR DESCRIPTION
## What & why

This rebases the Build⇄Loadout bridge foundations (previously stacked on a stale
base in draft #1332) onto current `main`, then closes the **Phase-1 gate** by
teaching the Wizard's Wardrobe Transfer encoder to export **weapon slots**.

Until now weapon slots were always dropped from the generated WW import code
because their `equipType` (`ONE_HAND` / `TWO_HAND` / `OFF_HAND`) is hard-matched
on import and the loadout model doesn't store a weapon type — so a planned build
arrived in-game missing both weapons. They now export.

## Commits in this PR

1. **export setups as Wizard's Wardrobe import codes** (Phase 1 core, ex-#1332) —
   real Transfer JSON (`loadoutSetupToWWTransfer`), `esoEquipmentEnums`,
   `WizardWardrobeTransferPanel`, wired into the loadout `ExportDialog`.
2. **bridge builds into loadouts and Wizard's Wardrobe** (Phase 2 data core,
   ex-#1332) — `buildSetupToLoadoutSetup` / `buildSetupToWWTransfer`.
3. **export weapon slots in Wizard's Wardrobe codes** (new — the Phase-1 gate).

## How weapon equipType is derived

- Weapon type label (from `getWeaponTypeLabel`) → `EQUIP_TYPE` via the new pure
  `weaponLabelToEquipType` / `WEAPON_LABEL_TO_EQUIP_TYPE` map:
  one-handers → `ONE_HAND`, shield → `OFF_HAND`, every two-hander
  (greatsword / battle axe / maul / bow / **all** staves, incl. the generic
  "Staff" label) → `TWO_HAND`.
- `equipType` is intrinsic to the weapon, not the slot, so a one-hander sitting in
  the off-hand slot still exports as `ONE_HAND`.
- **Slot-specificity guard** (same one `isTwoHandedWeapon` uses): only classify
  items whose own metadata marks them a slot-specific weapon/offhand item.
  Generic LibSets ids — which collide with unrelated weapon icons in UESP's icon
  DB — stay reported in `unresolvedSlots` rather than emitting a wrong,
  hard-matched tuple. Honest-by-omission is preserved.

## Tests

- New `wizardWardrobeTransfer.weaponSlots.test.ts`: the pure label→equipType map,
  plus the encoder branches (resolves real weapons; omits generic-id and
  unidentifiable weapons with the right reason).
- Full `loadout-manager` + `build-editor` suites: **635 passed / 13 skipped**,
  `npm run validate` (tsc + ESLint + Prettier) clean.

## ⚠️ Honest limitation — in-game round-trip not verified

The actual paste-into-ESO round-trip **cannot be verified from this environment**
(no game client). The encoding is cross-checked against the addon source and the
ESO API enum values, but a human still needs to generate a code in the running
app, paste it into Wizard's Wardrobe in-game, and confirm weapons now equip
before we should treat the gate as fully closed (and take the bridge work out of
draft).

## Follow-ups (separate PRs) — two owner decisions needed first

- **Send to Wizard's Wardrobe** in the Build Editor action hub
  (`BuildCompletionHeader`) using `buildSetupToWWTransfer` + the existing panel.
- Phase 2 UI merge (richer pickers + stat engine), Phase 3 IA (Loadout Library),
  Phase 4 differentiators (comparator + health badges).

Owner decisions to confirm before the invasive UI work: **(a)** make the Build
Editor the single canonical editor and retire the Loadout Manager's pickers, or
keep a "lite" editor too? **(b)** rename `/loadout-manager` (e.g. `/loadouts`)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7gNoALG622PMAjq88vVRZ)_