### PR TITLE
feat(build↔loadout bridge): Send to Wizard's Wardrobe from the Build Editor (Phase 2)

### DIFF
--- a/src/features/build-editor/components/BuildCompletionHeader.tsx
+++ b/src/features/build-editor/components/BuildCompletionHeader.tsx
@@ -6,6 +6,7 @@
 
 import {
   ArrowBack as ArrowBackIcon,
+  AutoFixHighOutlined,
   Close as CloseIcon,
   ContentCopyOutlined,
   FileDownloadOutlined,
@@ -50,10 +51,13 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/features/auth/AuthContext';
 import { tempBuildApi } from '@/features/build-editor/api/temp-build-api';
 import { PublishBuildDialog } from '@/features/build-hub/components/PublishBuildDialog';
+import { WizardWardrobeTransferPanel } from '@/features/loadout-manager/components/WizardWardrobeTransferPanel';
+import { validateGearConfig } from '@/features/loadout-manager/utils/itemSlotValidator';
 import { saveBuild, updateSavedBuild } from '@/store/saved_builds';
 import { attachBuildToSlot, selectSavedRosters } from '@/store/saved_rosters';
 import type { RootState } from '@/store/storeWithHistory';
 import { encodeBuildToURL } from '@/utils/buildEncoding';
+import { getBaseUrl } from '@/utils/envUtils';
 import { snapshotBuildToSlot } from '@/utils/rosterBuildBridge';
 
 import { ESO_CLASSES } from '../data/esoStaticData';
@@ -68,6 +72,7 @@ import {
   setBuildName,
 } from '../store/buildEditorSlice';
 import { BE_TOKENS } from '../theme/buildEditorTokens';
+import { buildSetupToLoadoutSetup } from '../utils/buildLoadoutBridge';
 import { exportBuildToCSPSLua } from '../utils/cspsExport';
 import {
   parseCSPSInput,
@@ -187,6 +192,22 @@ export const BuildCompletionHeader: React.FC = () => {
   const [cspsExportOpen, setCspsExportOpen] = React.useState(false);
   const [exportLua, setExportLua] = React.useState('');
 
+  // Wizard's Wardrobe export state — bridges every build setup into a paste-in
+  // WW import code (one per setup) via the shared loadout-manager panel.
+  const [wwExportOpen, setWwExportOpen] = React.useState(false);
+  // Convert the build's setups into loadout setups the WW panel understands.
+  // The panel runs the actual WW encoding internally, per setup.
+  const wwSetups = React.useMemo(
+    () => build.setups.map((setup) => buildSetupToLoadoutSetup(setup)),
+    [build.setups],
+  );
+  // Mirror the loadout ExportDialog gate: withhold codes if any setup has a
+  // blocking gear-slot error, so a broken setup can't be pasted into the game.
+  const wwExportBlocked = React.useMemo(
+    () => build.setups.some((setup) => validateGearConfig(setup.gear ?? {}).errors.length > 0),
+    [build.setups],
+  );
+
   const handleSave = (): void => {
     if (!build.name.trim()) {
       enqueueSnackbar('Please enter a build name before saving.', { variant: 'warning' });
@@ -232,7 +253,7 @@ export const BuildCompletionHeader: React.FC = () => {
         enqueueSnackbar('Could not encode build for sharing.', { variant: 'error' });
         return;
       }
-      const url = `${window.location.origin}${import.meta.env.BASE_URL}bv?b=${encoded}`;
+      const url = `${getBaseUrl()}bv?b=${encoded}`;
       navigator.clipboard
         .writeText(url)
         .then(() => enqueueSnackbar('Share link copied to clipboard!', { variant: 'info' }))
@@ -256,7 +277,7 @@ export const BuildCompletionHeader: React.FC = () => {
         enqueueSnackbar('Could not encode build.', { variant: 'error' });
         return;
       }
-      window.open(`${import.meta.env.BASE_URL}bv?b=${encoded}`, '_blank', 'noopener,noreferrer');
+      window.open(`${getBaseUrl()}bv?b=${encoded}`, '_blank', 'noopener,noreferrer');
     });
   };
 
@@ -328,7 +349,7 @@ export const BuildCompletionHeader: React.FC = () => {
         .create(encoded)
         .then((result) => {
           setIsCreatingLink(false);
-          const url = `${window.location.origin}${import.meta.env.BASE_URL}b/${result.id}`;
+          const url = `${getBaseUrl()}b/${result.id}`;
           setTempLink(url);
           setTempLinkExpiry(result.expires_at);
           setTempLinkDialogOpen(true);
@@ -433,6 +454,11 @@ export const BuildCompletionHeader: React.FC = () => {
     setCspsCharacters([]);
     setImportParsed(false);
     setImportError(null);
+  };
+
+  // ── Wizard's Wardrobe export handler ────────────────────────────────
+  const handleWWExportOpen = (): void => {
+    setWwExportOpen(true);
   };
 
   // ── CSPS Export handlers ────────────────────────────────────────────
@@ -809,6 +835,27 @@ export const BuildCompletionHeader: React.FC = () => {
                 )}
               </IconButton>
             </Tooltip>
+            <Divider orientation="vertical" flexItem sx={dividerSx} />
+            <Tooltip title="Send to Wizard's Wardrobe (paste-in import code)">
+              <IconButton
+                size="small"
+                onClick={handleWWExportOpen}
+                aria-label="Send to Wizard's Wardrobe"
+                sx={{
+                  borderRadius: 0,
+                  width: 34,
+                  height: 34,
+                  color: isDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.4)',
+                  transition: 'all 0.15s ease',
+                  '&:hover': {
+                    background: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)',
+                    color: isDark ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.75)',
+                  },
+                }}
+              >
+                <AutoFixHighOutlined sx={{ fontSize: 16 }} />
+              </IconButton>
+            </Tooltip>
           </Box>
         )}
 
@@ -1143,6 +1190,17 @@ export const BuildCompletionHeader: React.FC = () => {
                   <SyncAltIcon sx={{ fontSize: 18 }} />
                 </ListItemIcon>
                 <ListItemText>Export to CSPS</ListItemText>
+              </MuiMenuItem>
+              <MuiMenuItem
+                onClick={() => {
+                  setMoreAnchor(null);
+                  handleWWExportOpen();
+                }}
+              >
+                <ListItemIcon>
+                  <AutoFixHighOutlined sx={{ fontSize: 18 }} />
+                </ListItemIcon>
+                <ListItemText>Send to Wizard&apos;s Wardrobe</ListItemText>
               </MuiMenuItem>
               <Divider />
               {/* Publish — shown in More menu on mobile since it's stripped from inline strip */}
@@ -1648,6 +1706,57 @@ export const BuildCompletionHeader: React.FC = () => {
                 </Tooltip>
               </Stack>
             </Stack>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Wizard's Wardrobe export dialog — lazy-mounted. Bridges each build
+          setup into a paste-in WW import code via the shared loadout panel. */}
+      {wwExportOpen && (
+        <Dialog
+          open
+          onClose={() => setWwExportOpen(false)}
+          maxWidth="sm"
+          fullWidth
+          slotProps={dialogSlotProps}
+        >
+          <DialogTitle
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              fontFamily: 'Space Grotesk, Inter, system-ui',
+              fontWeight: 700,
+              fontSize: 16,
+              pb: 0.5,
+            }}
+          >
+            Send to Wizard&apos;s Wardrobe
+            <IconButton
+              onClick={() => setWwExportOpen(false)}
+              size="small"
+              aria-label="Close Wizard's Wardrobe export dialog"
+              sx={{ color: 'text.secondary' }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </DialogTitle>
+          <DialogContent>
+            <Typography
+              variant="caption"
+              sx={{
+                color: 'text.secondary',
+                display: 'block',
+                mb: 2,
+                fontSize: 12,
+                fontFamily: 'Space Grotesk, Inter, system-ui',
+              }}
+            >
+              Generate a paste-in import code for each setup in this build. Editor-only details
+              (attributes, mundus, curse) aren&apos;t carried — Wizard&apos;s Wardrobe doesn&apos;t
+              store them.
+            </Typography>
+            <WizardWardrobeTransferPanel setups={wwSetups} disabled={wwExportBlocked} />
           </DialogContent>
         </Dialog>
       )}

--- a/src/features/build-editor/components/BuildCompletionHeader.tsx
+++ b/src/features/build-editor/components/BuildCompletionHeader.tsx
@@ -201,12 +201,19 @@ export const BuildCompletionHeader: React.FC = () => {
     () => build.setups.map((setup) => buildSetupToLoadoutSetup(setup)),
     [build.setups],
   );
-  // Mirror the loadout ExportDialog gate: withhold codes if any setup has a
-  // blocking gear-slot error, so a broken setup can't be pasted into the game.
-  const wwExportBlocked = React.useMemo(
-    () => build.setups.some((setup) => validateGearConfig(setup.gear ?? {}).errors.length > 0),
+  // Mirror the loadout ExportDialog gate: collect per-setup blocking gear-slot
+  // errors so we can both withhold the codes and tell the user which setup/slot
+  // is the problem — the shared panel only renders a generic "resolve above"
+  // notice, so the dialog itself must surface the actual messages.
+  const wwBlockingErrors = React.useMemo(
+    () =>
+      build.setups.flatMap((setup, index) => {
+        const name = setup.name?.trim() || `Setup ${index + 1}`;
+        return validateGearConfig(setup.gear ?? {}).errors.map((error) => `${name}: ${error}`);
+      }),
     [build.setups],
   );
+  const wwExportBlocked = wwBlockingErrors.length > 0;
 
   const handleSave = (): void => {
     if (!build.name.trim()) {
@@ -1756,6 +1763,20 @@ export const BuildCompletionHeader: React.FC = () => {
               (attributes, mundus, curse) aren&apos;t carried — Wizard&apos;s Wardrobe doesn&apos;t
               store them.
             </Typography>
+            {wwExportBlocked && (
+              <Alert severity="error" sx={{ mb: 2, borderRadius: '10px' }}>
+                <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }}>
+                  Fix these gear slot issues before generating codes:
+                </Typography>
+                <Box component="ul" sx={{ pl: 2, my: 0.5 }}>
+                  {wwBlockingErrors.map((error, index) => (
+                    <Typography key={index} component="li" variant="caption">
+                      {error}
+                    </Typography>
+                  ))}
+                </Box>
+              </Alert>
+            )}
             <WizardWardrobeTransferPanel setups={wwSetups} disabled={wwExportBlocked} />
           </DialogContent>
         </Dialog>

--- a/src/features/build-editor/components/__tests__/BuildCompletionHeader.test.tsx
+++ b/src/features/build-editor/components/__tests__/BuildCompletionHeader.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests the "Send to Wizard's Wardrobe" wiring added in the build↔loadout
+ * bridge: the header turns every build setup into a paste-in WW import code via
+ * the shared loadout panel, and withholds the codes when a setup has a blocking
+ * gear-slot error (mirroring the loadout Export dialog gate). The bridge/encoder
+ * themselves are unit-tested elsewhere — here we assert the header wiring.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+
+import savedBuildsReducer from '@/store/saved_builds/savedBuildsSlice';
+import savedRostersReducer from '@/store/saved_rosters/savedRostersSlice';
+
+import buildEditorReducer, { loadBuild } from '../../store/buildEditorSlice';
+import type { Build, GearConfig } from '../../types/build.types';
+import { BuildCompletionHeader } from '../BuildCompletionHeader';
+
+// Guests render the full inline action strip without the auth-gated publish
+// dialog, which keeps this test focused on the transfer wiring.
+jest.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ isLoggedIn: false, accessToken: null }),
+}));
+
+// The shared WW panel pulls a context logger; stub it so the dialog can mount
+// without a LoggerProvider in this isolated render.
+jest.mock('@/hooks/useLogger', () => ({
+  useLogger: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() }),
+}));
+
+// A complete default Build straight from the reducer; we only override gear.
+const baseBuild: Build = buildEditorReducer(undefined, { type: '@@INIT' } as never).build;
+
+const renderHeader = (gear: GearConfig) => {
+  const store = configureStore({
+    reducer: {
+      buildEditor: buildEditorReducer,
+      savedBuilds: savedBuildsReducer,
+      savedRosters: savedRostersReducer,
+    },
+  });
+  store.dispatch(
+    loadBuild({
+      ...baseBuild,
+      name: 'Test Build',
+      setups: [{ ...baseBuild.setups[0], gear }],
+    }),
+  );
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SnackbarProvider>
+          <BuildCompletionHeader />
+        </SnackbarProvider>
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+const openWWDialog = (): void => {
+  fireEvent.click(screen.getByRole('button', { name: /send to wizard's wardrobe/i }));
+};
+
+describe('BuildCompletionHeader — Send to Wizard’s Wardrobe', () => {
+  it('opens the dialog and generates a paste-in import code for the build setup', async () => {
+    renderHeader({});
+    openWWDialog();
+
+    // The shared panel renders its in-game instructions and a per-setup copy button.
+    await waitFor(() => expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument());
+    expect(screen.getByText(/open Wizard's Wardrobe/i)).toBeInTheDocument();
+  });
+
+  it('withholds the codes when a setup has a blocking gear-slot error', async () => {
+    // An armor slot pointing at an item id that is not in the database is a
+    // blocking validation error, so codes must not be offered.
+    renderHeader({ 0: { id: 999999999 } });
+    openWWDialog();
+
+    await waitFor(() =>
+      expect(screen.getByText(/resolve the gear slot issues/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/build-editor/components/__tests__/BuildCompletionHeader.test.tsx
+++ b/src/features/build-editor/components/__tests__/BuildCompletionHeader.test.tsx
@@ -84,6 +84,11 @@ describe('BuildCompletionHeader — Send to Wizard’s Wardrobe', () => {
     await waitFor(() =>
       expect(screen.getByText(/resolve the gear slot issues/i)).toBeInTheDocument(),
     );
+    // The dialog must name the offending setup/slot, not just gate silently.
+    expect(
+      screen.getByText(/Fix these gear slot issues before generating codes/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Item ID 999999999 not found in database/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What & why

Phase 2 of the Build⇄Loadout bridge. The Phase-1 PR (#1333) taught the loadout
surface to emit Wizard's Wardrobe import codes and added the build→loadout→WW
encoder (`buildSetupToWWTransfer`). This PR surfaces that path in the **Build
Editor's action hub** so you can plan a build and push it straight into the game
without bouncing through the Loadout Manager.

**Stacked on #1333** — the bridge util (`buildSetupToLoadoutSetup`) and the
shared `WizardWardrobeTransferPanel` live on the Phase-1 branch, not yet on
`main`, so this PR is based on `claude/build-loadout-bridge-p1-fxe1jg`. Rebase to
`main` once #1333 merges.

## Changes

- Wire **"Send to Wizard's Wardrobe"** into `BuildCompletionHeader`:
  - Each build setup is bridged to a `LoadoutSetup` via `buildSetupToLoadoutSetup`
    and handed to the shared `WizardWardrobeTransferPanel`, which renders one
    paste-in import code per setup (the panel runs the WW encoding internally).
  - **Desktop:** a new wand icon in the Transfer segment (Import | Export | Send).
  - **Medium / mobile:** a "Send to Wizard's Wardrobe" item in the overflow menu,
    next to "Export to CSPS".
  - **Validation gate** mirrors the loadout `ExportDialog`: codes are withheld
    when any setup has a blocking gear-slot error (`validateGearConfig`), so a
    broken setup can't be pasted into the game.
- Route the header's three share/link URLs through the `getBaseUrl()` env helper
  instead of raw `import.meta.env.BASE_URL`. Equivalent behavior, matches the
  repo convention (`setupTests` mocks `envUtils` precisely to avoid `import.meta`
  in Jest), and makes the component renderable under ts-jest.

## Tests

- New `BuildCompletionHeader.test.tsx`: opening the dialog generates a per-setup
  import code; a setup with a blocking gear-slot error withholds the codes and
  shows the resolve-errors message.
- Full `build-editor` + `loadout-manager` suites: **641 passed / 13 skipped**.
  `tsc`, ESLint, and Prettier clean on the changed files.

## ⚠️ Honest limitation

As with Phase 1, the in-game paste-into-ESO round-trip can't be verified from
this environment (no game client). This PR is pure UI wiring over the
already-tested encoder; a human should still generate a code from a build in the
running app and confirm it imports in Wizard's Wardrobe in-game.

## Follow-ups (separate PRs)

Per the owner decisions recorded on #1333 — Build Editor is the canonical editor,
and `/loadout-manager` will be renamed to `/loadouts` (with a redirect) — the
remaining phases are: Phase 3 IA (Loadout Library), Phase 4 differentiators
(comparator + health badges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7gNoALG622PMAjq88vVRZ)_