### PR TITLE
fix(reports): scope My Reports cache to the current user

### DIFF
--- a/src/features/user_reports/UserReports.test.tsx
+++ b/src/features/user_reports/UserReports.test.tsx
@@ -993,4 +993,184 @@ describe('UserReports Component', () => {
       expect(screen.queryByText('Report 1')).not.toBeInTheDocument();
     });
   });
+
+  describe('Account switch (private-data isolation)', () => {
+    const userA = { id: 111, name: 'Alice' };
+    const userB = { id: 222, name: 'Bob' };
+
+    const authFor = (user: { id: number; name: string } | null) => ({
+      accessToken: validToken,
+      isLoggedIn: true,
+      isBanned: false,
+      banReason: null,
+      currentUser: user,
+      userLoading: false,
+      userError: null,
+      setAccessToken: jest.fn(),
+      rebindAccessToken: jest.fn(),
+      refetchUser: jest.fn(),
+    });
+
+    const aliceReports = {
+      reportData: {
+        reports: {
+          data: [
+            {
+              code: 'ALICE_PRIVATE_1',
+              startTime: 1640995200000,
+              endTime: 1640998800000,
+              title: "Alice's Private Raid",
+              visibility: 'private',
+              zone: { name: 'Cloudrest' },
+              owner: { name: 'Alice' },
+            },
+          ],
+          total: 1,
+          current_page: 1,
+          per_page: 100,
+          last_page: 1,
+          has_more_pages: false,
+        },
+      },
+    };
+
+    const bobReports = {
+      reportData: {
+        reports: {
+          data: [
+            {
+              code: 'BOB_OWN_1',
+              startTime: 1641081600000,
+              endTime: 1641085200000,
+              title: "Bob's Own Raid",
+              visibility: 'private',
+              zone: { name: 'Sunspire' },
+              owner: { name: 'Bob' },
+            },
+          ],
+          total: 1,
+          current_page: 1,
+          per_page: 100,
+          last_page: 1,
+          has_more_pages: false,
+        },
+      },
+    };
+
+    const treeFor = (store: ReturnType<typeof createMockStore>) => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/my-reports']}>
+          <ThemeProvider theme={defaultTheme}>
+            <LoggerProvider config={{ enableConsole: false, enableStorage: false }}>
+              <EsoLogsClientProvider>
+                <AuthProvider>
+                  <UserReports />
+                </AuthProvider>
+              </EsoLogsClientProvider>
+            </LoggerProvider>
+          </ThemeProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Returns reports scoped to the requested userID, mirroring the real API
+    // (getUserReports is keyed by userID). Empty for any unknown user.
+    const queryByUser =
+      (reportsByUser: Record<number, unknown>) => (params: { variables?: { userID?: number } }) => {
+        const userID = params.variables?.userID;
+        if (userID !== undefined && reportsByUser[userID]) {
+          return Promise.resolve(reportsByUser[userID]);
+        }
+        // Fallback (e.g. the current-user query, which the auth mock bypasses).
+        return Promise.resolve(mockUserData);
+      };
+
+    it("refetches for the new user and never renders the previous user's rows after an in-session switch", async () => {
+      const store = createMockStore();
+      mockLocalStorage.getItem.mockReturnValue(validToken);
+      mockClient.query.mockImplementation(queryByUser({ 111: aliceReports, 222: bobReports }));
+
+      // Alice logs in and warms My Reports.
+      (useAuth as jest.Mock).mockReturnValue(authFor(userA));
+      const { rerender } = render(treeFor(store));
+      await waitFor(() => expect(screen.getByText("Alice's Private Raid")).toBeInTheDocument());
+      expect(store.getState().userReports.loadedUserId).toBe(111);
+
+      // Bob logs in in the same session (token swap, no full reload): the slice
+      // is a singleton, so without user-scoping Bob would see Alice's rows.
+      (useAuth as jest.Mock).mockReturnValue(authFor(userB));
+      rerender(treeFor(store));
+
+      await waitFor(() => expect(screen.getByText("Bob's Own Raid")).toBeInTheDocument());
+      // Alice's private report must be gone.
+      expect(screen.queryByText("Alice's Private Raid")).not.toBeInTheDocument();
+      expect(store.getState().userReports.loadedUserId).toBe(222);
+
+      // Bob's data must have been fetched fresh from the network for his userID.
+      const bobNetworkCall = mockClient.query.mock.calls.find(
+        (c) => c[0].variables?.userID === 222 && c[0].fetchPolicy === 'network-only',
+      );
+      expect(bobNetworkCall).toBeDefined();
+    });
+
+    it("clears the previous user's rows even when the new user has no reports", async () => {
+      const emptyForBob = {
+        reportData: {
+          reports: {
+            data: [],
+            total: 0,
+            current_page: 1,
+            per_page: 100,
+            last_page: 1,
+            has_more_pages: false,
+          },
+        },
+      };
+
+      const store = createMockStore();
+      mockLocalStorage.getItem.mockReturnValue(validToken);
+      mockClient.query.mockImplementation(queryByUser({ 111: aliceReports, 222: emptyForBob }));
+
+      (useAuth as jest.Mock).mockReturnValue(authFor(userA));
+      const { rerender } = render(treeFor(store));
+      await waitFor(() => expect(screen.getByText("Alice's Private Raid")).toBeInTheDocument());
+
+      // Switch to Bob, who has zero reports — the scariest leak is a foreign row
+      // surviving because the empty fetch never replaces it.
+      (useAuth as jest.Mock).mockReturnValue(authFor(userB));
+      rerender(treeFor(store));
+
+      await waitFor(() =>
+        expect(screen.queryByText("Alice's Private Raid")).not.toBeInTheDocument(),
+      );
+      expect(store.getState().userReports.loadedUserId).toBe(222);
+      expect(store.getState().userReports.totalCount).toBe(0);
+    });
+
+    it("does not surface the previous user's rows when logged in without an identifiable user", async () => {
+      // A report-scopes-only token (no user subject) keeps isLoggedIn true while
+      // currentUser is null. The load effect cannot refetch (no owner), so the
+      // render guard + branch-3 purge must ensure the prior user's rows are
+      // neither shown nor retained.
+      const store = createMockStore();
+      mockLocalStorage.getItem.mockReturnValue(validToken);
+      mockClient.query.mockImplementation(queryByUser({ 111: aliceReports }));
+
+      (useAuth as jest.Mock).mockReturnValue(authFor(userA));
+      const { rerender } = render(treeFor(store));
+      await waitFor(() => expect(screen.getByText("Alice's Private Raid")).toBeInTheDocument());
+      expect(store.getState().userReports.loadedUserId).toBe(111);
+
+      // Swap in the scopes-only identity: still logged in, no currentUser.
+      (useAuth as jest.Mock).mockReturnValue(authFor(null));
+      rerender(treeFor(store));
+
+      await waitFor(() =>
+        expect(screen.queryByText("Alice's Private Raid")).not.toBeInTheDocument(),
+      );
+      // Cache is purged (not merely hidden) so nothing of Alice's lingers.
+      expect(store.getState().userReports.loadedUserId).toBeNull();
+      expect(store.getState().userReports.totalCount).toBe(0);
+    });
+  });
 });

--- a/src/features/user_reports/UserReports.tsx
+++ b/src/features/user_reports/UserReports.tsx
@@ -47,6 +47,7 @@ import {
   setSort,
   clearSearchText,
   clearCache,
+  resetForUser,
   selectPaginatedReports,
   selectFilteredCount,
   selectFilteredTotalPages,
@@ -72,6 +73,11 @@ import {
 import { useReportPageLayout } from '../reports/useReportPageLayout';
 
 const REPORTS_PER_PAGE = 10;
+
+// Stable empty list returned by the render-time owner guard so a cache that
+// belongs to a different user (or to no current user) never paints its rows.
+// Module-level to keep a stable reference across renders.
+const EMPTY_REPORTS: ReturnType<typeof selectPaginatedReports> = [];
 
 // Skeleton row component that matches the exact table structure
 const ReportsTableSkeletonRow: React.FC<{ index: number }> = function ReportsTableSkeletonRow({
@@ -197,7 +203,7 @@ export const UserReports: React.FC = () => {
   }, []);
 
   // Redux selectors
-  const paginatedReports = useSelector(selectPaginatedReports);
+  const rawPaginatedReports = useSelector(selectPaginatedReports);
   const filteredCount = useSelector(selectFilteredCount);
   const filteredTotalPages = useSelector(selectFilteredTotalPages);
   const loading = useSelector(selectLoading);
@@ -209,6 +215,18 @@ export const UserReports: React.FC = () => {
   const sort = useSelector(selectSort);
   const hasActiveFilters = useSelector(selectHasActiveFilters);
   const cacheInfo = useSelector(selectCacheInfo);
+
+  // Private-data isolation — render-time owner guard. The cache purge on an
+  // account switch is dispatched from a post-paint effect below, so without a
+  // guard evaluated DURING render the table could paint the previous user's
+  // private rows for a single frame before that effect runs. It also covers the
+  // logged-in-but-no-currentUser edge (a report-scopes-only token with no user
+  // subject), where the load effect intentionally does not refetch: there is no
+  // current user to match, so the prior user's rows must not be surfaced. Hold
+  // the rows back until the cache's recorded owner matches the signed-in user.
+  const cacheMatchesUser =
+    cacheInfo.loadedUserId === null || cacheInfo.loadedUserId === currentUser?.id;
+  const paginatedReports = cacheMatchesUser ? rawPaginatedReports : EMPTY_REPORTS;
 
   // Get the current page from URL query parameter
   const currentPageFromUrl = parseInt(searchParams.get('page') || '1', 10);
@@ -360,14 +378,54 @@ export const UserReports: React.FC = () => {
       return;
     }
 
-    // Fetch all reports when user is logged in and we have currentUser data.
-    // Guard with hasFetchedAll (not totalCachedReports) so we don't re-dispatch
-    // after a failed fetch or when the user genuinely has zero reports (ESO-595).
-    if (currentUser?.id && !cacheInfo.hasFetchedAll && !isFetchingAll && !hasError) {
+    const userId = currentUser?.id;
+
+    // Private-data isolation. The userReports slice is a session-long singleton:
+    // AuthContext swaps currentUser on logout/login with no full reload and no
+    // clearCache, and userReports is excluded from redux-persist. So an in-session
+    // account switch (A logs out, B logs in; or a cross-tab token swap) leaves A's
+    // rows + hasFetchedAll=true in Redux, and the load gate below would skip B's
+    // fetch — rendering A's private reports under B's header. When the cached owner
+    // no longer matches the logged-in user, rebind the slice to the current user
+    // and refetch fresh before doing anything else. resetForUser sets the new owner
+    // up front (so any of the previous account's in-flight pages are dropped by the
+    // slice identity guard) and forceNetwork bypasses Apollo's session-long cache so
+    // we never re-serve another account's rows.
+    if (userId && cacheInfo.loadedUserId !== null && cacheInfo.loadedUserId !== userId) {
+      setHasError(false);
+      setInitialLoading(true);
+      staleRevalidationLatchedRef.current = false;
+      dispatch(resetForUser(userId));
       dispatch(
         fetchAllUserReports({
           client,
-          userId: currentUser.id,
+          userId,
+          limit: 100,
+          forceNetwork: true,
+        }),
+      )
+        .unwrap()
+        .catch((err) => {
+          setHasError(true);
+          logger.error(
+            'Failed to fetch reports after account switch',
+            err instanceof Error ? err : new Error(String(err)),
+          );
+        })
+        .finally(() => {
+          setInitialLoading(false);
+        });
+      return;
+    }
+
+    // Fetch all reports when user is logged in and we have currentUser data.
+    // Guard with hasFetchedAll (not totalCachedReports) so we don't re-dispatch
+    // after a failed fetch or when the user genuinely has zero reports (ESO-595).
+    if (userId && !cacheInfo.hasFetchedAll && !isFetchingAll && !hasError) {
+      dispatch(
+        fetchAllUserReports({
+          client,
+          userId,
           limit: 100,
         }),
       )
@@ -383,8 +441,16 @@ export const UserReports: React.FC = () => {
           setInitialLoading(false);
         });
     } else if (currentUser === null && !userLoading) {
-      // Handle case where user is logged in but currentUser is null
+      // Handle case where user is logged in but currentUser is null (e.g. a
+      // report-scopes-only token with no user subject). There is no identifiable
+      // owner to refetch for, so drop any prior user's cached rows rather than
+      // leave them in the slice (the render guard hides them, this clears the
+      // state). Guard on loadedUserId so this clears at most once — clearCache
+      // resets it to null, so the effect does not re-dispatch on the next render.
       setInitialLoading(false);
+      if (cacheInfo.loadedUserId !== null) {
+        dispatch(clearCache());
+      }
     } else if (cacheInfo.hasFetchedAll) {
       setInitialLoading(false);
       // Revisiting an already-loaded list. If it has gone stale, revalidate in
@@ -405,7 +471,7 @@ export const UserReports: React.FC = () => {
       // toggles isFetchingAll, re-entering this effect (and .pending re-clears the
       // Redux error). Manual Refresh stays the recovery path.
       if (
-        currentUser?.id &&
+        userId &&
         isStale &&
         !isFetchingAll &&
         !hasError &&
@@ -415,7 +481,7 @@ export const UserReports: React.FC = () => {
         dispatch(
           fetchAllUserReports({
             client,
-            userId: currentUser.id,
+            userId,
             limit: 100,
             forceNetwork: true,
           }),
@@ -438,6 +504,7 @@ export const UserReports: React.FC = () => {
     userLoading,
     cacheInfo.hasFetchedAll,
     cacheInfo.lastFetched,
+    cacheInfo.loadedUserId,
     isFetchingAll,
     hasError,
     dispatch,

--- a/src/store/user_reports/userReportsSelectors.test.ts
+++ b/src/store/user_reports/userReportsSelectors.test.ts
@@ -12,6 +12,7 @@ import {
   selectLoading,
   selectIsFetchingAll,
   selectError,
+  selectLoadedUserId,
   selectAllReportsArray,
   selectIsPageCached,
   selectPageReports,
@@ -81,6 +82,8 @@ const createMockState = (overrides?: Partial<RootState['userReports']>): RootSta
       isFetchingAll: false,
       error: null,
       lastFetched: Date.now(),
+      hasFetchedAll: true,
+      loadedUserId: 1,
       ...overrides,
     },
   } as RootState;
@@ -146,6 +149,16 @@ describe('userReportsSelectors', () => {
     it('should select error', () => {
       const state = createMockState({ error: 'Test error' });
       expect(selectError(state)).toBe('Test error');
+    });
+
+    it('should select loadedUserId', () => {
+      const state = createMockState({ loadedUserId: 999 });
+      expect(selectLoadedUserId(state)).toBe(999);
+    });
+
+    it('should select null loadedUserId when no user is loaded', () => {
+      const state = createMockState({ loadedUserId: null });
+      expect(selectLoadedUserId(state)).toBeNull();
     });
   });
 
@@ -386,6 +399,13 @@ describe('userReportsSelectors', () => {
       expect(cacheInfo.cachedPages).toEqual([1, 2]);
       expect(cacheInfo.lastFetched).toBeGreaterThan(0);
       expect(typeof cacheInfo.isStale).toBe('boolean');
+    });
+
+    it('should expose the cached owner (loadedUserId) for account-switch detection', () => {
+      const state = createMockState({ loadedUserId: 42 });
+      const cacheInfo = selectCacheInfo(state);
+
+      expect(cacheInfo.loadedUserId).toBe(42);
     });
 
     it('should mark cache as stale after 5 minutes', () => {

--- a/src/store/user_reports/userReportsSelectors.ts
+++ b/src/store/user_reports/userReportsSelectors.ts
@@ -34,6 +34,9 @@ export const selectHasFetchedAll = (state: RootState): boolean => state.userRepo
 
 export const selectLastFetched = (state: RootState): number | null => state.userReports.lastFetched;
 
+export const selectLoadedUserId = (state: RootState): number | null =>
+  state.userReports.loadedUserId;
+
 // Get all cached reports as an array
 export const selectAllReportsArray = createSelector([selectAllReports], (reportsMap) =>
   Object.values(reportsMap),
@@ -151,14 +154,17 @@ export const selectHasActiveFilters = createSelector([selectFilters], (filters) 
 // doing so would cause a new object to be returned on every Redux action, triggering
 // unnecessary re-renders in all consumers (ESO-595).
 export const selectCacheInfo = createSelector(
-  [selectAllReports, selectPages, selectHasFetchedAll, selectLastFetched],
-  (reports, pages, hasFetchedAll, lastFetched) => ({
+  [selectAllReports, selectPages, selectHasFetchedAll, selectLastFetched, selectLoadedUserId],
+  (reports, pages, hasFetchedAll, lastFetched, loadedUserId) => ({
     totalCachedReports: Object.keys(reports).length,
     cachedPages: Object.keys(pages)
       .map(Number)
       .sort((a, b) => a - b),
     lastFetched,
     hasFetchedAll,
+    // Owner of the cached rows; the My Reports page invalidates the cache when
+    // this no longer matches the logged-in user (private-data isolation).
+    loadedUserId,
     isStale: lastFetched ? Date.now() - lastFetched > 5 * 60 * 1000 : true, // 5 minutes
   }),
 );

--- a/src/store/user_reports/userReportsSlice.test.ts
+++ b/src/store/user_reports/userReportsSlice.test.ts
@@ -8,6 +8,7 @@ import userReportsReducer, {
   setSort,
   clearSearchText,
   clearCache,
+  resetForUser,
   resetFilters,
   fetchUserReportsPage,
   fetchAllUserReports,
@@ -40,6 +41,8 @@ const createTestStore = (initialState?: Partial<UserReportsState>) => {
             isFetchingAll: false,
             error: null,
             lastFetched: null,
+            hasFetchedAll: false,
+            loadedUserId: null,
             ...initialState,
           },
         }
@@ -153,6 +156,8 @@ describe('userReportsSlice', () => {
         },
         totalCount: 2,
         lastFetched: Date.now(),
+        hasFetchedAll: true,
+        loadedUserId: 111,
       });
 
       store.dispatch(clearCache());
@@ -162,6 +167,38 @@ describe('userReportsSlice', () => {
       expect(state.pages).toEqual({});
       expect(state.totalCount).toBe(0);
       expect(state.lastFetched).toBeNull();
+      expect(state.hasFetchedAll).toBe(false);
+      // Owner is dropped so the next user's pages are not mistaken for a foreign
+      // write by the fulfilled identity guard.
+      expect(state.loadedUserId).toBeNull();
+    });
+
+    it('should handle resetForUser by clearing data and rebinding the owner', () => {
+      const store = createTestStore({
+        reports: {
+          ABC123: mockReports[0],
+          DEF456: mockReports[1],
+        },
+        pages: {
+          1: ['ABC123', 'DEF456'],
+        },
+        totalCount: 2,
+        lastFetched: Date.now(),
+        hasFetchedAll: true,
+        loadedUserId: 111,
+      });
+
+      store.dispatch(resetForUser(222));
+
+      const state = store.getState().userReports;
+      // Previous user's rows are purged...
+      expect(state.reports).toEqual({});
+      expect(state.pages).toEqual({});
+      expect(state.totalCount).toBe(0);
+      expect(state.lastFetched).toBeNull();
+      expect(state.hasFetchedAll).toBe(false);
+      // ...and the slice is rebound to the new user up front.
+      expect(state.loadedUserId).toBe(222);
     });
   });
 
@@ -290,6 +327,72 @@ describe('userReportsSlice', () => {
       const state = store.getState().userReports;
       expect(Object.keys(state.reports).length).toBe(2);
       expect(state.pages[1].length).toBe(2);
+    });
+
+    it('records the owner (loadedUserId) of the fetched reports', async () => {
+      const store = createTestStore();
+
+      mockClient.query.mockResolvedValue({
+        reportData: {
+          reports: {
+            data: mockReports,
+            total: 2,
+            current_page: 1,
+            per_page: 10,
+            last_page: 1,
+            has_more_pages: false,
+          },
+        },
+      });
+
+      await store.dispatch(
+        fetchUserReportsPage({
+          client: mockClient as never,
+          userId: 777,
+          page: 1,
+          limit: 10,
+        }),
+      );
+
+      const state = store.getState().userReports;
+      expect(state.loadedUserId).toBe(777);
+      expect(state.reports).toHaveProperty('ABC123');
+    });
+
+    it('drops a fulfilled page belonging to a different user (identity guard)', async () => {
+      // Slice already owned by user 111 (e.g. a previous account's in-flight
+      // bulk fetch is still resolving after a switch).
+      const store = createTestStore({ loadedUserId: 111 });
+
+      mockClient.query.mockResolvedValue({
+        reportData: {
+          reports: {
+            data: mockReports,
+            total: 2,
+            current_page: 1,
+            per_page: 10,
+            last_page: 1,
+            has_more_pages: false,
+          },
+        },
+      });
+
+      // A page resolves for a *different* user (222) — it must not pollute 111's
+      // slice (private-data isolation).
+      await store.dispatch(
+        fetchUserReportsPage({
+          client: mockClient as never,
+          userId: 222,
+          page: 1,
+          limit: 10,
+        }),
+      );
+
+      const state = store.getState().userReports;
+      expect(state.reports).toEqual({});
+      expect(state.pages[1]).toBeUndefined();
+      expect(state.loadedUserId).toBe(111);
+      expect(state.loading).toBe(false);
     });
   });
 

--- a/src/store/user_reports/userReportsSlice.ts
+++ b/src/store/user_reports/userReportsSlice.ts
@@ -44,6 +44,14 @@ export interface UserReportsState {
   // Prevents the data-loading useEffect from re-dispatching after an error or
   // when the user genuinely has zero reports (ESO-595).
   hasFetchedAll: boolean;
+  // The ESO Logs user id whose reports currently populate this slice (null when
+  // empty). The slice is a session-long singleton that is NOT cleared on
+  // logout/login — AuthContext swaps currentUser with no full reload or
+  // clearCache, and userReports is excluded from redux-persist. Recording the
+  // owner lets the My Reports page detect an in-session account switch and purge
+  // before it renders the previous user's private reports under a new user's
+  // header (private-data isolation).
+  loadedUserId: number | null;
 }
 
 const initialState: UserReportsState = {
@@ -65,6 +73,7 @@ const initialState: UserReportsState = {
   error: null,
   lastFetched: null,
   hasFetchedAll: false,
+  loadedUserId: null,
 };
 
 // Async thunk to fetch a page of user reports
@@ -210,6 +219,23 @@ const userReportsSlice = createSlice({
       state.totalCount = 0;
       state.lastFetched = null;
       state.hasFetchedAll = false;
+      // Drop the owner so the next user's pages pass the fulfilled identity
+      // guard below and a fresh fetch is not mistaken for a foreign-user write.
+      state.loadedUserId = null;
+    },
+    // Like clearCache, but immediately rebinds the slice to a specific user.
+    // Used by the My Reports page on a detected account switch: setting the new
+    // owner up front means any of the *previous* account's in-flight page
+    // requests (which are not individually aborted) are rejected by the
+    // fulfilled identity guard instead of momentarily rendering under the new
+    // user's header (private-data isolation).
+    resetForUser: (state, action: PayloadAction<number>) => {
+      state.reports = {};
+      state.pages = {};
+      state.totalCount = 0;
+      state.lastFetched = null;
+      state.hasFetchedAll = false;
+      state.loadedUserId = action.payload;
     },
     resetFilters: (state) => {
       state.filters = initialState.filters;
@@ -224,6 +250,20 @@ const userReportsSlice = createSlice({
         state.error = null;
       })
       .addCase(fetchUserReportsPage.fulfilled, (state, action) => {
+        const incomingUserId = action.meta.arg.userId;
+
+        // Identity guard (private-data isolation). Once the slice belongs to a
+        // user, drop a page that resolves for a *different* user. After an
+        // in-session account switch the previous account's in-flight bulk fetch
+        // can still resolve (its individual page requests are not aborted); this
+        // stops those late pages from writing the old user's rows into the new
+        // user's slice. Under normal flow the slice was cleared on the switch
+        // (loadedUserId === null here), so the page applies.
+        if (state.loadedUserId !== null && state.loadedUserId !== incomingUserId) {
+          state.loading = false;
+          return;
+        }
+
         const { reports, page, totalCount } = action.payload;
 
         // Store reports in normalized structure
@@ -241,6 +281,8 @@ const userReportsSlice = createSlice({
         state.totalCount = totalCount;
         state.loading = false;
         state.lastFetched = Date.now();
+        // Record (or confirm) the owner of the data now in the slice.
+        state.loadedUserId = incomingUserId;
       })
       .addCase(fetchUserReportsPage.rejected, (state, action) => {
         state.loading = false;
@@ -263,7 +305,14 @@ const userReportsSlice = createSlice({
   },
 });
 
-export const { setCurrentPage, setFilters, setSort, clearSearchText, clearCache, resetFilters } =
-  userReportsSlice.actions;
+export const {
+  setCurrentPage,
+  setFilters,
+  setSort,
+  clearSearchText,
+  clearCache,
+  resetForUser,
+  resetFilters,
+} = userReportsSlice.actions;
 
 export default userReportsSlice.reducer;


### PR DESCRIPTION
## Problem

The `userReports` Redux slice is a session-long singleton that is **not** cleared on logout/login:

- `AuthContext` swaps `currentUser` via React state on login/logout with **no full page reload** and **no `clearCache`** (login `OAuthRedirect` → `rebindAccessToken()` + `navigate()`; logout `HeaderBar.handleLogout` → `localStorage.removeItem` + `rebindAccessToken()` + `navigate('/')`).
- `userReports` is **excluded from redux-persist** (whitelist is `ui, loadout, dashboard, savedRosters, savedBuilds`), so a manual reload clears it but an in-session switch does not.

So an in-session account switch — **A logs out and B logs in**, or a **cross-tab token swap** — left A's rows and `hasFetchedAll=true` in the slice. The load gate (`!hasFetchedAll`) then **skipped B's fetch**, rendering **A's private reports under B's header** until the 5-minute stale TTL elapsed. Verified reachable: neither the login nor logout flow reloads the page or resets the slice.

## Fix

Scope the cache to the current user (mirrors the write-once-owner / identity-guard prior art from the loadout account-sync code):

- **Record the owner** of the cached rows (`loadedUserId`) and expose it via `selectCacheInfo`.
- **Identity guard** in `fetchUserReportsPage.fulfilled` drops a page whose `userId` no longer matches the slice owner, so a previous account's in-flight bulk fetch cannot write its rows into the new user's slice.
- On a detected switch the load effect calls a new **`resetForUser`** action (clears data **and** rebinds the owner atomically) and refetches **network-only**, bypassing Apollo's session-long cache.
- A **render-time owner guard** holds rows back until the cache owner matches the signed-in user. This closes two defense-in-depth gaps an adversarial review surfaced:
  - the **one-frame flash** before the post-paint purge effect runs, and
  - the **logged-in-but-no-`currentUser`** edge (a report-scopes-only token with no user subject), where the prior user's rows would otherwise linger persistently. The `currentUser === null` branch also purges the slice in that case.

Composes with the existing `forceNetwork` / stale-revisit revalidation and the ESO-595 `!hasError` / latch guards; convergence (no re-dispatch loop / double-fetch) was traced and confirmed.

## Tests

- **Slice**: owner recording on fulfilled, identity-guard drop of a foreign-user page, `resetForUser`, `clearCache` owner reset.
- **Selectors**: `selectLoadedUserId` and `selectCacheInfo.loadedUserId`.
- **Component integration**: warm as A → switch to B → B's data fetched (network-only) and A's rows gone; the zero-report-B case; and the report-scopes-only (`currentUser === null`) case.

## Verification

- `tsc --noEmit` clean; ESLint clean on changed production files; Prettier on changed files only.
- Targeted Jest (`UserReports` + `userReports` slice/selectors): **85/85 pass**.
- Full suite minus the known timing-flaky `GearPicker` icon-race suites: **4271 pass**. The intermittent `GearPicker.*` / `scribing-e2e` failures are a documented CPU-load flake (different suites fail each run, 60–100s runtimes), unrelated to these files — no import path connects them.

## Smoke-test before merge

Log in as A, open **My Reports**, then switch to B **without a page reload** (or via a second tab) and confirm B's data shows and none of A's rows appear.