### PR TITLE
Remove misleading "+" from crit damage targets in sticky footer

### DIFF
--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -5834,7 +5834,7 @@ const CalculatorComponent: React.FC = () => {
                           ? 'Target: 125%'
                           : gameMode === 'pvp'
                             ? 'Target: 125%'
-                            : 'PvE: 125%+\nPvP: 100%+',
+                            : 'PvE: 125%\nPvP: 100%',
                     },
                   })}
                 {selectedTab === 2 &&


### PR DESCRIPTION
## What

In the critical damage calculator's sticky summary footer, the **"both" game mode** displayed the crit targets as `PvE: 125%+` / `PvP: 100%+`, while selecting a single game mode showed `Target: 125%` with **no** plus sign.

This PR drops the trailing `+` so the targets read `PvE: 125%` / `PvP: 100%`.

## Why

The `+` was inconsistent across modes and misleading — appended directly to a percentage it reads like an additive operator (`125 + something`) rather than "125% or higher". Removing it makes the crit targets read consistently in all game modes.

## Changes

- `src/components/Calculator.tsx` — crit damage `targetRanges` for "both" mode: `'PvE: 125%+\nPvP: 100%+'` → `'PvE: 125%\nPvP: 100%'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7ZDA7s8uJXvHeApFVKiGB)_