### PR TITLE
feat(routing): rename /loadout-manager → /loadouts with redirect (Phase 3 IA)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Box, Container } from '@mui/material';
 import { SnackbarProvider } from 'notistack';
 import React, { Suspense, useEffect, useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { Routes, Route, BrowserRouter } from 'react-router-dom';
+import { Routes, Route, BrowserRouter, Navigate } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import { AnalyticsListener } from './components/AnalyticsListener';
@@ -663,7 +663,7 @@ const AppRoutes: React.FC = () => {
               }
             />
             <Route
-              path="/loadout-manager"
+              path="/loadouts"
               element={
                 <ErrorBoundary>
                   <Suspense fallback={<LoadingFallback />}>
@@ -672,6 +672,10 @@ const AppRoutes: React.FC = () => {
                 </ErrorBoundary>
               }
             />
+            {/* Legacy route — /loadout-manager was renamed to /loadouts.
+                Keep a permanent client-side redirect so old links/bookmarks
+                still resolve. */}
+            <Route path="/loadout-manager" element={<Navigate to="/loadouts" replace />} />
             <Route
               path="/build-editor"
               element={

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,7 +40,7 @@ export const Footer: React.FC = React.memo(() => {
 
       { label: 'Text Editor', href: '/text-editor' },
 
-      { label: 'Loadout Manager', href: '/loadout-manager' },
+      { label: 'Loadout Manager', href: '/loadouts' },
 
       { label: 'Gear Sets', href: '/gear-sets' },
     ],

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -688,7 +688,7 @@ export const HeaderBar: React.FC = () => {
       desc: 'Manage gear loadouts',
       icon: '⚔️',
       accent: '#ef4444',
-      path: '/loadout-manager',
+      path: '/loadouts',
     },
     {
       text: 'Roster Builder',

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -8,7 +8,7 @@ const ROUTE_NAMES: Record<string, string> = {
   '/text-editor': 'Text Editor',
   '/calculator': 'Calculator',
   '/parse-analysis': 'Parse Analysis',
-  '/loadout-manager': 'Loadout Manager',
+  '/loadouts': 'Loadout Manager',
   '/roster-builder': 'Roster Builder',
   '/build-editor': 'Build Editor',
   '/roster-hub': 'Roster Hub',


### PR DESCRIPTION
## What & why

Phase 3 IA foundation for the build⇄loadout consolidation, per the owner
decision recorded on #1333 (rename `/loadout-manager` → `/loadouts`). This is the
small, standalone routing change so it can land independently of the bridge PRs
(#1333 / #1334) — it has **no dependency** on the bridge code, so it's based on
`main`.

## Changes

- The Loadout Manager now lives at **`/loadouts`**.
- The old **`/loadout-manager`** path is kept as a permanent client-side redirect
  (`<Navigate to="/loadouts" replace />`) so existing links and bookmarks still
  resolve.
- Updated the three user-facing references to the new path: the header nav
  (`HeaderBar`), the footer link (`Footer`), and the breadcrumb title map
  (`AppLayout`).

## Scope / non-goals

- The **feature directory** `src/features/loadout-manager/` is intentionally left
  unchanged — renaming it would touch 100+ import sites with no user-facing
  benefit. This PR renames the **route** only.
- The user-facing label stays "Loadout Manager" for now; a display-name change
  (if desired) is a separate decision.

## Tests

- `tsc`, ESLint, Prettier clean on all four changed files.
- `App.test.tsx` (full app-shell render) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7gNoALG622PMAjq88vVRZ)_