### PR TITLE
Default Backstabber to off on the Critical Damage tab

### DIFF
--- a/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
+++ b/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
@@ -12,6 +12,12 @@ import {
 } from './PlayerCriticalDamageDetailsView';
 
 const FIGHTING_FINESSE_SOURCE_NAME = 'Fighting Finesse';
+const BACKSTABBER_SOURCE_NAME = 'Backstabber';
+
+// Backstabber only applies while flanking (rear/side arc), which can't be detected
+// from log data. Default it OFF so the displayed critical damage reflects the
+// unconditional baseline; users can toggle it on if they were reliably flanking.
+const BACKSTABBER_DEFAULT_ENABLED = false;
 
 interface PlayerCriticalDamageDataExtended extends PlayerCriticalDamageData {
   criticalDamageSources: CriticalDamageSourceWithActiveState[];
@@ -57,10 +63,20 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
     );
   }, [criticalDamageData?.criticalDamageSources]);
 
+  const backstabberSource = React.useMemo(() => {
+    return criticalDamageData?.criticalDamageSources?.find(
+      (source) => source.source === 'always_on' && source.name === BACKSTABBER_SOURCE_NAME,
+    );
+  }, [criticalDamageData?.criticalDamageSources]);
+
   const [localFightingFinesseEnabled, setLocalFightingFinesseEnabled] = React.useState<boolean>(
     () => {
       return fightingFinesseSource?.wasActive ?? true;
     },
+  );
+
+  const [backstabberEnabled, setBackstabberEnabled] = React.useState<boolean>(
+    BACKSTABBER_DEFAULT_ENABLED,
   );
 
   React.useEffect(() => {
@@ -78,16 +94,30 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
   // Individual state always takes priority (local state)
   const fightingFinesseEnabled = localFightingFinesseEnabled;
 
+  // Total critical damage to subtract for toggleable always-on sources that are
+  // currently disabled. Both Fighting Finesse and Backstabber are baked into the
+  // static critical damage, so turning either off removes its contribution.
+  const critDamageAdjustment = React.useMemo(() => {
+    let adjustment = 0;
+    if (fightingFinesseSource && !fightingFinesseEnabled) {
+      adjustment += CriticalDamageValues.FIGHTING_FINESSE;
+    }
+    if (backstabberSource && !backstabberEnabled) {
+      adjustment += CriticalDamageValues.BACKSTABBER;
+    }
+    return adjustment;
+  }, [fightingFinesseSource, fightingFinesseEnabled, backstabberSource, backstabberEnabled]);
+
   const adjustedCriticalDamageData = React.useMemo(() => {
     if (!criticalDamageData) {
       return null;
     }
 
-    if (!fightingFinesseSource || fightingFinesseEnabled) {
+    if (critDamageAdjustment === 0) {
       return criticalDamageData;
     }
 
-    const adjustment = CriticalDamageValues.FIGHTING_FINESSE;
+    const adjustment = critDamageAdjustment;
 
     const adjustedDataPoints = criticalDamageData.dataPoints.map((point) => ({
       ...point,
@@ -115,7 +145,7 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
       timeAtCapPercentage: adjustedTimeAtCapPercentage,
       staticCriticalDamage: Math.max(0, criticalDamageData.staticCriticalDamage - adjustment),
     };
-  }, [criticalDamageData, fightingFinesseEnabled, fightingFinesseSource]);
+  }, [criticalDamageData, critDamageAdjustment]);
 
   const adjustedCriticalDamageSources = React.useMemo(() => {
     const sources = criticalDamageData?.criticalDamageSources ?? [];
@@ -126,21 +156,34 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
           wasActive: fightingFinesseEnabled,
         };
       }
+      if (source.source === 'always_on' && source.name === BACKSTABBER_SOURCE_NAME) {
+        return {
+          ...source,
+          wasActive: backstabberEnabled,
+        };
+      }
       return source;
     });
-  }, [criticalDamageData?.criticalDamageSources, fightingFinesseEnabled]);
+  }, [criticalDamageData?.criticalDamageSources, fightingFinesseEnabled, backstabberEnabled]);
 
   const toggleableSourceNames = React.useMemo(() => {
-    return adjustedCriticalDamageSources.some(
-      (source) => source.source === 'always_on' && source.name === FIGHTING_FINESSE_SOURCE_NAME,
-    )
-      ? new Set<string>([FIGHTING_FINESSE_SOURCE_NAME])
-      : undefined;
+    const names = new Set<string>();
+    for (const source of adjustedCriticalDamageSources) {
+      if (
+        source.source === 'always_on' &&
+        (source.name === FIGHTING_FINESSE_SOURCE_NAME || source.name === BACKSTABBER_SOURCE_NAME)
+      ) {
+        names.add(source.name);
+      }
+    }
+    return names.size > 0 ? names : undefined;
   }, [adjustedCriticalDamageSources]);
 
   const handleSourceToggle = React.useCallback((sourceName: string, nextValue: boolean) => {
     if (sourceName === FIGHTING_FINESSE_SOURCE_NAME) {
       setLocalFightingFinesseEnabled(nextValue);
+    } else if (sourceName === BACKSTABBER_SOURCE_NAME) {
+      setBackstabberEnabled(nextValue);
     }
   }, []);
 

--- a/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
+++ b/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
@@ -4,6 +4,7 @@ import { FightFragment } from '../../../graphql/gql/graphql';
 import { usePlayerData } from '../../../hooks';
 import type { PhaseTransitionInfo } from '../../../hooks/usePhaseTransitions';
 import { CriticalDamageValues } from '../../../types/abilities';
+import { filterDataPointsByActiveCombat } from '../../../utils/activeCombatTimeUtils';
 import { CriticalDamageSourceWithActiveState } from '../../../utils/CritDamageUtils';
 
 import {
@@ -130,10 +131,17 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
         ? Math.max(...adjustedDataPoints.map((point) => point.criticalDamage))
         : 0;
 
+    // Time at cap must stay filtered to active-combat data points, matching the worker's
+    // calculation. Fall back to all data points if active intervals weren't provided.
+    const activeCombatIntervals = criticalDamageData.activeCombatIntervals;
+    const capDataPoints = activeCombatIntervals
+      ? filterDataPointsByActiveCombat(adjustedDataPoints, activeCombatIntervals)
+      : adjustedDataPoints;
+
     const adjustedTimeAtCapPercentage =
-      adjustedDataPoints.length > 0
-        ? (adjustedDataPoints.filter((point) => point.criticalDamage >= 125).length /
-            adjustedDataPoints.length) *
+      capDataPoints.length > 0
+        ? (capDataPoints.filter((point) => point.criticalDamage >= 125).length /
+            capDataPoints.length) *
           100
         : 0;
 

--- a/src/features/report_details/critical_damage/PlayerCriticalDamageDetailsView.tsx
+++ b/src/features/report_details/critical_damage/PlayerCriticalDamageDetailsView.tsx
@@ -55,6 +55,9 @@ export interface PlayerCriticalDamageData {
   timeAtCapPercentage: number;
   criticalDamageAlerts: CriticalDamageAlert[];
   inactiveCombatIntervals: Array<{ start: number; end: number }>;
+  /** Active combat intervals (absolute timestamps). Used to keep time-at-cap filtered to
+   * active combat when toggleable critical-damage sources are turned off. */
+  activeCombatIntervals?: Array<{ start: number; end: number }>;
 }
 
 interface CriticalMultiplierInfo {

--- a/src/workers/calculations/CalculateCriticalDamage.ts
+++ b/src/workers/calculations/CalculateCriticalDamage.ts
@@ -58,6 +58,9 @@ export interface PlayerCriticalDamageDataExtended {
   staticCriticalDamage: number;
   /** Inactive combat intervals (gaps in boss damage) in seconds relative to fight start */
   inactiveCombatIntervals: Array<{ start: number; end: number }>;
+  /** Active combat intervals (boss taking damage) in absolute timestamps; used to recompute
+   * active-combat-filtered stats (e.g. time at cap) when toggleable sources are adjusted. */
+  activeCombatIntervals: Array<{ start: number; end: number }>;
 }
 
 export interface CriticalDamageCalculationResult {
@@ -260,6 +263,7 @@ export function calculateCriticalDamageData(
       criticalDamageSources: playerData.allSources,
       staticCriticalDamage: playerData.staticCriticalDamage,
       inactiveCombatIntervals,
+      activeCombatIntervals: activeCombatTimeResult.activeCombatIntervals,
     };
   });
 


### PR DESCRIPTION
## Summary

On the per-player **Critical Damage** tab (the expandable report detail page), the **Backstabber** source previously rendered as active (on) by default. Backstabber is modeled as an `always_on` critical-damage source, so it was always counted in the displayed critical damage.

In reality, Backstabber's +10% only applies while **flanking** (rear/side arc), which can't be detected from combat-log data. Showing it on by default overstates the unconditional critical-damage baseline.

This change makes Backstabber **default to off**, while leaving it toggleable so users can switch it back on if they were reliably flanking.

## What changed

- Generalized the existing **Fighting Finesse** toggle logic in `PlayerCriticalDamageDetails.tsx` to also cover Backstabber.
- Backstabber now defaults to **off** (`BACKSTABBER_DEFAULT_ENABLED = false`).
- Disabling a toggleable always-on source now subtracts its contribution from the displayed metrics, max, time-at-cap, static crit damage, and the chart — previously handled only for Fighting Finesse, now driven by a shared `critDamageAdjustment` total.
- Backstabber is added to the interactive (toggleable) source set so the checklist renders its toggle.

## Verification

- `tsc --noEmit` — passes
- `eslint` on the changed file — passes
- `jest` for `critical_damage/` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012djCFQvynh1Rn2AsSPJV99)_