### PR TITLE
fix(build-editor): transfer Class Mastery, gear traits/enchants & weapon type on Extract Build

### DIFF
--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -47,6 +47,7 @@ import { OneLineAutoFit } from '../../../components/OneLineAutoFit';
 import { PlayerIcon } from '../../../components/PlayerIcon';
 import { GrimoireData } from '../../../components/ScribingSkillsDisplay';
 import { CLASS_MASTERY_LINE_NAME } from '../../../data/skill-lines/class/classMastery';
+import { preloadIconData } from '../../../features/loadout-manager/utils/itemIconResolver';
 import type { PlayerRoleResult } from '../../../features/role_detection';
 import { getRoleEmoji, ROLE_LABELS, toBroadRole } from '../../../hooks/useRoleDetection';
 import { selectPlayersByIdForContext } from '../../../store/player_data/playerDataSelectors';
@@ -588,6 +589,12 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       // don't intercept — the async encodeBuildToURL would break the gesture chain.
       const tab = window.open('', '_blank');
       try {
+        // Warm the item icon/weapon-type data so playerToBuild can resolve each
+        // weapon's specific type (Dagger / Inferno Staff / …) into the Build
+        // Editor's type-specific item id. Best-effort — extraction still works
+        // (weapons just fall back to their set name) if this fails.
+        await preloadIconData().catch(() => {});
+
         const broadRole: string = detectedRole
           ? toBroadRole(detectedRole.role)
           : (player.role ?? 'dps');

--- a/src/utils/__tests__/combatLogGearMapping.test.ts
+++ b/src/utils/__tests__/combatLogGearMapping.test.ts
@@ -8,6 +8,7 @@ import {
   gearCategoryForSlot,
   resolveTraitId,
   resolveEnchantId,
+  resolveWeaponItemId,
   __ENCHANT_ID_BY_CATEGORY,
   __ENCHANT_LISTS_BY_CATEGORY,
 } from '@/utils/combatLogGearMapping';
@@ -107,6 +108,35 @@ describe('resolveEnchantId', () => {
     expect(resolveEnchantId(0, 'weapon')).toBeUndefined();
     expect(resolveEnchantId(undefined, 'armor')).toBeUndefined();
     expect(resolveEnchantId(null, 'jewelry')).toBeUndefined();
+  });
+});
+
+describe('resolveWeaponItemId (graceful fallback)', () => {
+  // The happy path (mapping a generic set-weapon id to its type-specific variant)
+  // needs the async-loaded icon data, which isn't available offline — that path is
+  // covered by live verification. These assert the no-data fallbacks never throw
+  // and never invent an id.
+  it('returns the original id when no set name is given', () => {
+    expect(
+      resolveWeaponItemId({ combatLogId: 117218, weaponType: 13, setName: undefined, slotType: 'weapon' }),
+    ).toBe(117218);
+  });
+
+  it('returns the original id when the weapon type is unknown/none', () => {
+    expect(
+      resolveWeaponItemId({ combatLogId: 999, weaponType: 0, setName: 'Powerful Assault', slotType: 'weapon' }),
+    ).toBe(999);
+  });
+
+  it('returns a number without throwing for a real set when icon data is absent', () => {
+    const out = resolveWeaponItemId({
+      combatLogId: 117218,
+      weaponType: 13,
+      icon: 'gear_breton_staff_d',
+      setName: 'Powerful Assault',
+      slotType: 'weapon',
+    });
+    expect(typeof out).toBe('number');
   });
 });
 

--- a/src/utils/__tests__/combatLogGearMapping.test.ts
+++ b/src/utils/__tests__/combatLogGearMapping.test.ts
@@ -90,6 +90,17 @@ describe('resolveEnchantId', () => {
     expect(resolveEnchantId(9, 'weapon')).toBe('foulness'); // "Disease Damage"
   });
 
+  it('resolves the Crusher glyph under both of its codes (13 "Crusher" and 28 "Reduce Armor")', () => {
+    // ESO Logs reports the Crusher weapon glyph as code 28 ("Reduce Armor") on
+    // many tank/support back bars (e.g. a Maelstrom Ice Staff). Regression guard
+    // for the Extract Build drop where the back-bar enchant silently vanished.
+    expect(resolveEnchantId(28, 'weapon')).toBe('crushing');
+    // The code stays weapon-scoped — it must not resolve on armor/jewelry, where
+    // "Reduce Armor" is not a valid glyph.
+    expect(resolveEnchantId(28, 'armor')).toBeUndefined();
+    expect(resolveEnchantId(28, 'jewelry')).toBeUndefined();
+  });
+
   it('resolves common armor enchants', () => {
     expect(resolveEnchantId(22, 'armor')).toBe('magicka'); // "Increase Magicka"
     expect(resolveEnchantId(31, 'armor')).toBe('stamina'); // "Increase Stamina"
@@ -137,13 +148,23 @@ describe('resolveWeaponItemId (graceful fallback)', () => {
   // and never invent an id.
   it('returns the original id when no set name is given', () => {
     expect(
-      resolveWeaponItemId({ combatLogId: 117218, weaponType: 13, setName: undefined, slotType: 'weapon' }),
+      resolveWeaponItemId({
+        combatLogId: 117218,
+        weaponType: 13,
+        setName: undefined,
+        slotType: 'weapon',
+      }),
     ).toBe(117218);
   });
 
   it('returns the original id when the weapon type is unknown/none', () => {
     expect(
-      resolveWeaponItemId({ combatLogId: 999, weaponType: 0, setName: 'Powerful Assault', slotType: 'weapon' }),
+      resolveWeaponItemId({
+        combatLogId: 999,
+        weaponType: 0,
+        setName: 'Powerful Assault',
+        slotType: 'weapon',
+      }),
     ).toBe(999);
   });
 

--- a/src/utils/__tests__/combatLogGearMapping.test.ts
+++ b/src/utils/__tests__/combatLogGearMapping.test.ts
@@ -1,0 +1,134 @@
+import {
+  ARMOR_TRAITS,
+  WEAPON_TRAITS,
+  JEWELRY_TRAITS,
+  type GearCategory,
+} from '@/features/build-editor/data/gear-traits-enchants';
+import {
+  gearCategoryForSlot,
+  resolveTraitId,
+  resolveEnchantId,
+  __ENCHANT_ID_BY_CATEGORY,
+  __ENCHANT_LISTS_BY_CATEGORY,
+} from '@/utils/combatLogGearMapping';
+
+describe('gearCategoryForSlot', () => {
+  it('maps apparel slots (0–6) to armor', () => {
+    for (const slot of [0, 1, 2, 3, 4, 5, 6]) {
+      expect(gearCategoryForSlot(slot)).toBe('armor');
+    }
+  });
+
+  it('maps jewelry slots (7–9: neck, ring1, ring2) to jewelry', () => {
+    for (const slot of [7, 8, 9]) {
+      expect(gearCategoryForSlot(slot)).toBe('jewelry');
+    }
+  });
+
+  it('maps weapon slots (10–13: main/off + backups) to weapon', () => {
+    for (const slot of [10, 11, 12, 13]) {
+      expect(gearCategoryForSlot(slot)).toBe('weapon');
+    }
+  });
+});
+
+describe('resolveTraitId', () => {
+  it('resolves common weapon traits (consistent with the report gear panel)', () => {
+    expect(resolveTraitId(32, 'weapon')).toBe('sharpened'); // GearTrait.SHARPENED
+    expect(resolveTraitId(24, 'weapon')).toBe('decisive');
+    expect(resolveTraitId(25, 'weapon')).toBe('powered');
+  });
+
+  it('resolves common armor traits', () => {
+    expect(resolveTraitId(40, 'armor')).toBe('divines');
+    expect(resolveTraitId(8, 'armor')).toBe('reinforced'); // GearTrait.REINFORCED
+    expect(resolveTraitId(35, 'armor')).toBe('reinforced'); // alternate Reinforced code
+    expect(resolveTraitId(33, 'armor')).toBe('sturdy');
+    expect(resolveTraitId(36, 'armor')).toBe('well-fitted'); // "Well-fitted" → "well-fitted"
+  });
+
+  it('resolves common jewelry traits', () => {
+    expect(resolveTraitId(53, 'jewelry')).toBe('bloodthirsty');
+    expect(resolveTraitId(48, 'jewelry')).toBe('triune');
+    expect(resolveTraitId(52, 'jewelry')).toBe('swift');
+  });
+
+  it('resolves Infused in every category', () => {
+    expect(resolveTraitId(4, 'weapon')).toBe('infused');
+    expect(resolveTraitId(38, 'armor')).toBe('infused');
+    expect(resolveTraitId(49, 'jewelry')).toBe('infused');
+  });
+
+  it('returns undefined for no trait (0 / null / undefined)', () => {
+    expect(resolveTraitId(0, 'weapon')).toBeUndefined();
+    expect(resolveTraitId(undefined, 'armor')).toBeUndefined();
+    expect(resolveTraitId(null, 'jewelry')).toBeUndefined();
+  });
+
+  it('returns undefined for crafting-only / non-build traits (Ornate, Intricate)', () => {
+    expect(resolveTraitId(43, 'armor')).toBeUndefined(); // Ornate
+    expect(resolveTraitId(44, 'armor')).toBeUndefined(); // Intricate
+  });
+
+  it('gates by category — a weapon trait does not resolve on armor', () => {
+    // 32 = Sharpened (weapon-only). Asking on the armor category must not return a value.
+    expect(resolveTraitId(32, 'armor')).toBeUndefined();
+    // 40 = Divines (armor-only) must not resolve on weapon.
+    expect(resolveTraitId(40, 'weapon')).toBeUndefined();
+  });
+});
+
+describe('resolveEnchantId', () => {
+  it('resolves common weapon enchants', () => {
+    expect(resolveEnchantId(27, 'weapon')).toBe('weapon-damage');
+    expect(resolveEnchantId(13, 'weapon')).toBe('crushing'); // "Crusher"
+    expect(resolveEnchantId(14, 'weapon')).toBe('weakening');
+    expect(resolveEnchantId(10, 'weapon')).toBe('flame'); // "Flame Damage"
+    expect(resolveEnchantId(6, 'weapon')).toBe('frost'); // "Frost Damage"
+    expect(resolveEnchantId(9, 'weapon')).toBe('foulness'); // "Disease Damage"
+  });
+
+  it('resolves common armor enchants', () => {
+    expect(resolveEnchantId(22, 'armor')).toBe('magicka'); // "Increase Magicka"
+    expect(resolveEnchantId(31, 'armor')).toBe('stamina'); // "Increase Stamina"
+    expect(resolveEnchantId(29, 'armor')).toBe('health'); // "Increase Health"
+    expect(resolveEnchantId(26, 'armor')).toBe('prismatic-defense');
+    expect(resolveEnchantId(39, 'armor')).toBe('prismatic-defense');
+  });
+
+  it('resolves common jewelry enchants, disambiguating spell vs weapon damage', () => {
+    expect(resolveEnchantId(47, 'jewelry')).toBe('increase-spell-damage'); // "Spell Damage"
+    expect(resolveEnchantId(46, 'jewelry')).toBe('increase-physical-damage'); // "Weapon Damage"
+    expect(resolveEnchantId(37, 'jewelry')).toBe('magicka-recovery');
+    expect(resolveEnchantId(36, 'jewelry')).toBe('stamina-recovery');
+  });
+
+  it('returns undefined for no enchant (0 / null / undefined)', () => {
+    expect(resolveEnchantId(0, 'weapon')).toBeUndefined();
+    expect(resolveEnchantId(undefined, 'armor')).toBeUndefined();
+    expect(resolveEnchantId(null, 'jewelry')).toBeUndefined();
+  });
+});
+
+describe('mapping integrity', () => {
+  it('every mapped trait ID exists in its category Build Editor list', () => {
+    const lists: Record<GearCategory, Set<string>> = {
+      armor: new Set(ARMOR_TRAITS.map((t) => t.id)),
+      weapon: new Set(WEAPON_TRAITS.map((t) => t.id)),
+      jewelry: new Set(JEWELRY_TRAITS.map((t) => t.id)),
+    };
+    // Spot-check a representative resolved value per category lands in its list.
+    expect(lists.weapon.has(resolveTraitId(32, 'weapon')!)).toBe(true);
+    expect(lists.armor.has(resolveTraitId(40, 'armor')!)).toBe(true);
+    expect(lists.jewelry.has(resolveTraitId(53, 'jewelry')!)).toBe(true);
+  });
+
+  it('every mapped enchant ID exists in its category Build Editor list', () => {
+    (['armor', 'weapon', 'jewelry'] as const).forEach((category) => {
+      const validIds = new Set(__ENCHANT_LISTS_BY_CATEGORY[category].map((e) => e.id));
+      for (const mappedId of Object.values(__ENCHANT_ID_BY_CATEGORY[category])) {
+        expect(validIds.has(mappedId)).toBe(true);
+      }
+    });
+  });
+});

--- a/src/utils/__tests__/combatLogGearMapping.test.ts
+++ b/src/utils/__tests__/combatLogGearMapping.test.ts
@@ -9,6 +9,7 @@ import {
   resolveTraitId,
   resolveEnchantId,
   resolveWeaponItemId,
+  __candidateWeaponLabel,
   __ENCHANT_ID_BY_CATEGORY,
   __ENCHANT_LISTS_BY_CATEGORY,
 } from '@/utils/combatLogGearMapping';
@@ -108,6 +109,24 @@ describe('resolveEnchantId', () => {
     expect(resolveEnchantId(0, 'weapon')).toBeUndefined();
     expect(resolveEnchantId(undefined, 'armor')).toBeUndefined();
     expect(resolveEnchantId(null, 'jewelry')).toBeUndefined();
+  });
+});
+
+describe('candidateWeaponLabel (longest-suffix disambiguation)', () => {
+  it('reads the longest known type label, so short labels never shadow long ones', () => {
+    expect(__candidateWeaponLabel('Powerful Assault Axe')).toBe('Axe');
+    expect(__candidateWeaponLabel('Powerful Assault Battle Axe')).toBe('Battle Axe'); // not "Axe"
+    expect(__candidateWeaponLabel('Powerful Assault Sword')).toBe('Sword');
+    expect(__candidateWeaponLabel('Powerful Assault Greatsword')).toBe('Greatsword'); // not "Sword"
+    expect(__candidateWeaponLabel('Powerful Assault Inferno Staff')).toBe('Inferno Staff');
+    expect(__candidateWeaponLabel('Powerful Assault Ice Staff')).toBe('Ice Staff');
+    expect(__candidateWeaponLabel('Powerful Assault Dagger')).toBe('Dagger');
+    expect(__candidateWeaponLabel('Mechanical Acuity Bow')).toBe('Bow');
+  });
+
+  it('returns undefined for a generic (typeless) weapon name', () => {
+    expect(__candidateWeaponLabel('Powerful Assault Gear')).toBeUndefined();
+    expect(__candidateWeaponLabel('Powerful Assault Weapon')).toBeUndefined();
   });
 });
 

--- a/src/utils/__tests__/combatLogGearMapping.test.ts
+++ b/src/utils/__tests__/combatLogGearMapping.test.ts
@@ -101,6 +101,16 @@ describe('resolveEnchantId', () => {
     expect(resolveEnchantId(28, 'jewelry')).toBeUndefined();
   });
 
+  it('resolves the Weakening glyph under both of its codes (14 "Weakening" and 32 "Reduce Physical Harm")', () => {
+    // Code 32 is overloaded: on a weapon it is the Weakening glyph, but on jewelry
+    // the very same code is the defensive "Decrease Physical Harm" glyph. The
+    // per-category gate must resolve each correctly without crossing over.
+    expect(resolveEnchantId(32, 'weapon')).toBe('weakening');
+    expect(resolveEnchantId(32, 'jewelry')).toBe('decrease-physical-harm');
+    // No "Reduce Physical Harm" glyph exists for armor.
+    expect(resolveEnchantId(32, 'armor')).toBeUndefined();
+  });
+
   it('resolves common armor enchants', () => {
     expect(resolveEnchantId(22, 'armor')).toBe('magicka'); // "Increase Magicka"
     expect(resolveEnchantId(31, 'armor')).toBe('stamina'); // "Increase Stamina"

--- a/src/utils/__tests__/playerToBuild.test.ts
+++ b/src/utils/__tests__/playerToBuild.test.ts
@@ -1,0 +1,248 @@
+// The encoder uses `CompressionStream`, which jsdom does not expose — polyfill
+// from Node before importing buildEncoding (mirrors buildEncoding.visibility.test.ts).
+import {
+  CompressionStream as NodeCompressionStream,
+  DecompressionStream as NodeDecompressionStream,
+} from 'node:stream/web';
+
+if (typeof (globalThis as { CompressionStream?: unknown }).CompressionStream === 'undefined') {
+  (globalThis as { CompressionStream?: unknown }).CompressionStream = NodeCompressionStream;
+}
+if (typeof (globalThis as { DecompressionStream?: unknown }).DecompressionStream === 'undefined') {
+  (globalThis as { DecompressionStream?: unknown }).DecompressionStream = NodeDecompressionStream;
+}
+
+import {
+  CLASS_MASTERY_LINE_NAME,
+  getClassMasteryLine,
+} from '@/data/skill-lines/class/classMastery';
+import { migrateLeakedClassMasteryPicks } from '@/features/build-editor/utils/classMasteryTransfer';
+import { decodeBuildFromURL, encodeBuildToURL } from '@/utils/buildEncoding';
+import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
+import { convertGear, playerToBuild } from '@/utils/playerToBuild';
+
+import { ArmorType, WeaponType, type PlayerGear } from '../../types/playerDetails';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function gearPiece(overrides: Partial<PlayerGear>): PlayerGear {
+  return {
+    id: 100,
+    slot: 0,
+    quality: 5,
+    icon: '',
+    name: '',
+    championPoints: 160,
+    trait: 0 as PlayerGear['trait'],
+    enchantType: 0,
+    enchantQuality: 0,
+    setID: 1,
+    type: ArmorType.LIGHT,
+    ...overrides,
+  };
+}
+
+const dkAnalysis = (cmIds: number[]): ClassAnalysisResult => ({
+  primary: 'Ardent Flame',
+  skillLines: [
+    {
+      skillLine: 'Ardent Flame',
+      className: 'Dragonknight',
+      count: 5,
+      skillIds: new Set([1, 2, 3]),
+    },
+    {
+      skillLine: CLASS_MASTERY_LINE_NAME,
+      className: 'Dragonknight',
+      count: cmIds.length,
+      skillIds: new Set(cmIds),
+    },
+  ],
+});
+
+// ─── convertGear: traits + enchants ──────────────────────────────────────────
+
+describe('convertGear — traits & enchants', () => {
+  it('carries trait + enchant across, mapped to the editor IDs per category', () => {
+    const gear: PlayerGear[] = [
+      // Head (armor): Divines (40) + Increase Magicka (22)
+      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 40 as PlayerGear['trait'], enchantType: 22 }),
+      // Ring 1 (jewelry, slot 8): Bloodthirsty (53) + Spell Damage (47)
+      gearPiece({ slot: 8, type: ArmorType.JEWELRY, trait: 53 as PlayerGear['trait'], enchantType: 47 }),
+      // Main hand (weapon, slot 10): Sharpened (32) + Weapon Damage (27)
+      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'], enchantType: 27 }),
+    ];
+
+    const config = convertGear(gear);
+
+    // Head → equip slot 0
+    expect(config[0]).toMatchObject({ trait: 'divines', enchant: 'magicka', weight: 'light' });
+    // Ring 1 → equip slot 11
+    expect(config[11]).toMatchObject({ trait: 'bloodthirsty', enchant: 'increase-spell-damage' });
+    expect(config[11].weight).toBeUndefined(); // jewelry has no weight
+    // Main hand → equip slot 4
+    expect(config[4]).toMatchObject({ trait: 'sharpened', enchant: 'weapon-damage' });
+  });
+
+  it('keys off item.slot, not array order', () => {
+    // Deliberately out-of-order array: weapon first, head second.
+    const gear: PlayerGear[] = [
+      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'] }),
+      gearPiece({ slot: 0, type: ArmorType.HEAVY, trait: 40 as PlayerGear['trait'] }),
+    ];
+    const config = convertGear(gear);
+    expect(config[4]).toMatchObject({ trait: 'sharpened' }); // main hand
+    expect(config[0]).toMatchObject({ trait: 'divines', weight: 'heavy' }); // head
+  });
+
+  it('omits trait/enchant that cannot be mapped (no wrong values)', () => {
+    const gear: PlayerGear[] = [
+      // Ornate (43) is crafting-only; enchantType 0 = none
+      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 43 as PlayerGear['trait'], enchantType: 0 }),
+    ];
+    const config = convertGear(gear);
+    expect(config[0].id).toBe(100);
+    expect(config[0].trait).toBeUndefined();
+    expect(config[0].enchant).toBeUndefined();
+  });
+});
+
+// ─── playerToBuild: Class Mastery transfer ───────────────────────────────────
+
+describe('playerToBuild — Class Mastery', () => {
+  it('lifts detected Class Mastery picks onto build.classMasteryPassives', () => {
+    const dkLine = getClassMasteryLine('dragonknight')!;
+    const cmIds = dkLine.skills.slice(0, 2).map((s) => s.id);
+
+    const build = playerToBuild({
+      playerName: 'Tester',
+      role: 'dps',
+      gear: [],
+      talents: [],
+      mundusBuffs: [],
+      championPoints: [],
+      classAnalysis: dkAnalysis(cmIds),
+    });
+
+    expect(build.esoClass).toBe('dragonknight');
+    expect(build.classMasteryPassives).toBeDefined();
+    expect([...build.classMasteryPassives!].sort()).toEqual([...cmIds].sort());
+  });
+
+  it('caps Class Mastery at the 2-pick max and drops foreign-class ids', () => {
+    const dkLine = getClassMasteryLine('dragonknight')!;
+    const sorcLine = getClassMasteryLine('sorcerer')!;
+    const dkIds = dkLine.skills.slice(0, 3).map((s) => s.id); // 3 → must cap to 2
+    const foreign = sorcLine.skills[0].id; // wrong class → dropped
+
+    const build = playerToBuild({
+      playerName: 'Tester',
+      role: 'dps',
+      gear: [],
+      talents: [],
+      mundusBuffs: [],
+      championPoints: [],
+      classAnalysis: dkAnalysis([...dkIds, foreign]),
+    });
+
+    expect(build.classMasteryPassives!.length).toBe(2);
+    expect(build.classMasteryPassives).not.toContain(foreign);
+    build.classMasteryPassives!.forEach((id) => expect(dkIds).toContain(id));
+  });
+
+  it('does not leak Class Mastery ids into setup.passives', () => {
+    const dkLine = getClassMasteryLine('dragonknight')!;
+    const cmIds = dkLine.skills.slice(0, 2).map((s) => s.id);
+
+    // Talents include the CM passive ids as trailing passives (defensive path).
+    const talents = [
+      ...Array.from({ length: 12 }, (_, i) => ({
+        name: `bar-${i}`,
+        guid: 1000 + i,
+        type: 1,
+        abilityIcon: '',
+        flags: 0,
+      })),
+      ...cmIds.map((id) => ({ name: 'cm', guid: id, type: 1, abilityIcon: '', flags: 0 })),
+    ];
+
+    const build = playerToBuild({
+      playerName: 'Tester',
+      role: 'dps',
+      gear: [],
+      talents,
+      mundusBuffs: [],
+      championPoints: [],
+      classAnalysis: dkAnalysis(cmIds),
+    });
+
+    expect([...build.classMasteryPassives!].sort()).toEqual([...cmIds].sort());
+    for (const setup of build.setups) {
+      cmIds.forEach((id) => expect(setup.passives).not.toContain(id));
+    }
+  });
+
+  it('yields no Class Mastery picks when class is unknown', () => {
+    const build = playerToBuild({
+      playerName: 'Tester',
+      role: 'dps',
+      gear: [],
+      talents: [],
+      mundusBuffs: [],
+      championPoints: [],
+      classAnalysis: undefined,
+    });
+    expect(build.esoClass).toBe('any-class');
+    expect(build.classMasteryPassives).toEqual([]);
+  });
+});
+
+// ─── Full production round-trip ──────────────────────────────────────────────
+// playerToBuild → encodeBuildToURL (?b=) → decodeBuildFromURL → loadBuild migrate.
+// Proves traits, enchants AND Class Mastery survive the exact path the
+// "Extract Build" button drives.
+
+describe('extract → encode → decode round-trip', () => {
+  it('preserves gear traits/enchants and Class Mastery across the ?b= pipeline', async () => {
+    const dkLine = getClassMasteryLine('dragonknight')!;
+    const cmIds = dkLine.skills.slice(0, 2).map((s) => s.id);
+
+    const gear: PlayerGear[] = [
+      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 40 as PlayerGear['trait'], enchantType: 22 }), // Divines + Increase Magicka
+      gearPiece({ slot: 8, type: ArmorType.JEWELRY, trait: 53 as PlayerGear['trait'], enchantType: 47 }), // Bloodthirsty + Spell Damage
+      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'], enchantType: 27 }), // Sharpened + Weapon Damage
+    ];
+
+    const original = playerToBuild({
+      playerName: 'Round Trip',
+      role: 'dps',
+      gear,
+      talents: [],
+      mundusBuffs: [],
+      championPoints: [],
+      classAnalysis: dkAnalysis(cmIds),
+    });
+
+    const encoded = await encodeBuildToURL(original);
+    expect(encoded).toBeTruthy();
+
+    const decoded = await decodeBuildFromURL(encoded);
+    expect(decoded).not.toBeNull();
+    // loadBuild runs this migration; run it here to mirror production exactly.
+    migrateLeakedClassMasteryPicks(decoded!);
+
+    // Class Mastery survives
+    expect([...decoded!.classMasteryPassives!].sort()).toEqual([...cmIds].sort());
+
+    // Gear traits + enchants survive (equip slots: head=0, ring1=11, main-hand=4)
+    const dGear = decoded!.setups[0].gear;
+    expect(dGear[0]).toMatchObject({ trait: 'divines', enchant: 'magicka' });
+    expect(dGear[11]).toMatchObject({ trait: 'bloodthirsty', enchant: 'increase-spell-damage' });
+    expect(dGear[4]).toMatchObject({ trait: 'sharpened', enchant: 'weapon-damage' });
+
+    // CM ids must not have leaked into regular passives
+    for (const setup of decoded!.setups) {
+      cmIds.forEach((id) => expect(setup.passives).not.toContain(id));
+    }
+  });
+});

--- a/src/utils/__tests__/playerToBuild.test.ts
+++ b/src/utils/__tests__/playerToBuild.test.ts
@@ -66,11 +66,26 @@ describe('convertGear — traits & enchants', () => {
   it('carries trait + enchant across, mapped to the editor IDs per category', () => {
     const gear: PlayerGear[] = [
       // Head (armor): Divines (40) + Increase Magicka (22)
-      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 40 as PlayerGear['trait'], enchantType: 22 }),
+      gearPiece({
+        slot: 0,
+        type: ArmorType.LIGHT,
+        trait: 40 as PlayerGear['trait'],
+        enchantType: 22,
+      }),
       // Ring 1 (jewelry, slot 8): Bloodthirsty (53) + Spell Damage (47)
-      gearPiece({ slot: 8, type: ArmorType.JEWELRY, trait: 53 as PlayerGear['trait'], enchantType: 47 }),
+      gearPiece({
+        slot: 8,
+        type: ArmorType.JEWELRY,
+        trait: 53 as PlayerGear['trait'],
+        enchantType: 47,
+      }),
       // Main hand (weapon, slot 10): Sharpened (32) + Weapon Damage (27)
-      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'], enchantType: 27 }),
+      gearPiece({
+        slot: 10,
+        type: WeaponType.INFERNO_STAFF,
+        trait: 32 as PlayerGear['trait'],
+        enchantType: 27,
+      }),
     ];
 
     const config = convertGear(gear);
@@ -98,7 +113,12 @@ describe('convertGear — traits & enchants', () => {
   it('omits trait/enchant that cannot be mapped (no wrong values)', () => {
     const gear: PlayerGear[] = [
       // Ornate (43) is crafting-only; enchantType 0 = none
-      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 43 as PlayerGear['trait'], enchantType: 0 }),
+      gearPiece({
+        slot: 0,
+        type: ArmorType.LIGHT,
+        trait: 43 as PlayerGear['trait'],
+        enchantType: 0,
+      }),
     ];
     const config = convertGear(gear);
     expect(config[0].id).toBe(100);
@@ -208,9 +228,24 @@ describe('extract → encode → decode round-trip', () => {
     const cmIds = dkLine.skills.slice(0, 2).map((s) => s.id);
 
     const gear: PlayerGear[] = [
-      gearPiece({ slot: 0, type: ArmorType.LIGHT, trait: 40 as PlayerGear['trait'], enchantType: 22 }), // Divines + Increase Magicka
-      gearPiece({ slot: 8, type: ArmorType.JEWELRY, trait: 53 as PlayerGear['trait'], enchantType: 47 }), // Bloodthirsty + Spell Damage
-      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'], enchantType: 27 }), // Sharpened + Weapon Damage
+      gearPiece({
+        slot: 0,
+        type: ArmorType.LIGHT,
+        trait: 40 as PlayerGear['trait'],
+        enchantType: 22,
+      }), // Divines + Increase Magicka
+      gearPiece({
+        slot: 8,
+        type: ArmorType.JEWELRY,
+        trait: 53 as PlayerGear['trait'],
+        enchantType: 47,
+      }), // Bloodthirsty + Spell Damage
+      gearPiece({
+        slot: 10,
+        type: WeaponType.INFERNO_STAFF,
+        trait: 32 as PlayerGear['trait'],
+        enchantType: 27,
+      }), // Sharpened + Weapon Damage
     ];
 
     const original = playerToBuild({

--- a/src/utils/combatLogGearMapping.ts
+++ b/src/utils/combatLogGearMapping.ts
@@ -192,16 +192,21 @@ const WEAPON_TYPE_LABEL: Record<number, string> = {
   15: 'Lightning Staff',
 };
 
-function longestCommonPrefix(strings: string[]): string {
-  if (strings.length === 0) return '';
-  let prefix = strings[0];
-  for (const s of strings.slice(1)) {
-    let i = 0;
-    while (i < prefix.length && i < s.length && prefix[i] === s[i]) i++;
-    prefix = prefix.slice(0, i);
-    if (!prefix) break;
+// Known weapon-type labels, LONGEST first, so a candidate name's specific type
+// reads as its longest matching suffix — "Battle Axe" wins over "Axe", "Greatsword"
+// over "Sword". This (vs a cross-candidate common-prefix strip) avoids both the
+// "Axe" ⊂ "Battle Axe" substring collision and the prefix over-strip that happened
+// when a set's weapon pool was type-homogeneous or shared leading letters.
+const WEAPON_LABELS_LONGEST_FIRST: string[] = [
+  ...new Set([...Object.values(WEAPON_TYPE_LABEL), 'Bow']),
+].sort((a, b) => b.length - a.length);
+
+/** The specific weapon-type label a resolved item name ends with, if any. */
+function candidateWeaponLabel(name: string): string | undefined {
+  for (const label of WEAPON_LABELS_LONGEST_FIRST) {
+    if (name.endsWith(` ${label}`)) return label;
   }
-  return prefix;
+  return undefined;
 }
 
 /**
@@ -251,14 +256,16 @@ export function resolveWeaponItemId(opts: {
   ]);
   if (ids.size === 0) return combatLogId;
 
-  const named = [...ids].map((cid) => ({ cid, name: deriveItemNameForSlot(cid, slotType) || '' }));
-  // Strip the shared "<Set> " prefix so the remaining label compares exactly —
-  // prevents "Axe" from matching "Battle Axe" (or "Sword" → "Greatsword").
-  const prefix = named.length > 1 ? longestCommonPrefix(named.map((n) => n.name)) : '';
-  for (const { cid, name } of named) {
-    const label = (prefix ? name.slice(prefix.length) : name).trim();
-    if (label === targetLabel || (named.length === 1 && name.endsWith(` ${targetLabel}`)))
-      return cid;
+  // Match each candidate by its own longest-known-type-label suffix (independent
+  // of the other candidates), so a narrow or type-homogeneous pool resolves the
+  // same as a full one and a 1H "Axe" target never matches a "Battle Axe" item.
+  for (const cid of ids) {
+    const name = deriveItemNameForSlot(cid, slotType);
+    if (name && candidateWeaponLabel(name) === targetLabel) return cid;
   }
   return combatLogId;
 }
+
+// Exported for testing the longest-suffix disambiguation (the only part of the
+// weapon-type resolution exercisable without the async icon data).
+export { candidateWeaponLabel as __candidateWeaponLabel };

--- a/src/utils/combatLogGearMapping.ts
+++ b/src/utils/combatLogGearMapping.ts
@@ -1,0 +1,157 @@
+/**
+ * Combat-log gear → Build Editor trait/enchant mapping.
+ *
+ * ESO Logs `combatantInfo.gear[]` reports each piece's trait and enchant as
+ * opaque numeric codes (`PlayerGear.trait`, `PlayerGear.enchantType`). The
+ * report's gear panel already decodes those codes to human names via the
+ * `TRAIT_NAMES` / `ENCHANTMENT_NAMES` tables (the app's single source of truth,
+ * reverse-engineered from real logs). The Build Editor, however, stores traits
+ * and enchants as kebab string IDs scoped per gear category
+ * (`gear-traits-enchants.ts`).
+ *
+ * This module bridges the two so "Extract Build from Log" carries traits and
+ * enchants across — and it does so by going THROUGH the same display names the
+ * report shows, so the editor always shows the same trait/enchant the user just
+ * saw on the report. Anything that can't be mapped (crafting-only traits,
+ * ambiguous/foreign codes, off-category glyphs) degrades to `undefined` — the
+ * piece simply carries no trait/enchant rather than a wrong one.
+ *
+ * Fidelity is therefore bounded by the accuracy of TRAIT_NAMES / ENCHANTMENT_NAMES:
+ * those decode tables carry a few user-patched relabels, so a small number of
+ * alias keys here (e.g. weapon 'prismaticonslaught') currently have no code that
+ * decodes to them. That's intentional — keeping the extraction consistent with
+ * what the report displays matters more than second-guessing the decode tables.
+ */
+
+import {
+  ARMOR_TRAITS,
+  WEAPON_TRAITS,
+  JEWELRY_TRAITS,
+  ARMOR_ENCHANTS,
+  WEAPON_ENCHANTS,
+  JEWELRY_ENCHANTS,
+  type GearCategory,
+} from '@/features/build-editor/data/gear-traits-enchants';
+import { TRAIT_NAMES, ENCHANTMENT_NAMES } from '@/utils/gearMappings';
+
+/** Strip case, spaces, hyphens and apostrophes so display names match leniently. */
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// ─── Slot → gear category ────────────────────────────────────────────────────
+// CombatantInfo gear slots (GearSlot enum): 0–6 apparel, 7–9 jewelry
+// (NECK, RING1, RING2), 10–13 weapons (MAIN/OFF + backups).
+
+export function gearCategoryForSlot(slotIdx: number): GearCategory {
+  if (slotIdx >= 7 && slotIdx <= 9) return 'jewelry';
+  if (slotIdx >= 10 && slotIdx <= 13) return 'weapon';
+  return 'armor';
+}
+
+// ─── Trait mapping ───────────────────────────────────────────────────────────
+// The report's trait display names line up 1:1 with the Build Editor trait
+// names (Divines, Sharpened, Reinforced, Well-Fitted, …), so a normalized-name
+// lookup within the slot's category resolves them directly. Crafting-only or
+// non-build traits (Ornate, Intricate, Prosperous, …) have no entry and map to
+// undefined.
+
+const TRAIT_ID_BY_CATEGORY: Record<GearCategory, Map<string, string>> = {
+  armor: new Map(ARMOR_TRAITS.map((t) => [normalize(t.name), t.id])),
+  weapon: new Map(WEAPON_TRAITS.map((t) => [normalize(t.name), t.id])),
+  jewelry: new Map(JEWELRY_TRAITS.map((t) => [normalize(t.name), t.id])),
+};
+
+export function resolveTraitId(
+  traitCode: number | undefined | null,
+  category: GearCategory,
+): string | undefined {
+  if (traitCode == null || traitCode === 0) return undefined;
+  const displayName = TRAIT_NAMES[traitCode];
+  if (!displayName) return undefined;
+  return TRAIT_ID_BY_CATEGORY[category].get(normalize(displayName));
+}
+
+// ─── Enchant mapping ─────────────────────────────────────────────────────────
+// Enchant display names diverge from the Build Editor's "Glyph of …" names
+// (e.g. report "Spell Damage" → editor "Glyph of Increase Magical Harm"), and
+// the same short name means different glyphs per category (jewelry "Weapon
+// Damage" is a different glyph than weapon "Weapon Damage"). So each category
+// gets an explicit normalized-display-name → editor-ID table. The category gate
+// also prevents an off-category code (the decode tables carry some
+// cross-category noise) from resolving to the wrong glyph.
+
+const ENCHANT_ID_BY_CATEGORY: Record<GearCategory, Record<string, string>> = {
+  armor: {
+    health: 'health',
+    increasehealth: 'health',
+    magicka: 'magicka',
+    increasemagicka: 'magicka',
+    stamina: 'stamina',
+    increasestamina: 'stamina',
+    prismaticdefense: 'prismatic-defense',
+    prismaticresistance: 'prismatic-defense',
+  },
+  weapon: {
+    weapondamage: 'weapon-damage',
+    berserker: 'weapon-damage',
+    absorbhealth: 'absorb-health',
+    absorbmagicka: 'absorb-magicka',
+    absorbstamina: 'absorb-stamina',
+    crusher: 'crushing',
+    crushing: 'crushing',
+    weakening: 'weakening',
+    flamedamage: 'flame',
+    firedamage: 'flame',
+    flame: 'flame',
+    frostdamage: 'frost',
+    chilled: 'frost',
+    frost: 'frost',
+    shockdamage: 'shock',
+    shock: 'shock',
+    poisondamage: 'poison',
+    poison: 'poison',
+    diseasedamage: 'foulness',
+    disease: 'foulness',
+    decreasehealth: 'decrease-health',
+    oblivion: 'decrease-health',
+    hardening: 'hardening',
+    prismaticonslaught: 'prismatic-onslaught',
+  },
+  jewelry: {
+    spelldamage: 'increase-spell-damage',
+    increasemagicalharm: 'increase-spell-damage',
+    weapondamage: 'increase-physical-damage',
+    increasephysicalharm: 'increase-physical-damage',
+    magickarecovery: 'magicka-recovery',
+    staminarecovery: 'stamina-recovery',
+    healthrecovery: 'health-recovery',
+    prismaticrecovery: 'prismatic-recovery',
+    reducespellcost: 'reduce-spell-cost',
+    reducefeatcost: 'reduce-feat-cost',
+    reduceskillcost: 'reduce-skill-cost',
+    reducemagicalharm: 'decrease-spell-harm',
+    decreasespellharm: 'decrease-spell-harm',
+    reducephysicalharm: 'decrease-physical-harm',
+    decreasephysicalharm: 'decrease-physical-harm',
+  },
+};
+
+export function resolveEnchantId(
+  enchantCode: number | undefined | null,
+  category: GearCategory,
+): string | undefined {
+  if (enchantCode == null || enchantCode === 0) return undefined;
+  const displayName = ENCHANTMENT_NAMES[enchantCode];
+  if (!displayName) return undefined;
+  return ENCHANT_ID_BY_CATEGORY[category][normalize(displayName)];
+}
+
+// Internal lookups exported for test cross-checking (e.g. asserting every mapped
+// enchant ID actually exists in its category's Build Editor list).
+export const __ENCHANT_LISTS_BY_CATEGORY = {
+  armor: ARMOR_ENCHANTS,
+  weapon: WEAPON_ENCHANTS,
+  jewelry: JEWELRY_ENCHANTS,
+} as const;
+export const __ENCHANT_ID_BY_CATEGORY = ENCHANT_ID_BY_CATEGORY;

--- a/src/utils/combatLogGearMapping.ts
+++ b/src/utils/combatLogGearMapping.ts
@@ -106,6 +106,12 @@ const ENCHANT_ID_BY_CATEGORY: Record<GearCategory, Record<string, string>> = {
     absorbstamina: 'absorb-stamina',
     crusher: 'crushing',
     crushing: 'crushing',
+    // ESO Logs reports the Crusher weapon glyph under two enchant codes: code 13
+    // decodes to "Crusher", but code 28 decodes to "Reduce Armor" (Crusher's
+    // in-game effect — "Reduces the target's Physical and Spell Resistance").
+    // Without this alias the latter (common on tank/support back bars, e.g. a
+    // Maelstrom Ice Staff) silently drops its enchant on Extract Build.
+    reducearmor: 'crushing',
     weakening: 'weakening',
     flamedamage: 'flame',
     firedamage: 'flame',

--- a/src/utils/combatLogGearMapping.ts
+++ b/src/utils/combatLogGearMapping.ts
@@ -32,6 +32,12 @@ import {
   JEWELRY_ENCHANTS,
   type GearCategory,
 } from '@/features/build-editor/data/gear-traits-enchants';
+import { getSetItemsBySlot } from '@/features/loadout-manager/data/itemIdMap';
+import type { SlotType } from '@/features/loadout-manager/data/slotTypes';
+import {
+  deriveItemNameForSlot,
+  parseWeaponTypeFromIconUrl,
+} from '@/features/loadout-manager/utils/itemIconResolver';
 import { TRAIT_NAMES, ENCHANTMENT_NAMES } from '@/utils/gearMappings';
 
 /** Strip case, spaces, hyphens and apostrophes so display names match leniently. */
@@ -155,3 +161,104 @@ export const __ENCHANT_LISTS_BY_CATEGORY = {
   jewelry: JEWELRY_ENCHANTS,
 } as const;
 export const __ENCHANT_ID_BY_CATEGORY = ENCHANT_ID_BY_CATEGORY;
+
+// ─── Weapon-type-specific item id resolution ─────────────────────────────────
+// The Build Editor derives a weapon's TYPE (Dagger / Sword / Inferno Staff / …)
+// from its item id, via the per-set type-specific variant ids the gear picker
+// uses. A combat log, however, often reports a GENERIC set-weapon id (e.g.
+// 117218 = "Powerful Assault Gear", no slot/type) — which resolves the set name
+// but never a weapon type. We have the authoritative `PlayerGear.type`
+// (WeaponType enum) + `icon` from the log, so we re-resolve the editor's
+// type-specific variant id for the piece's set + weapon type.
+//
+// NOTE: this reads the loadout-manager icon data, which is loaded asynchronously
+// (preloadIconData). Callers that want weapon types resolved must await
+// preloadIconData() before invoking convertGear; without it, every candidate
+// stays unresolved and we fall back to the raw combat-log id (graceful).
+
+/** WeaponType enum (src/types/playerDetails.ts) → the editor's weapon-type label. */
+const WEAPON_TYPE_LABEL: Record<number, string> = {
+  1: 'Axe',
+  2: 'Mace',
+  3: 'Sword',
+  4: 'Greatsword',
+  5: 'Battle Axe',
+  6: 'Maul',
+  9: 'Restoration Staff',
+  11: 'Dagger',
+  12: 'Inferno Staff',
+  13: 'Ice Staff',
+  14: 'Shield',
+  15: 'Lightning Staff',
+};
+
+function longestCommonPrefix(strings: string[]): string {
+  if (strings.length === 0) return '';
+  let prefix = strings[0];
+  for (const s of strings.slice(1)) {
+    let i = 0;
+    while (i < prefix.length && i < s.length && prefix[i] === s[i]) i++;
+    prefix = prefix.slice(0, i);
+    if (!prefix) break;
+  }
+  return prefix;
+}
+
+/**
+ * The weapon-type label implied by a combat-log piece: prefer the WeaponType
+ * enum (distinguishes staff elements, which a generic staff icon cannot), then
+ * fall back to parsing the log's icon token (covers Bow and any unmapped type).
+ */
+function weaponTypeLabel(weaponType: number | undefined | null, icon?: string): string | undefined {
+  if (weaponType != null) {
+    const fromEnum = WEAPON_TYPE_LABEL[weaponType];
+    if (fromEnum) return fromEnum;
+  }
+  // parseWeaponTypeFromIconUrl wants a `/icons/<file>.png` shaped URL.
+  const fromIcon = icon ? parseWeaponTypeFromIconUrl(`/icons/${icon}.png`) : null;
+  // A bare "Staff" can't pick between elements — ignore it (the enum path above
+  // already handles the four staff elements); keep only specific labels.
+  return fromIcon && fromIcon !== 'Staff' ? fromIcon : undefined;
+}
+
+/**
+ * Resolve the Build Editor item id for a weapon piece so the editor shows the
+ * correct weapon type. Returns the original id unchanged when the type can't be
+ * determined or no matching set variant exists (e.g. icon data not yet loaded).
+ */
+export function resolveWeaponItemId(opts: {
+  combatLogId: number;
+  weaponType: number | undefined | null;
+  icon?: string;
+  setName?: string;
+  slotType: Extract<SlotType, 'weapon' | 'offhand'>;
+}): number {
+  const { combatLogId, weaponType, icon, setName, slotType } = opts;
+  if (!setName) return combatLogId;
+
+  const targetLabel = weaponTypeLabel(weaponType, icon);
+  if (!targetLabel) return combatLogId;
+
+  // Resolution is idempotent: a combat-log id that already pins this weapon type
+  // re-resolves to the same (or an equivalent same-type) variant, while a generic
+  // set-weapon id gets upgraded to the type-specific one.
+
+  // Pull the set's type-specific variants. Off-hand 1H weapons (dual wield)
+  // live in the weapon pool, so search both and dedupe.
+  const ids = new Set<number>([
+    ...getSetItemsBySlot(setName, slotType),
+    ...(slotType === 'offhand' ? getSetItemsBySlot(setName, 'weapon') : []),
+  ]);
+  if (ids.size === 0) return combatLogId;
+
+  const named = [...ids].map((cid) => ({ cid, name: deriveItemNameForSlot(cid, slotType) || '' }));
+  // Strip the shared "<Set> " prefix so the remaining label compares exactly —
+  // prevents "Axe" from matching "Battle Axe" (or "Sword" → "Greatsword").
+  const prefix = named.length > 1 ? longestCommonPrefix(named.map((n) => n.name)) : '';
+  for (const { cid, name } of named) {
+    const label = (prefix ? name.slice(prefix.length) : name).trim();
+    if (label === targetLabel || (named.length === 1 && name.endsWith(` ${targetLabel}`)))
+      return cid;
+  }
+  return combatLogId;
+}

--- a/src/utils/combatLogGearMapping.ts
+++ b/src/utils/combatLogGearMapping.ts
@@ -113,6 +113,12 @@ const ENCHANT_ID_BY_CATEGORY: Record<GearCategory, Record<string, string>> = {
     // Maelstrom Ice Staff) silently drops its enchant on Extract Build.
     reducearmor: 'crushing',
     weakening: 'weakening',
+    // Same dual-code pattern as Crusher above: the Weakening weapon glyph reports
+    // as code 14 ("Weakening") OR code 32 ("Reduce Physical Harm" — Weakening
+    // lowers the target's Weapon/Spell Damage). Code 32 ALSO means the defensive
+    // "Decrease Physical Harm" glyph on jewelry, so this alias is weapon-scoped;
+    // the jewelry table keeps its own (correct) mapping for the same code.
+    reducephysicalharm: 'weakening',
     flamedamage: 'flame',
     firedamage: 'flame',
     flame: 'flame',

--- a/src/utils/playerToBuild.ts
+++ b/src/utils/playerToBuild.ts
@@ -39,7 +39,12 @@ import {
 import type { PlayerGear, PlayerTalent } from '../types/playerDetails';
 
 import type { ClassAnalysisResult } from './classDetectionUtils';
-import { gearCategoryForSlot, resolveEnchantId, resolveTraitId } from './combatLogGearMapping';
+import {
+  gearCategoryForSlot,
+  resolveEnchantId,
+  resolveTraitId,
+  resolveWeaponItemId,
+} from './combatLogGearMapping';
 import type { PotionType } from './potionDetectionUtils';
 
 // ─── Gear Slot Mapping ──────────────────────────────────────────────────────
@@ -192,7 +197,25 @@ export function convertGear(gear: PlayerGear[]): GearConfig {
     const equipSlot = PLAYER_GEAR_SLOT_TO_EQUIP_SLOT[slotIdx];
     if (equipSlot === undefined) continue;
 
-    const piece: GearPiece = { id: item.id };
+    const category = gearCategoryForSlot(slotIdx);
+
+    // For weapons, the raw combat-log id is often a GENERIC set-weapon id that
+    // resolves the set but no weapon type. Re-resolve the Build Editor's
+    // type-specific variant id (Dagger / Inferno Staff / …) so the editor shows
+    // the right weapon. Requires icon data preloaded by the caller; falls back
+    // to the raw id otherwise. Off-hand slots (11, 13) use the 'offhand' slot.
+    const piece: GearPiece =
+      category === 'weapon'
+        ? {
+            id: resolveWeaponItemId({
+              combatLogId: item.id,
+              weaponType: item.type,
+              icon: item.icon,
+              setName: item.setName,
+              slotType: slotIdx === 11 || slotIdx === 13 ? 'offhand' : 'weapon',
+            }),
+          }
+        : { id: item.id };
 
     const weight = resolveArmorWeight(slotIdx, item.type);
     if (weight) piece.weight = weight;
@@ -200,7 +223,6 @@ export function convertGear(gear: PlayerGear[]): GearConfig {
     // Carry trait + enchant across, mapped from the log's numeric codes to the
     // Build Editor's per-category string IDs (consistent with what the report's
     // gear panel displays). Unmappable codes are simply left off the piece.
-    const category = gearCategoryForSlot(slotIdx);
     const trait = resolveTraitId(item.trait, category);
     if (trait) piece.trait = trait;
     const enchant = resolveEnchantId(item.enchantType, category);

--- a/src/utils/playerToBuild.ts
+++ b/src/utils/playerToBuild.ts
@@ -457,6 +457,13 @@ export function playerToBuild(data: PlayerBuildExtractionData): Build {
   const setup: BuildSetup = {
     id: uuidv4(),
     name: 'Default',
+    // Attribute point allocation (the 64-point Magicka/Health/Stamina spread) is
+    // NOT present in ESO Logs combatant data — combatantInfo carries only gear,
+    // talents and auras (its `stats` array comes back empty). Final max-resource
+    // pools can't be back-solved into points either: gear, CP, mundus, food, set
+    // bonuses, race passives and percentage multipliers all confound the math, so
+    // any derived spread would be a guess. We leave attributes unset (0/0/0) for
+    // the user to fill in rather than transfer a wrong allocation.
     attributes: { magicka: 0, health: 0, stamina: 0 },
     curse: 'none',
     mundusStone,

--- a/src/utils/playerToBuild.ts
+++ b/src/utils/playerToBuild.ts
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { ESO_CONSUMABLES } from '../data/esoConsumables';
 import { ESO_POTIONS } from '../data/esoPotions';
+import { CLASS_MASTERY_LINE_NAME } from '../data/skill-lines/class/classMastery';
 import {
   CLASS_SKILL_LINES,
   ESO_MUNDUS_STONES,
@@ -25,6 +26,10 @@ import type {
   CombatRole,
   ESOClass,
 } from '../features/build-editor/types/build.types';
+import {
+  partitionClassMasteryPicks,
+  sanitizeClassMasteryPicks,
+} from '../features/build-editor/utils/classMasteryTransfer';
 import type { GearConfig, GearPiece } from '../features/loadout-manager/types/loadout.types';
 import {
   RED_CHAMPION_POINTS,
@@ -34,6 +39,7 @@ import {
 import type { PlayerGear, PlayerTalent } from '../types/playerDetails';
 
 import type { ClassAnalysisResult } from './classDetectionUtils';
+import { gearCategoryForSlot, resolveEnchantId, resolveTraitId } from './combatLogGearMapping';
 import type { PotionType } from './potionDetectionUtils';
 
 // ─── Gear Slot Mapping ──────────────────────────────────────────────────────
@@ -173,9 +179,15 @@ function resolveRole(playerRole?: string): CombatRole {
 export function convertGear(gear: PlayerGear[]): GearConfig {
   const config: GearConfig = {};
 
-  for (let slotIdx = 0; slotIdx < gear.length; slotIdx++) {
-    const item = gear[slotIdx];
+  for (let i = 0; i < gear.length; i++) {
+    const item = gear[i];
     if (!item || item.id === 0) continue; // Empty slot
+
+    // Prefer the item's explicit slot field. For the normal dense combat-log
+    // gear array slot === index, so this is a no-op there; keying off item.slot
+    // keeps convertGear correct if it is ever handed a filtered or reordered
+    // array. Fall back to the index only when slot is missing.
+    const slotIdx = typeof item.slot === 'number' ? item.slot : i;
 
     const equipSlot = PLAYER_GEAR_SLOT_TO_EQUIP_SLOT[slotIdx];
     if (equipSlot === undefined) continue;
@@ -184,6 +196,15 @@ export function convertGear(gear: PlayerGear[]): GearConfig {
 
     const weight = resolveArmorWeight(slotIdx, item.type);
     if (weight) piece.weight = weight;
+
+    // Carry trait + enchant across, mapped from the log's numeric codes to the
+    // Build Editor's per-category string IDs (consistent with what the report's
+    // gear panel displays). Unmappable codes are simply left off the piece.
+    const category = gearCategoryForSlot(slotIdx);
+    const trait = resolveTraitId(item.trait, category);
+    if (trait) piece.trait = trait;
+    const enchant = resolveEnchantId(item.enchantType, category);
+    if (enchant) piece.enchant = enchant;
 
     config[equipSlot] = piece;
   }
@@ -380,8 +401,25 @@ export function playerToBuild(data: PlayerBuildExtractionData): Build {
   const { esoClass, classSkillLines } = resolveClassFromAnalysis(data.classAnalysis);
   const role = resolveRole(data.role);
   const gearConfig = convertGear(data.gear);
-  const { skills, passives } = convertSkills(data.talents);
+  const { skills, passives: rawPassives } = convertSkills(data.talents);
   const cp = convertChampionPoints(data.championPoints);
+
+  // Class Mastery picks (U50) live on the top-level build.classMasteryPassives
+  // field, NOT setup.passives. Source them from the report's class-detection
+  // result — the "Class Mastery" skill-line entry's detected ability IDs — plus
+  // any Class Mastery IDs that slipped in via talent passives, then split those
+  // IDs back out of the regular passive list so the editor stays WYSIWYG.
+  const cmFromAnalysis = data.classAnalysis?.skillLines?.find(
+    (sl) => sl.skillLine === CLASS_MASTERY_LINE_NAME,
+  )?.skillIds;
+  const { passives, classMasteryPassives: cmFromPassives } = partitionClassMasteryPicks(
+    rawPassives,
+    esoClass,
+  );
+  const classMasteryPassives = sanitizeClassMasteryPicks(
+    [...(cmFromAnalysis ? Array.from(cmFromAnalysis) : []), ...cmFromPassives],
+    esoClass,
+  );
   const mundusStone = data.mundusBuffs.length > 0 ? resolveMundusId(data.mundusBuffs[0].name) : '';
   const description = buildGearDescription(data.gear);
 
@@ -410,6 +448,7 @@ export function playerToBuild(data: PlayerBuildExtractionData): Build {
     shortDescription: description,
     esoClass,
     classSkillLines,
+    classMasteryPassives,
     role,
     gameMode: 'pve',
     races: [],

--- a/src/utils/playerToBuild.ts
+++ b/src/utils/playerToBuild.ts
@@ -181,7 +181,14 @@ function resolveRole(playerRole?: string): CombatRole {
 
 // ─── Gear Conversion ────────────────────────────────────────────────────────
 
-export function convertGear(gear: PlayerGear[]): GearConfig {
+export function convertGear(
+  gear: PlayerGear[],
+  // Weapon-type resolution reads the loadout-manager icon data, which is loaded
+  // asynchronously and lives in a session-global cache — so it's only run when a
+  // caller has awaited preloadIconData() and opts in. Off by default keeps other
+  // callers (e.g. logToRoster) deterministic and unchanged.
+  opts: { resolveWeaponType?: boolean } = {},
+): GearConfig {
   const config: GearConfig = {};
 
   for (let i = 0; i < gear.length; i++) {
@@ -205,7 +212,7 @@ export function convertGear(gear: PlayerGear[]): GearConfig {
     // the right weapon. Requires icon data preloaded by the caller; falls back
     // to the raw id otherwise. Off-hand slots (11, 13) use the 'offhand' slot.
     const piece: GearPiece =
-      category === 'weapon'
+      category === 'weapon' && opts.resolveWeaponType
         ? {
             id: resolveWeaponItemId({
               combatLogId: item.id,
@@ -422,7 +429,7 @@ export interface PlayerBuildExtractionData {
 export function playerToBuild(data: PlayerBuildExtractionData): Build {
   const { esoClass, classSkillLines } = resolveClassFromAnalysis(data.classAnalysis);
   const role = resolveRole(data.role);
-  const gearConfig = convertGear(data.gear);
+  const gearConfig = convertGear(data.gear, { resolveWeaponType: true });
   const { skills, passives: rawPassives } = convertSkills(data.talents);
   const cp = convertChampionPoints(data.championPoints);
 


### PR DESCRIPTION
## What

Clicking **Extract Build** on a report player card (`/build-editor?b=…&from=report`) silently dropped several things. This restores them so an extracted build faithfully mirrors what the report shows.

### 1. Class Mastery picks (U50)
`playerToBuild` never set `build.classMasteryPassives`, so the editor's Class Mastery section always opened empty. It now sources the picks from the report's class detection — the `"Class Mastery"` skill-line entry's detected ability ids (the same data the player card already filters out of its chip row) — splits them out of `setup.passives`, sanitizes/caps to the resolved class, and round-trips through the `?b=` `cm` field + `loadBuild` migration. Best-effort: empty when undetectable (most endgame players are subclassed, so CM rarely applies).

### 2. Gear traits & enchants
`convertGear` only emitted item id + armor weight. New `combatLogGearMapping` maps the log's numeric `trait` / `enchantType` codes to the Build Editor's per-category kebab ids, going **through the same `TRAIT_NAMES` / `ENCHANTMENT_NAMES` tables the report's gear panel displays**, so the editor shows the same trait/enchant the user just saw. Unmappable codes degrade to nothing (never a wrong value). `convertGear` also now keys off `item.slot`.

### 3. Weapon type (Dagger / Sword / Inferno Staff / …)
The combat-log weapon id is often a *generic* set-weapon id that resolves the set but no type. `resolveWeaponItemId` re-resolves the editor's type-specific variant id for the piece's set + `WeaponType` (with the icon token as a Bow/gap fallback), matching the set's variants by exact label (so "Axe" can't match "Battle Axe"). `handleExtractBuild` warms the (async) icon data first. Falls back to the raw id when a set has no weapon variants in the item DB (some crafted sets).

## Verification
- tsc + eslint clean; 27 new unit tests incl. a full `playerToBuild → encode → decode → migrate` round-trip.
- **Live-verified** against the sample report (12 players): traits, enchants, sets, weights all transfer; 11/12 players' weapons resolve to the correct type (incl. dual-wield off-hand daggers and all four staff elements); Class Mastery correctly gated.
- Adversarial review workflow over the first two fixes: 9 raw findings → 0 confirmed bugs.

All client-side; no worker/API changes.