### PR TITLE
feat(build-editor): expand all sections by default on mobile

### DIFF
--- a/src/features/build-editor/components/BuildEditorLayout.tsx
+++ b/src/features/build-editor/components/BuildEditorLayout.tsx
@@ -10,8 +10,10 @@
  * stay mounted for the rest of the session. This keeps the initial React render
  * bounded to ~3 sections instead of all 11.
  *
- * Mobile (<960px): Single column, sections collapsible (SectionCard's
- * <Collapse unmountOnExit> already handles lazy mounting), bottom nav bar.
+ * Mobile (<960px): Single column, bottom nav bar. Sections start expanded so
+ * the user lands on actionable content rather than a wall of collapsed headers;
+ * each section can still be collapsed manually via its header. (SectionCard's
+ * <Collapse> mounts the content immediately when expanded.)
  */
 
 import {
@@ -65,10 +67,11 @@ export const BuildEditorLayout: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const progress = useSectionProgress();
   const isDirty = useSelector(selectIsDirty);
-  // On mobile, SectionCard's <Collapse unmountOnExit> already lazy-mounts content,
-  // so LazySection would be redundant — pass eager=true there. On desktop, the
-  // first two rows (Identity, Character, Subclassing) sit above the fold and
-  // should render immediately without IntersectionObserver wait.
+  // On mobile, sections start expanded (defaultExpanded) and SectionCard's
+  // <Collapse> mounts their content immediately, so LazySection would be
+  // redundant — pass eager=true there. On desktop, the first two rows (Identity,
+  // Character, Subclassing) sit above the fold and should render immediately
+  // without IntersectionObserver wait.
   const lazyDesktop = !isMobile;
   // Lazy read via the store — subscribing to `build` here would force the
   // whole layout (and every SectionCard child) to re-render on every edit.
@@ -178,7 +181,7 @@ export const BuildEditorLayout: React.FC = () => {
                 icon={<GeneralIcon />}
                 complete={progress.general}
                 variant="primary"
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <GeneralSection />
               </SectionCard>
@@ -190,7 +193,7 @@ export const BuildEditorLayout: React.FC = () => {
                 title="Character"
                 icon={<CharacterIcon />}
                 complete={progress.character}
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="character" />}
               >
                 <CharacterSection />
@@ -204,7 +207,7 @@ export const BuildEditorLayout: React.FC = () => {
                 title="Subclassing"
                 icon={<SubclassingIcon />}
                 complete={progress.subclassing}
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <SubclassingSection />
               </SectionCard>
@@ -216,7 +219,7 @@ export const BuildEditorLayout: React.FC = () => {
                 title="Class Mastery"
                 icon={<ClassMasteryIcon />}
                 complete={progress['class-mastery']}
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <ClassMasterySection />
               </SectionCard>
@@ -235,7 +238,7 @@ export const BuildEditorLayout: React.FC = () => {
                 complete={progress.equipment}
                 variant="primary"
                 gridRow={isMobile ? undefined : 'span 2'}
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="gear" />}
               >
                 <EquipmentSection />
@@ -249,7 +252,7 @@ export const BuildEditorLayout: React.FC = () => {
                 icon={<SkillsIcon />}
                 complete={progress.skills}
                 variant="primary"
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="skills" />}
               >
                 <SkillsSection />
@@ -262,7 +265,7 @@ export const BuildEditorLayout: React.FC = () => {
                 title="Consumables"
                 icon={<ConsumableIcon />}
                 complete={progress.consumables}
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="consumables" />}
               >
                 <ConsumablesSection />
@@ -282,7 +285,7 @@ export const BuildEditorLayout: React.FC = () => {
                 complete={progress.champion}
                 variant="primary"
                 gridColumn={isMobile ? undefined : 'span 2'}
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="champion" />}
               >
                 <ChampionSection />
@@ -296,7 +299,7 @@ export const BuildEditorLayout: React.FC = () => {
                 title="Passives"
                 icon={<PassiveIcon />}
                 complete={progress.passives}
-                defaultExpanded={!isMobile}
+                defaultExpanded
                 headerAction={<SectionHeaderActions section="passives" />}
               >
                 <PassivesSection />
@@ -316,7 +319,7 @@ export const BuildEditorLayout: React.FC = () => {
                 complete={progress.stats}
                 variant="primary"
                 gridColumn={isMobile ? undefined : 'span 2'}
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <StatsSection />
               </SectionCard>
@@ -334,7 +337,7 @@ export const BuildEditorLayout: React.FC = () => {
                 icon={<GuideIcon />}
                 complete={progress.guide}
                 gridColumn={isMobile ? undefined : 'span 2'}
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <GuideSection />
               </SectionCard>
@@ -353,7 +356,7 @@ export const BuildEditorLayout: React.FC = () => {
                 complete={progress.settings}
                 variant="subtle"
                 gridColumn={isMobile ? undefined : 'span 2'}
-                defaultExpanded={!isMobile}
+                defaultExpanded
               >
                 <SettingsSection />
               </SectionCard>

--- a/tests/build-editor-mobile.spec.ts
+++ b/tests/build-editor-mobile.spec.ts
@@ -36,7 +36,7 @@ test.describe('C1/C2 – Picker glass fallback (perf tier: low)', () => {
   test('gear picker paper has an opaque background when backdrop-filter is stripped', async ({
     page,
   }) => {
-    // Open the Equipment section (starts collapsed on mobile) via the nav rail
+    // Jump to the Equipment section via the nav rail (sections start expanded on mobile)
     const equipNav = page.getByRole('button', { name: /Equipment/i }).first();
     await equipNav.click();
 


### PR DESCRIPTION
## What

On mobile (`<960px`), every build-editor section now starts **expanded** instead of collapsed. Previously a mobile user landed on `/build-editor` looking at all 12 collapsed section headers with no actionable content above the fold.

Change: `defaultExpanded={!isMobile}` → `defaultExpanded` on every `SectionCard` in `BuildEditorLayout.tsx`. Sections can still be collapsed manually via their headers (the toggle is unchanged).

## Why / trade-off (please read)

This was requested explicitly. For the record, I'd flagged a trade-off before implementing and the maintainer chose to proceed with **all sections open**:

- **Perf:** mobile section content is rendered inside `<Collapse>`, so expanding all sections mounts all heavy content (gear lists, skill bars, champion tree, stat engine) on load. The prior collapsed-by-default behavior was a deliberate perf strategy for low-tier mobile GPUs (see `documentation/features/BUILD_EDITOR_MOBILE_UX_AUDIT_2026-06-12.md`, Appendix B). Worth keeping an eye on mobile load/scroll performance.
- The "tap a nav item and land on a collapsed section" dead-end (audit finding H3) was already fixed independently, so nav-tap still expands + scrolls correctly either way.

If mobile perf regresses noticeably, a good follow-up would be expanding only the first (or first *incomplete*) section instead.

## Testing

- `npm run validate` — typecheck + lint + format all pass
- `npm test -- --watchAll=false` — pass
- Build-editor jest suite: 276/276 pass
- Updated a stale comment in `tests/build-editor-mobile.spec.ts`; the H3 and M6 mobile e2e tests remain valid (nav-tap on an already-expanded section is a no-op; the "expand all" loop simply finds nothing to expand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7Af5EHhzD5PWPXSR8RGPw)_