### PR TITLE
feat(build-hub): pre-fill publish dialog from the build's name and description

### DIFF
--- a/src/features/build-editor/components/BuildCompletionHeader.tsx
+++ b/src/features/build-editor/components/BuildCompletionHeader.tsx
@@ -1203,6 +1203,8 @@ export const BuildCompletionHeader: React.FC = () => {
           role={build.role}
           gameMode={build.gameMode}
           visibility={build.settings.visibility}
+          defaultTitle={build.name}
+          defaultDescription={build.shortDescription}
           onClose={() => setPublishOpen(false)}
           onPublished={() => {
             enqueueSnackbar('Build published to the Hub!', { variant: 'success' });

--- a/src/features/build-hub/components/PublishBuildDialog.tsx
+++ b/src/features/build-hub/components/PublishBuildDialog.tsx
@@ -46,6 +46,15 @@ interface PublishBuildDialogProps {
   gameMode: string;
   /** The build's current visibility choice (from build.settings.visibility). */
   visibility?: HubBuildVisibility;
+  /**
+   * Seeds the Title field in create mode (typically the build's `name`). The
+   * user can still edit it — publishing what they leave here keeps the Hub
+   * listing in sync with the build's own identity. Ignored in edit mode (the
+   * existing published title wins).
+   */
+  defaultTitle?: string;
+  /** Seeds the Description field in create mode (typically `shortDescription`). */
+  defaultDescription?: string;
   onClose: () => void;
   onPublished: () => void;
   token: string;
@@ -62,6 +71,8 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
   role,
   gameMode,
   visibility = 'public',
+  defaultTitle = '',
+  defaultDescription = '',
   onClose,
   onPublished,
   token,
@@ -92,29 +103,41 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
     }
     setLoading(true);
     setError(null);
+    const trimmedTitle = title.trim();
+    const trimmedDescription = description.trim();
     try {
-      // The encoded blob also embeds settings.visibility (as `vs`). If the user
-      // changed visibility in this dialog, re-encode so the blob matches the
-      // selected value — otherwise client-side share gating that reads the
-      // decoded build would act on a stale visibility (e.g. treat a now-private
-      // build as shareable). Fall back to the original blob if re-encode fails.
+      // The encoded blob embeds the build's name/shortDescription (`n`/`d`) and
+      // visibility (`vs`). Keep them in sync with what's actually being
+      // published so the Hub card, the description column, and the build you
+      // open from the listing all agree — and so client-side share gating that
+      // reads the decoded build acts on the selected visibility, not a stale
+      // one. Fall back to the original blob if decode/re-encode fails (the
+      // server's title/description/visibility metadata is still authoritative).
       let syncedBuildData = buildData;
       try {
         const decoded = await decodeBuildFromURL(buildData);
-        if (decoded && decoded.settings.visibility !== selectedVisibility) {
-          const reencoded = await encodeBuildToURL({
-            ...decoded,
-            settings: { ...decoded.settings, visibility: selectedVisibility },
-          });
-          if (reencoded) syncedBuildData = reencoded;
+        if (decoded) {
+          const needsResync =
+            decoded.settings.visibility !== selectedVisibility ||
+            decoded.name !== trimmedTitle ||
+            decoded.shortDescription !== trimmedDescription;
+          if (needsResync) {
+            const reencoded = await encodeBuildToURL({
+              ...decoded,
+              name: trimmedTitle,
+              shortDescription: trimmedDescription,
+              settings: { ...decoded.settings, visibility: selectedVisibility },
+            });
+            if (reencoded) syncedBuildData = reencoded;
+          }
         }
       } catch {
-        /* keep original blob; server `visibility` metadata is still authoritative */
+        /* keep original blob; server metadata is still authoritative */
       }
 
       const payload: PublishBuildPayload = {
-        title: title.trim(),
-        description: description.trim(),
+        title: trimmedTitle,
+        description: trimmedDescription,
         eso_class: esoClass,
         role,
         game_mode: gameMode,
@@ -149,15 +172,19 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
         setIsAnonymous(editingBuild.is_anonymous ?? false);
         setSelectedVisibility(editingBuild.visibility ?? visibility);
       } else {
-        setTitle('');
-        setDescription('');
+        // Create mode: pre-fill from the build's own name / short description so
+        // the author doesn't retype what they already named. Fully editable —
+        // whatever they leave is what gets published (and synced back into the
+        // encoded blob on publish, see handlePublish).
+        setTitle(defaultTitle);
+        setDescription(defaultDescription);
         setSelectedTags([]);
         setIsAnonymous(false);
         setSelectedVisibility(visibility);
       }
       setError(null);
     }
-  }, [open, editingBuild, visibility]);
+  }, [open, editingBuild, visibility, defaultTitle, defaultDescription]);
 
   const atTagLimit = selectedTags.length >= MAX_TAGS;
 
@@ -191,7 +218,11 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           slotProps={{ htmlInput: { maxLength: 100 } }}
-          helperText={`${title.length}/100`}
+          helperText={
+            isEditMode
+              ? `${title.length}/100`
+              : `Shown on your Build Hub card — edit for a different public title · ${title.length}/100`
+          }
           required
           fullWidth
           size="small"

--- a/src/features/build-hub/components/PublishBuildDialog.tsx
+++ b/src/features/build-hub/components/PublishBuildDialog.tsx
@@ -111,14 +111,19 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
       // published so the Hub card, the description column, and the build you
       // open from the listing all agree — and so client-side share gating that
       // reads the decoded build acts on the selected visibility, not a stale
-      // one. Fall back to the original blob if decode/re-encode fails (the
-      // server's title/description/visibility metadata is still authoritative).
+      // one. Visibility is special: a `?b=` blob bypasses the owner-gated API,
+      // so if the selected visibility can't be written into the blob we fail
+      // closed rather than publish a self-contained payload that is more
+      // permissive than the row. Title/description-only drift can safely keep
+      // the original blob (cosmetic staleness; the server re-validates anyway).
       let syncedBuildData = buildData;
+      let visibilityResyncFailed = false;
       try {
         const decoded = await decodeBuildFromURL(buildData);
         if (decoded) {
+          const visibilityDiverged = decoded.settings.visibility !== selectedVisibility;
           const needsResync =
-            decoded.settings.visibility !== selectedVisibility ||
+            visibilityDiverged ||
             decoded.name !== trimmedTitle ||
             decoded.shortDescription !== trimmedDescription;
           if (needsResync) {
@@ -128,11 +133,20 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
               shortDescription: trimmedDescription,
               settings: { ...decoded.settings, visibility: selectedVisibility },
             });
-            if (reencoded) syncedBuildData = reencoded;
+            if (reencoded) {
+              syncedBuildData = reencoded;
+            } else if (visibilityDiverged) {
+              visibilityResyncFailed = true;
+            }
           }
         }
       } catch {
-        /* keep original blob; server metadata is still authoritative */
+        /* keep original blob; the server re-validates the embedded visibility */
+      }
+
+      if (visibilityResyncFailed) {
+        setError('Could not apply the selected visibility. Please try again.');
+        return;
       }
 
       const payload: PublishBuildPayload = {

--- a/src/features/build-hub/components/PublishBuildDialog.tsx
+++ b/src/features/build-hub/components/PublishBuildDialog.tsx
@@ -117,7 +117,7 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
       // permissive than the row. Title/description-only drift can safely keep
       // the original blob (cosmetic staleness; the server re-validates anyway).
       let syncedBuildData = buildData;
-      let visibilityResyncFailed = false;
+      let resyncError: string | null = null;
       try {
         const decoded = await decodeBuildFromURL(buildData);
         if (decoded) {
@@ -136,16 +136,21 @@ export const PublishBuildDialog: React.FC<PublishBuildDialogProps> = ({
             if (reencoded) {
               syncedBuildData = reencoded;
             } else if (visibilityDiverged) {
-              visibilityResyncFailed = true;
+              resyncError = 'Could not apply the selected visibility. Please try again.';
             }
           }
+        } else {
+          // The blob we'd publish can't be decoded (empty, corrupt, or larger
+          // than the decode cap). Publishing it would create an unopenable Hub
+          // row and we can't verify/sync its embedded visibility. Fail closed.
+          resyncError = 'Could not prepare this build for publishing. Please try again.';
         }
       } catch {
-        /* keep original blob; the server re-validates the embedded visibility */
+        resyncError = 'Could not prepare this build for publishing. Please try again.';
       }
 
-      if (visibilityResyncFailed) {
-        setError('Could not apply the selected visibility. Please try again.');
+      if (resyncError) {
+        setError(resyncError);
         return;
       }
 

--- a/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
+++ b/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
@@ -147,6 +147,53 @@ describe('PublishBuildDialog publish-time sync', () => {
     expect(payload.build_data).toBe('ENCODED_ORIGINAL');
   });
 
+  it('fails closed: switching visibility with a failed re-encode aborts publish (no stale blob sent)', async () => {
+    // Decoded blob is Public; the author switches to Private but the re-encode
+    // fails. The dialog must NOT publish a Public self-contained blob tagged
+    // Private — it surfaces an error and never calls the API.
+    mockEncode.mockResolvedValue(''); // re-encode fails
+
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        visibility="public"
+        defaultTitle="Lightning Sorc"
+        defaultDescription="A tagline"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /private/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not apply the selected visibility/i)).toBeInTheDocument(),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('still publishes when only title/description drift and re-encode fails (keeps original blob)', async () => {
+    // Title changed but visibility unchanged; re-encode fails. Title/description
+    // drift is cosmetic, never a privacy leak, so the publish proceeds with the
+    // original blob rather than failing closed.
+    mockEncode.mockResolvedValue(''); // re-encode fails
+
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        visibility="public"
+        defaultTitle="Lightning Sorc"
+        defaultDescription="A tagline"
+      />,
+    );
+
+    fireEvent.change(titleInput(), { target: { value: 'Renamed Build' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    const [payload] = mockCreate.mock.calls[0];
+    expect(payload).toMatchObject({ title: 'Renamed Build', build_data: 'ENCODED_ORIGINAL' });
+  });
+
   it('blocks publishing with an empty title', () => {
     render(<PublishBuildDialog {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: 'Publish' }));

--- a/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
+++ b/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
@@ -194,6 +194,30 @@ describe('PublishBuildDialog publish-time sync', () => {
     expect(payload).toMatchObject({ title: 'Renamed Build', build_data: 'ENCODED_ORIGINAL' });
   });
 
+  it('fails closed: aborts publish when the build_data cannot be decoded', async () => {
+    // Corrupt / oversized blob → decode resolves null. Publishing it would
+    // create an unopenable Hub row (and we can't verify its embedded
+    // visibility), so the dialog aborts and never calls the API — even though
+    // the pre-filled title satisfies the required-field guard.
+    mockDecode.mockResolvedValue(null);
+
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        defaultTitle="Lightning Sorc"
+        defaultDescription="A tagline"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not prepare this build for publishing/i)).toBeInTheDocument(),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockEncode).not.toHaveBeenCalled();
+  });
+
   it('blocks publishing with an empty title', () => {
     render(<PublishBuildDialog {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: 'Publish' }));

--- a/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
+++ b/src/features/build-hub/components/__tests__/PublishBuildDialog.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * PublishBuildDialog — create-mode pre-fill + publish-time blob re-sync.
+ *
+ * Create mode seeds Title/Description from the build's own name/shortDescription
+ * (via defaultTitle/defaultDescription) so the author doesn't retype them, and
+ * on publish the encoded build_data is re-encoded so its embedded name/
+ * description match what's actually published. Edit mode keeps pre-filling from
+ * the already-published build and ignores the defaults.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { PublishBuildDialog } from '../PublishBuildDialog';
+import type { HubBuild } from '../../types/build-hub.types';
+
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+jest.mock('../../api/build-hub-api', () => ({
+  buildHubApi: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+const mockDecode = jest.fn();
+const mockEncode = jest.fn();
+jest.mock('../../../../utils/buildEncoding', () => ({
+  decodeBuildFromURL: (...args: unknown[]) => mockDecode(...args),
+  encodeBuildToURL: (...args: unknown[]) => mockEncode(...args),
+}));
+
+const baseProps = {
+  open: true,
+  buildData: 'ENCODED_ORIGINAL',
+  esoClass: 'sorcerer',
+  role: 'magicka-dps',
+  gameMode: 'pve',
+  token: 'tok',
+  onClose: jest.fn(),
+  onPublished: jest.fn(),
+};
+
+const titleInput = (): HTMLInputElement =>
+  screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement;
+const descInput = (): HTMLInputElement =>
+  screen.getByRole('textbox', { name: /description/i }) as HTMLInputElement;
+
+beforeEach(() => {
+  mockCreate.mockReset().mockResolvedValue(undefined);
+  mockUpdate.mockReset().mockResolvedValue(undefined);
+  // A minimal decoded build the component can spread + re-encode.
+  mockDecode.mockReset().mockResolvedValue({
+    name: 'Lightning Sorc',
+    shortDescription: 'A tagline',
+    settings: { visibility: 'public', dlc: 'Base Game', setupOrder: [0] },
+  });
+  mockEncode.mockReset().mockResolvedValue('ENCODED_SYNCED');
+});
+
+describe('PublishBuildDialog pre-fill', () => {
+  it('seeds Title and Description from the build in create mode', () => {
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        defaultTitle="Lightning Sorc"
+        defaultDescription="Pew pew lightning build"
+      />,
+    );
+    expect(titleInput().value).toBe('Lightning Sorc');
+    expect(descInput().value).toBe('Pew pew lightning build');
+  });
+
+  it('starts blank when the build has no name/description', () => {
+    render(<PublishBuildDialog {...baseProps} />);
+    expect(titleInput().value).toBe('');
+    expect(descInput().value).toBe('');
+  });
+
+  it('ignores defaults in edit mode and uses the published title/description', () => {
+    const editingBuild = {
+      id: 'b1',
+      title: 'Published Title',
+      description: 'Published description',
+      tags: ['meta'],
+      is_anonymous: false,
+      visibility: 'public',
+    } as unknown as HubBuild;
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        editingBuild={editingBuild}
+        defaultTitle="IGNORED"
+        defaultDescription="IGNORED"
+      />,
+    );
+    expect(titleInput().value).toBe('Published Title');
+    expect(descInput().value).toBe('Published description');
+  });
+});
+
+describe('PublishBuildDialog publish-time sync', () => {
+  it('re-encodes the blob with the edited title/description and creates with synced data', async () => {
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        defaultTitle="Lightning Sorc"
+        defaultDescription="A tagline"
+      />,
+    );
+
+    // Author refines the public-facing title before publishing.
+    fireEvent.change(titleInput(), { target: { value: 'Endgame Lightning Sorc' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+
+    // Re-encoded with the new identity (name + shortDescription).
+    expect(mockEncode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Endgame Lightning Sorc',
+        shortDescription: 'A tagline',
+      }),
+    );
+    const [payload] = mockCreate.mock.calls[0];
+    expect(payload).toMatchObject({
+      title: 'Endgame Lightning Sorc',
+      description: 'A tagline',
+      build_data: 'ENCODED_SYNCED',
+    });
+  });
+
+  it('keeps the original blob when nothing diverges (no re-encode needed)', async () => {
+    render(
+      <PublishBuildDialog
+        {...baseProps}
+        defaultTitle="Lightning Sorc"
+        defaultDescription="A tagline"
+      />,
+    );
+    // Publish without editing — decoded name/desc/visibility already match.
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(mockEncode).not.toHaveBeenCalled();
+    const [payload] = mockCreate.mock.calls[0];
+    expect(payload.build_data).toBe('ENCODED_ORIGINAL');
+  });
+
+  it('blocks publishing with an empty title', () => {
+    render(<PublishBuildDialog {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(screen.getByText(/please enter a title/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -2134,16 +2134,27 @@ export const BuildViewPage: React.FC = () => {
             // retained payload — used by the share `?b=` link and the
             // Remix/Edit → /build-editor?b= path — carries the authoritative
             // metadata too. Otherwise Remix reopens the editor with the stale
-            // name/description and a later publish would reintroduce it. Fall
-            // back to the original blob if the re-encode fails.
+            // values and a later publish would reintroduce them.
+            const visibilityDiverged =
+              authoritative.settings.visibility !== decoded.settings.visibility;
             let buildData = hubBuild.build_data;
             if (
+              visibilityDiverged ||
               authoritative.name !== decoded.name ||
-              authoritative.shortDescription !== decoded.shortDescription ||
-              authoritative.settings.visibility !== decoded.settings.visibility
+              authoritative.shortDescription !== decoded.shortDescription
             ) {
               const reencoded = await encodeBuildToURL(authoritative);
-              if (reencoded) buildData = reencoded;
+              if (reencoded) {
+                buildData = reencoded;
+              } else if (visibilityDiverged) {
+                // Re-encode failed and the blob's embedded visibility no longer
+                // matches the authoritative Hub value. Fail closed: never retain
+                // a blob that Open-in-Editor (?b=) could reopen at a more
+                // permissive visibility than the server enforces — drop it so no
+                // stale-visibility payload leaks. (Title/description-only drift
+                // keeps the original blob: cosmetic staleness, never a leak.)
+                buildData = '';
+              }
             }
             onDecoded(authoritative, buildData);
           }),

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -71,7 +71,7 @@ import {
 import { useViewTransitionNavigate } from '../hooks/useViewTransitionNavigate';
 import { selectSavedBuilds } from '../store/saved_builds';
 import { CHAMPION_POINT_ABILITIES, ChampionPointAbilityId } from '../types/champion-points';
-import { decodeBuildFromURL } from '../utils/buildEncoding';
+import { decodeBuildFromURL, encodeBuildToURL } from '../utils/buildEncoding';
 import { getGearSetTooltipPropsByName } from '../utils/gearSetTooltipMapper';
 import { sanitizeImageUrl, sanitizeYoutubeUrl } from '../utils/sanitize-url';
 import { useSetPieceCounts } from '../utils/setPieceCounting';
@@ -2108,7 +2108,7 @@ export const BuildViewPage: React.FC = () => {
       void buildHubApi
         .get(idParam, accessToken)
         .then(({ build: hubBuild }) =>
-          decodeBuildFromURL(hubBuild.build_data).then((decoded) => {
+          decodeBuildFromURL(hubBuild.build_data).then(async (decoded) => {
             // The Hub record's columns are authoritative — the values embedded
             // in build_data (visibility `vs`, name `n`, shortDescription `d`)
             // can be stale: a build published before the dialog synced
@@ -2117,18 +2117,35 @@ export const BuildViewPage: React.FC = () => {
             // Override the decoded values with server truth so the opened build
             // matches its Hub card and downstream share/copy gating can't be
             // fooled by a stale blob.
-            const authoritative = decoded
-              ? {
-                  ...decoded,
-                  name: hubBuild.title ?? decoded.name,
-                  shortDescription: hubBuild.description ?? decoded.shortDescription,
-                  settings: {
-                    ...decoded.settings,
-                    visibility: hubBuild.visibility ?? decoded.settings.visibility,
-                  },
-                }
-              : decoded;
-            onDecoded(authoritative, hubBuild.build_data);
+            if (!decoded) {
+              onDecoded(decoded, hubBuild.build_data);
+              return;
+            }
+            const authoritative = {
+              ...decoded,
+              name: hubBuild.title ?? decoded.name,
+              shortDescription: hubBuild.description ?? decoded.shortDescription,
+              settings: {
+                ...decoded.settings,
+                visibility: hubBuild.visibility ?? decoded.settings.visibility,
+              },
+            };
+            // When server truth diverged from the blob, re-encode so the
+            // retained payload — used by the share `?b=` link and the
+            // Remix/Edit → /build-editor?b= path — carries the authoritative
+            // metadata too. Otherwise Remix reopens the editor with the stale
+            // name/description and a later publish would reintroduce it. Fall
+            // back to the original blob if the re-encode fails.
+            let buildData = hubBuild.build_data;
+            if (
+              authoritative.name !== decoded.name ||
+              authoritative.shortDescription !== decoded.shortDescription ||
+              authoritative.settings.visibility !== decoded.settings.visibility
+            ) {
+              const reencoded = await encodeBuildToURL(authoritative);
+              if (reencoded) buildData = reencoded;
+            }
+            onDecoded(authoritative, buildData);
           }),
         )
         .catch(handleFetchError);

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -2222,6 +2222,18 @@ export const BuildViewPage: React.FC = () => {
   const isOwned = Boolean(ownedSavedBuild);
 
   const handleOpenInEditor = (): void => {
+    if (!encodedParam && !ownedSavedBuild) {
+      // The retained payload was intentionally dropped (fail-closed on a
+      // visibility mismatch we couldn't re-encode) and there's no local saved
+      // copy to open by id. Navigating with an empty ?b= would drop the user
+      // into an unrelated/empty editor, so surface an error instead.
+      setSnackbar({
+        open: true,
+        message: 'This build cannot be opened in the editor right now. Try reloading the page.',
+        severity: 'error',
+      });
+      return;
+    }
     const base = `/build-editor?b=${encodeURIComponent(encodedParam)}`;
     // Forward drill that morphs the shared build-hero header into the editor's
     // header — consistent with every other build navigation (which uses

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -2222,11 +2222,14 @@ export const BuildViewPage: React.FC = () => {
   const isOwned = Boolean(ownedSavedBuild);
 
   const handleOpenInEditor = (): void => {
-    if (!encodedParam && !ownedSavedBuild) {
-      // The retained payload was intentionally dropped (fail-closed on a
-      // visibility mismatch we couldn't re-encode) and there's no local saved
-      // copy to open by id. Navigating with an empty ?b= would drop the user
-      // into an unrelated/empty editor, so surface an error instead.
+    if (!encodedParam) {
+      // No usable self-contained payload to hand the editor — the retained blob
+      // was dropped (fail-closed on a visibility mismatch we couldn't re-encode)
+      // or never set. The editor loads only from a non-empty ?b=; navigating
+      // with an empty one opens a blank editor while ?id= still acts as the
+      // save target, so a save would overwrite the owner's saved build with
+      // blank data. Refuse to navigate (even for owned builds) and surface an
+      // error instead.
       setSnackbar({
         open: true,
         message: 'This build cannot be opened in the editor right now. Try reloading the page.',

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -2109,15 +2109,25 @@ export const BuildViewPage: React.FC = () => {
         .get(idParam, accessToken)
         .then(({ build: hubBuild }) =>
           decodeBuildFromURL(hubBuild.build_data).then((decoded) => {
-            // The Hub record's `visibility` column is authoritative — the value
-            // embedded in build_data can be stale (e.g. a build published before
-            // dialog re-encode, or edited out-of-band). Override the decoded
-            // value with server truth so downstream share/copy gating can't be
+            // The Hub record's columns are authoritative — the values embedded
+            // in build_data (visibility `vs`, name `n`, shortDescription `d`)
+            // can be stale: a build published before the dialog synced
+            // title/description into the blob, one whose publish-time re-encode
+            // fell back to the original blob, or one edited out-of-band.
+            // Override the decoded values with server truth so the opened build
+            // matches its Hub card and downstream share/copy gating can't be
             // fooled by a stale blob.
-            const authoritative =
-              decoded && hubBuild.visibility
-                ? { ...decoded, settings: { ...decoded.settings, visibility: hubBuild.visibility } }
-                : decoded;
+            const authoritative = decoded
+              ? {
+                  ...decoded,
+                  name: hubBuild.title ?? decoded.name,
+                  shortDescription: hubBuild.description ?? decoded.shortDescription,
+                  settings: {
+                    ...decoded.settings,
+                    visibility: hubBuild.visibility ?? decoded.settings.visibility,
+                  },
+                }
+              : decoded;
             onDecoded(authoritative, hubBuild.build_data);
           }),
         )

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -23,6 +23,13 @@ jest.mock('../features/auth/AuthContext', () => ({
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
+}));
+
+// Mock the view-transition navigate so we can assert the exact target the
+// Edit/Remix button navigates to without pulling in startViewTransition/morph.
+const mockNavigate = jest.fn();
+jest.mock('../hooks/useViewTransitionNavigate', () => ({
+  useViewTransitionNavigate: () => mockNavigate,
 }));
 
 jest.mock('../features/build-hub/api/build-hub-api', () => ({
@@ -100,6 +107,7 @@ describe('BuildViewPage visibility enforcement', () => {
     mockDecode.mockResolvedValue(null);
     mockEncode.mockResolvedValue('');
     mockUseSelector.mockReturnValue([]);
+    mockNavigate.mockReset();
   });
 
   it('resolves ?id= builds only through the visibility-checked API, never router state', async () => {
@@ -244,6 +252,43 @@ describe('BuildViewPage visibility enforcement', () => {
 
     await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
     expect(mockEncode).not.toHaveBeenCalled();
+  });
+
+  it('fails closed: a private ?id= build with a stale public blob + failed re-encode never leaks the blob to the editor', async () => {
+    // The owner-authorized API returns a now-Private row, but its stored blob
+    // still encodes Public. The authoritative visibility is Private, so when the
+    // re-encode fails we must NOT retain the stale Public blob for the editor —
+    // Open-in-Editor would otherwise reopen the build as Public.
+    mockGet.mockResolvedValue({
+      build: {
+        build_data: 'stale-public-blob',
+        visibility: 'private',
+        title: 'My Private Build',
+        description: '',
+      },
+    } as Awaited<ReturnType<typeof buildHubApi.get>>);
+    mockDecode.mockResolvedValue(fullBuild('public'));
+    mockEncode.mockResolvedValue(''); // re-encode fails
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/bv', search: '?id=build-private' }]}>
+        <Routes>
+          <Route path="/bv" element={<BuildViewPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+    await waitFor(() => expect(mockEncode).toHaveBeenCalled());
+
+    // Remix/Edit must not carry the stale Public payload (fail closed → empty b).
+    fireEvent.click(
+      screen.getByRole('button', { name: /open your own editable copy|edit your saved build/i }),
+    );
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const target = mockNavigate.mock.calls[0][0] as string;
+    expect(target).not.toContain('stale-public-blob');
+    expect(target).toBe('/build-editor?b=');
   });
 
   it('rejects a Private ?b= payload (forwarded/address-bar link) as not-found', async () => {

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 // load/visibility flow and exercise the not-found branch (notFound || !build).
 jest.mock('../utils/buildEncoding', () => ({
   decodeBuildFromURL: jest.fn(async () => null),
+  encodeBuildToURL: jest.fn(async () => ''),
 }));
 
 jest.mock('../features/loadout-manager/data/skillLineSkills', () => ({
@@ -40,11 +41,12 @@ jest.mock('../features/build-viewer/components/BuildViewShell', () => ({
 import { useSelector } from 'react-redux';
 
 import { buildHubApi } from '../features/build-hub/api/build-hub-api';
-import { decodeBuildFromURL } from '../utils/buildEncoding';
+import { decodeBuildFromURL, encodeBuildToURL } from '../utils/buildEncoding';
 import { BuildViewPage } from './BuildViewPage';
 
 const mockGet = buildHubApi.get as jest.MockedFunction<typeof buildHubApi.get>;
 const mockDecode = decodeBuildFromURL as jest.MockedFunction<typeof decodeBuildFromURL>;
+const mockEncode = encodeBuildToURL as jest.MockedFunction<typeof encodeBuildToURL>;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 const renderWithStaleState = (buildId: string, staleBuildData: string) =>
@@ -96,6 +98,7 @@ describe('BuildViewPage visibility enforcement', () => {
     // clearAllMocks wipes implementations; re-assert defaults so bare jest.fn()s
     // never return undefined (which would break `.then` / `savedBuilds.find`).
     mockDecode.mockResolvedValue(null);
+    mockEncode.mockResolvedValue('');
     mockUseSelector.mockReturnValue([]);
   });
 
@@ -203,6 +206,44 @@ describe('BuildViewPage visibility enforcement', () => {
     expect(screen.getByText('Authoritative description')).toBeInTheDocument();
     expect(screen.queryByText('Stale Name')).not.toBeInTheDocument();
     expect(screen.queryByText('Stale description')).not.toBeInTheDocument();
+    // The retained payload (share `?b=` link + Remix/Edit → /build-editor?b=) is
+    // re-encoded with server truth so the editor never reopens with the stale
+    // metadata that a later republish could reintroduce.
+    await waitFor(() =>
+      expect(mockEncode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Authoritative Title',
+          shortDescription: 'Authoritative description',
+        }),
+      ),
+    );
+  });
+
+  it('does not re-encode the retained payload when the blob already matches the Hub metadata', async () => {
+    mockGet.mockResolvedValue({
+      build: {
+        build_data: 'fresh-blob',
+        visibility: 'public',
+        title: 'Same Title',
+        description: 'Same description',
+      },
+    } as Awaited<ReturnType<typeof buildHubApi.get>>);
+    mockDecode.mockResolvedValue({
+      ...(fullBuild('public') as Record<string, unknown>),
+      name: 'Same Title',
+      shortDescription: 'Same description',
+    } as never);
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/bv', search: '?id=build-8' }]}>
+        <Routes>
+          <Route path="/bv" element={<BuildViewPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+    expect(mockEncode).not.toHaveBeenCalled();
   });
 
   it('rejects a Private ?b= payload (forwarded/address-bar link) as not-found', async () => {

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -290,6 +290,40 @@ describe('BuildViewPage visibility enforcement', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('fails closed for an OWNED build too: dropped payload never opens the editor with an empty ?b= (no save-target corruption)', async () => {
+    // Same dropped-payload scenario, but the viewer owns a local saved copy of
+    // the build. Navigating /build-editor?b=&id=<savedId> would open a blank
+    // editor while ?id= stays the save target — a save would overwrite the
+    // saved build with blank data. The guard must refuse to navigate.
+    mockUseSelector.mockReturnValue([{ id: 'saved-1', build: { id: 'b1' } }]);
+    mockGet.mockResolvedValue({
+      build: {
+        build_data: 'stale-public-blob',
+        visibility: 'private',
+        title: 'My Private Build',
+        description: '',
+      },
+    } as Awaited<ReturnType<typeof buildHubApi.get>>);
+    mockDecode.mockResolvedValue(fullBuild('public')); // id 'b1', matches the saved build
+    mockEncode.mockResolvedValue(''); // re-encode fails → payload dropped
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/bv', search: '?id=build-private' }]}>
+        <Routes>
+          <Route path="/bv" element={<BuildViewPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+    await waitFor(() => expect(mockEncode).toHaveBeenCalled());
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /edit your saved build|open your own editable copy/i }),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('rejects a Private ?b= payload (forwarded/address-bar link) as not-found', async () => {
     mockDecode.mockResolvedValue({ settings: { visibility: 'private' } } as never);
 

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -281,14 +281,13 @@ describe('BuildViewPage visibility enforcement', () => {
     await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
     await waitFor(() => expect(mockEncode).toHaveBeenCalled());
 
-    // Remix/Edit must not carry the stale Public payload (fail closed → empty b).
+    // Remix/Edit must not open the editor with the dropped payload — the guard
+    // refuses to navigate rather than dropping the user into an empty/unrelated
+    // editor (and certainly never with the stale Public blob).
     fireEvent.click(
       screen.getByRole('button', { name: /open your own editable copy|edit your saved build/i }),
     );
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    const target = mockNavigate.mock.calls[0][0] as string;
-    expect(target).not.toContain('stale-public-blob');
-    expect(target).toBe('/build-editor?b=');
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('rejects a Private ?b= payload (forwarded/address-bar link) as not-found', async () => {

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -171,6 +171,40 @@ describe('BuildViewPage visibility enforcement', () => {
     expect(screen.queryByText(/No build found/i)).not.toBeInTheDocument();
   });
 
+  it('overrides stale embedded name/description with the authoritative Hub title/description on ?id= loads', async () => {
+    // The blob carries a STALE name/description (e.g. the publish-time re-encode
+    // fell back to the original blob, or the build predates dialog title sync).
+    // The Hub record's title/description columns are authoritative, so the
+    // opened build must match its Hub card — not the stale blob.
+    mockGet.mockResolvedValue({
+      build: {
+        build_data: 'blob-with-stale-name',
+        visibility: 'public',
+        title: 'Authoritative Title',
+        description: 'Authoritative description',
+      },
+    } as Awaited<ReturnType<typeof buildHubApi.get>>);
+    mockDecode.mockResolvedValue({
+      ...(fullBuild('public') as Record<string, unknown>),
+      name: 'Stale Name',
+      shortDescription: 'Stale description',
+    } as never);
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/bv', search: '?id=build-7' }]}>
+        <Routes>
+          <Route path="/bv" element={<BuildViewPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Authoritative Title');
+    expect(screen.getByText('Authoritative description')).toBeInTheDocument();
+    expect(screen.queryByText('Stale Name')).not.toBeInTheDocument();
+    expect(screen.queryByText('Stale description')).not.toBeInTheDocument();
+  });
+
   it('rejects a Private ?b= payload (forwarded/address-bar link) as not-found', async () => {
     mockDecode.mockResolvedValue({ settings: { visibility: 'private' } } as never);
 

--- a/src/pages/MyBuildsPage.tsx
+++ b/src/pages/MyBuildsPage.tsx
@@ -353,6 +353,8 @@ export const MyBuildsPage: React.FC = () => {
           role={publishTarget.saved.build.role}
           gameMode={publishTarget.saved.build.gameMode ?? 'pve'}
           visibility={publishTarget.saved.build.settings.visibility}
+          defaultTitle={publishTarget.saved.build.name}
+          defaultDescription={publishTarget.saved.build.shortDescription}
           token={accessToken}
           onClose={() => setPublishTarget(null)}
           onPublished={() => setPublishTarget(null)}


### PR DESCRIPTION
## Summary

The **Publish to Build Hub** dialog opened with **blank Title/Description** in create mode, forcing authors to retype the name and description they had already entered on the build. It now **pre-fills Title from `build.name` and Description from `build.shortDescription`**. (Edit mode is unchanged — it still seeds from the published build.)

## The design choice: one identity, separate by choice

The fields pre-fill but stay fully editable:

- **Leave them** → the Hub listing matches your build's name/description exactly (the common case).
- **Edit them** → you get a custom public title/description *for the listing only* — no permanent second name to maintain, and no silent rename of your working build.

A helper line under Title — "Shown on your Build Hub card — edit for a different public title" — makes the relationship clear.

## Consistency under the hood

- On publish, the encoded `build_data` is re-synced so its embedded name/description/visibility match what is published.
- The Hub **view** path (`?id=`) treats the server's `title`/`description`/`visibility` columns as authoritative and overrides the decoded blob — so an opened build always matches its Hub card, including for older or stale-blob builds.

## Hardening (Codex review loop, GPT-5.5)

Native review: clean. Adversarial review drove 4 rounds of real fixes, all visibility/privacy hardening this change touches:

1. Re-encode authoritative metadata into the retained payload so Remix/Edit and the share link don't carry stale title/description.
2. **Fail closed on the view**: if the authoritative visibility diverges from the blob and the re-encode fails, drop the retained payload instead of keeping a stale (possibly more-permissive) blob.
3. **Fail closed on publish**: abort with a clear error instead of sending a Public/Link-Only blob tagged with a Private payload.
4. **Block editor open on empty/undecodeable payloads** (owned builds included) so a dropped payload can't open a blank editor that overwrites a saved build, and so corrupt/oversized `build_data` can't create an unopenable Hub row.

## Testing

- `tsc --noEmit`, `eslint`, `prettier --check` — clean.
- **22 jest tests** across `PublishBuildDialog` and `BuildViewPage.visibility` covering pre-fill, edit-mode override, publish-time re-sync, and every fail-closed branch above.

## Known follow-up (out of scope)

Private build blobs travel through `/build-editor?b=<blob>` URLs on the Edit path. This is **pre-existing and site-wide** (e.g. `MyBuildsPage.tsx:225` does the same for all builds) — not introduced here — and the "private blobs stay out of the URL" invariant currently applies only to the forwardable `/bv` view page. Routing builds to the editor via router state instead of the query string is a separate editor-navigation refactor, tracked as a follow-up.
