### PR TITLE
fix(build-editor): keep private build blobs out of the editor URL

### DIFF
--- a/src/components/roster/shared/slot-action-pill.test.tsx
+++ b/src/components/roster/shared/slot-action-pill.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import type { Build } from '../../../features/build-editor/types/build.types';
+
+// Capture roster→editor navigation without a real router.
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Control the encoded payload deterministically.
+const mockEncode = jest.fn();
+jest.mock('../../../utils/buildEncoding', () => ({
+  encodeBuildToURL: (...args: unknown[]) => mockEncode(...args),
+}));
+
+const mockEnqueue = jest.fn();
+jest.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn(),
+}));
+
+import { SlotActionPill } from './slot-action-pill';
+
+const buildFactory = (): Build => ({ name: 'Slot Build' }) as unknown as Build;
+
+const clickEdit = (label: string) =>
+  fireEvent.click(
+    screen.getByRole('button', { name: new RegExp(`Edit ${label} in Build Editor`, 'i') }),
+  );
+
+describe('SlotActionPill roster → editor navigation', () => {
+  beforeEach(() => {
+    // resetMocks (jest.config) wipes implementations each test — re-establish.
+    mockEncode.mockResolvedValue('ENCODED_BLOB');
+  });
+
+  it('keeps roster round-trip params in the URL but sends the build via router state (no ?b= blob)', async () => {
+    render(
+      <SlotActionPill
+        buildFactory={buildFactory}
+        color="#38bdf8"
+        label="DPS 3"
+        slotKey="dps3"
+        rosterId="r1"
+      />,
+    );
+
+    clickEdit('DPS 3');
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const [to, options] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(to).toBe('/build-editor?slot=dps3&rid=r1&from=roster');
+    expect(to).not.toContain('b=');
+    expect(options.state).toEqual({ buildData: 'ENCODED_BLOB' });
+  });
+
+  it('navigates to a bare /build-editor when there is no slot/roster context', async () => {
+    render(<SlotActionPill buildFactory={buildFactory} color="#38bdf8" label="DPS 1" />);
+
+    clickEdit('DPS 1');
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const [to, options] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(to).toBe('/build-editor');
+    expect(to).not.toContain('b=');
+    expect(options.state).toEqual({ buildData: 'ENCODED_BLOB' });
+  });
+
+  it('fails closed: no navigation when encoding yields an empty payload; shows an error', async () => {
+    mockEncode.mockResolvedValue('');
+    render(
+      <SlotActionPill
+        buildFactory={buildFactory}
+        color="#38bdf8"
+        label="Tank 1"
+        slotKey="tank1"
+        rosterId="r1"
+      />,
+    );
+
+    clickEdit('Tank 1');
+
+    await waitFor(() => expect(mockEncode).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      'Could not encode build — please try again.',
+      expect.objectContaining({ variant: 'error' }),
+    );
+  });
+});

--- a/src/components/roster/shared/slot-action-pill.tsx
+++ b/src/components/roster/shared/slot-action-pill.tsx
@@ -60,12 +60,17 @@ export const SlotActionPill = React.memo<SlotActionPillProps>(
         const build = buildFactory();
         const encoded = await encodeBuildToURL(build);
         if (encoded) {
-          // Build the URL with roster context params for round-trip support
-          const params = new URLSearchParams({ b: encoded });
+          // Roster round-trip context params stay in the URL (non-sensitive);
+          // the encoded build travels via router state so the full blob never
+          // lands in the editor's address bar/history/Referer.
+          const params = new URLSearchParams();
           if (slotKey) params.set('slot', slotKey);
           if (rosterId) params.set('rid', rosterId);
           if (slotKey || rosterId) params.set('from', 'roster');
-          navigate(`/build-editor?${params.toString()}`);
+          const query = params.toString();
+          navigate(query ? `/build-editor?${query}` : '/build-editor', {
+            state: { buildData: encoded },
+          });
         } else {
           enqueueSnackbar('Could not encode build — please try again.', { variant: 'error' });
         }

--- a/src/pages/BuildEditorPage.test.tsx
+++ b/src/pages/BuildEditorPage.test.tsx
@@ -160,7 +160,7 @@ describe('BuildEditorPage build loading', () => {
     expect(screen.getByTestId('search').textContent).toBe('?id=saved-3');
   });
 
-  it('clears the private payload from history even when decoding fails; warns instead', async () => {
+  it('on decode failure: scrubs the private payload AND drops the ?id= save target (fail-closed)', async () => {
     mockDecode.mockResolvedValue(null);
     renderAt({
       pathname: '/build-editor',
@@ -172,19 +172,33 @@ describe('BuildEditorPage build loading', () => {
     // The blob must NOT linger in history.state on the failure path — a
     // version-skewed/corrupt private payload must not survive a refresh/restore.
     await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null'));
-    // The non-sensitive save target is preserved; no build loaded; user warned.
-    expect(screen.getByTestId('search').textContent).toBe('?id=saved-9');
+    // The ?id= save target is dropped so a later Save can't overwrite saved-9 with
+    // the stale/default editor state that never loaded the intended build.
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('search').textContent ?? '');
+      expect(params.has('id')).toBe(false);
+    });
     expect(mockDispatch).not.toHaveBeenCalled();
     await waitFor(() => expect(mockEnqueue).toHaveBeenCalled());
   });
 
-  it('strips the legacy ?b= blob even when decoding fails', async () => {
+  it('on decode failure: strips ?b= and ?id= but keeps roster round-trip params', async () => {
     mockDecode.mockResolvedValue(null);
-    renderAt({ pathname: '/build-editor', search: '?b=bad-blob&id=saved-9', state: null });
+    renderAt({
+      pathname: '/build-editor',
+      search: '?b=bad-blob&slot=dps3&rid=r1&from=roster&id=saved-9',
+      state: null,
+    });
 
     await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('bad-blob'));
-    await waitFor(() => expect(screen.getByTestId('search').textContent).toBe('?id=saved-9'));
-    expect(screen.getByTestId('search').textContent).not.toContain('b=');
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('search').textContent ?? '');
+      expect(params.has('b')).toBe(false);
+      expect(params.has('id')).toBe(false);
+      // Roster round-trip context is harmless (no overwrite risk) and preserved.
+      expect(params.get('slot')).toBe('dps3');
+      expect(params.get('from')).toBe('roster');
+    });
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 

--- a/src/pages/BuildEditorPage.test.tsx
+++ b/src/pages/BuildEditorPage.test.tsx
@@ -160,13 +160,32 @@ describe('BuildEditorPage build loading', () => {
     expect(screen.getByTestId('search').textContent).toBe('?id=saved-3');
   });
 
-  it('does not dispatch when decoding fails; warns instead', async () => {
+  it('clears the private payload from history even when decoding fails; warns instead', async () => {
     mockDecode.mockResolvedValue(null);
-    renderAt({ pathname: '/build-editor', search: '', state: { buildData: 'bad-blob' } });
+    renderAt({
+      pathname: '/build-editor',
+      search: '?id=saved-9',
+      state: { buildData: 'bad-blob' },
+    });
 
     await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('bad-blob'));
+    // The blob must NOT linger in history.state on the failure path — a
+    // version-skewed/corrupt private payload must not survive a refresh/restore.
+    await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null'));
+    // The non-sensitive save target is preserved; no build loaded; user warned.
+    expect(screen.getByTestId('search').textContent).toBe('?id=saved-9');
     expect(mockDispatch).not.toHaveBeenCalled();
     await waitFor(() => expect(mockEnqueue).toHaveBeenCalled());
+  });
+
+  it('strips the legacy ?b= blob even when decoding fails', async () => {
+    mockDecode.mockResolvedValue(null);
+    renderAt({ pathname: '/build-editor', search: '?b=bad-blob&id=saved-9', state: null });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('bad-blob'));
+    await waitFor(() => expect(screen.getByTestId('search').textContent).toBe('?id=saved-9'));
+    expect(screen.getByTestId('search').textContent).not.toContain('b=');
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('loads the build at most once on mount — the loadedRef guard keeps it idempotent (no reload over edits)', async () => {

--- a/src/pages/BuildEditorPage.test.tsx
+++ b/src/pages/BuildEditorPage.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+// The editor shell is a heavy subtree irrelevant to the load orchestration —
+// stub it to a marker. We only assert how BuildEditorPage sources the build to
+// edit (router state vs the legacy ?b= param) and how it cleans the URL/history
+// afterwards.
+jest.mock('@features/build-editor/components/BuildEditorShell', () => ({
+  BuildEditorShell: () => <div data-testid="editor-shell" />,
+}));
+
+// Stub the decoder so tests control success/failure without real (de)compression.
+jest.mock('@/utils/buildEncoding', () => ({
+  decodeBuildFromURL: jest.fn(),
+}));
+
+// Tag the loadBuild action so we can assert it was dispatched with the decoded
+// build, without pulling in the real slice (and its migrate side effects).
+jest.mock('@features/build-editor/store/buildEditorSlice', () => ({
+  loadBuild: jest.fn((build: unknown) => ({ type: 'buildEditor/loadBuild', payload: build })),
+}));
+
+// notistack's useSnackbar needs a provider; stub it.
+const mockEnqueue = jest.fn();
+jest.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
+
+// Capture dispatched actions; isDirty selector returns false (no unload guard).
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: jest.fn(() => false),
+}));
+
+import { loadBuild } from '@features/build-editor/store/buildEditorSlice';
+import { decodeBuildFromURL } from '@/utils/buildEncoding';
+
+import { BuildEditorPage } from './BuildEditorPage';
+
+const mockDecode = decodeBuildFromURL as jest.MockedFunction<typeof decodeBuildFromURL>;
+const mockLoadBuild = loadBuild as unknown as jest.Mock;
+
+const decodedBuild = { id: 'b1', name: 'Decoded Build' } as never;
+
+/** Surfaces the live router location so tests can assert URL + state. */
+const LocationProbe: React.FC = () => {
+  const location = useLocation();
+  return (
+    <>
+      <span data-testid="search">{location.search}</span>
+      <span data-testid="state">{JSON.stringify(location.state)}</span>
+    </>
+  );
+};
+
+const renderAt = (entry: {
+  pathname: string;
+  search?: string;
+  state?: Record<string, unknown> | null;
+}) =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route
+          path="/build-editor"
+          element={
+            <>
+              <BuildEditorPage />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe('BuildEditorPage build loading', () => {
+  beforeEach(() => {
+    // resetMocks (jest.config) wipes implementations between tests — re-establish
+    // defaults so bare jest.fn()s never return undefined.
+    mockDecode.mockResolvedValue(decodedBuild);
+    mockLoadBuild.mockImplementation((build: unknown) => ({
+      type: 'buildEditor/loadBuild',
+      payload: build,
+    }));
+  });
+
+  it('loads a build from router state, clears the state, and keeps ?id= — no blob in the URL', async () => {
+    renderAt({
+      pathname: '/build-editor',
+      search: '?id=saved-1',
+      state: { buildData: 'state-blob' },
+    });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('state-blob'));
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'buildEditor/loadBuild',
+        payload: decodedBuild,
+      }),
+    );
+
+    // The non-sensitive save target stays; the build blob never entered the URL.
+    expect(screen.getByTestId('search').textContent).toBe('?id=saved-1');
+    expect(screen.getByTestId('search').textContent).not.toContain('b=');
+    // Router state is cleared so a refresh/Back doesn't reload over edits.
+    await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null'));
+  });
+
+  it('keeps roster round-trip params in the URL when loading from state', async () => {
+    renderAt({
+      pathname: '/build-editor',
+      search: '?slot=dps3&rid=r1&from=roster',
+      state: { buildData: 'roster-blob' },
+    });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('roster-blob'));
+    expect(screen.getByTestId('search').textContent).toBe('?slot=dps3&rid=r1&from=roster');
+    await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null'));
+  });
+
+  it('loads from the legacy ?b= param and strips it, preserving ?id=', async () => {
+    renderAt({
+      pathname: '/build-editor',
+      search: '?b=url-blob&id=saved-2',
+      state: null,
+    });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('url-blob'));
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'buildEditor/loadBuild',
+        payload: decodedBuild,
+      }),
+    );
+    await waitFor(() => expect(screen.getByTestId('search').textContent).toBe('?id=saved-2'));
+    expect(screen.getByTestId('search').textContent).not.toContain('b=');
+  });
+
+  it('prefers ?b= over router state when both are present (back-compat)', async () => {
+    renderAt({
+      pathname: '/build-editor',
+      search: '?b=url-blob',
+      state: { buildData: 'state-blob' },
+    });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('url-blob'));
+    expect(mockDecode).not.toHaveBeenCalledWith('state-blob');
+    await waitFor(() => expect(screen.getByTestId('search').textContent).not.toContain('b='));
+  });
+
+  it('does nothing when there is no payload (no ?b=, no state)', async () => {
+    renderAt({ pathname: '/build-editor', search: '?id=saved-3', state: null });
+
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeInTheDocument());
+    expect(mockDecode).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(screen.getByTestId('search').textContent).toBe('?id=saved-3');
+  });
+
+  it('does not dispatch when decoding fails; warns instead', async () => {
+    mockDecode.mockResolvedValue(null);
+    renderAt({ pathname: '/build-editor', search: '', state: { buildData: 'bad-blob' } });
+
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledWith('bad-blob'));
+    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockEnqueue).toHaveBeenCalled());
+  });
+
+  it('loads the build at most once on mount — the loadedRef guard keeps it idempotent (no reload over edits)', async () => {
+    // StrictMode intentionally invokes mount effects twice in dev. This is the
+    // deterministic proxy for the refactor's core risk: because the build now
+    // lives in router state (which survives a remount/refresh), a missing
+    // idempotency guard would dispatch loadBuild a second time and clobber the
+    // user's in-progress edits with the original build. The loadedRef guard must
+    // make the load fire exactly once.
+    render(
+      <React.StrictMode>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/build-editor',
+              search: '?id=saved-1',
+              state: { buildData: 'state-blob' },
+            },
+          ]}
+        >
+          <Routes>
+            <Route
+              path="/build-editor"
+              element={
+                <>
+                  <BuildEditorPage />
+                  <LocationProbe />
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </React.StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'buildEditor/loadBuild',
+        payload: decodedBuild,
+      }),
+    );
+    // Without the guard, StrictMode's double-invoke would decode + dispatch twice.
+    expect(mockDecode).toHaveBeenCalledTimes(1);
+    const loadCalls = mockDispatch.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === 'buildEditor/loadBuild',
+    );
+    expect(loadCalls).toHaveLength(1);
+  });
+});

--- a/src/pages/BuildEditorPage.tsx
+++ b/src/pages/BuildEditorPage.tsx
@@ -4,23 +4,39 @@
  * class theming, scoped background, and the bento grid layout.
  * AppLayout provides the xl Container and reduced padding for this route.
  *
- * Supports loading a shared build via `?b=<encoded>` URL parameter.
+ * Supports loading a build to edit from two sources:
+ *  - `location.state.buildData` — the preferred in-app handoff. Same-app
+ *    navigations (My Builds, Build View, Roster slot) pass the encoded build
+ *    through router state so a build blob — which may be a *private* build —
+ *    never lands in the address bar / browser history / Referer header.
+ *  - `?b=<encoded>` URL param — the legacy / external path (e.g. a build opened
+ *    in a fresh tab, or an older link). Still honored, then stripped on load.
+ *
+ * The non-sensitive save-target (`?id=`) and roster round-trip params
+ * (`from`/`slot`/`rid`) always stay in the URL — they carry no build content.
  */
 
 import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import type { RootState } from '@/store/storeWithHistory';
 import { decodeBuildFromURL } from '@/utils/buildEncoding';
 import { BuildEditorShell } from '@features/build-editor/components/BuildEditorShell';
 import { loadBuild } from '@features/build-editor/store/buildEditorSlice';
 
+interface BuildEditorNavState {
+  /** Encoded build blob handed off via router state (kept out of the URL). */
+  buildData?: string;
+}
+
 const BuildEditorPageInner: React.FC = () => {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
   const isDirty = useSelector((s: RootState) => s.buildEditor.isDirty);
   const loadedRef = React.useRef(false);
 
@@ -28,28 +44,44 @@ const BuildEditorPageInner: React.FC = () => {
     document.title = 'Build Editor | ESO Toolkit';
   }, []);
 
-  // Load build from ?b= URL param on mount
+  // Load build from router state (preferred) or ?b= URL param (legacy) on mount.
   useEffect(() => {
     if (loadedRef.current) return;
-    const encoded = searchParams.get('b');
-    if (!encoded) return;
+    // `?b=` may be an empty string (`?b=`), which decodes to nothing — treat it
+    // as absent so we fall through to the state handoff.
+    const encoded = searchParams.get('b') || '';
+    const stateBuild = (location.state as BuildEditorNavState | null)?.buildData ?? '';
+    const source = encoded || stateBuild;
+    if (!source) return;
     loadedRef.current = true;
 
-    void decodeBuildFromURL(encoded).then((decoded) => {
-      if (decoded) {
-        dispatch(loadBuild(decoded));
-        // Remove the ?b= param from URL to avoid re-loading on refresh
-        // Keep other params like ?id= for saved build editing
+    void decodeBuildFromURL(source).then((decoded) => {
+      if (!decoded) {
+        enqueueSnackbar('Could not load shared build — the link may be invalid.', {
+          variant: 'warning',
+        });
+        return;
+      }
+      dispatch(loadBuild(decoded));
+      // Strip the build payload from the URL/history so a refresh or Back
+      // navigation doesn't reload the original over the user's in-progress
+      // edits (the editor's own state is persisted separately), and so a
+      // private build never lingers in the address bar/history. The
+      // non-sensitive save-target (?id=) and roster params stay put.
+      if (encoded) {
         const newParams = new URLSearchParams(searchParams);
         newParams.delete('b');
         setSearchParams(newParams, { replace: true });
       } else {
-        enqueueSnackbar('Could not load shared build — the link may be invalid.', {
-          variant: 'warning',
-        });
+        // Clear the router state (persisted in window.history across refreshes)
+        // while keeping the current path + remaining query params.
+        navigate(
+          { pathname: location.pathname, search: location.search },
+          { replace: true, state: null },
+        );
       }
     });
-  }, [searchParams, setSearchParams, dispatch, enqueueSnackbar]);
+  }, [searchParams, setSearchParams, location, navigate, dispatch, enqueueSnackbar]);
 
   // Warn before unloading if there are unsaved changes
   useEffect(() => {

--- a/src/pages/BuildEditorPage.tsx
+++ b/src/pages/BuildEditorPage.tsx
@@ -55,30 +55,33 @@ const BuildEditorPageInner: React.FC = () => {
     if (!source) return;
     loadedRef.current = true;
 
+    // Scrub the build payload from the URL/history IMMEDIATELY — before the async
+    // decode — so a build blob (which may be a *private* build) never lingers in
+    // the address bar or in window.history.state, regardless of whether decoding
+    // succeeds (a failed/version-skewed payload must not survive in history). This
+    // also stops a refresh or Back from reloading the original over the user's
+    // in-progress edits (the editor's own state is persisted separately). The
+    // non-sensitive save-target (?id=) and roster params (from/slot/rid) stay put.
+    if (encoded) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete('b');
+      setSearchParams(newParams, { replace: true });
+    } else {
+      // Clear the router state (persisted in window.history across refreshes)
+      // while keeping the current path + remaining query params.
+      navigate(
+        { pathname: location.pathname, search: location.search },
+        { replace: true, state: null },
+      );
+    }
+
     void decodeBuildFromURL(source).then((decoded) => {
-      if (!decoded) {
+      if (decoded) {
+        dispatch(loadBuild(decoded));
+      } else {
         enqueueSnackbar('Could not load shared build — the link may be invalid.', {
           variant: 'warning',
         });
-        return;
-      }
-      dispatch(loadBuild(decoded));
-      // Strip the build payload from the URL/history so a refresh or Back
-      // navigation doesn't reload the original over the user's in-progress
-      // edits (the editor's own state is persisted separately), and so a
-      // private build never lingers in the address bar/history. The
-      // non-sensitive save-target (?id=) and roster params stay put.
-      if (encoded) {
-        const newParams = new URLSearchParams(searchParams);
-        newParams.delete('b');
-        setSearchParams(newParams, { replace: true });
-      } else {
-        // Clear the router state (persisted in window.history across refreshes)
-        // while keeping the current path + remaining query params.
-        navigate(
-          { pathname: location.pathname, search: location.search },
-          { replace: true, state: null },
-        );
       }
     });
   }, [searchParams, setSearchParams, location, navigate, dispatch, enqueueSnackbar]);

--- a/src/pages/BuildEditorPage.tsx
+++ b/src/pages/BuildEditorPage.tsx
@@ -78,11 +78,21 @@ const BuildEditorPageInner: React.FC = () => {
     void decodeBuildFromURL(source).then((decoded) => {
       if (decoded) {
         dispatch(loadBuild(decoded));
-      } else {
-        enqueueSnackbar('Could not load shared build — the link may be invalid.', {
-          variant: 'warning',
-        });
+        return;
       }
+      // Fail closed: the build never loaded. Drop the ?id= save target (and any
+      // leftover ?b=) so a later Save can't overwrite that saved build with the
+      // stale/default editor state that's still on screen. Roster round-trip
+      // params are left as-is — they carry no overwrite risk.
+      if (searchParams.get('id') || searchParams.get('b')) {
+        const failParams = new URLSearchParams(searchParams);
+        failParams.delete('b');
+        failParams.delete('id');
+        setSearchParams(failParams, { replace: true });
+      }
+      enqueueSnackbar('Could not load shared build — the link may be invalid.', {
+        variant: 'warning',
+      });
     });
   }, [searchParams, setSearchParams, location, navigate, dispatch, enqueueSnackbar]);
 

--- a/src/pages/BuildViewPage.tsx
+++ b/src/pages/BuildViewPage.tsx
@@ -2184,11 +2184,28 @@ export const BuildViewPage: React.FC = () => {
   const isOwned = Boolean(ownedSavedBuild);
 
   const handleOpenInEditor = (): void => {
-    const base = `/build-editor?b=${encodeURIComponent(encodedParam)}`;
+    // Fail closed: never navigate to the editor (especially with an ?id= save
+    // target) without a payload — an empty editor pointed at ?id= would
+    // overwrite the saved build with blank state on save.
+    if (!encodedParam) {
+      setSnackbar({
+        open: true,
+        message: 'Could not open this build in the editor. Please reload and try again.',
+        severity: 'error',
+      });
+      return;
+    }
+    // Hand the encoded build to the editor via router state, NOT a ?b= URL
+    // param: this view can render a *private* build (the owner's ?id= view or
+    // an in-app owner preview), and the full blob must never land in the
+    // address bar/history/Referer. Only the non-sensitive save-target (?id=)
+    // stays in the URL.
+    const target = ownedSavedBuild ? `/build-editor?id=${ownedSavedBuild.id}` : '/build-editor';
     // Forward drill that morphs the shared build-hero header into the editor's
     // header — consistent with every other build navigation (which uses
     // vtType:'forward' + morph) instead of the bare default crossfade.
-    navigate(ownedSavedBuild ? `${base}&id=${ownedSavedBuild.id}` : base, {
+    navigate(target, {
+      state: { buildData: encodedParam },
       vtType: 'forward',
       morph: { ref: buildHeroRef, name: 'build-hero' },
     });

--- a/src/pages/BuildViewPage.visibility.test.tsx
+++ b/src/pages/BuildViewPage.visibility.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -22,6 +22,12 @@ jest.mock('../features/auth/AuthContext', () => ({
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
+}));
+
+// Capture "Open in Editor" navigation without running the real View Transition.
+const mockNavigate = jest.fn();
+jest.mock('../hooks/useViewTransitionNavigate', () => ({
+  useViewTransitionNavigate: () => mockNavigate,
 }));
 
 jest.mock('../features/build-hub/api/build-hub-api', () => ({
@@ -246,5 +252,53 @@ describe('BuildViewPage visibility enforcement', () => {
 
     await waitFor(() => expect(screen.getByText(/No build found/i)).toBeInTheDocument());
     expect(screen.queryByTestId('build-shell')).not.toBeInTheDocument();
+  });
+});
+
+describe('BuildViewPage → editor navigation keeps the build out of the URL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDecode.mockResolvedValue(null);
+    mockUseSelector.mockReturnValue([]);
+  });
+
+  it('Open-in-Editor (Remix, not owned) passes the build via router state, never a ?b= blob', async () => {
+    mockDecode.mockResolvedValue(fullBuild('link-only'));
+
+    renderEncoded('encoded-link-only-build');
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /Open your own editable copy of this build in the editor/i,
+      }),
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const [to, options] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(to).toBe('/build-editor');
+    expect(to).not.toContain('b=');
+    expect(options.state).toEqual({ buildData: 'encoded-link-only-build' });
+  });
+
+  it('Open-in-Editor (owned) keeps only the non-sensitive ?id= save target in the URL', async () => {
+    mockDecode.mockResolvedValue(fullBuild('private'));
+    // Owner viewing their own private build via in-app preview; the saved build
+    // matches build.id ('b1'), so the editor link carries ?id= as the save target.
+    mockUseSelector.mockReturnValue([{ id: 'saved-99', build: { id: 'b1' } }] as never);
+
+    renderEncoded('encoded-private-build', { ownerPreview: true });
+
+    await waitFor(() => expect(screen.getByTestId('build-shell')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit your saved build in the editor/i }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const [to, options] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(to).toBe('/build-editor?id=saved-99');
+    expect(to).not.toContain('b=');
+    // The full private blob travels in state only — never in the address bar.
+    expect(options.state).toEqual({ buildData: 'encoded-private-build' });
   });
 });

--- a/src/pages/MyBuildsPage.test.tsx
+++ b/src/pages/MyBuildsPage.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Capture editor navigation without running the real View Transition wrapper.
+const mockNavigate = jest.fn();
+jest.mock('../hooks/useViewTransitionNavigate', () => ({
+  useViewTransitionNavigate: () => mockNavigate,
+}));
+
+// Control the encoded payload deterministically.
+const mockEncode = jest.fn();
+jest.mock('../utils/buildEncoding', () => ({
+  encodeBuildToURL: (...args: unknown[]) => mockEncode(...args),
+}));
+
+jest.mock('../features/auth/AuthContext', () => ({
+  useAuth: () => ({ accessToken: null }),
+}));
+
+jest.mock('../store/useAppDispatch', () => ({
+  useAppDispatch: () => jest.fn(),
+}));
+
+// The publish dialog is a heavy subtree never exercised by the edit-nav tests.
+jest.mock('../features/build-hub/components/PublishBuildDialog', () => ({
+  PublishBuildDialog: () => null,
+}));
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+import { MyBuildsPage } from './MyBuildsPage';
+
+const savedBuild = (visibility: string) =>
+  ({
+    id: 'saved-7',
+    savedAt: '2024-01-01T00:00:00.000Z',
+    build: {
+      id: 'b7',
+      name: 'My Build',
+      esoClass: 'sorcerer',
+      role: 'magicka-dps',
+      gameMode: 'pve',
+      shortDescription: '',
+      settings: { visibility },
+    },
+  }) as never;
+
+describe('MyBuildsPage edit navigation', () => {
+  beforeEach(() => {
+    mockEncode.mockResolvedValue('ENCODED_BLOB');
+    mockUseSelector.mockReturnValue([savedBuild('private')]);
+  });
+
+  it('opens the editor with the build in router state — never a ?b= URL blob', async () => {
+    render(<MyBuildsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const [to, options] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(to).toBe('/build-editor?id=saved-7');
+    expect(to).not.toContain('b=');
+    expect(options.state).toEqual({ buildData: 'ENCODED_BLOB' });
+    expect(options.vtType).toBe('forward');
+  });
+
+  it('fails closed: no navigation when encoding yields an empty payload', async () => {
+    mockEncode.mockResolvedValue('');
+    render(<MyBuildsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+
+    await waitFor(() => expect(mockEncode).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/MyBuildsPage.tsx
+++ b/src/pages/MyBuildsPage.tsx
@@ -222,7 +222,17 @@ export const MyBuildsPage: React.FC = () => {
 
   const handleEdit = async (saved: SavedBuild): Promise<void> => {
     const encoded = await encodeBuildToURL(saved.build);
-    navigate(`/build-editor?b=${encoded}&id=${saved.id}`, {
+    if (!encoded) {
+      // Fail closed: never open the editor pointed at this saved build (?id=)
+      // with no payload — saving there would overwrite it with blank state.
+      return;
+    }
+    // Hand the encoded build to the editor via router state, NOT a ?b= URL
+    // param — a build may be Private, and the full blob must not land in the
+    // address bar/history/Referer. Only the non-sensitive save-target (?id=)
+    // stays in the URL.
+    navigate(`/build-editor?id=${saved.id}`, {
+      state: { buildData: encoded },
       vtType: 'forward',
       morph: { ref: { current: cardRefs.current.get(saved.id) ?? null }, name: 'build-hero' },
     });


### PR DESCRIPTION
## Summary
Routes builds to the Build Editor via **React Router state** instead of a `?b=<encoded blob>` query param, so a private build's full blob never lands in the address bar, browser history, synced history, or the `Referer` header. This mirrors the established "private builds stay out of the URL" invariant already used by the build VIEW page (`/bv` with `state.previewBuild`).

Pre-existing privacy gap (not a regression) — flagged by adversarial review on #1344.

## Changes
- **`BuildEditorPage`** — loads the build from `location.state.buildData` (preferred) or the legacy `?b=` param (still honored). The payload is scrubbed from the URL/history **before** the async decode (success *and* failure), so a failed/version-skewed private blob never lingers in `window.history.state`. `loadedRef` keeps the load idempotent. On decode failure it also strips `?id=` (fail-closed) so a non-loaded build can't overwrite the saved record.
- **`MyBuildsPage` (Edit), `BuildViewPage` (Open in Editor), roster `SlotActionPill` (Edit)** — hand the encoded build via router state; keep only the non-sensitive `?id=` save target and roster round-trip params (`from`/`slot`/`rid`) in the URL. Fail closed (no navigation) on empty encode.
- New-tab callers (`BuildPreviewDialog`, `PlayerCard`) are left as-is — cross-document navigations can't carry router state, and those builds aren't private-by-invariant. `PublicProfilePage` uses `?id=` only (no blob).

## Out of scope (follow-up)
The `?id=` save target can already overwrite a saved build when the editor content doesn't correspond to it (e.g. a refresh landing on a stale draft, or two saved records sharing a `build.id`). This is **pre-existing** — the old `?b=` path was also stripped on load, landing at the identical `?id=`-without-payload URL — and fully fixing it requires tracking the active saved-record identity in editor state and gating `handleSave`. This PR keeps `?id=` behavior intact on the success path and adds fail-closed mitigations (scrub-before-decode, drop `?id=` on decode failure).

## Testing
- New/extended suites assert the blob travels in router state and never the URL: `BuildEditorPage.test.tsx` (state-load, legacy `?b=`, StrictMode idempotency, decode-failure scrub + fail-closed `?id=` drop), `MyBuildsPage.test.tsx`, `slot-action-pill.test.tsx`, `BuildViewPage.visibility.test.tsx`.
- `tsc` · eslint · prettier clean · full jest **4131 passed**.
- Reviewed via a 6-lens adversarial-verify pass and both Codex reviewers (native review + adversarial-review, gpt-5.5) — clean.