### PR TITLE
fix(reports): make Latest Reports / My Reports refresh reflect healed empty logs

### DIFF
--- a/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { useLatestReportsQuery, type LatestReportsQueryInput } from './useLatestReportsQuery';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+// useLatestReportsQuery reads the client via useEsoLogsClientInstance (returns
+// the client directly, unlike the profile hook's { client, isReady } context).
+
+const mockClient = { query: jest.fn() };
+
+jest.mock('../../../EsoLogsClientContext', () => ({
+  useEsoLogsClientInstance: () => mockClient,
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const START = 1_700_000_000_000;
+
+const makeReport = (code: string, { empty = false }: { empty?: boolean } = {}) => ({
+  code,
+  title: `Report ${code}`,
+  startTime: START,
+  // An empty (still-processing) log has zero duration and no parsed fights.
+  endTime: empty ? START : START + 360_000,
+  visibility: 'public',
+  segments: empty ? 0 : 3,
+  fights: empty ? [] : [{ id: 1 }],
+  zone: { id: 1, name: 'Rockgrove' },
+  owner: { name: 'Tester' },
+});
+
+const pageResult = (
+  reports: ReturnType<typeof makeReport>[],
+  opts: { hasMore?: boolean } = {},
+) => ({
+  reportData: {
+    reports: {
+      data: reports,
+      total: reports.length,
+      from: 1,
+      to: reports.length,
+      current_page: 1,
+      per_page: 25,
+      last_page: opts.hasMore ? 2 : 1,
+      has_more_pages: opts.hasMore ?? false,
+    },
+  },
+});
+
+const baseInput: LatestReportsQueryInput = {
+  page: 1,
+  zoneId: null,
+  range: 'all',
+  customFrom: null,
+  customTo: null,
+};
+
+beforeEach(() => {
+  mockClient.query.mockReset();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useLatestReportsQuery', () => {
+  it('fetches with fetchPolicy network-only so Refresh / re-navigation never re-serves cached empties', async () => {
+    mockClient.query.mockResolvedValueOnce(pageResult([makeReport('AAA')]));
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    // The fix: without network-only the cache-first default would re-serve the
+    // session-long cached snapshot (stale still-processing empties) on Refresh.
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.objectContaining({ fetchPolicy: 'network-only', errorPolicy: 'all' }),
+    );
+    expect(result.current.reports.map((r) => r.code)).toEqual(['AAA']);
+  });
+
+  it('hides empty logs on a mixed page (but reports how many were hidden)', async () => {
+    mockClient.query.mockResolvedValueOnce(
+      pageResult([makeReport('REAL'), makeReport('EMPTY', { empty: true })]),
+    );
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.reports.map((r) => r.code)).toEqual(['REAL']);
+    expect(result.current.hiddenEmptyCount).toBe(1);
+  });
+
+  it('fails open and shows them all when the whole page is empty (never a dead-end wall)', async () => {
+    mockClient.query.mockResolvedValueOnce(
+      pageResult([makeReport('E1', { empty: true }), makeReport('E2', { empty: true })]),
+    );
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.reports.map((r) => r.code)).toEqual(['E1', 'E2']);
+    expect(result.current.hiddenEmptyCount).toBe(0);
+  });
+
+  it('refetch re-hits the network (so an explicit Refresh actually replaces healed empties)', async () => {
+    mockClient.query
+      // First load: an all-empty page is shown via fail-open.
+      .mockResolvedValueOnce(pageResult([makeReport('PENDING', { empty: true })]))
+      // After the log finishes parsing upstream, a forced refetch returns it healed.
+      .mockResolvedValueOnce(pageResult([makeReport('HEALED')]));
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.reports.map((r) => r.code)).toEqual(['PENDING']);
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(result.current.reports.map((r) => r.code)).toEqual(['HEALED']));
+
+    expect(mockClient.query).toHaveBeenCalledTimes(2);
+    expect(mockClient.query).toHaveBeenLastCalledWith(
+      expect.objectContaining({ fetchPolicy: 'network-only' }),
+    );
+  });
+});

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
@@ -30,10 +30,7 @@ const makeReport = (code: string, { empty = false }: { empty?: boolean } = {}) =
   owner: { name: 'Tester' },
 });
 
-const pageResult = (
-  reports: ReturnType<typeof makeReport>[],
-  opts: { hasMore?: boolean } = {},
-) => ({
+const pageResult = (reports: ReturnType<typeof makeReport>[]) => ({
   reportData: {
     reports: {
       data: reports,
@@ -42,11 +39,14 @@ const pageResult = (
       to: reports.length,
       current_page: 1,
       per_page: 25,
-      last_page: opts.hasMore ? 2 : 1,
-      has_more_pages: opts.hasMore ?? false,
+      last_page: 1,
+      has_more_pages: false,
     },
   },
 });
+
+// A cache-only read with nothing usable cached (cold cache).
+const EMPTY_CACHE = { reportData: { reports: null } };
 
 const baseInput: LatestReportsQueryInput = {
   page: 1,
@@ -56,6 +56,26 @@ const baseInput: LatestReportsQueryInput = {
   customTo: null,
 };
 
+/**
+ * Route mocked client.query calls by fetchPolicy: cache-only reads drain
+ * `cache`, network-only reads drain `network`. This mirrors the hand-composed
+ * cache-and-network in the hook (a cache-only peek followed by a network-only
+ * revalidation).
+ */
+function primeClient(opts: { cache?: unknown[]; network?: unknown[] }) {
+  const cache = [...(opts.cache ?? [])];
+  const network = [...(opts.network ?? [])];
+  mockClient.query.mockImplementation((params: { fetchPolicy?: string }) => {
+    if (params.fetchPolicy === 'cache-only') {
+      return Promise.resolve(cache.shift() ?? EMPTY_CACHE);
+    }
+    return Promise.resolve(network.shift() ?? pageResult([]));
+  });
+}
+
+const fetchPolicies = () =>
+  mockClient.query.mock.calls.map((c) => (c[0] as { fetchPolicy?: string }).fetchPolicy);
+
 beforeEach(() => {
   mockClient.query.mockReset();
 });
@@ -63,26 +83,37 @@ beforeEach(() => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('useLatestReportsQuery', () => {
-  it('uses cache-first on mount (cheap on API points, resilient re-navigation)', async () => {
-    mockClient.query.mockResolvedValueOnce(pageResult([makeReport('AAA')]));
+  it('does cache-and-network on mount: a cache-only peek, then a network-only revalidation', async () => {
+    // Cache holds a stale snapshot; the network returns the healed page.
+    primeClient({
+      cache: [pageResult([makeReport('STALE', { empty: true })])],
+      network: [pageResult([makeReport('FRESH')])],
+    });
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockClient.query).toHaveBeenCalledTimes(1);
-    // Ordinary loads reuse the cache; only an explicit Refresh forces the network
-    // (asserted below). Page/filter changes vary the variables, so they miss the
-    // cache and hit the network without needing network-only.
-    expect(mockClient.query).toHaveBeenCalledWith(
-      expect.objectContaining({ fetchPolicy: 'cache-first', errorPolicy: 'all' }),
-    );
+    // Two reads: peek the cache (no network), then revalidate from the network.
+    expect(fetchPolicies()).toEqual(['cache-only', 'network-only']);
+    // The network result wins — a healed log never stays stale across a re-visit.
+    expect(result.current.reports.map((r) => r.code)).toEqual(['FRESH']);
+    expect(result.current.hiddenEmptyCount).toBe(0);
+  });
+
+  it('falls back to the network read when nothing is cached (cold cache)', async () => {
+    primeClient({ network: [pageResult([makeReport('AAA')])] });
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchPolicies()).toEqual(['cache-only', 'network-only']);
     expect(result.current.reports.map((r) => r.code)).toEqual(['AAA']);
   });
 
   it('hides empty logs on a mixed page (but reports how many were hidden)', async () => {
-    mockClient.query.mockResolvedValueOnce(
-      pageResult([makeReport('REAL'), makeReport('EMPTY', { empty: true })]),
-    );
+    primeClient({
+      network: [pageResult([makeReport('REAL'), makeReport('EMPTY', { empty: true })])],
+    });
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -92,9 +123,9 @@ describe('useLatestReportsQuery', () => {
   });
 
   it('fails open and shows them all when the whole page is empty (never a dead-end wall)', async () => {
-    mockClient.query.mockResolvedValueOnce(
-      pageResult([makeReport('E1', { empty: true }), makeReport('E2', { empty: true })]),
-    );
+    primeClient({
+      network: [pageResult([makeReport('E1', { empty: true }), makeReport('E2', { empty: true })])],
+    });
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -103,30 +134,26 @@ describe('useLatestReportsQuery', () => {
     expect(result.current.hiddenEmptyCount).toBe(0);
   });
 
-  it('refetch (explicit Refresh) forces network-only to replace healed empties; mount stays cache-first', async () => {
-    mockClient.query
-      // First load: an all-empty page is shown via fail-open.
-      .mockResolvedValueOnce(pageResult([makeReport('PENDING', { empty: true })]))
-      // After the log finishes parsing upstream, a forced refetch returns it healed.
-      .mockResolvedValueOnce(pageResult([makeReport('HEALED')]));
+  it('refetch (explicit Refresh) revalidates network-only and skips the cache peek', async () => {
+    primeClient({
+      // Mount: cold cache, network shows the still-processing page (fail-open).
+      network: [
+        pageResult([makeReport('PENDING', { empty: true })]),
+        // Refresh: the log has since healed upstream.
+        pageResult([makeReport('HEALED')]),
+      ],
+    });
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.reports.map((r) => r.code)).toEqual(['PENDING']);
-    // Mount read through the cache.
-    expect(mockClient.query).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ fetchPolicy: 'cache-first' }),
-    );
+    // Mount = cache peek + network revalidate.
+    expect(fetchPolicies()).toEqual(['cache-only', 'network-only']);
 
     act(() => result.current.refetch());
     await waitFor(() => expect(result.current.reports.map((r) => r.code)).toEqual(['HEALED']));
 
-    expect(mockClient.query).toHaveBeenCalledTimes(2);
-    // Refresh bypassed the cache.
-    expect(mockClient.query).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ fetchPolicy: 'network-only' }),
-    );
+    // Refresh added exactly one network-only read, with no extra cache peek.
+    expect(fetchPolicies()).toEqual(['cache-only', 'network-only', 'network-only']);
   });
 });

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
@@ -156,4 +156,41 @@ describe('useLatestReportsQuery', () => {
     // Refresh added exactly one network-only read, with no extra cache peek.
     expect(fetchPolicies()).toEqual(['cache-only', 'network-only', 'network-only']);
   });
+
+  it('ignores a superseded in-flight load when page/filter changes (out-of-order responses)', async () => {
+    // Page 1's network read resolves LATE; page 2's resolves immediately.
+    let resolvePage1Network: (v: unknown) => void = () => {};
+    const page1Network = new Promise((res) => {
+      resolvePage1Network = res;
+    });
+
+    mockClient.query.mockImplementation(
+      (params: { fetchPolicy?: string; variables?: { page?: number } }) => {
+        if (params.fetchPolicy === 'cache-only') return Promise.resolve(EMPTY_CACHE);
+        return params.variables?.page === 1
+          ? page1Network
+          : Promise.resolve(pageResult([makeReport('PAGE2')]));
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      (props: LatestReportsQueryInput) => useLatestReportsQuery(props),
+      {
+        initialProps: { ...baseInput, page: 1 },
+      },
+    );
+
+    // Switch to page 2 before page 1's network resolves.
+    rerender({ ...baseInput, page: 2 });
+    await waitFor(() => expect(result.current.reports.map((r) => r.code)).toEqual(['PAGE2']));
+
+    // Resolve page 1 late — the superseded response must be dropped, not applied.
+    resolvePage1Network(pageResult([makeReport('PAGE1-STALE')]));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.reports.map((r) => r.code)).toEqual(['PAGE2']);
+  });
 });

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
@@ -63,17 +63,18 @@ beforeEach(() => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('useLatestReportsQuery', () => {
-  it('fetches with fetchPolicy network-only so Refresh / re-navigation never re-serves cached empties', async () => {
+  it('uses cache-first on mount (cheap on API points, resilient re-navigation)', async () => {
     mockClient.query.mockResolvedValueOnce(pageResult([makeReport('AAA')]));
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(mockClient.query).toHaveBeenCalledTimes(1);
-    // The fix: without network-only the cache-first default would re-serve the
-    // session-long cached snapshot (stale still-processing empties) on Refresh.
+    // Ordinary loads reuse the cache; only an explicit Refresh forces the network
+    // (asserted below). Page/filter changes vary the variables, so they miss the
+    // cache and hit the network without needing network-only.
     expect(mockClient.query).toHaveBeenCalledWith(
-      expect.objectContaining({ fetchPolicy: 'network-only', errorPolicy: 'all' }),
+      expect.objectContaining({ fetchPolicy: 'cache-first', errorPolicy: 'all' }),
     );
     expect(result.current.reports.map((r) => r.code)).toEqual(['AAA']);
   });
@@ -102,7 +103,7 @@ describe('useLatestReportsQuery', () => {
     expect(result.current.hiddenEmptyCount).toBe(0);
   });
 
-  it('refetch re-hits the network (so an explicit Refresh actually replaces healed empties)', async () => {
+  it('refetch (explicit Refresh) forces network-only to replace healed empties; mount stays cache-first', async () => {
     mockClient.query
       // First load: an all-empty page is shown via fail-open.
       .mockResolvedValueOnce(pageResult([makeReport('PENDING', { empty: true })]))
@@ -112,12 +113,19 @@ describe('useLatestReportsQuery', () => {
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.reports.map((r) => r.code)).toEqual(['PENDING']);
+    // Mount read through the cache.
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fetchPolicy: 'cache-first' }),
+    );
 
     act(() => result.current.refetch());
     await waitFor(() => expect(result.current.reports.map((r) => r.code)).toEqual(['HEALED']));
 
     expect(mockClient.query).toHaveBeenCalledTimes(2);
-    expect(mockClient.query).toHaveBeenLastCalledWith(
+    // Refresh bypassed the cache.
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({ fetchPolicy: 'network-only' }),
     );
   });

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useEsoLogsClientInstance } from '../../../EsoLogsClientContext';
 import {
@@ -85,6 +85,11 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
 
   const { page, zoneId, range, customFrom, customTo } = input;
 
+  // Identifies the latest fetch so a slower, superseded request (e.g. the page or
+  // filters changed mid-flight) can't overwrite newer state — including the
+  // two-step cache-only + network-only sequence below. Mirrors useLatestReport.
+  const requestIdRef = useRef(0);
+
   // Map a GetLatestReports response into hook state. Returns false when the
   // payload carried no reports pagination — an empty cache-only read, or a
   // degraded response — so the caller can decide whether that is an error
@@ -133,6 +138,7 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
 
   const fetchReports = useCallback(
     async (skipCachePeek = false): Promise<void> => {
+      const requestId = ++requestIdRef.current;
       setState((prev) => ({ ...prev, loading: true, error: null }));
 
       const variables = buildVariables({ page, zoneId, range, customFrom, customTo });
@@ -158,7 +164,10 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
               errorPolicy: 'all',
               fetchPolicy: 'cache-only',
             });
-            applyReportData(cached, true); // keep loading: true; the network result follows
+            // Drop the peek if a newer load has superseded this one.
+            if (requestId === requestIdRef.current) {
+              applyReportData(cached, true); // keep loading: true; the network result follows
+            }
           } catch {
             // Nothing usable in the cache yet — fall through to the network read.
           }
@@ -170,6 +179,7 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
           errorPolicy: 'all',
           fetchPolicy: 'network-only',
         });
+        if (requestId !== requestIdRef.current) return; // superseded by a newer load
         if (!applyReportData(fresh, false)) {
           setState((prev) => ({
             ...prev,
@@ -179,6 +189,7 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
           }));
         }
       } catch (error) {
+        if (requestId !== requestIdRef.current) return; // superseded by a newer load
         // Keep whatever is already shown (e.g. the cache peek) and surface the
         // error rather than blanking the list.
         setState((prev) => ({

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -85,82 +85,95 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
 
   const { page, zoneId, range, customFrom, customTo } = input;
 
-  const fetchReports = useCallback(async (): Promise<void> => {
-    setState((prev) => ({ ...prev, loading: true, error: null }));
+  const fetchReports = useCallback(
+    async (fetchPolicy: 'cache-first' | 'network-only' = 'cache-first'): Promise<void> => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
 
-    try {
-      const variables = buildVariables({ page, zoneId, range, customFrom, customTo });
-      const result = await client.query<GetLatestReportsQuery>({
-        query: GetLatestReportsDocument,
-        variables,
-        errorPolicy: 'all',
-        // Always hit the network. The Apollo client defaults to cache-first and
-        // the session-long singleton cache persists across mounts, so without
-        // this an explicit Refresh — or navigating back to the page — re-serves
-        // the previous snapshot without a round-trip. That matters here because
-        // Latest Reports' freshest page is dominated by just-uploaded logs that
-        // are still parsing on ESO Logs (segments: 0, fights: []); those self-
-        // heal within minutes, but a cached read would keep showing them (or a
-        // stale "Empty" badge) until a filter change or hard reload busts the
-        // cache. Mirrors useProfileUploadedReports, the sibling reports list.
-        fetchPolicy: 'network-only',
-      });
+      try {
+        const variables = buildVariables({ page, zoneId, range, customFrom, customTo });
+        const result = await client.query<GetLatestReportsQuery>({
+          query: GetLatestReportsDocument,
+          variables,
+          errorPolicy: 'all',
+          // Normal loads (mount, page/zone/date change) use the default
+          // cache-first: page/filter changes vary the variables so they always
+          // miss the cache and hit the network anyway, while a plain re-mount of
+          // the same view reuses the cached page — cheap on API points and
+          // resilient if the network is briefly down or rate-limited. Only an
+          // explicit Refresh passes 'network-only' (see `refetch` below).
+          //
+          // This is load-bearing for the empty-log UX: the Apollo client
+          // defaults to cache-first against a session-long singleton cache, so
+          // before this split an explicit Refresh re-served the previous
+          // snapshot without a round-trip. Latest Reports' freshest page is
+          // dominated by just-uploaded logs still parsing on ESO Logs
+          // (segments: 0, fights: []) that self-heal within minutes; without a
+          // forced network read, Refresh could never clear a healed log's stale
+          // "Empty" badge. Forcing the network only on Refresh fixes that
+          // without making every mount a paid, cache-bypassing fetch.
+          fetchPolicy,
+        });
 
-      const reportPagination = result.reportData?.reports;
-      if (!reportPagination) {
+        const reportPagination = result.reportData?.reports;
+        if (!reportPagination) {
+          setState((prev) => ({
+            ...prev,
+            loading: false,
+            error:
+              'No reports data available. This may be due to authentication issues or API limitations.',
+          }));
+          return;
+        }
+
+        // Keep the non-null narrowing on the query's own row type (which now also
+        // carries `fights`) rather than the bare summary fragment, so the empty-log
+        // partition below can read the authoritative fight count.
+        const fetched = (reportPagination.data ?? []).filter(
+          (report): report is NonNullable<typeof report> => report !== null,
+        );
+        // Hide empty (no-combat) logs, but never the whole page: if every report
+        // the server returned would be hidden — e.g. a busy upload window where the
+        // freshest page is dominated by still-parsing logs — fail open and show
+        // them all so the user is never stranded on an "every report is empty" wall.
+        const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
+
+        const currentPage = reportPagination.current_page || 1;
+        const lastPage = reportPagination.last_page;
+        const hasMorePages = reportPagination.has_more_pages || false;
+        const totalPages = lastPage > 0 ? lastPage : hasMorePages ? currentPage + 1 : currentPage;
+
+        setState({
+          reports: reportsToShow,
+          hiddenEmptyCount,
+          loading: false,
+          error: null,
+          pagination: {
+            currentPage,
+            totalPages,
+            totalReports: reportPagination.total ?? 0,
+            perPage: reportPagination.per_page || REPORTS_PER_PAGE,
+            hasMorePages,
+            from: reportPagination.from ?? null,
+            to: reportPagination.to ?? null,
+          },
+        });
+      } catch (error) {
         setState((prev) => ({
           ...prev,
           loading: false,
-          error:
-            'No reports data available. This may be due to authentication issues or API limitations.',
+          error: error instanceof Error ? error.message : 'Failed to fetch latest reports',
         }));
-        return;
       }
-
-      // Keep the non-null narrowing on the query's own row type (which now also
-      // carries `fights`) rather than the bare summary fragment, so the empty-log
-      // partition below can read the authoritative fight count.
-      const fetched = (reportPagination.data ?? []).filter(
-        (report): report is NonNullable<typeof report> => report !== null,
-      );
-      // Hide empty (no-combat) logs, but never the whole page: if every report
-      // the server returned would be hidden — e.g. a busy upload window where the
-      // freshest page is dominated by still-parsing logs — fail open and show
-      // them all so the user is never stranded on an "every report is empty" wall.
-      const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
-
-      const currentPage = reportPagination.current_page || 1;
-      const lastPage = reportPagination.last_page;
-      const hasMorePages = reportPagination.has_more_pages || false;
-      const totalPages = lastPage > 0 ? lastPage : hasMorePages ? currentPage + 1 : currentPage;
-
-      setState({
-        reports: reportsToShow,
-        hiddenEmptyCount,
-        loading: false,
-        error: null,
-        pagination: {
-          currentPage,
-          totalPages,
-          totalReports: reportPagination.total ?? 0,
-          perPage: reportPagination.per_page || REPORTS_PER_PAGE,
-          hasMorePages,
-          from: reportPagination.from ?? null,
-          to: reportPagination.to ?? null,
-        },
-      });
-    } catch (error) {
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch latest reports',
-      }));
-    }
-  }, [client, page, zoneId, range, customFrom, customTo]);
+    },
+    [client, page, zoneId, range, customFrom, customTo],
+  );
 
   useEffect(() => {
-    void fetchReports();
+    // Mount + filter/page changes: cache-first (see fetchReports).
+    void fetchReports('cache-first');
   }, [fetchReports]);
 
-  return { ...state, refetch: () => void fetchReports() };
+  // Refresh is the user's explicit "give me the live state" action, so it bypasses
+  // the cache — this is what actually clears a healed log's stale "Empty" badge.
+  return { ...state, refetch: () => void fetchReports('network-only') };
 }

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -179,6 +179,13 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
           errorPolicy: 'all',
           fetchPolicy: 'network-only',
         });
+        // The request-id guard keeps the DISPLAYED state from the newest load. A
+        // superseded same-variable response can still write its (seconds-older)
+        // snapshot into Apollo's shared cache before this check — but that is within
+        // cache-and-network's tolerance: the only effect is a future cache-only peek
+        // briefly showing that snapshot, which the same mount's network read then
+        // corrects. We intentionally don't use no-cache here (that would leave the
+        // peek with nothing to paint) or hand-roll abort/writeQuery for it.
         if (requestId !== requestIdRef.current) return; // superseded by a newer load
         if (!applyReportData(fresh, false)) {
           setState((prev) => ({

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -94,6 +94,16 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
         query: GetLatestReportsDocument,
         variables,
         errorPolicy: 'all',
+        // Always hit the network. The Apollo client defaults to cache-first and
+        // the session-long singleton cache persists across mounts, so without
+        // this an explicit Refresh — or navigating back to the page — re-serves
+        // the previous snapshot without a round-trip. That matters here because
+        // Latest Reports' freshest page is dominated by just-uploaded logs that
+        // are still parsing on ESO Logs (segments: 0, fights: []); those self-
+        // heal within minutes, but a cached read would keep showing them (or a
+        // stale "Empty" badge) until a filter change or hard reload busts the
+        // cache. Mirrors useProfileUploadedReports, the sibling reports list.
+        fetchPolicy: 'network-only',
       });
 
       const reportPagination = result.reportData?.reports;

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -85,79 +85,102 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
 
   const { page, zoneId, range, customFrom, customTo } = input;
 
+  // Map a GetLatestReports response into hook state. Returns false when the
+  // payload carried no reports pagination — an empty cache-only read, or a
+  // degraded response — so the caller can decide whether that is an error
+  // (network read) or simply "nothing cached yet" (cache peek).
+  const applyReportData = useCallback(
+    (result: GetLatestReportsQuery, loading: boolean): boolean => {
+      const reportPagination = result.reportData?.reports;
+      if (!reportPagination) return false;
+
+      // Keep the non-null narrowing on the query's own row type (which now also
+      // carries `fights`) rather than the bare summary fragment, so the empty-log
+      // partition below can read the authoritative fight count.
+      const fetched = (reportPagination.data ?? []).filter(
+        (report): report is NonNullable<typeof report> => report !== null,
+      );
+      // Hide empty (no-combat) logs, but never the whole page: if every report
+      // the server returned would be hidden — e.g. a busy upload window where the
+      // freshest page is dominated by still-parsing logs — fail open and show
+      // them all so the user is never stranded on an "every report is empty" wall.
+      const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
+
+      const currentPage = reportPagination.current_page || 1;
+      const lastPage = reportPagination.last_page;
+      const hasMorePages = reportPagination.has_more_pages || false;
+      const totalPages = lastPage > 0 ? lastPage : hasMorePages ? currentPage + 1 : currentPage;
+
+      setState({
+        reports: reportsToShow,
+        hiddenEmptyCount,
+        loading,
+        error: null,
+        pagination: {
+          currentPage,
+          totalPages,
+          totalReports: reportPagination.total ?? 0,
+          perPage: reportPagination.per_page || REPORTS_PER_PAGE,
+          hasMorePages,
+          from: reportPagination.from ?? null,
+          to: reportPagination.to ?? null,
+        },
+      });
+      return true;
+    },
+    [],
+  );
+
   const fetchReports = useCallback(
-    async (fetchPolicy: 'cache-first' | 'network-only' = 'cache-first'): Promise<void> => {
+    async (skipCachePeek = false): Promise<void> => {
       setState((prev) => ({ ...prev, loading: true, error: null }));
 
+      const variables = buildVariables({ page, zoneId, range, customFrom, customTo });
       try {
-        const variables = buildVariables({ page, zoneId, range, customFrom, customTo });
-        const result = await client.query<GetLatestReportsQuery>({
+        // cache-and-network, hand-composed: client.query() doesn't accept that
+        // fetchPolicy, so on a normal load we first read the cache (cache-only
+        // never touches the network) to paint an already-seen view instantly — no
+        // skeleton flash, and the last-known list stays put if the network is slow
+        // or down — and THEN always revalidate from the network below. That second
+        // read is what matters for the empty-log UX: the freshest page is dominated
+        // by just-uploaded logs still parsing on ESO Logs (segments: 0, fights: [])
+        // that self-heal within minutes, so revalidating on every mount means a
+        // healed log's stale "Empty" badge can never survive a re-visit (the prior
+        // cache-first default re-served the old snapshot with no round-trip). The
+        // cache stays warm because each network read writes back to it. An explicit
+        // Refresh skips the peek — the list is already on screen — and just
+        // revalidates.
+        if (!skipCachePeek) {
+          try {
+            const cached = await client.query<GetLatestReportsQuery>({
+              query: GetLatestReportsDocument,
+              variables,
+              errorPolicy: 'all',
+              fetchPolicy: 'cache-only',
+            });
+            applyReportData(cached, true); // keep loading: true; the network result follows
+          } catch {
+            // Nothing usable in the cache yet — fall through to the network read.
+          }
+        }
+
+        const fresh = await client.query<GetLatestReportsQuery>({
           query: GetLatestReportsDocument,
           variables,
           errorPolicy: 'all',
-          // Normal loads (mount, page/zone/date change) use the default
-          // cache-first: page/filter changes vary the variables so they always
-          // miss the cache and hit the network anyway, while a plain re-mount of
-          // the same view reuses the cached page — cheap on API points and
-          // resilient if the network is briefly down or rate-limited. Only an
-          // explicit Refresh passes 'network-only' (see `refetch` below).
-          //
-          // This is load-bearing for the empty-log UX: the Apollo client
-          // defaults to cache-first against a session-long singleton cache, so
-          // before this split an explicit Refresh re-served the previous
-          // snapshot without a round-trip. Latest Reports' freshest page is
-          // dominated by just-uploaded logs still parsing on ESO Logs
-          // (segments: 0, fights: []) that self-heal within minutes; without a
-          // forced network read, Refresh could never clear a healed log's stale
-          // "Empty" badge. Forcing the network only on Refresh fixes that
-          // without making every mount a paid, cache-bypassing fetch.
-          fetchPolicy,
+          fetchPolicy: 'network-only',
         });
-
-        const reportPagination = result.reportData?.reports;
-        if (!reportPagination) {
+        if (!applyReportData(fresh, false)) {
           setState((prev) => ({
             ...prev,
             loading: false,
             error:
               'No reports data available. This may be due to authentication issues or API limitations.',
           }));
-          return;
         }
-
-        // Keep the non-null narrowing on the query's own row type (which now also
-        // carries `fights`) rather than the bare summary fragment, so the empty-log
-        // partition below can read the authoritative fight count.
-        const fetched = (reportPagination.data ?? []).filter(
-          (report): report is NonNullable<typeof report> => report !== null,
-        );
-        // Hide empty (no-combat) logs, but never the whole page: if every report
-        // the server returned would be hidden — e.g. a busy upload window where the
-        // freshest page is dominated by still-parsing logs — fail open and show
-        // them all so the user is never stranded on an "every report is empty" wall.
-        const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
-
-        const currentPage = reportPagination.current_page || 1;
-        const lastPage = reportPagination.last_page;
-        const hasMorePages = reportPagination.has_more_pages || false;
-        const totalPages = lastPage > 0 ? lastPage : hasMorePages ? currentPage + 1 : currentPage;
-
-        setState({
-          reports: reportsToShow,
-          hiddenEmptyCount,
-          loading: false,
-          error: null,
-          pagination: {
-            currentPage,
-            totalPages,
-            totalReports: reportPagination.total ?? 0,
-            perPage: reportPagination.per_page || REPORTS_PER_PAGE,
-            hasMorePages,
-            from: reportPagination.from ?? null,
-            to: reportPagination.to ?? null,
-          },
-        });
       } catch (error) {
+        // Keep whatever is already shown (e.g. the cache peek) and surface the
+        // error rather than blanking the list.
         setState((prev) => ({
           ...prev,
           loading: false,
@@ -165,15 +188,16 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
         }));
       }
     },
-    [client, page, zoneId, range, customFrom, customTo],
+    [client, page, zoneId, range, customFrom, customTo, applyReportData],
   );
 
   useEffect(() => {
-    // Mount + filter/page changes: cache-first (see fetchReports).
-    void fetchReports('cache-first');
+    // Mount + page/zone/date changes: peek the cache for an instant paint, then
+    // revalidate from the network (see fetchReports).
+    void fetchReports();
   }, [fetchReports]);
 
-  // Refresh is the user's explicit "give me the live state" action, so it bypasses
-  // the cache — this is what actually clears a healed log's stale "Empty" badge.
-  return { ...state, refetch: () => void fetchReports('network-only') };
+  // Refresh just revalidates from the network — the list is already on screen, so
+  // there is no cache to peek, and this is what clears a healed log's stale badge.
+  return { ...state, refetch: () => void fetchReports(true) };
 }

--- a/src/features/user_reports/UserReports.test.tsx
+++ b/src/features/user_reports/UserReports.test.tsx
@@ -506,6 +506,40 @@ describe('UserReports Component', () => {
         nowSpy.mockRestore();
       }
     });
+
+    it('does not loop when a stale background revalidation fails', async () => {
+      const store = createMockStore();
+      mockLocalStorage.getItem.mockReturnValue(validToken);
+      (useAuth as jest.Mock).mockReturnValue(loggedInAuth());
+      // Initial load succeeds (cache-first); the forced revalidation rejects.
+      mockClient.query.mockImplementation((params) => {
+        if (params.query === mockGetCurrentUserDocument) return Promise.resolve(mockUserData);
+        if (params.fetchPolicy === 'network-only') return Promise.reject(new Error('network down'));
+        return Promise.resolve(mockReportsData);
+      });
+
+      const first = render(treeFor(store));
+      await waitFor(() => expect(screen.getByText('Test Report 1')).toBeInTheDocument());
+      first.unmount();
+
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 6 * 60 * 1000);
+      try {
+        render(treeFor(store));
+        // Let the rejected revalidation settle and any effect re-runs flush.
+        await waitFor(() =>
+          expect(
+            mockClient.query.mock.calls.filter((c) => c[0].fetchPolicy === 'network-only').length,
+          ).toBe(1),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        // The latch must keep it at exactly one attempt — no retry storm.
+        expect(
+          mockClient.query.mock.calls.filter((c) => c[0].fetchPolicy === 'network-only').length,
+        ).toBe(1);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
   });
 
   describe('Error handling', () => {

--- a/src/features/user_reports/UserReports.test.tsx
+++ b/src/features/user_reports/UserReports.test.tsx
@@ -435,6 +435,13 @@ describe('UserReports Component', () => {
       await waitFor(() => {
         expect(mockClient.query).toHaveBeenCalled();
       });
+
+      // Refresh must bypass Apollo's cache (forceNetwork → network-only) so a log
+      // that has since finished processing on ESO Logs no longer shows a stale
+      // "Empty" badge. clearCache() only clears Redux, not the Apollo cache.
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.objectContaining({ fetchPolicy: 'network-only' }),
+      );
     });
   });
 

--- a/src/features/user_reports/UserReports.test.tsx
+++ b/src/features/user_reports/UserReports.test.tsx
@@ -445,6 +445,69 @@ describe('UserReports Component', () => {
     });
   });
 
+  describe('Stale revisit revalidation', () => {
+    const loggedInAuth = () => ({
+      accessToken: validToken,
+      isLoggedIn: true,
+      isBanned: false,
+      banReason: null,
+      currentUser: { id: 12345, name: 'TestUser' },
+      userLoading: false,
+      userError: null,
+      setAccessToken: jest.fn(),
+      rebindAccessToken: jest.fn(),
+      refetchUser: jest.fn(),
+    });
+
+    const treeFor = (store: ReturnType<typeof createMockStore>) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/my-reports']}>
+          <ThemeProvider theme={defaultTheme}>
+            <LoggerProvider config={{ enableConsole: false, enableStorage: false }}>
+              <EsoLogsClientProvider>
+                <AuthProvider>
+                  <UserReports />
+                </AuthProvider>
+              </EsoLogsClientProvider>
+            </LoggerProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    it('revalidates in the background (network-only) when a warm list is revisited stale', async () => {
+      const store = createMockStore();
+      mockLocalStorage.getItem.mockReturnValue(validToken);
+      (useAuth as jest.Mock).mockReturnValue(loggedInAuth());
+      mockClient.query.mockImplementation((params) =>
+        Promise.resolve(
+          params.query === mockGetCurrentUserDocument ? mockUserData : mockReportsData,
+        ),
+      );
+
+      // First visit warms the Redux store (initial load is cache-first, never forced).
+      const first = render(treeFor(store));
+      await waitFor(() => expect(screen.getByText('Test Report 1')).toBeInTheDocument());
+      expect(mockClient.query).not.toHaveBeenCalledWith(
+        expect.objectContaining({ fetchPolicy: 'network-only' }),
+      );
+      first.unmount();
+
+      // Simulate the 5-minute TTL elapsing, then revisit (remount on the same store).
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 6 * 60 * 1000);
+      try {
+        render(treeFor(store));
+        await waitFor(() =>
+          expect(mockClient.query).toHaveBeenCalledWith(
+            expect.objectContaining({ fetchPolicy: 'network-only' }),
+          ),
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
   describe('Error handling', () => {
     it('should display error message when fetching user data fails', async () => {
       // Mock auth to return userError state

--- a/src/features/user_reports/UserReports.tsx
+++ b/src/features/user_reports/UserReports.tsx
@@ -379,12 +379,43 @@ export const UserReports: React.FC = () => {
       setInitialLoading(false);
     } else if (cacheInfo.hasFetchedAll) {
       setInitialLoading(false);
+      // Revisiting an already-loaded list. If it has gone stale, revalidate in
+      // the background so a log that has since finished processing on ESO Logs
+      // loses its "Empty" badge without the user clicking Refresh. Redux keeps the
+      // existing rows on screen during the refetch (no flash) and forceNetwork
+      // bypasses Apollo's cache-first default. Staleness is computed here with a
+      // live clock: the memoized selectCacheInfo.isStale is frozen at its
+      // last-input-change time, so it never flips to stale on an otherwise static
+      // store.
+      const STALE_AFTER_MS = 5 * 60 * 1000; // matches selectCacheInfo's TTL
+      const isStale =
+        cacheInfo.lastFetched === null || Date.now() - cacheInfo.lastFetched > STALE_AFTER_MS;
+      // Skip when the last load errored: fetchAllUserReports.rejected also sets
+      // hasFetchedAll, so without this guard a failed initial load would land
+      // here, re-dispatch, and loop — re-clearing the error each time via
+      // fetchAllUserReports.pending. The ESO-595 guard above relies on the same
+      // "don't auto-retry after an error" rule; manual Refresh stays the recovery.
+      if (currentUser?.id && isStale && !isFetchingAll && !hasError) {
+        dispatch(
+          fetchAllUserReports({
+            client,
+            userId: currentUser.id,
+            limit: 100,
+            forceNetwork: true,
+          }),
+        )
+          .unwrap()
+          .catch(() => {
+            // Keep showing the existing rows if the background refresh fails.
+          });
+      }
     }
   }, [
     isLoggedIn,
     currentUser,
     userLoading,
     cacheInfo.hasFetchedAll,
+    cacheInfo.lastFetched,
     isFetchingAll,
     hasError,
     dispatch,

--- a/src/features/user_reports/UserReports.tsx
+++ b/src/features/user_reports/UserReports.tsx
@@ -226,6 +226,14 @@ export const UserReports: React.FC = () => {
   // Track fetch error to prevent infinite re-fetch loop (ESO-595)
   const [hasError, setHasError] = React.useState(false);
 
+  // Guards the background stale-revisit revalidation against an infinite retry
+  // loop: a failed background fetch leaves the list stale (lastFetched unchanged)
+  // and toggles isFetchingAll, which would otherwise re-enter the effect and
+  // re-dispatch forever. We attempt it at most once per stale window and only
+  // re-arm after a SUCCESSFUL revalidation (a failure leaves it latched, so
+  // recovery is via manual Refresh).
+  const staleRevalidationLatchedRef = React.useRef(false);
+
   // Fetch page data
   const fetchPage = useCallback(
     async (page: number) => {
@@ -390,12 +398,20 @@ export const UserReports: React.FC = () => {
       const STALE_AFTER_MS = 5 * 60 * 1000; // matches selectCacheInfo's TTL
       const isStale =
         cacheInfo.lastFetched === null || Date.now() - cacheInfo.lastFetched > STALE_AFTER_MS;
-      // Skip when the last load errored: fetchAllUserReports.rejected also sets
-      // hasFetchedAll, so without this guard a failed initial load would land
-      // here, re-dispatch, and loop — re-clearing the error each time via
-      // fetchAllUserReports.pending. The ESO-595 guard above relies on the same
-      // "don't auto-retry after an error" rule; manual Refresh stays the recovery.
-      if (currentUser?.id && isStale && !isFetchingAll && !hasError) {
+      // Skip when the last load errored (fetchAllUserReports.rejected also sets
+      // hasFetchedAll, so a failed initial load lands here) and when this stale
+      // window's attempt is already latched — without the latch a background
+      // failure would re-dispatch forever, since it leaves the list stale and
+      // toggles isFetchingAll, re-entering this effect (and .pending re-clears the
+      // Redux error). Manual Refresh stays the recovery path.
+      if (
+        currentUser?.id &&
+        isStale &&
+        !isFetchingAll &&
+        !hasError &&
+        !staleRevalidationLatchedRef.current
+      ) {
+        staleRevalidationLatchedRef.current = true;
         dispatch(
           fetchAllUserReports({
             client,
@@ -405,8 +421,14 @@ export const UserReports: React.FC = () => {
           }),
         )
           .unwrap()
+          .then(() => {
+            // Re-arm only on success so a later stale window can revalidate again;
+            // a successful fetch also refreshes lastFetched, so this won't loop.
+            staleRevalidationLatchedRef.current = false;
+          })
           .catch(() => {
-            // Keep showing the existing rows if the background refresh fails.
+            // Keep showing the existing rows; leave the latch set so a failed
+            // background refresh does not retry until the user clicks Refresh.
           });
       }
     }

--- a/src/features/user_reports/UserReports.tsx
+++ b/src/features/user_reports/UserReports.tsx
@@ -261,12 +261,16 @@ export const UserReports: React.FC = () => {
       dispatch(clearCache());
       dispatch(setCurrentPage(1));
       setSearchParams({ page: '1' });
-      // Fetch all reports again
+      // Fetch all reports again, bypassing Apollo's cache. clearCache() only
+      // clears Redux; without forceNetwork the cache-first default would
+      // re-serve the same stale getUserReports pages (e.g. a log that has since
+      // finished processing would still show its "Empty" badge).
       dispatch(
         fetchAllUserReports({
           client,
           userId: currentUser.id,
           limit: 100,
+          forceNetwork: true,
         }),
       );
     }

--- a/src/hooks/useLatestReport.test.tsx
+++ b/src/hooks/useLatestReport.test.tsx
@@ -67,6 +67,17 @@ describe('useLatestReport', () => {
     expect(result.current.report?.code).toBe('AAA');
   });
 
+  it('reads live state (network-only) so the landing pick is never a stale cached report', async () => {
+    mockClient.query.mockResolvedValue(reportsResult([makeReport('AAA')]));
+
+    const { result } = renderHook(() => useLatestReport());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockClient.query).toHaveBeenCalledWith(
+      expect.objectContaining({ fetchPolicy: 'network-only' }),
+    );
+  });
+
   it('skips empty logs and returns the newest report with data', async () => {
     mockClient.query.mockResolvedValue(
       reportsResult([

--- a/src/hooks/useLatestReport.ts
+++ b/src/hooks/useLatestReport.ts
@@ -62,6 +62,14 @@ export const useLatestReport = (): LatestReportState & { refetch: () => Promise<
           page: 1,
           userID,
         },
+        // This landing shortcut only picks the newest non-empty report to link
+        // to, so always read live state: the Apollo client defaults to
+        // cache-first against a session-long cache, which would keep pointing at
+        // a stale "latest" pick (e.g. a since-healed empty log) after the data
+        // moved on. There is no list to keep painted here, so the simple
+        // network-only read is the right call (matches the explicit-refresh path
+        // in useLatestReportsQuery / userReportsSlice).
+        fetchPolicy: 'network-only',
       });
 
       const reportPagination = reportsResult.reportData?.reports;

--- a/src/store/user_reports/userReportsSlice.ts
+++ b/src/store/user_reports/userReportsSlice.ts
@@ -80,39 +80,51 @@ export const fetchUserReportsPage = createAsyncThunk<
     userId: number;
     page: number;
     limit?: number;
+    /** Bypass Apollo's cache for an explicit refresh (see fetchPolicy note). */
+    forceNetwork?: boolean;
   },
   { rejectValue: string }
->('userReports/fetchPage', async ({ client, userId, page, limit = 100 }, { rejectWithValue }) => {
-  try {
-    const result: GetUserReportsQuery = await client.query({
-      query: GetUserReportsDocument,
-      variables: {
-        limit,
+>(
+  'userReports/fetchPage',
+  async ({ client, userId, page, limit = 100, forceNetwork = false }, { rejectWithValue }) => {
+    try {
+      const result: GetUserReportsQuery = await client.query({
+        query: GetUserReportsDocument,
+        variables: {
+          limit,
+          page,
+          userID: userId,
+        },
+        // Ordinary loads/navigation reuse Apollo's cache; an explicit Refresh
+        // passes forceNetwork so it bypasses the session-long singleton cache
+        // and reflects logs that have finished processing on ESO Logs (clearing
+        // stale "Empty" badges). Without this, handleRefresh clears Redux but the
+        // cache-first default re-serves the same stale getUserReports page.
+        // Mirrors the split in useLatestReportsQuery.
+        fetchPolicy: forceNetwork ? 'network-only' : 'cache-first',
+      });
+
+      const reportPagination = result.reportData?.reports;
+
+      if (!reportPagination) {
+        return rejectWithValue('No reports data available');
+      }
+
+      const reports = (reportPagination.data || []).filter(
+        (report): report is UserReportSummaryFragment => report !== null,
+      );
+
+      return {
+        reports,
         page,
-        userID: userId,
-      },
-    });
-
-    const reportPagination = result.reportData?.reports;
-
-    if (!reportPagination) {
-      return rejectWithValue('No reports data available');
+        totalCount: reportPagination.total,
+        perPage: reportPagination.per_page,
+      };
+    } catch (error) {
+      return rejectWithValue(error instanceof Error ? error.message : 'Failed to fetch reports');
     }
-
-    const reports = (reportPagination.data || []).filter(
-      (report): report is UserReportSummaryFragment => report !== null,
-    );
-
-    return {
-      reports,
-      page,
-      totalCount: reportPagination.total,
-      perPage: reportPagination.per_page,
-    };
-  } catch (error) {
-    return rejectWithValue(error instanceof Error ? error.message : 'Failed to fetch reports');
-  }
-});
+  },
+);
 
 // Async thunk to fetch all user reports across all pages
 export const fetchAllUserReports = createAsyncThunk<
@@ -121,11 +133,16 @@ export const fetchAllUserReports = createAsyncThunk<
     client: EsoLogsClient;
     userId: number;
     limit?: number;
+    /** Forwarded to each page fetch so an explicit Refresh bypasses the cache. */
+    forceNetwork?: boolean;
   },
   { rejectValue: string; state: { userReports: UserReportsState } }
 >(
   'userReports/fetchAll',
-  async ({ client, userId, limit = 100 }, { dispatch, rejectWithValue, signal }) => {
+  async (
+    { client, userId, limit = 100, forceNetwork = false },
+    { dispatch, rejectWithValue, signal },
+  ) => {
     try {
       // Fetch first page to get total count
       const firstPageResult = await dispatch(
@@ -134,6 +151,7 @@ export const fetchAllUserReports = createAsyncThunk<
           userId,
           page: 1,
           limit,
+          forceNetwork,
         }),
       ).unwrap();
 
@@ -153,6 +171,7 @@ export const fetchAllUserReports = createAsyncThunk<
             userId,
             page,
             limit,
+            forceNetwork,
           }),
         ).unwrap();
       }


### PR DESCRIPTION
## Why

Users reported Latest Reports **still** showing empty logs after PR #1352. That fix (fail-open: show an all-empty page with "Empty" badges instead of a dead-end wall) works as designed — but empties also *stuck around* because refreshing/revisiting re-served stale cache.

Root cause: the Apollo client has no `defaultOptions` (`src/esologsClient.ts`), so report-list queries defaulted to **cache-first** against a session-long singleton cache. An explicit Refresh — or navigating back — re-served the previous snapshot with no network round-trip, so still-processing logs (`segments:0`, `fights:[]`) kept their stale "Empty" badge after they finished parsing on ESO Logs.

## What

Volatile report lists now **revalidate against the network while keeping cached data visible** (cache-and-network):

- **Latest Reports** (`useLatestReportsQuery`): `client.query()` can't take `cache-and-network`, so it's composed — a `cache-only` peek (no network; paints an already-seen view instantly, degrades to nothing on a cold cache) followed by a `network-only` revalidation. Refresh skips the peek. A monotonic **request-id guard** drops superseded responses (page/filter races).
- **My Reports** (`userReportsSlice` + `UserReports`): a `forceNetwork` flag threads through `fetchUserReportsPage`/`fetchAllUserReports`. Explicit Refresh forces the network; a **stale revisit** (5-min TTL, computed with a live clock since the memoized `selectCacheInfo.isStale` is frozen) revalidates in the background with Redux rows kept on screen. A **latch** fires it at most once per stale window and re-arms only on success, so a failed background fetch can't loop (and `!hasError` keeps a failed *initial* load from looping).
- **useLatestReport** (authenticated landing shortcut): `network-only` so its "latest" pick is never a stale cached report.

## Review

Driven through a `/codex:review` + `/codex:adversarial-review` loop (4 iterations) to convergence: from CLEAN → caught network-only-everywhere as too blunt → caught the cache-first-mount staleness → caught a background-retry loop + an out-of-order race → down to one benign cache-coherence note. Each substantive finding was fixed with a regression test.

## Validation

- `tsc --noEmit`: clean · eslint: clean · prettier: clean
- jest: full suite **4273 passed / 17 skipped / 0 failed**, including new tests for cache-and-network mount, refetch-skips-peek, out-of-order supersession (Latest Reports), background stale-revisit + no-loop-on-failure (My Reports), and network-only (useLatestReport)

## Deliberately out of scope (documented, not introduced here)

- **My Reports cache is not user-scoped**: the load gate keys only on `hasFetchedAll`, so an in-session identity switch within the 5-min TTL can render the prior user's cached rows. This predates this PR (the gate was never user-scoped); it warrants its own focused tenant-isolation fix.
- **Cache-coherence edge**: a superseded same-variable network response can leave a seconds-older snapshot in Apollo's shared cache; the request-id guard keeps *displayed* state correct, and the next revalidation corrects the cache. Commented inline.

> Note: the cache-layer behavior couldn't be live-verified in this environment — a quick smoke-test (load a page of still-processing logs → wait for processing → Refresh / revisit) before merge is recommended.