### PR TITLE
feat(loadouts): Loadout Library (Section A of build⇄loadout bridge)

### DIFF
--- a/src/features/loadout-manager/components/LoadoutLibraryPanel.test.tsx
+++ b/src/features/loadout-manager/components/LoadoutLibraryPanel.test.tsx
@@ -1,0 +1,102 @@
+import { ThemeProvider, createTheme } from '@mui/material';
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+
+import savedLoadoutsReducer from '@/store/saved_loadouts/savedLoadoutsSlice';
+import type { SavedLoadout } from '@/store/saved_loadouts/savedLoadoutsSlice';
+
+import type { LoadoutSetup } from '../types/loadout.types';
+
+import { LoadoutLibraryPanel } from './LoadoutLibraryPanel';
+
+const makeSetup = (name = 'My Setup'): LoadoutSetup => ({
+  name,
+  disabled: false,
+  condition: { boss: 'Lokkestiiz' },
+  skills: { 0: { 3: 12345 }, 1: {} },
+  cp: { 1: 67890 },
+  food: { id: 111 },
+  gear: { 0: { id: '222', trait: 'divines' } },
+  code: '',
+});
+
+const makeEntry = (overrides: Partial<SavedLoadout> = {}): SavedLoadout => ({
+  id: 'entry-1',
+  name: 'Trial Tank',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  setup: makeSetup(),
+  meta: { trialId: 'SS' },
+  ...overrides,
+});
+
+const renderPanel = (loadouts: SavedLoadout[] = [], onLoad?: jest.Mock) => {
+  const store = configureStore({
+    reducer: { savedLoadouts: savedLoadoutsReducer },
+    preloadedState: loadouts.length ? { savedLoadouts: { loadouts } } : undefined,
+  });
+  const utils = render(
+    <Provider store={store}>
+      <ThemeProvider theme={createTheme({ palette: { mode: 'dark' } })}>
+        <LoadoutLibraryPanel onLoad={onLoad} />
+      </ThemeProvider>
+    </Provider>,
+  );
+  return { store, ...utils };
+};
+
+describe('LoadoutLibraryPanel', () => {
+  it('shows an empty state when there are no saved loadouts', () => {
+    renderPanel();
+    expect(screen.getByText('Your library is empty')).toBeInTheDocument();
+    expect(screen.getByText(/No saved loadouts yet/i)).toBeInTheDocument();
+  });
+
+  it('renders a card per saved loadout with name and count', () => {
+    renderPanel([makeEntry(), makeEntry({ id: 'entry-2', name: 'Healer' })]);
+    expect(screen.getByText('Trial Tank')).toBeInTheDocument();
+    expect(screen.getByText('Healer')).toBeInTheDocument();
+    expect(screen.getByText('2 saved loadouts')).toBeInTheDocument();
+  });
+
+  it('invokes onLoad with the entry setup when Load is clicked', () => {
+    const onLoad = jest.fn();
+    renderPanel([makeEntry()], onLoad);
+    fireEvent.click(screen.getByRole('button', { name: 'Load' }));
+    expect(onLoad).toHaveBeenCalledTimes(1);
+    expect(onLoad.mock.calls[0][0]).toMatchObject({ name: 'My Setup' });
+  });
+
+  it('duplicates a loadout into the library', () => {
+    const { store } = renderPanel([makeEntry()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    const { loadouts } = store.getState().savedLoadouts;
+    expect(loadouts).toHaveLength(2);
+    expect(loadouts.some((l) => l.name === 'Trial Tank (copy)')).toBe(true);
+  });
+
+  it('deletes a loadout after confirming', () => {
+    const { store } = renderPanel([makeEntry()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Delete Loadout?')).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(store.getState().savedLoadouts.loadouts).toHaveLength(0);
+  });
+
+  it('renames a loadout', () => {
+    const { store } = renderPanel([makeEntry()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    const dialog = screen.getByRole('dialog');
+    const nameInput = within(dialog).getByLabelText('Name');
+    fireEvent.change(nameInput, { target: { value: 'Renamed Tank' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(store.getState().savedLoadouts.loadouts[0].name).toBe('Renamed Tank');
+  });
+});

--- a/src/features/loadout-manager/components/LoadoutLibraryPanel.test.tsx
+++ b/src/features/loadout-manager/components/LoadoutLibraryPanel.test.tsx
@@ -61,12 +61,16 @@ describe('LoadoutLibraryPanel', () => {
     expect(screen.getByText('2 saved loadouts')).toBeInTheDocument();
   });
 
-  it('invokes onLoad with the entry setup when Load is clicked', () => {
+  it('invokes onLoad with the entry setup and the full entry when Load is clicked', () => {
     const onLoad = jest.fn();
-    renderPanel([makeEntry()], onLoad);
+    renderPanel([makeEntry({ name: 'Renamed Tank' })], onLoad);
     fireEvent.click(screen.getByRole('button', { name: 'Load' }));
     expect(onLoad).toHaveBeenCalledTimes(1);
+    // 1st arg: the embedded setup (name may be the original, pre-rename value).
     expect(onLoad.mock.calls[0][0]).toMatchObject({ name: 'My Setup' });
+    // 2nd arg: the saved entry, carrying the canonical (possibly renamed) name
+    // the loader adopts so the inserted setup matches the clicked card.
+    expect(onLoad.mock.calls[0][1]).toMatchObject({ name: 'Renamed Tank' });
   });
 
   it('duplicates a loadout into the library', () => {

--- a/src/features/loadout-manager/components/LoadoutLibraryPanel.tsx
+++ b/src/features/loadout-manager/components/LoadoutLibraryPanel.tsx
@@ -1,0 +1,388 @@
+/**
+ * Loadout Library Panel
+ *
+ * Lists the user's saved loadouts (the `savedLoadouts` slice) as cards and
+ * exposes Load / Duplicate / Rename / Delete actions. This is the loadout
+ * counterpart of the "My Builds" list — saved loadouts are named, persisted,
+ * and browsable, rather than the session-scoped working trial/character tree.
+ */
+
+import {
+  Bookmark as BookmarkIcon,
+  ContentCopy as DuplicateIcon,
+  Delete as DeleteIcon,
+  DriveFileRenameOutline as RenameIcon,
+  PlayArrow as LoadIcon,
+} from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  deleteSavedLoadout,
+  renameSavedLoadout,
+  saveLoadout,
+  selectSavedLoadouts,
+  type SavedLoadout,
+} from '@/store/saved_loadouts';
+import { useAppDispatch } from '@/store/useAppDispatch';
+
+import type { LoadoutSetup } from '../types/loadout.types';
+import {
+  formatProgressSection,
+  getSetupConditionSummary,
+  getSetupProgressSections,
+} from '../utils/setupDisplay';
+
+interface LoadoutLibraryPanelProps {
+  /**
+   * Invoked when the user loads a library entry into the working area. The host
+   * (LoadoutManager) decides where it lands (current trial/page).
+   */
+  onLoad?: (setup: LoadoutSetup, entry: SavedLoadout) => void;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+interface LibraryCardProps {
+  entry: SavedLoadout;
+  isDarkMode: boolean;
+  onLoad?: (setup: LoadoutSetup, entry: SavedLoadout) => void;
+  onDuplicate: (entry: SavedLoadout) => void;
+  onRename: (entry: SavedLoadout) => void;
+  onDelete: (entry: SavedLoadout) => void;
+}
+
+const LibraryCard: React.FC<LibraryCardProps> = ({
+  entry,
+  isDarkMode,
+  onLoad,
+  onDuplicate,
+  onRename,
+  onDelete,
+}) => {
+  const conditionSummary = getSetupConditionSummary(entry.setup);
+  const progressSections = getSetupProgressSections(entry.setup);
+
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        border: isDarkMode ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(0,0,0,0.1)',
+        borderRadius: 2,
+        background: isDarkMode ? 'rgba(15,23,42,0.6)' : 'rgba(248,250,252,0.8)',
+        backdropFilter: 'blur(10px)',
+        transition: 'border-color 0.2s ease',
+        '&:hover': {
+          borderColor: isDarkMode ? 'rgba(56,189,248,0.3)' : 'rgba(59,130,246,0.25)',
+        },
+      }}
+    >
+      <CardContent sx={{ pb: 1 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 700,
+              fontSize: '1rem',
+              color: isDarkMode ? '#f1f5f9' : '#0f172a',
+              wordBreak: 'break-word',
+            }}
+          >
+            {entry.name || 'Unnamed Loadout'}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5, ml: 1, flexShrink: 0, flexWrap: 'wrap' }}>
+            {entry.meta?.trialId && (
+              <Chip label={entry.meta.trialId} size="small" sx={{ fontSize: '0.7rem' }} />
+            )}
+            {entry.meta?.characterName && (
+              <Chip
+                label={entry.meta.characterName}
+                size="small"
+                variant="outlined"
+                sx={{ fontSize: '0.7rem' }}
+              />
+            )}
+          </Box>
+        </Box>
+        <Typography
+          variant="caption"
+          sx={{ color: isDarkMode ? '#94a3b8' : '#64748b', mt: 0.5, display: 'block' }}
+        >
+          Updated {formatDate(entry.updatedAt)}
+        </Typography>
+        {conditionSummary && (
+          <Typography
+            variant="body2"
+            sx={{ mt: 0.5, color: isDarkMode ? '#94a3b8' : '#64748b', fontSize: '0.8rem' }}
+          >
+            {conditionSummary}
+          </Typography>
+        )}
+        {entry.description && (
+          <Typography
+            variant="body2"
+            sx={{
+              mt: 1,
+              color: isDarkMode ? '#94a3b8' : '#64748b',
+              fontSize: '0.8rem',
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {entry.description}
+          </Typography>
+        )}
+        <Stack
+          direction="row"
+          spacing={0.5}
+          sx={{ mt: 1, flexWrap: 'wrap', rowGap: 0.5 }}
+          useFlexGap
+        >
+          {progressSections.length === 0 ? (
+            <Chip label="Empty setup" size="small" variant="outlined" sx={{ fontSize: '0.7rem' }} />
+          ) : (
+            progressSections.map((section, index) => (
+              <Chip
+                key={`${section.type}-${index}`}
+                label={formatProgressSection(section)}
+                size="small"
+                variant="outlined"
+                sx={{ height: 22, fontSize: '0.7rem' }}
+              />
+            ))
+          )}
+        </Stack>
+      </CardContent>
+      <Divider sx={{ opacity: 0.5 }} />
+      <CardActions sx={{ gap: 1, px: 2, py: 1 }}>
+        {onLoad && (
+          <Button
+            size="small"
+            startIcon={<LoadIcon />}
+            onClick={() => onLoad(entry.setup, entry)}
+            sx={{ textTransform: 'none', fontWeight: 600 }}
+          >
+            Load
+          </Button>
+        )}
+        <Button
+          size="small"
+          startIcon={<DuplicateIcon />}
+          onClick={() => onDuplicate(entry)}
+          sx={{
+            textTransform: 'none',
+            fontWeight: 500,
+            color: isDarkMode ? '#94a3b8' : '#64748b',
+          }}
+        >
+          Duplicate
+        </Button>
+        <Button
+          size="small"
+          startIcon={<RenameIcon />}
+          onClick={() => onRename(entry)}
+          sx={{
+            textTransform: 'none',
+            fontWeight: 500,
+            color: isDarkMode ? '#94a3b8' : '#64748b',
+          }}
+        >
+          Rename
+        </Button>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          size="small"
+          startIcon={<DeleteIcon />}
+          onClick={() => onDelete(entry)}
+          color="error"
+          sx={{ textTransform: 'none', fontWeight: 500 }}
+        >
+          Delete
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+export const LoadoutLibraryPanel: React.FC<LoadoutLibraryPanelProps> = ({ onLoad }) => {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+  const dispatch = useAppDispatch();
+  const savedLoadouts = useSelector(selectSavedLoadouts);
+
+  const [pendingDelete, setPendingDelete] = useState<SavedLoadout | null>(null);
+  const [renameTarget, setRenameTarget] = useState<SavedLoadout | null>(null);
+  const [renameName, setRenameName] = useState('');
+  const [renameDescription, setRenameDescription] = useState('');
+
+  const handleDuplicate = (entry: SavedLoadout): void => {
+    dispatch(
+      saveLoadout({
+        name: `${entry.name} (copy)`,
+        setup: entry.setup,
+        description: entry.description,
+        meta: entry.meta,
+      }),
+    );
+  };
+
+  const handleOpenRename = (entry: SavedLoadout): void => {
+    setRenameTarget(entry);
+    setRenameName(entry.name);
+    setRenameDescription(entry.description ?? '');
+  };
+
+  const handleSubmitRename = (): void => {
+    if (!renameTarget || !renameName.trim()) {
+      return;
+    }
+    dispatch(
+      renameSavedLoadout({
+        id: renameTarget.id,
+        name: renameName.trim(),
+        description: renameDescription.trim(),
+      }),
+    );
+    setRenameTarget(null);
+  };
+
+  const handleConfirmDelete = (): void => {
+    if (pendingDelete) {
+      dispatch(deleteSavedLoadout(pendingDelete.id));
+      setPendingDelete(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{ fontWeight: 700, color: isDarkMode ? '#f1f5f9' : '#0f172a' }}
+        >
+          Loadout Library
+        </Typography>
+        <Typography variant="body2" sx={{ color: isDarkMode ? '#94a3b8' : '#64748b', mt: 0.25 }}>
+          {savedLoadouts.length === 0
+            ? 'No saved loadouts yet. Use "Save to Library" on a setup to add one.'
+            : `${savedLoadouts.length} saved loadout${savedLoadouts.length === 1 ? '' : 's'}`}
+        </Typography>
+      </Box>
+
+      {savedLoadouts.length === 0 ? (
+        <Box
+          sx={{
+            textAlign: 'center',
+            py: 8,
+            border: isDarkMode ? '2px dashed rgba(255,255,255,0.1)' : '2px dashed rgba(0,0,0,0.1)',
+            borderRadius: 3,
+          }}
+        >
+          <BookmarkIcon sx={{ fontSize: 48, color: isDarkMode ? '#334155' : '#cbd5e1', mb: 2 }} />
+          <Typography variant="h6" sx={{ color: isDarkMode ? '#475569' : '#94a3b8' }}>
+            Your library is empty
+          </Typography>
+          <Typography variant="body2" sx={{ color: isDarkMode ? '#475569' : '#94a3b8', mt: 1 }}>
+            Save a setup to the library to reuse it across trials and characters.
+          </Typography>
+        </Box>
+      ) : (
+        <Stack spacing={2}>
+          {savedLoadouts.map((entry) => (
+            <LibraryCard
+              key={entry.id}
+              entry={entry}
+              isDarkMode={isDarkMode}
+              onLoad={onLoad}
+              onDuplicate={handleDuplicate}
+              onRename={handleOpenRename}
+              onDelete={setPendingDelete}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {/* Rename dialog */}
+      <Dialog
+        open={renameTarget !== null}
+        onClose={() => setRenameTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Rename Loadout</DialogTitle>
+        <DialogContent>
+          <TextField
+            value={renameName}
+            onChange={(event) => setRenameName(event.target.value)}
+            autoFocus
+            fullWidth
+            margin="dense"
+            label="Name"
+          />
+          <TextField
+            value={renameDescription}
+            onChange={(event) => setRenameDescription(event.target.value)}
+            fullWidth
+            margin="dense"
+            label="Description (optional)"
+            multiline
+            minRows={2}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenameTarget(null)}>Cancel</Button>
+          <Button onClick={handleSubmitRename} variant="contained" disabled={!renameName.trim()}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
+      <Dialog
+        open={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Delete Loadout?</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ color: 'text.secondary' }}>
+            Are you sure you want to delete <strong>{pendingDelete?.name}</strong>? This cannot be
+            undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingDelete(null)}>Cancel</Button>
+          <Button onClick={handleConfirmDelete} color="error" variant="contained">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/src/features/loadout-manager/components/LoadoutManager.tsx
+++ b/src/features/loadout-manager/components/LoadoutManager.tsx
@@ -35,6 +35,8 @@ import {
   Snackbar,
   Stack,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   Typography,
   useMediaQuery,
@@ -47,6 +49,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { WorkInProgressDisclaimer } from '@/components/WorkInProgressDisclaimer';
 import { useDropdownMenuProps } from '@/hooks/useDropdownMenuDirection';
+import { selectSavedLoadouts } from '@/store/saved_loadouts';
 import type { RootState } from '@/store/storeWithHistory';
 
 import { preloadChampionPointData } from '../data/championPointData';
@@ -89,6 +92,7 @@ import {
 
 import { CharacterSelector } from './CharacterSelector';
 import { ExportDialog } from './ExportDialog';
+import { LoadoutLibraryPanel } from './LoadoutLibraryPanel';
 import { SetupEditor } from './SetupEditor';
 import { SetupList } from './SetupList';
 
@@ -146,7 +150,9 @@ export const LoadoutManager: React.FC = () => {
     currentTrial ? selectTrialPages(state, currentTrial) : [],
   );
   const currentCharacter = useSelector((state: RootState) => state.loadout.currentCharacter);
+  const savedLoadoutCount = useSelector(selectSavedLoadouts).length;
 
+  const [view, setView] = useState<'setups' | 'library'>('setups');
   const [selectedSetupIndex, setSelectedSetupIndex] = useState<number | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -282,6 +288,21 @@ export const LoadoutManager: React.FC = () => {
       setDrawerOpen(true);
     }
     showSnackbar('Blank setup added.', 'success');
+  };
+
+  const handleLoadFromLibrary = (setup: LoadoutSetup): void => {
+    if (!ensureTrialSelected()) {
+      return;
+    }
+    // Clone so future edits to the working setup don't mutate the library entry.
+    const cloned: LoadoutSetup = JSON.parse(JSON.stringify(setup));
+    dispatch(addSetup({ trialId: currentTrial!, pageIndex: currentPage, setup: cloned }));
+    setView('setups');
+    setSelectedSetupIndex(setups.length);
+    if (isMdDown) {
+      setDrawerOpen(true);
+    }
+    showSnackbar(`Loaded "${setup.name}" into the current page.`, 'success');
   };
 
   const handleDuplicateSetup = (index: number): void => {
@@ -888,71 +909,93 @@ export const LoadoutManager: React.FC = () => {
           </Stack>
         </Paper>
 
-        {/* ── Main content: list + editor ───────────────────── */}
-        <Stack direction={{ xs: 'column', lg: 'row' }} spacing={2} sx={{ alignItems: 'stretch' }}>
-          {/* Setup list — narrower on desktop */}
-          <Box
-            sx={{
-              width: { xs: '100%', lg: '38%' },
-              flexShrink: 0,
-              minWidth: 0,
-              maxHeight: { lg: 'calc(100vh - 280px)' },
-              display: 'flex',
-            }}
-          >
-            <SetupList
-              setups={setups}
-              selectedIndex={selectedSetupIndex}
-              filterText={searchTerm}
-              onOpenDetails={handleOpenDetails}
-              onDuplicateSetup={handleDuplicateSetup}
-              onDeleteSetup={handleDeleteSetup}
-              onCopySetup={handleCopySetup}
-            />
-          </Box>
+        {/* ── View toggle: working setups vs saved library ───── */}
+        <ToggleButtonGroup
+          value={view}
+          exclusive
+          size="small"
+          onChange={(_event, next: 'setups' | 'library' | null) => {
+            if (next) setView(next);
+          }}
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          <ToggleButton value="setups" sx={{ textTransform: 'none', px: 2 }}>
+            Setups
+          </ToggleButton>
+          <ToggleButton value="library" sx={{ textTransform: 'none', px: 2 }}>
+            Library{savedLoadoutCount > 0 ? ` (${savedLoadoutCount})` : ''}
+          </ToggleButton>
+        </ToggleButtonGroup>
 
-          {/* Editor — wider on desktop */}
-          {!isMdDown && (
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              {selectedSetup ? (
-                <SetupEditor
-                  setup={selectedSetup}
-                  setupIndex={selectedSetupIndex ?? 0}
-                  trialId={currentTrial ?? 'GEN'}
-                  pageIndex={currentPage}
-                  variant="page"
-                />
-              ) : (
-                <Paper
-                  elevation={0}
-                  sx={{
-                    height: '100%',
-                    minHeight: 200,
-                    borderRadius: 2,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    textAlign: 'center',
-                    px: 3,
-                    py: 4,
-                    color: 'text.secondary',
-                    backgroundColor: isDarkMode ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.01)',
-                    border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
-                  }}
-                >
-                  <Stack spacing={1} sx={{ alignItems: 'center' }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                      Select a setup
-                    </Typography>
-                    <Typography variant="body2">
-                      Choose a loadout from the list to review gear, skills, and CP.
-                    </Typography>
-                  </Stack>
-                </Paper>
-              )}
+        {view === 'library' ? (
+          <LoadoutLibraryPanel onLoad={handleLoadFromLibrary} />
+        ) : (
+          /* ── Main content: list + editor ───────────────────── */
+          <Stack direction={{ xs: 'column', lg: 'row' }} spacing={2} sx={{ alignItems: 'stretch' }}>
+            {/* Setup list — narrower on desktop */}
+            <Box
+              sx={{
+                width: { xs: '100%', lg: '38%' },
+                flexShrink: 0,
+                minWidth: 0,
+                maxHeight: { lg: 'calc(100vh - 280px)' },
+                display: 'flex',
+              }}
+            >
+              <SetupList
+                setups={setups}
+                selectedIndex={selectedSetupIndex}
+                filterText={searchTerm}
+                onOpenDetails={handleOpenDetails}
+                onDuplicateSetup={handleDuplicateSetup}
+                onDeleteSetup={handleDeleteSetup}
+                onCopySetup={handleCopySetup}
+              />
             </Box>
-          )}
-        </Stack>
+
+            {/* Editor — wider on desktop */}
+            {!isMdDown && (
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                {selectedSetup ? (
+                  <SetupEditor
+                    setup={selectedSetup}
+                    setupIndex={selectedSetupIndex ?? 0}
+                    trialId={currentTrial ?? 'GEN'}
+                    pageIndex={currentPage}
+                    variant="page"
+                  />
+                ) : (
+                  <Paper
+                    elevation={0}
+                    sx={{
+                      height: '100%',
+                      minHeight: 200,
+                      borderRadius: 2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      textAlign: 'center',
+                      px: 3,
+                      py: 4,
+                      color: 'text.secondary',
+                      backgroundColor: isDarkMode ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.01)',
+                      border: `1px solid ${isDarkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+                    }}
+                  >
+                    <Stack spacing={1} sx={{ alignItems: 'center' }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                        Select a setup
+                      </Typography>
+                      <Typography variant="body2">
+                        Choose a loadout from the list to review gear, skills, and CP.
+                      </Typography>
+                    </Stack>
+                  </Paper>
+                )}
+              </Box>
+            )}
+          </Stack>
+        )}
       </Stack>
 
       {/* Hidden file input */}

--- a/src/features/loadout-manager/components/LoadoutManager.tsx
+++ b/src/features/loadout-manager/components/LoadoutManager.tsx
@@ -49,7 +49,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { WorkInProgressDisclaimer } from '@/components/WorkInProgressDisclaimer';
 import { useDropdownMenuProps } from '@/hooks/useDropdownMenuDirection';
-import { selectSavedLoadouts } from '@/store/saved_loadouts';
+import { selectSavedLoadouts, type SavedLoadout } from '@/store/saved_loadouts';
 import type { RootState } from '@/store/storeWithHistory';
 
 import { preloadChampionPointData } from '../data/championPointData';
@@ -290,19 +290,29 @@ export const LoadoutManager: React.FC = () => {
     showSnackbar('Blank setup added.', 'success');
   };
 
-  const handleLoadFromLibrary = (setup: LoadoutSetup): void => {
+  const handleLoadFromLibrary = (setup: LoadoutSetup, entry: SavedLoadout): void => {
     if (!ensureTrialSelected()) {
       return;
     }
-    // Clone so future edits to the working setup don't mutate the library entry.
+    // addSetup no-ops when no character is selected (the working tree is keyed by
+    // character). currentTrial can fall back to a default, so guard on the
+    // character explicitly rather than reporting a phantom success.
+    if (!currentCharacter) {
+      showSnackbar('Pick or import a character before loading a loadout.', 'error');
+      return;
+    }
+    // Clone so future edits to the working setup don't mutate the library entry,
+    // and adopt the library entry's name so the inserted setup matches the card
+    // the user clicked (the embedded setup.name can be stale after a rename).
     const cloned: LoadoutSetup = JSON.parse(JSON.stringify(setup));
+    cloned.name = entry.name;
     dispatch(addSetup({ trialId: currentTrial!, pageIndex: currentPage, setup: cloned }));
     setView('setups');
     setSelectedSetupIndex(setups.length);
     if (isMdDown) {
       setDrawerOpen(true);
     }
-    showSnackbar(`Loaded "${setup.name}" into the current page.`, 'success');
+    showSnackbar(`Loaded "${entry.name}" into the current page.`, 'success');
   };
 
   const handleDuplicateSetup = (index: number): void => {

--- a/src/features/loadout-manager/components/SetupEditor.tsx
+++ b/src/features/loadout-manager/components/SetupEditor.tsx
@@ -8,9 +8,14 @@
  * - Tabs stay full-width but without per-tab "Clear" header rows
  */
 
-import { ContentCopy, ContentPaste, Delete, FileCopy } from '@mui/icons-material';
+import { BookmarkAdd, ContentCopy, ContentPaste, Delete, FileCopy } from '@mui/icons-material';
 import {
   Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Paper,
   Typography,
   Tabs,
@@ -21,6 +26,7 @@ import {
   Snackbar,
   Alert,
   ChipProps,
+  TextField,
   Tooltip,
   useTheme,
 } from '@mui/material';
@@ -28,6 +34,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { useLogger } from '@/hooks/useLogger';
+import { saveLoadout } from '@/store/saved_loadouts';
 
 import { duplicateSetup, deleteSetup, replaceSetup } from '../store/loadoutSlice';
 import { LoadoutSetup, ClipboardSetup } from '../types/loadout.types';
@@ -99,6 +106,9 @@ export const SetupEditor: React.FC<SetupEditorProps> = ({
   const isDarkMode = theme.palette.mode === 'dark';
   const isDrawer = variant === 'drawer';
   const [currentTab, setCurrentTab] = React.useState(0);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveDescription, setSaveDescription] = useState('');
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
@@ -219,6 +229,31 @@ export const SetupEditor: React.FC<SetupEditorProps> = ({
   const handleDuplicate = (): void => {
     dispatch(duplicateSetup({ trialId, pageIndex, setupIndex }));
     showSnackbar('Setup duplicated!', 'success');
+  };
+
+  const handleOpenSaveDialog = (): void => {
+    setSaveName(setup.name || 'Untitled loadout');
+    setSaveDescription('');
+    setSaveDialogOpen(true);
+  };
+
+  const handleSaveToLibrary = (): void => {
+    const name = saveName.trim();
+    if (!name) {
+      return;
+    }
+    // Clone so later edits to the working setup don't mutate the library entry.
+    const clonedSetup: LoadoutSetup = JSON.parse(JSON.stringify(setup));
+    dispatch(
+      saveLoadout({
+        name,
+        setup: clonedSetup,
+        description: saveDescription.trim() || undefined,
+        meta: { trialId },
+      }),
+    );
+    setSaveDialogOpen(false);
+    showSnackbar(`Saved "${name}" to your library.`, 'success');
   };
 
   const handleDelete = (): void => {
@@ -351,6 +386,31 @@ export const SetupEditor: React.FC<SetupEditorProps> = ({
                   }}
                 >
                   <ContentPaste fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Box
+                sx={{
+                  width: '1px',
+                  height: 20,
+                  flexShrink: 0,
+                  backgroundColor: isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+                }}
+              />
+              <Tooltip title="Save to library" arrow>
+                <IconButton
+                  size="small"
+                  onClick={handleOpenSaveDialog}
+                  color="success"
+                  aria-label="Save to library"
+                  sx={{
+                    borderRadius: 0,
+                    px: 0.75,
+                    '&:hover': {
+                      backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)',
+                    },
+                  }}
+                >
+                  <BookmarkAdd fontSize="small" />
                 </IconButton>
               </Tooltip>
               <Box
@@ -537,6 +597,41 @@ export const SetupEditor: React.FC<SetupEditorProps> = ({
           />
         </TabPanel>
       </Box>
+
+      {/* Save to library dialog */}
+      <Dialog
+        open={saveDialogOpen}
+        onClose={() => setSaveDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Save to Library</DialogTitle>
+        <DialogContent>
+          <TextField
+            value={saveName}
+            onChange={(event) => setSaveName(event.target.value)}
+            autoFocus
+            fullWidth
+            margin="dense"
+            label="Name"
+          />
+          <TextField
+            value={saveDescription}
+            onChange={(event) => setSaveDescription(event.target.value)}
+            fullWidth
+            margin="dense"
+            label="Description (optional)"
+            multiline
+            minRows={2}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSaveDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSaveToLibrary} variant="contained" disabled={!saveName.trim()}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Snackbar */}
       <Snackbar

--- a/src/features/loadout-manager/index.ts
+++ b/src/features/loadout-manager/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { LoadoutManager } from './components/LoadoutManager';
+export { LoadoutLibraryPanel } from './components/LoadoutLibraryPanel';
 export { SetupList } from './components/SetupList';
 export { SetupEditor } from './components/SetupEditor';
 export { SkillSelector } from './components/SkillSelector';

--- a/src/store/saved_loadouts/index.ts
+++ b/src/store/saved_loadouts/index.ts
@@ -1,0 +1,9 @@
+export { default as savedLoadoutsReducer } from './savedLoadoutsSlice';
+export {
+  saveLoadout,
+  updateSavedLoadout,
+  renameSavedLoadout,
+  deleteSavedLoadout,
+} from './savedLoadoutsSlice';
+export { selectSavedLoadouts, selectSavedLoadoutById } from './savedLoadoutsSelectors';
+export type { SavedLoadout, SavedLoadoutMeta } from './savedLoadoutsSlice';

--- a/src/store/saved_loadouts/savedLoadoutsSelectors.ts
+++ b/src/store/saved_loadouts/savedLoadoutsSelectors.ts
@@ -1,0 +1,9 @@
+import type { RootState } from '../storeWithHistory';
+
+export const selectSavedLoadouts = (state: RootState): RootState['savedLoadouts']['loadouts'] =>
+  state.savedLoadouts.loadouts;
+
+export const selectSavedLoadoutById =
+  (id: string) =>
+  (state: RootState): RootState['savedLoadouts']['loadouts'][number] | undefined =>
+    state.savedLoadouts.loadouts.find((l) => l.id === id);

--- a/src/store/saved_loadouts/savedLoadoutsSlice.test.ts
+++ b/src/store/saved_loadouts/savedLoadoutsSlice.test.ts
@@ -1,0 +1,183 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import type { LoadoutSetup } from '../../features/loadout-manager/types/loadout.types';
+
+import savedLoadoutsReducer, {
+  saveLoadout,
+  updateSavedLoadout,
+  renameSavedLoadout,
+  deleteSavedLoadout,
+} from './savedLoadoutsSlice';
+import type { SavedLoadout } from './savedLoadoutsSlice';
+
+const makeSetup = (name = 'My Setup'): LoadoutSetup => ({
+  name,
+  disabled: false,
+  condition: { boss: 'Lokkestiiz' },
+  skills: { 0: { 3: 12345 }, 1: {} },
+  cp: { 1: 67890 },
+  food: { id: 111 },
+  gear: { 0: { id: '222', trait: 'divines' } },
+  code: '',
+});
+
+const createTestStore = (loadouts: SavedLoadout[] = []) =>
+  configureStore({
+    reducer: { savedLoadouts: savedLoadoutsReducer },
+    preloadedState: loadouts.length ? { savedLoadouts: { loadouts } } : undefined,
+  });
+
+describe('savedLoadoutsSlice', () => {
+  it('starts with an empty library', () => {
+    const store = createTestStore();
+    expect(store.getState().savedLoadouts.loadouts).toEqual([]);
+  });
+
+  describe('saveLoadout', () => {
+    it('prepends a new loadout with generated id and timestamps', () => {
+      const store = createTestStore();
+      const setup = makeSetup();
+
+      store.dispatch(saveLoadout({ name: 'Tank DD', setup, meta: { trialId: 'SS' } }));
+
+      const { loadouts } = store.getState().savedLoadouts;
+      expect(loadouts).toHaveLength(1);
+      const [entry] = loadouts;
+      expect(entry.id).toBeTruthy();
+      expect(entry.name).toBe('Tank DD');
+      expect(entry.setup).toEqual(setup);
+      expect(entry.meta).toEqual({ trialId: 'SS' });
+      expect(entry.createdAt).toBe(entry.updatedAt);
+      expect(() => new Date(entry.createdAt).toISOString()).not.toThrow();
+    });
+
+    it('puts the most recently saved loadout first', () => {
+      const store = createTestStore();
+      store.dispatch(saveLoadout({ name: 'First', setup: makeSetup('First') }));
+      store.dispatch(saveLoadout({ name: 'Second', setup: makeSetup('Second') }));
+
+      const names = store.getState().savedLoadouts.loadouts.map((l) => l.name);
+      expect(names).toEqual(['Second', 'First']);
+    });
+
+    it('gives each saved loadout a distinct id', () => {
+      const store = createTestStore();
+      store.dispatch(saveLoadout({ name: 'A', setup: makeSetup('A') }));
+      store.dispatch(saveLoadout({ name: 'B', setup: makeSetup('B') }));
+
+      const [a, b] = store.getState().savedLoadouts.loadouts;
+      expect(a.id).not.toBe(b.id);
+    });
+  });
+
+  describe('updateSavedLoadout', () => {
+    it('replaces the setup and bumps updatedAt without changing id/createdAt', () => {
+      const existing: SavedLoadout = {
+        id: 'fixed-id',
+        name: 'Original',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        setup: makeSetup('Original'),
+      };
+      const store = createTestStore([existing]);
+
+      const newSetup = makeSetup('Edited');
+      store.dispatch(updateSavedLoadout({ id: 'fixed-id', setup: newSetup }));
+
+      const [entry] = store.getState().savedLoadouts.loadouts;
+      expect(entry.id).toBe('fixed-id');
+      expect(entry.createdAt).toBe('2020-01-01T00:00:00.000Z');
+      expect(entry.setup).toEqual(newSetup);
+      expect(entry.name).toBe('Original');
+      expect(entry.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+    });
+
+    it('can update name and description alongside the setup', () => {
+      const existing: SavedLoadout = {
+        id: 'id-1',
+        name: 'Old',
+        description: 'old desc',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        setup: makeSetup(),
+      };
+      const store = createTestStore([existing]);
+
+      store.dispatch(
+        updateSavedLoadout({
+          id: 'id-1',
+          setup: makeSetup(),
+          name: 'New',
+          description: 'new desc',
+        }),
+      );
+
+      const [entry] = store.getState().savedLoadouts.loadouts;
+      expect(entry.name).toBe('New');
+      expect(entry.description).toBe('new desc');
+    });
+
+    it('is a no-op when the id does not exist', () => {
+      const existing: SavedLoadout = {
+        id: 'id-1',
+        name: 'Old',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        setup: makeSetup(),
+      };
+      const store = createTestStore([existing]);
+
+      store.dispatch(updateSavedLoadout({ id: 'missing', setup: makeSetup('X') }));
+
+      expect(store.getState().savedLoadouts.loadouts).toEqual([existing]);
+    });
+  });
+
+  describe('renameSavedLoadout', () => {
+    it('updates name (and optional description) and bumps updatedAt', () => {
+      const existing: SavedLoadout = {
+        id: 'id-1',
+        name: 'Before',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        setup: makeSetup(),
+      };
+      const store = createTestStore([existing]);
+
+      store.dispatch(renameSavedLoadout({ id: 'id-1', name: 'After', description: 'desc' }));
+
+      const [entry] = store.getState().savedLoadouts.loadouts;
+      expect(entry.name).toBe('After');
+      expect(entry.description).toBe('desc');
+      expect(entry.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+      // setup is untouched by rename
+      expect(entry.setup).toEqual(existing.setup);
+    });
+
+    it('is a no-op when the id does not exist', () => {
+      const store = createTestStore();
+      store.dispatch(renameSavedLoadout({ id: 'nope', name: 'X' }));
+      expect(store.getState().savedLoadouts.loadouts).toEqual([]);
+    });
+  });
+
+  describe('deleteSavedLoadout', () => {
+    it('removes only the matching loadout', () => {
+      const a: SavedLoadout = {
+        id: 'a',
+        name: 'A',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        setup: makeSetup('A'),
+      };
+      const b: SavedLoadout = { ...a, id: 'b', name: 'B', setup: makeSetup('B') };
+      const store = createTestStore([a, b]);
+
+      store.dispatch(deleteSavedLoadout('a'));
+
+      const { loadouts } = store.getState().savedLoadouts;
+      expect(loadouts).toHaveLength(1);
+      expect(loadouts[0].id).toBe('b');
+    });
+  });
+});

--- a/src/store/saved_loadouts/savedLoadoutsSlice.ts
+++ b/src/store/saved_loadouts/savedLoadoutsSlice.ts
@@ -1,0 +1,116 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { LoadoutSetup } from '../../features/loadout-manager/types/loadout.types';
+
+/**
+ * Light provenance so a library row can show context (trial/character) without
+ * decoding the gear payload.
+ */
+export interface SavedLoadoutMeta {
+  trialId?: string;
+  characterName?: string;
+}
+
+/**
+ * A named, persisted loadout — the library counterpart of {@link SavedBuild}.
+ * The portable payload is a single {@link LoadoutSetup} (the WW/loadout unit).
+ */
+export interface SavedLoadout {
+  id: string; // uuid
+  name: string;
+  description?: string;
+  createdAt: string; // ISO
+  updatedAt: string; // ISO
+  setup: LoadoutSetup;
+  meta?: SavedLoadoutMeta;
+}
+
+interface SavedLoadoutsState {
+  loadouts: SavedLoadout[];
+}
+
+const initialState: SavedLoadoutsState = {
+  loadouts: [],
+};
+
+interface SaveLoadoutInput {
+  name: string;
+  setup: LoadoutSetup;
+  description?: string;
+  meta?: SavedLoadoutMeta;
+}
+
+const savedLoadoutsSlice = createSlice({
+  name: 'savedLoadouts',
+  initialState,
+  reducers: {
+    saveLoadout: {
+      reducer(state, action: PayloadAction<SavedLoadout>) {
+        state.loadouts.unshift(action.payload);
+      },
+      prepare({ name, setup, description, meta }: SaveLoadoutInput) {
+        const now = new Date().toISOString();
+        return {
+          payload: {
+            id: uuidv4(),
+            name,
+            description,
+            createdAt: now,
+            updatedAt: now,
+            setup,
+            meta,
+          } satisfies SavedLoadout,
+        };
+      },
+    },
+    updateSavedLoadout(
+      state,
+      action: PayloadAction<{
+        id: string;
+        setup: LoadoutSetup;
+        name?: string;
+        description?: string;
+        meta?: SavedLoadoutMeta;
+      }>,
+    ) {
+      const idx = state.loadouts.findIndex((l) => l.id === action.payload.id);
+      if (idx === -1) {
+        return;
+      }
+      const existing = state.loadouts[idx];
+      state.loadouts[idx] = {
+        ...existing,
+        name: action.payload.name ?? existing.name,
+        description:
+          action.payload.description !== undefined
+            ? action.payload.description
+            : existing.description,
+        setup: action.payload.setup,
+        meta: action.payload.meta ?? existing.meta,
+        updatedAt: new Date().toISOString(),
+      };
+    },
+    renameSavedLoadout(
+      state,
+      action: PayloadAction<{ id: string; name: string; description?: string }>,
+    ) {
+      const idx = state.loadouts.findIndex((l) => l.id === action.payload.id);
+      if (idx === -1) {
+        return;
+      }
+      state.loadouts[idx].name = action.payload.name;
+      if (action.payload.description !== undefined) {
+        state.loadouts[idx].description = action.payload.description;
+      }
+      state.loadouts[idx].updatedAt = new Date().toISOString();
+    },
+    deleteSavedLoadout(state, action: PayloadAction<string>) {
+      state.loadouts = state.loadouts.filter((l) => l.id !== action.payload);
+    },
+  },
+});
+
+export const { saveLoadout, updateSavedLoadout, renameSavedLoadout, deleteSavedLoadout } =
+  savedLoadoutsSlice.actions;
+export default savedLoadoutsSlice.reducer;

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -30,6 +30,7 @@ import parseAnalysisReducer from './parse_analysis/parseAnalysisSlice';
 import playerDataReducer from './player_data/playerDataSlice';
 import reportReducer from './report/reportSlice';
 import { savedBuildsReducer } from './saved_builds';
+import { savedLoadoutsReducer } from './saved_loadouts';
 import { savedRostersReducer } from './saved_rosters';
 import uiReducer, { UIState } from './ui/uiSlice';
 import userReportsReducer from './user_reports';
@@ -46,6 +47,7 @@ const rootReducer = combineReducers({
   playerData: playerDataReducer,
   report: reportReducer,
   savedBuilds: savedBuildsReducer,
+  savedLoadouts: savedLoadoutsReducer,
   savedRosters: savedRostersReducer,
   ui: uiReducer,
   userReports: userReportsReducer,
@@ -112,7 +114,7 @@ const persistConfig = {
   key: 'root',
   storage,
   transforms: [uiTransform], // Apply transform to exclude report-specific UI state
-  whitelist: ['ui', 'loadout', 'dashboard', 'savedRosters', 'savedBuilds'], // Persist essential data, loadout, saved rosters, and saved builds
+  whitelist: ['ui', 'loadout', 'dashboard', 'savedRosters', 'savedBuilds', 'savedLoadouts'], // Persist essential data, loadout, saved rosters, saved builds, and saved loadouts
 };
 
 const persistedReducer = persistReducer<RootState>(persistConfig, rootReducer);


### PR DESCRIPTION
## Summary

Section **A. Loadout Library** from `BUILD_LOADOUT_BRIDGE_REMAINING_PHASES_PLAN.md` (the plan doc currently lives on the unmerged `claude/bridge-phases-plan` branch / PR #1336).

Loadouts now get the same first-class **saved, named, browsable** treatment that builds (`saved_builds`) and rosters (`saved_rosters`) already have, instead of only the session-scoped working trial/character tree.

## What's included

- **`src/store/saved_loadouts/`** — a new slice mirroring `saved_builds`/`saved_rosters`:
  - Reducers: `saveLoadout`, `updateSavedLoadout`, `renameSavedLoadout`, `deleteSavedLoadout`
  - `selectSavedLoadouts` / `selectSavedLoadoutById`, plus an `index.ts` barrel
  - Entry shape mirrors `SavedBuild` (`id`, `name`, `description?`, `createdAt`, `updatedAt`, `setup: LoadoutSetup`, `meta?`)
- **`storeWithHistory.ts`** — reducer registered **and** `savedLoadouts` added to the redux-persist whitelist (without this, saved loadouts wouldn't survive reload).
- **`LoadoutLibraryPanel`** — saved loadouts as cards (trial/character chips, condition + progress chips, updated date) with **Load / Duplicate / Rename / Delete** actions and an empty state, reusing the *My Builds* visual language.
- **`LoadoutManager`** — hosts the panel behind a **Setups / Library** toggle. Loading an entry deep-clones it into the current trial/page (so library entries aren't mutated by later edits).
- **`SetupEditor`** — a **"Save to Library"** action (name/description dialog) — the entry point that populates the library.

## Tests

- `savedLoadoutsSlice.test.ts` — CRUD + rename, ordering, id uniqueness, no-op-on-missing-id (mirrors the `savedBuildsSlice`/`userReportsSlice` patterns).
- `LoadoutLibraryPanel.test.tsx` — empty state, card rendering, Load callback, duplicate, rename, delete-with-confirm.

Verification run locally: `npx tsc --noEmit` ✅, ESLint (changed files) ✅, Prettier ✅, and Jest for the new + adjacent suites (`saved_loadouts`, `storeWithHistory`, `loadout-manager`) — **375 passed / 13 skipped**.

## Scope notes (deferred — not claimed done)

These two items from the plan's UI section depend on the **unmerged** P1/P2 Wizard's Wardrobe bridge work (#1333 weapon-slot export, #1334 `buildLoadoutBridge.ts` + WW dialog), which is **not on `main`** yet:

- The Build Editor WW dialog **"Save as loadout"** entry point (plan marks this Optional; reuses the not-yet-merged `buildSetupToLoadoutSetup`).
- A single-setup **"Export → WW"** action on library cards (on `main`, WW export only exists for the whole working tree via `ExportDialog`).

Per the plan, the existing `pages` working tree is intentionally **not** migrated into the library here — "Save to Library" is an explicit user action; a migration is a separate, riskier follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012WrFStaYFYWv4FHzBa27Gc)_