### PR TITLE
fix(latest-reports): never hide an entire page of empty logs

### DIFF
--- a/src/features/latest_reports/components/ReportCard.tsx
+++ b/src/features/latest_reports/components/ReportCard.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useState } from 'react';
 
 import type { UserReportSummaryFragment } from '../../../graphql/gql/graphql';
 import {
+  EMPTY_REPORT_TOOLTIP,
   formatReportDateTime,
   formatReportDuration,
   getReportVisibilityColor,
@@ -180,10 +181,7 @@ export const ReportCard: React.FC<ReportCardProps> = ({ report, onSelect, showOw
               {title}
             </Typography>
             {empty && (
-              <Tooltip
-                title="This log may contain no fight data due to an upload or parsing issue on ESO Logs"
-                arrow
-              >
+              <Tooltip title={EMPTY_REPORT_TOOLTIP} arrow>
                 <Chip
                   label="Empty"
                   size="small"

--- a/src/features/latest_reports/components/ReportsEmptyState.tsx
+++ b/src/features/latest_reports/components/ReportsEmptyState.tsx
@@ -28,7 +28,10 @@ export function selectEmptyStateKind(input: EmptyStateInput): EmptyStateKind {
   if (searchActive && loadedCount > 0) return 'search-no-match';
   // The server returned nothing for the active zone/date filter.
   if (serverFilterActive && loadedCount === 0) return 'filter-no-results';
-  // Every row on this page was an empty (no-combat) log.
+  // Every row on this page was an empty (no-combat) log. Kept as defense-in-depth:
+  // `useLatestReportsQuery` now fails open (`selectReportsForDisplay`) and shows
+  // the reports instead of hiding the whole page, so this branch is no longer
+  // reachable from that surface — do NOT "simplify" the hook to re-arm the wall.
   if (loadedCount === 0 && hiddenEmptyCount > 0) return 'all-hidden';
   return 'cold-empty';
 }

--- a/src/features/latest_reports/components/ReportsResultsMeta.tsx
+++ b/src/features/latest_reports/components/ReportsResultsMeta.tsx
@@ -51,7 +51,7 @@ export const ReportsResultsMeta: React.FC<ReportsResultsMetaProps> = ({
         )}
         {hiddenEmptyCount > 0 && (
           <Tooltip
-            title="Logs with no combat data — usually caused by an upload or parsing issue on ESO Logs — are hidden from this list because there is nothing to view"
+            title="Logs with no combat data yet — still processing on ESO Logs, or with a parsing issue — are hidden from this list because there is nothing to view"
             arrow
           >
             <Typography

--- a/src/features/latest_reports/components/ReportsTable.test.tsx
+++ b/src/features/latest_reports/components/ReportsTable.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { UserReportSummaryFragment } from '../../../graphql/gql/graphql';
+
+import { ReportsTable } from './ReportsTable';
+
+const report: UserReportSummaryFragment = {
+  __typename: 'Report',
+  code: 'XYZ123',
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  title: 'Rockgrove HM',
+  visibility: 'public',
+  segments: 3,
+  zone: { __typename: 'Zone', id: 1, name: 'Rockgrove' },
+  owner: { __typename: 'User', name: 'Alice' },
+};
+
+const emptyReport: UserReportSummaryFragment = {
+  ...report,
+  code: 'EMPTY1',
+  title: 'Still Processing',
+  segments: 0,
+  endTime: report.startTime,
+};
+
+describe('ReportsTable', () => {
+  it('renders each report as a keyboard-operable link row', () => {
+    const onSelect = jest.fn();
+    render(<ReportsTable reports={[report]} onSelect={onSelect} />);
+    const row = screen.getByRole('link', { name: /Rockgrove HM, Rockgrove\. View report\./i });
+    expect(row).toHaveAttribute('tabindex', '0');
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith('XYZ123', expect.anything());
+  });
+
+  it('flags an empty (no-combat) row with an "Empty" badge', () => {
+    // Parity with ReportCard's badge: now that the list fails open and shows
+    // whole pages of still-processing logs (instead of a dead-end wall), the
+    // default desktop table view must forewarn the user before they open one.
+    const onSelect = jest.fn();
+    render(<ReportsTable reports={[emptyReport]} onSelect={onSelect} />);
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+
+  it('does not flag a normal report', () => {
+    const onSelect = jest.fn();
+    render(<ReportsTable reports={[report]} onSelect={onSelect} />);
+    expect(screen.queryByText('Empty')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/latest_reports/components/ReportsTable.tsx
+++ b/src/features/latest_reports/components/ReportsTable.tsx
@@ -8,6 +8,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -15,9 +16,11 @@ import React from 'react';
 
 import type { UserReportSummaryFragment } from '../../../graphql/gql/graphql';
 import {
+  EMPTY_REPORT_TOOLTIP,
   formatReportDateTime,
   formatReportDuration,
   getReportVisibilityColor,
+  isReportEmpty,
 } from '../../reports/reportFormatting';
 
 interface ReportsTableProps {
@@ -48,6 +51,11 @@ export const ReportsTable: React.FC<ReportsTableProps> = ({ reports, onSelect })
           {reports.map((report) => {
             const title = report.title || 'Untitled Report';
             const zoneName = report.zone?.name || 'Unknown Zone';
+            // Flag no-combat logs so the (default) table view forewarns the user
+            // before they open one — matching the card view's "Empty" badge.
+            // Load-bearing now that the list fails open and shows whole pages of
+            // still-processing logs instead of hiding them.
+            const empty = isReportEmpty(report);
             return (
               <TableRow
                 key={report.code}
@@ -95,22 +103,35 @@ export const ReportsTable: React.FC<ReportsTableProps> = ({ reports, onSelect })
               >
                 <TableCell sx={{ verticalAlign: 'top', whiteSpace: 'normal' }}>
                   <Box>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: 'primary.main',
-                        fontWeight: 'medium',
-                        overflowWrap: 'anywhere',
-                        wordBreak: 'break-word',
-                        lineHeight: 1.4,
-                        display: '-webkit-box',
-                        WebkitLineClamp: 2,
-                        WebkitBoxOrient: 'vertical',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      {title}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: 'primary.main',
+                          fontWeight: 'medium',
+                          overflowWrap: 'anywhere',
+                          wordBreak: 'break-word',
+                          lineHeight: 1.4,
+                          display: '-webkit-box',
+                          WebkitLineClamp: 2,
+                          WebkitBoxOrient: 'vertical',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        {title}
+                      </Typography>
+                      {empty && (
+                        <Tooltip title={EMPTY_REPORT_TOOLTIP} arrow>
+                          <Chip
+                            label="Empty"
+                            size="small"
+                            color="warning"
+                            variant="outlined"
+                            sx={{ flexShrink: 0, fontSize: '0.65rem', height: 18, mt: 0.25 }}
+                          />
+                        </Tooltip>
+                      )}
+                    </Box>
                     <Typography
                       variant="caption"
                       sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -7,7 +7,7 @@ import {
   GetLatestReportsQueryVariables,
   UserReportSummaryFragment,
 } from '../../../graphql/gql/graphql';
-import { partitionReportsByData } from '../../reports/reportFormatting';
+import { selectReportsForDisplay } from '../../reports/reportFormatting';
 
 import { rangeToEpochMs, type DateRangePreset } from './rangeToEpochMs';
 
@@ -113,7 +113,11 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
       const fetched = (reportPagination.data ?? []).filter(
         (report): report is NonNullable<typeof report> => report !== null,
       );
-      const { reportsWithData, emptyCount } = partitionReportsByData(fetched);
+      // Hide empty (no-combat) logs, but never the whole page: if every report
+      // the server returned would be hidden — e.g. a busy upload window where the
+      // freshest page is dominated by still-parsing logs — fail open and show
+      // them all so the user is never stranded on an "every report is empty" wall.
+      const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
 
       const currentPage = reportPagination.current_page || 1;
       const lastPage = reportPagination.last_page;
@@ -121,8 +125,8 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
       const totalPages = lastPage > 0 ? lastPage : hasMorePages ? currentPage + 1 : currentPage;
 
       setState({
-        reports: reportsWithData,
-        hiddenEmptyCount: emptyCount,
+        reports: reportsToShow,
+        hiddenEmptyCount,
         loading: false,
         error: null,
         pagination: {

--- a/src/features/profile_logs/ProfileLogsPanel.tsx
+++ b/src/features/profile_logs/ProfileLogsPanel.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 
 import { useViewTransitionNavigate } from '../../hooks/useViewTransitionNavigate';
 import {
+  EMPTY_REPORT_TOOLTIP,
   formatReportDateTime,
   formatReportDuration,
   isReportEmpty,
@@ -186,10 +187,7 @@ const LogRow: React.FC<{ report: ProfileReportSummary }> = ({ report }) => {
             {title}
           </Typography>
           {isReportEmpty(report) && (
-            <Tooltip
-              title="This log contains no combat data, likely due to an upload or parsing issue on ESO Logs"
-              arrow
-            >
+            <Tooltip title={EMPTY_REPORT_TOOLTIP} arrow>
               {/* Re-enable pointer events (the parent disables them for the
                   full-bleed row button) so the tooltip is reachable. */}
               <Chip

--- a/src/features/reports/components/ReportListMobile.tsx
+++ b/src/features/reports/components/ReportListMobile.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import type { UserReportSummaryFragment } from '../../../graphql/gql/graphql';
 import {
+  EMPTY_REPORT_TOOLTIP,
   formatReportDateTime,
   formatReportDuration,
   getReportVisibilityColor,
@@ -77,10 +78,7 @@ export const ReportListMobile: React.FC<ReportListMobileProps> = ({
                   {report.title || 'Untitled Report'}
                 </Typography>
                 {isReportEmpty(report) && (
-                  <Tooltip
-                    title="This log may contain no fight data due to an upload or parsing issue on ESO Logs"
-                    arrow
-                  >
+                  <Tooltip title={EMPTY_REPORT_TOOLTIP} arrow>
                     <Chip
                       label="Empty Log"
                       size="small"

--- a/src/features/reports/reportFormatting.test.ts
+++ b/src/features/reports/reportFormatting.test.ts
@@ -1,4 +1,4 @@
-import { isReportEmpty, partitionReportsByData } from './reportFormatting';
+import { isReportEmpty, partitionReportsByData, selectReportsForDisplay } from './reportFormatting';
 
 const baseReport = {
   startTime: 1_700_000_000_000,
@@ -100,5 +100,64 @@ describe('partitionReportsByData', () => {
 
   it('handles an empty list', () => {
     expect(partitionReportsByData([])).toEqual({ reportsWithData: [], emptyCount: 0 });
+  });
+});
+
+describe('selectReportsForDisplay', () => {
+  it('hides empty logs but keeps the reports that have data, counting the hidden ones', () => {
+    const healthy = { ...baseReport, code: 'A' };
+    const inProgress = { ...baseReport, code: 'B', segments: 0, endTime: baseReport.startTime };
+    const brokenSlipThrough = { ...baseReport, code: 'C', fights: [] };
+
+    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay([
+      healthy,
+      inProgress,
+      brokenSlipThrough,
+    ]);
+
+    expect(reportsToShow).toEqual([healthy]);
+    expect(hiddenEmptyCount).toBe(2);
+  });
+
+  it('fails open and shows every report when the whole page would be hidden', () => {
+    // The real-world dead-end: during a busy upload window the freshest page is
+    // dominated by just-uploaded logs that have not parsed fights yet
+    // (segments: 0, fights: []). Hiding all of them would strand the user on an
+    // "every report on this page is empty" wall, so we show them instead.
+    const stillParsing = [
+      { ...baseReport, code: 'A', segments: 0, endTime: baseReport.startTime, fights: [] },
+      { ...baseReport, code: 'B', segments: 0, endTime: baseReport.startTime, fights: [] },
+      { ...baseReport, code: 'C', segments: 0, endTime: baseReport.startTime, fights: [] },
+    ];
+
+    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(stillParsing);
+
+    expect(reportsToShow).toEqual(stillParsing);
+    expect(hiddenEmptyCount).toBe(0);
+  });
+
+  it('fails open for a single empty report rather than showing nothing', () => {
+    const onlyEmpty = [{ ...baseReport, code: 'A', fights: [] }];
+    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(onlyEmpty);
+    expect(reportsToShow).toEqual(onlyEmpty);
+    expect(hiddenEmptyCount).toBe(0);
+  });
+
+  it('returns nothing (not a fail-open) when the server returned no reports at all', () => {
+    // An empty input is a genuine "no results" — there is nothing to fail open
+    // to, so we must not fabricate rows. The page shows its cold/filter empty
+    // state, never the "all hidden" wall.
+    expect(selectReportsForDisplay([])).toEqual({ reportsToShow: [], hiddenEmptyCount: 0 });
+  });
+
+  it('leaves a fully healthy page untouched', () => {
+    const reports = [
+      { ...baseReport, code: 'A' },
+      { ...baseReport, code: 'B' },
+    ];
+    expect(selectReportsForDisplay(reports)).toEqual({
+      reportsToShow: reports,
+      hiddenEmptyCount: 0,
+    });
   });
 });

--- a/src/features/reports/reportFormatting.ts
+++ b/src/features/reports/reportFormatting.ts
@@ -99,6 +99,15 @@ export interface ReportEmptinessFields {
   fights?: ReadonlyArray<unknown> | null;
 }
 
+/**
+ * Shared tooltip copy for the per-report "Empty" badge (card + table views).
+ * Leads with the common, self-healing case — a just-uploaded log that ESO Logs
+ * has not finished parsing yet — rather than implying the upload failed, while
+ * still covering the rarer permanent parse failure.
+ */
+export const EMPTY_REPORT_TOOLTIP =
+  'No combat data yet — this log may still be processing on ESO Logs, or its fights failed to parse.';
+
 export const isReportEmpty = (report: ReportEmptinessFields): boolean => {
   // When the query selected fights, prefer that authoritative signal — but only
   // an empty list (resolver succeeded, zero fights) or a list with at least one
@@ -127,4 +136,36 @@ export const partitionReportsByData = <T extends ReportEmptinessFields>(
 ): { reportsWithData: T[]; emptyCount: number } => {
   const reportsWithData = reports.filter((report) => !isReportEmpty(report));
   return { reportsWithData, emptyCount: reports.length - reportsWithData.length };
+};
+
+/**
+ * Decides which loaded reports a public *browse* list should display while
+ * hiding empty (no-combat) logs — but WITHOUT ever blanking out the whole page.
+ *
+ * Hiding individual empty logs is correct when a page also carries real reports:
+ * it removes dead links that open to "No fights available". The failure mode is
+ * hiding *every* report on a page. During a busy upload window the freshest page
+ * can be dominated — or, at a peak, entirely composed — of just-uploaded logs
+ * that have not finished parsing yet (`segments: 0`, `fights: []`). Hiding all of
+ * them strands the user on a dead-end "every report on this page is empty" wall,
+ * even though those reports exist and self-heal within minutes as ESO Logs
+ * finishes parsing them. A *permanently* broken full page is statistically
+ * impossible — broken slip-throughs are well under 1% of logs — so an all-empty
+ * page is overwhelmingly a transient upload burst, not 25 genuinely dead logs.
+ *
+ * Therefore, when every loaded report would be hidden, fail OPEN and show them
+ * all (`hiddenEmptyCount: 0`). The reports stay individually openable and the
+ * list is never a dead end; the worst case is a recent log that opens to "No
+ * fights available" until it finishes parsing — strictly better than telling the
+ * user there is nothing here. This mirrors the fail-open fallback already used by
+ * `useLatestReport` (prefer a report with data, but never hide the only ones).
+ */
+export const selectReportsForDisplay = <T extends ReportEmptinessFields>(
+  reports: T[],
+): { reportsToShow: T[]; hiddenEmptyCount: number } => {
+  const { reportsWithData, emptyCount } = partitionReportsByData(reports);
+  if (reports.length > 0 && reportsWithData.length === 0) {
+    return { reportsToShow: reports, hiddenEmptyCount: 0 };
+  }
+  return { reportsToShow: reportsWithData, hiddenEmptyCount: emptyCount };
 };


### PR DESCRIPTION
## Problem

`/latest-reports` was showing **"Every report on this page is empty"** — a dead-end wall.

The data is healthy: probing the live ESO Logs proxy with the exact `getLatestReports` query the app sends shows ~24/25 reports on page 1 have fights. The "empty" reports are **recent, public, still-processing uploads** (`segments: 0`, `0s` duration, age 0.1–1.5h, `fights: []`) that self-heal within minutes once ESO Logs finishes parsing them.

Latest Reports hides empty/no-combat logs (so dead links don't surface). That's correct per-report — but during a busy raid/upload window the freshest page can be dominated, or briefly *entirely* composed, of these in-progress logs. The filter then hid **every** row → the wall, even though the reports exist and self-heal. (A *permanently* broken full page is statistically impossible — broken logs are <1% — so an all-empty page is always a transient burst.)

This is the only browse surface that *hides* empties; personal/profile lists only badge them, so they never dead-ended.

## Fix

- **`selectReportsForDisplay()`** (`reportFormatting.ts`): partition empties as before, but **if every loaded report would be hidden, fail open and show them all** (`hiddenEmptyCount: 0`). `useLatestReportsQuery` now uses it. This makes the wall *structurally unreachable* — `hiddenEmptyCount > 0` now implies `loadedCount > 0`, so the `all-hidden` empty-state branch can no longer fire from the hide-all surface (left in place with a "do not re-arm" comment as defense-in-depth). Mirrors the existing fail-open fallback in `useLatestReport.ts`.
- A 14-agent adversarial review (9/10 findings refuted) caught one real gap: the **desktop table view — the default — had no "Empty" badge** (only cards did), so failed-open in-progress logs looked normal. Added the badge to `ReportsTable` (+ test), and reworded the badge/hidden copy to lead with *"No combat data yet — still processing on ESO Logs…"* instead of implying an upload failure (shared `EMPTY_REPORT_TOOLTIP`, reused by card/table/profile/mobile).

## Verification

- tsc 0 · eslint 0 · prettier clean
- Full jest: **4229 passed / 17 skipped (313 suites)** — incl. new `selectReportsForDisplay` unit tests and `ReportsTable` badge test
- Root cause confirmed against live proxy data (browser ext was offline, so verified via proxy probe + unit/integration tests + adversarial review)

Frontend-only — the proxy is untouched, so no worker deploy is needed.