### PR TITLE
fix(hub): preload hub route chunks so lateral page transitions don't duplicate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,11 @@ import store, { persistor } from './store/storeWithHistory';
 import { initializeAnalytics } from './utils/analytics';
 import { getBaseUrl } from './utils/envUtils';
 import { initializeErrorTracking, addBreadcrumb } from './utils/errorTracking';
-import { importRosterHubPage, importBuildHubPage, importPackHubPage } from './utils/hubRoutePreload';
+import {
+  importRosterHubPage,
+  importBuildHubPage,
+  importPackHubPage,
+} from './utils/hubRoutePreload';
 // Initialize error tracking before the app starts
 initializeErrorTracking();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import store, { persistor } from './store/storeWithHistory';
 import { initializeAnalytics } from './utils/analytics';
 import { getBaseUrl } from './utils/envUtils';
 import { initializeErrorTracking, addBreadcrumb } from './utils/errorTracking';
+import { importRosterHubPage, importBuildHubPage, importPackHubPage } from './utils/hubRoutePreload';
 // Initialize error tracking before the app starts
 initializeErrorTracking();
 
@@ -182,7 +183,7 @@ const GearSetsPage = React.lazy(() =>
 );
 
 const RosterHubPage = React.lazy(() =>
-  import('./features/roster-hub/components/RosterHubPage').then((module) => ({
+  importRosterHubPage().then((module) => ({
     default: module.RosterHubPage,
   })),
 );
@@ -204,13 +205,13 @@ const TempBuildViewPage = React.lazy(() =>
 );
 
 const BuildHubPage = React.lazy(() =>
-  import('./features/build-hub/components/BuildHubPage').then((module) => ({
+  importBuildHubPage().then((module) => ({
     default: module.BuildHubPage,
   })),
 );
 
 const PackHubPage = React.lazy(() =>
-  import('./features/pack-hub/components/PackHubPage').then((module) => ({
+  importPackHubPage().then((module) => ({
     default: module.PackHubPage,
   })),
 );

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -43,6 +43,7 @@ import {
   useViewTransitionNavigate,
   type ViewTransitionType,
 } from '../hooks/useViewTransitionNavigate';
+import { preloadHubRoutes } from '../utils/hubRoutePreload';
 
 import { PerfTierToggle } from './PerfTierToggle';
 import { ThemeToggle } from './ThemeToggle';
@@ -523,6 +524,29 @@ export const HeaderBar: React.FC = () => {
     }
   }, [isLoggedIn, currentUser, userLoading, userError, refetchUser]);
 
+  // Warm the three hub route chunks (/roster-hub, /build-hub, /pack-hub) during
+  // idle time so the first lateral slide between them captures real destination
+  // content in its View Transition snapshot rather than a cold-chunk placeholder.
+  // Deferred to idle so it never competes with the page's own critical resources.
+  React.useEffect(() => {
+    const ric = (
+      window as unknown as {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+        cancelIdleCallback?: (handle: number) => void;
+      }
+    ).requestIdleCallback;
+    if (typeof ric === 'function') {
+      const handle = ric(() => preloadHubRoutes(), { timeout: 2500 });
+      return () => {
+        (
+          window as unknown as { cancelIdleCallback?: (handle: number) => void }
+        ).cancelIdleCallback?.(handle);
+      };
+    }
+    const timer = window.setTimeout(() => preloadHubRoutes(), 200);
+    return () => window.clearTimeout(timer);
+  }, []);
+
   const userLabel = React.useMemo(() => {
     if (userDisplayName) return userDisplayName;
     if (userLoading) return 'Loading…';
@@ -838,6 +862,11 @@ export const HeaderBar: React.FC = () => {
                 <Button
                   key={item.text}
                   color="inherit"
+                  // Warm the hub chunks the instant the user shows intent (hover or
+                  // keyboard focus) so even a click faster than the idle preload still
+                  // captures real content in the slide's View Transition snapshot.
+                  onPointerEnter={() => preloadHubRoutes()}
+                  onFocus={() => preloadHubRoutes()}
                   onClick={() =>
                     navigate(item.path, { vtType: getLateralTransitionType(item.path) })
                   }

--- a/src/utils/hubRoutePreload.test.ts
+++ b/src/utils/hubRoutePreload.test.ts
@@ -1,6 +1,6 @@
-// `preloadHubRoutes` keeps a module-level "already warmed" flag, so each test
-// loads a fresh copy of the module (resetMocks in jest.config.cjs only resets
-// mock state, not module singletons).
+// `preloadHubRoutes` keeps module-level state tracking which importers are
+// loading/loaded, so each test loads a fresh copy of the module (resetMocks in
+// jest.config.cjs only resets mock state, not module singletons).
 const loadFresh = (): typeof import('./hubRoutePreload').preloadHubRoutes => {
   let fn!: typeof import('./hubRoutePreload').preloadHubRoutes;
   jest.isolateModules(() => {
@@ -9,8 +9,13 @@ const loadFresh = (): typeof import('./hubRoutePreload').preloadHubRoutes => {
   return fn;
 };
 
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
 describe('preloadHubRoutes', () => {
-  it('fires every importer exactly once and is idempotent across calls', () => {
+  it('fires every importer once and skips ones already loaded', async () => {
     const preloadHubRoutes = loadFresh();
     const importers = [
       jest.fn().mockResolvedValue(undefined),
@@ -23,7 +28,8 @@ describe('preloadHubRoutes', () => {
       expect(imp).toHaveBeenCalledTimes(1);
     }
 
-    // Second call must be a no-op — the chunks are already warming.
+    // A second call must not re-fire importers that already resolved.
+    await flush();
     preloadHubRoutes(importers);
     for (const imp of importers) {
       expect(imp).toHaveBeenCalledTimes(1);
@@ -38,7 +44,25 @@ describe('preloadHubRoutes', () => {
     expect(failing).toHaveBeenCalledTimes(1);
 
     // Let the swallowed rejection settle so it never surfaces as unhandled.
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
+  });
+
+  it('retries an importer whose previous preload rejected', async () => {
+    // A transient background failure must not permanently poison warming: a later
+    // call (hover/focus/idle) should re-attempt the chunk.
+    const preloadHubRoutes = loadFresh();
+    let attempt = 0;
+    const flaky = jest.fn(() => {
+      attempt += 1;
+      return attempt === 1 ? Promise.reject(new Error('blip')) : Promise.resolve(undefined);
+    });
+
+    preloadHubRoutes([flaky]);
+    expect(flaky).toHaveBeenCalledTimes(1);
+
+    // After the rejection settles, the importer is cleared and can retry.
+    await flush();
+    preloadHubRoutes([flaky]);
+    expect(flaky).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/hubRoutePreload.test.ts
+++ b/src/utils/hubRoutePreload.test.ts
@@ -1,0 +1,44 @@
+// `preloadHubRoutes` keeps a module-level "already warmed" flag, so each test
+// loads a fresh copy of the module (resetMocks in jest.config.cjs only resets
+// mock state, not module singletons).
+const loadFresh = (): typeof import('./hubRoutePreload').preloadHubRoutes => {
+  let fn!: typeof import('./hubRoutePreload').preloadHubRoutes;
+  jest.isolateModules(() => {
+    fn = (require('./hubRoutePreload') as typeof import('./hubRoutePreload')).preloadHubRoutes;
+  });
+  return fn;
+};
+
+describe('preloadHubRoutes', () => {
+  it('fires every importer exactly once and is idempotent across calls', () => {
+    const preloadHubRoutes = loadFresh();
+    const importers = [
+      jest.fn().mockResolvedValue(undefined),
+      jest.fn().mockResolvedValue(undefined),
+      jest.fn().mockResolvedValue(undefined),
+    ];
+
+    preloadHubRoutes(importers);
+    for (const imp of importers) {
+      expect(imp).toHaveBeenCalledTimes(1);
+    }
+
+    // Second call must be a no-op — the chunks are already warming.
+    preloadHubRoutes(importers);
+    for (const imp of importers) {
+      expect(imp).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('does not throw or reject the caller when an importer fails', async () => {
+    const preloadHubRoutes = loadFresh();
+    const failing = jest.fn().mockRejectedValue(new Error('chunk load failed'));
+
+    expect(() => preloadHubRoutes([failing])).not.toThrow();
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    // Let the swallowed rejection settle so it never surfaces as unhandled.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/src/utils/hubRoutePreload.ts
+++ b/src/utils/hubRoutePreload.ts
@@ -1,0 +1,65 @@
+/**
+ * Hub route chunk preloading.
+ *
+ * The three "hub" pages — /roster-hub, /build-hub, /pack-hub — are peers in the
+ * top navigation and users frequently slide laterally between them. Each is a
+ * `React.lazy` code-split chunk.
+ *
+ * Why preload them: navigating to a hub whose chunk is still COLD breaks the
+ * native View Transition. react-router wraps navigation in `startTransition`, so
+ * while the lazy route suspends React keeps the *previous* page committed (the
+ * null Suspense fallback never paints). The View Transition therefore captures a
+ * non-destination "new" snapshot — effectively the page you just left — and the
+ * real content only commits after the transition has finished, so the slide looks
+ * like it plays against a duplicate of the old page and the destination then pops
+ * in. Once the chunk is warm React resolves it synchronously, the real content is
+ * captured in the snapshot, and the slide is clean — which is exactly why the
+ * glitch "goes away once triggered".
+ *
+ * Warming all three chunks shortly after the header mounts makes the first hop
+ * behave like a warm one, so the View Transition always captures real content.
+ *
+ * These importers are the SINGLE SOURCE OF TRUTH for the hub route chunks:
+ * `App.tsx` builds its `React.lazy` routes from the same functions, so preloading
+ * warms the exact chunk the route will later load (no path drift, guaranteed
+ * chunk identity).
+ */
+
+export const importRosterHubPage = (): Promise<typeof import('../features/roster-hub/components/RosterHubPage')> =>
+  import('../features/roster-hub/components/RosterHubPage');
+
+export const importBuildHubPage = (): Promise<typeof import('../features/build-hub/components/BuildHubPage')> =>
+  import('../features/build-hub/components/BuildHubPage');
+
+export const importPackHubPage = (): Promise<typeof import('../features/pack-hub/components/PackHubPage')> =>
+  import('../features/pack-hub/components/PackHubPage');
+
+const hubRouteImporters: ReadonlyArray<() => Promise<unknown>> = [
+  importRosterHubPage,
+  importBuildHubPage,
+  importPackHubPage,
+];
+
+let warmed = false;
+
+/**
+ * Warm the three hub route chunks so a subsequent hub navigation captures real
+ * destination content in its View Transition snapshot.
+ *
+ * Idempotent — only the first call triggers the imports; later calls are no-ops,
+ * so it is safe to invoke on every header mount. Import rejections are swallowed:
+ * a failed *preload* must never surface as an unhandled rejection — the route's
+ * own Suspense boundary and ErrorBoundary handle a genuine load failure when (and
+ * if) the user actually navigates there.
+ *
+ * @param importers Injectable for tests; defaults to the real hub route chunks.
+ */
+export function preloadHubRoutes(
+  importers: ReadonlyArray<() => Promise<unknown>> = hubRouteImporters,
+): void {
+  if (warmed) return;
+  warmed = true;
+  for (const load of importers) {
+    void load().catch(() => {});
+  }
+}

--- a/src/utils/hubRoutePreload.ts
+++ b/src/utils/hubRoutePreload.ts
@@ -40,26 +40,34 @@ const hubRouteImporters: ReadonlyArray<() => Promise<unknown>> = [
   importPackHubPage,
 ];
 
-let warmed = false;
+// Importers that are currently loading or have already loaded successfully.
+// Repeated calls skip these so we never re-fire a healthy preload. A REJECTED
+// preload is removed again (in the .catch) so a later call can retry: a transient
+// background failure (e.g. an idle preload during a network blip) must not
+// permanently poison hub warming and leave hover/focus/idle unable to re-warm.
+const warming = new Set<() => Promise<unknown>>();
 
 /**
  * Warm the three hub route chunks so a subsequent hub navigation captures real
  * destination content in its View Transition snapshot.
  *
- * Idempotent — only the first call triggers the imports; later calls are no-ops,
- * so it is safe to invoke on every header mount. Import rejections are swallowed:
- * a failed *preload* must never surface as an unhandled rejection — the route's
- * own Suspense boundary and ErrorBoundary handle a genuine load failure when (and
- * if) the user actually navigates there.
+ * Safe to invoke repeatedly (every header mount, plus hover/focus): an importer
+ * already loading or loaded is skipped, but one whose previous attempt rejected is
+ * retried. Import rejections are swallowed — a failed *preload* must never surface
+ * as an unhandled rejection; the route's own Suspense boundary and ErrorBoundary
+ * handle a genuine load failure if and when the user actually navigates there.
  *
  * @param importers Injectable for tests; defaults to the real hub route chunks.
  */
 export function preloadHubRoutes(
   importers: ReadonlyArray<() => Promise<unknown>> = hubRouteImporters,
 ): void {
-  if (warmed) return;
-  warmed = true;
   for (const load of importers) {
-    void load().catch(() => {});
+    if (warming.has(load)) continue;
+    warming.add(load);
+    void load().catch(() => {
+      // Transient failure — allow a later call (hover/focus/idle) to retry.
+      warming.delete(load);
+    });
   }
 }

--- a/src/utils/hubRoutePreload.ts
+++ b/src/utils/hubRoutePreload.ts
@@ -25,14 +25,17 @@
  * chunk identity).
  */
 
-export const importRosterHubPage = (): Promise<typeof import('../features/roster-hub/components/RosterHubPage')> =>
-  import('../features/roster-hub/components/RosterHubPage');
+export const importRosterHubPage = (): Promise<
+  typeof import('../features/roster-hub/components/RosterHubPage')
+> => import('../features/roster-hub/components/RosterHubPage');
 
-export const importBuildHubPage = (): Promise<typeof import('../features/build-hub/components/BuildHubPage')> =>
-  import('../features/build-hub/components/BuildHubPage');
+export const importBuildHubPage = (): Promise<
+  typeof import('../features/build-hub/components/BuildHubPage')
+> => import('../features/build-hub/components/BuildHubPage');
 
-export const importPackHubPage = (): Promise<typeof import('../features/pack-hub/components/PackHubPage')> =>
-  import('../features/pack-hub/components/PackHubPage');
+export const importPackHubPage = (): Promise<
+  typeof import('../features/pack-hub/components/PackHubPage')
+> => import('../features/pack-hub/components/PackHubPage');
 
 const hubRouteImporters: ReadonlyArray<() => Promise<unknown>> = [
   importRosterHubPage,


### PR DESCRIPTION
## Summary

Fixes the page-transition glitch when sliding between the three hub pages (**Roster Hub**, **Build Hub**, **Pack Hub**): on the **first** hop the page appeared to duplicate — the slide played a copy of the page you just left and the real content popped in afterward — then it was clean on every subsequent hop ("goes away once triggered").

### Root cause

Each hub is a `React.lazy` code-split chunk. On a **cold** first hop, react-router v7 wraps `navigate()` in `React.startTransition`, so React 19 keeps the **previous** page committed while the destination chunk loads (the null Suspense fallback never paints). `useViewTransitionNavigate`'s `waitForDomCommit` resolves for a non-morph slide on the first commit / 50 ms — before the real content mounts — so the native View Transition captures the **still-mounted old page** as its "new" snapshot. The slide animates old→old, and the destination renders only after the transition finishes. Once the chunk is warm React resolves it synchronously, the snapshot captures real content, and the slide is clean. This is the same cold-chunk class the *morph* path was hardened against earlier (`ac568066`), but lateral slides never used morphs, so they were uncovered.

### The fix

Warm the three hub chunks so the first hop behaves like a warm one — no change to the shared View Transition timing logic:

- `src/utils/hubRoutePreload.ts` — idempotent `preloadHubRoutes()` plus the three import thunks. `App.tsx` now builds its `React.lazy` hub routes from the **same** thunks, so preloading warms the exact chunk the route loads (guaranteed chunk identity; build confirms the three chunks still split).
- `HeaderBar` warms during `requestIdleCallback` on mount, and on `pointerenter`/`focus` of the nav buttons (closes the sub-idle first-click race).

### Verification

- `tsc` clean, `eslint` clean, `jest` green (new `hubRoutePreload.test.ts` + HeaderBar + useViewTransitionNavigate suites), `vite build` green with code-splitting intact.
- Live-verified in a production preview by instrumenting `document.startViewTransition` to record what each transition snapshots: the idle preload loaded all three hub chunks before any interaction, and every hop (forward + two slide-left + slide-right) captured the **real destination** content. The same `roster → build` slide in dev captured the old page, confirming the diagnosis (dev serves a lazy route as hundreds of sequential module fetches, so preload can't warm in time — a dev-only timing artifact).

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`