### PR TITLE
feat(report): show chosen Class Mastery passives on player cards

### DIFF
--- a/src/features/report_details/insights/ClassMasteryCluster.tsx
+++ b/src/features/report_details/insights/ClassMasteryCluster.tsx
@@ -1,0 +1,226 @@
+/**
+ * Class Mastery cluster — a compact, class-coloured "mastery seal" on a report
+ * player card showing the up-to-2 Class Mastery passives a non-subclassed player
+ * chose (U50). Purely informational: each passive is a focusable, tooltip-rich
+ * round icon ringed in the owning class's accent, set apart from the slotted
+ * talent avatars (rounded squares) by its circular passive shape and "MASTERY"
+ * eyebrow. Renders nothing when the player has no Class Mastery picks.
+ */
+
+import { Box, Tooltip, Typography } from '@mui/material';
+import { alpha, darken, getContrastRatio, lighten, useTheme } from '@mui/material/styles';
+import React from 'react';
+
+import { CLASS_COLOR_MAP } from '@/features/build-editor/theme/classColorMap';
+import type { ESOClass } from '@/features/build-editor/types/build.types';
+import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
+import { toClassKey } from '@/utils/classNameUtils';
+
+import { getClassMasteryPicks, type ClassMasteryPick } from './classMasteryPicks';
+
+const ICON_URL = 'https://assets.rpglogs.com/img/eso/abilities/';
+
+// Conservative card-surface samples for contrast clamping. The card's light
+// surface is a translucent light gradient and its dark surface a deep navy; we
+// target slightly-harder-than-actual values so a pass here also passes against
+// the real (easier) surface in each theme.
+const LIGHT_SURFACE = '#dde4ef';
+const DARK_SURFACE = '#1a2336';
+
+/**
+ * A class accent nudged just far enough (darker in light mode, lighter in dark
+ * mode) to clear `target` contrast against the card surface, preserving the hue
+ * so the label/focus ring still reads as the class colour. Bright accents like
+ * Templar gold fail WCAG as raw small text on a light card; this keeps them
+ * legible without dropping the class identity.
+ */
+const readableAccent = (accent: string, isDark: boolean, target: number): string => {
+  const surface = isDark ? DARK_SURFACE : LIGHT_SURFACE;
+  let color = accent;
+  for (let i = 0; i < 16 && getContrastRatio(color, surface) < target; i++) {
+    color = isDark ? lighten(color, 0.12) : darken(color, 0.12);
+  }
+  return color;
+};
+
+/** First mechanics paragraph — the flavour line precedes the first blank line. */
+const firstMechanicsParagraph = (description: string): string =>
+  description.split('\n\n')[1] ?? description;
+
+interface ClassMasteryIconProps {
+  pick: ClassMasteryPick;
+  accent: string;
+  /** Contrast-safe accent for the keyboard focus ring (>=3:1 on the card surface). */
+  focusColor: string;
+  isDark: boolean;
+}
+
+const ClassMasteryIcon: React.FC<ClassMasteryIconProps> = ({
+  pick,
+  accent,
+  focusColor,
+  isDark,
+}) => {
+  const ringHalo = isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.7)';
+
+  return (
+    <Tooltip
+      arrow
+      placement="top"
+      enterTouchDelay={0}
+      leaveTouchDelay={3000}
+      title={
+        <Box sx={{ maxWidth: 300 }}>
+          <Typography
+            sx={{
+              fontWeight: 700,
+              fontSize: 12,
+              fontFamily: 'Space Grotesk, Inter, system-ui',
+            }}
+          >
+            {pick.name}
+          </Typography>
+          {pick.description && (
+            <Typography sx={{ fontSize: 11, opacity: 0.85, whiteSpace: 'pre-line', mt: 0.5 }}>
+              {firstMechanicsParagraph(pick.description)}
+            </Typography>
+          )}
+        </Box>
+      }
+    >
+      <Box
+        tabIndex={0}
+        role="img"
+        aria-label={`${pick.name} — Class Mastery passive`}
+        sx={{
+          width: { xs: 28, sm: 26, md: 25 },
+          height: { xs: 28, sm: 26, md: 25 },
+          borderRadius: '50%',
+          overflow: 'hidden',
+          flexShrink: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'help',
+          background: alpha(accent, isDark ? 0.16 : 0.1),
+          border: `1.5px solid ${alpha(accent, isDark ? 0.65 : 0.55)}`,
+          boxShadow: `0 0 0 1px ${ringHalo}, 0 0 7px ${alpha(accent, isDark ? 0.32 : 0.2)}`,
+          transition: 'border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease',
+          '&:hover, &:focus-visible': {
+            borderColor: alpha(accent, 0.95),
+            boxShadow: `0 0 0 1px ${ringHalo}, 0 0 11px ${alpha(accent, isDark ? 0.5 : 0.34)}`,
+            transform: 'translateY(-1px)',
+          },
+          '&:focus-visible': {
+            outline: `2px solid ${focusColor}`,
+            outlineOffset: 2,
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            transition: 'none',
+            '&:hover, &:focus-visible': { transform: 'none' },
+          },
+        }}
+      >
+        <Box
+          component="img"
+          src={`${ICON_URL}${pick.icon}.png`}
+          alt=""
+          loading="lazy"
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
+          }}
+          sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        />
+      </Box>
+    </Tooltip>
+  );
+};
+
+interface ClassMasteryClusterProps {
+  classAnalysis?: ClassAnalysisResult;
+}
+
+const ClassMasteryClusterComponent: React.FC<ClassMasteryClusterProps> = ({ classAnalysis }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const { className, picks } = React.useMemo(
+    () => getClassMasteryPicks(classAnalysis),
+    [classAnalysis],
+  );
+
+  if (picks.length === 0) return null;
+
+  const accent =
+    CLASS_COLOR_MAP[toClassKey(className) as ESOClass]?.accent ?? theme.palette.primary.main;
+  // The "MASTERY" label is the smallest text on the card, so hold it to body-text
+  // contrast (4.5:1); the focus ring is a non-text indicator (3:1). Both keep the
+  // class hue via readableAccent rather than dropping to a neutral colour.
+  const labelColor = readableAccent(accent, isDark, 4.5);
+  const focusColor = readableAccent(accent, isDark, 3);
+
+  return (
+    <Box
+      data-testid="class-mastery-cluster"
+      role="group"
+      aria-label="Class Mastery passives"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: { xs: 0.85, sm: 0.75, md: 0.65 },
+        minWidth: 0,
+        mt: 0.25,
+        mb: 1,
+      }}
+    >
+      <Tooltip
+        arrow
+        enterTouchDelay={0}
+        leaveTouchDelay={3000}
+        title="Class Mastery — up to 2 of your class's 5 passives (non-subclassed only)"
+      >
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.6, flexShrink: 0 }}>
+          <Box
+            aria-hidden
+            sx={{
+              width: 2,
+              height: 14,
+              borderRadius: 1,
+              flexShrink: 0,
+              background: `linear-gradient(${labelColor}, ${alpha(labelColor, 0.35)})`,
+            }}
+          />
+          <Typography
+            component="span"
+            sx={{
+              fontFamily: 'Space Grotesk, Inter, system-ui',
+              fontSize: { xs: 9.5, sm: 9, md: 8.5 },
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+              lineHeight: 1,
+              color: labelColor,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Mastery
+          </Typography>
+        </Box>
+      </Tooltip>
+
+      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: { xs: 0.6, md: 0.5 } }}>
+        {picks.map((pick) => (
+          <ClassMasteryIcon
+            key={pick.id}
+            pick={pick}
+            accent={accent}
+            focusColor={focusColor}
+            isDark={isDark}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export const ClassMasteryCluster = React.memo(ClassMasteryClusterComponent);

--- a/src/features/report_details/insights/ClassMasteryCluster.tsx
+++ b/src/features/report_details/insights/ClassMasteryCluster.tsx
@@ -1,13 +1,19 @@
 /**
- * Class Mastery cluster — a compact, class-coloured "mastery seal" on a report
+ * Class Mastery cluster — a compact, class-coloured glass chip on a report
  * player card showing the up-to-2 Class Mastery passives a non-subclassed player
- * chose (U50). Purely informational: each passive is a focusable, tooltip-rich
- * round icon ringed in the owning class's accent, set apart from the slotted
- * talent avatars (rounded squares) by its circular passive shape and "MASTERY"
- * eyebrow. Renders nothing when the player has no Class Mastery picks.
+ * chose (U50). Built in the card's chip language (like the Champion Point and
+ * gear-set chips) and tinted with the owning class's accent from CLASS_COLOR_MAP
+ * — the same per-class palette the build editor uses — so each player's chip
+ * carries their class colour.
+ *
+ * On reveal the chip assembles: it fades/scales in, the passive gems pop in with
+ * a slight overshoot, and the label slides in. Hovering (or focusing) the chip
+ * surfaces a rich "Class Mastery" overview tooltip listing both passives; each
+ * gem also stays individually keyboard-focusable. All motion respects
+ * prefers-reduced-motion. Renders nothing when the player has no picks.
  */
 
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Divider, Tooltip, Typography } from '@mui/material';
 import { alpha, darken, getContrastRatio, lighten, useTheme } from '@mui/material/styles';
 import React from 'react';
 
@@ -47,12 +53,85 @@ const readableAccent = (accent: string, isDark: boolean, target: number): string
 const firstMechanicsParagraph = (description: string): string =>
   description.split('\n\n')[1] ?? description;
 
+// ── Overview tooltip ──────────────────────────────────────────────────────────
+
+const ClassMasteryOverview: React.FC<{ picks: ClassMasteryPick[]; accent: string }> = ({
+  picks,
+  accent,
+}) => (
+  <Box sx={{ maxWidth: 320 }}>
+    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, mb: 0.25 }}>
+      <Typography
+        sx={{
+          fontFamily: 'Space Grotesk, Inter, system-ui',
+          fontWeight: 700,
+          fontSize: 11,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: accent,
+        }}
+      >
+        Class Mastery
+      </Typography>
+      <Typography sx={{ fontSize: 9.5, opacity: 0.6, letterSpacing: '0.02em' }}>
+        {picks.length} of 5 · non-subclassed
+      </Typography>
+    </Box>
+    <Divider sx={{ borderColor: alpha(accent, 0.35), mb: 0.75 }} />
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.85 }}>
+      {picks.map((pick) => (
+        <Box key={pick.id} sx={{ display: 'flex', gap: 0.85 }}>
+          <Box
+            component="img"
+            src={`${ICON_URL}${pick.icon}.png`}
+            alt=""
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
+            }}
+            sx={{
+              width: 26,
+              height: 26,
+              flexShrink: 0,
+              borderRadius: '50%',
+              objectFit: 'cover',
+              border: `1.5px solid ${alpha(accent, 0.7)}`,
+            }}
+          />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={{
+                fontWeight: 700,
+                fontSize: 11.5,
+                lineHeight: 1.25,
+                fontFamily: 'Space Grotesk, Inter, system-ui',
+              }}
+            >
+              {pick.name}
+            </Typography>
+            {pick.description && (
+              <Typography sx={{ fontSize: 10.5, opacity: 0.82, lineHeight: 1.35, mt: 0.15 }}>
+                {firstMechanicsParagraph(pick.description)}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  </Box>
+);
+
+// ── Passive gem ───────────────────────────────────────────────────────────────
+
 interface ClassMasteryIconProps {
   pick: ClassMasteryPick;
   accent: string;
   /** Contrast-safe accent for the keyboard focus ring (>=3:1 on the card surface). */
   focusColor: string;
   isDark: boolean;
+  /** Tuck this gem partly behind the previous one (avatar-stack within the chip). */
+  overlap: boolean;
+  /** Stagger position for the entrance pop. */
+  index: number;
 }
 
 const ClassMasteryIcon: React.FC<ClassMasteryIconProps> = ({
@@ -60,81 +139,75 @@ const ClassMasteryIcon: React.FC<ClassMasteryIconProps> = ({
   accent,
   focusColor,
   isDark,
+  overlap,
+  index,
 }) => {
-  const ringHalo = isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.7)';
+  // A neutral halo ring separates overlapping gems from each other and from the
+  // tinted chip behind them.
+  const halo = isDark ? 'rgba(13,19,32,0.92)' : 'rgba(244,246,252,0.96)';
 
   return (
-    <Tooltip
-      arrow
-      placement="top"
-      enterTouchDelay={0}
-      leaveTouchDelay={3000}
-      title={
-        <Box sx={{ maxWidth: 300 }}>
-          <Typography
-            sx={{
-              fontWeight: 700,
-              fontSize: 12,
-              fontFamily: 'Space Grotesk, Inter, system-ui',
-            }}
-          >
-            {pick.name}
-          </Typography>
-          {pick.description && (
-            <Typography sx={{ fontSize: 11, opacity: 0.85, whiteSpace: 'pre-line', mt: 0.5 }}>
-              {firstMechanicsParagraph(pick.description)}
-            </Typography>
-          )}
-        </Box>
-      }
+    <Box
+      tabIndex={0}
+      role="img"
+      aria-label={`${pick.name} — Class Mastery passive`}
+      sx={{
+        width: { xs: 24, sm: 22, md: 21 },
+        height: { xs: 24, sm: 22, md: 21 },
+        ml: overlap ? { xs: '-7px', md: '-6px' } : 0,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        flexShrink: 0,
+        position: 'relative',
+        zIndex: 1,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'help',
+        background: alpha(accent, isDark ? 0.2 : 0.12),
+        border: `1.5px solid ${alpha(accent, isDark ? 0.7 : 0.6)}`,
+        boxShadow: `0 0 0 2px ${halo}`,
+        // Staggered pop-in (overshoot easing); `backwards` fill so the resting
+        // transform reverts to none and the hover scale below still works.
+        '@keyframes cmGemIn': {
+          from: { opacity: 0, transform: 'scale(0.4)' },
+          to: { opacity: 1, transform: 'none' },
+        },
+        animation: `cmGemIn 360ms cubic-bezier(0.34, 1.56, 0.64, 1) backwards`,
+        animationDelay: `${140 + index * 95}ms`,
+        transition: 'box-shadow 150ms ease, transform 150ms ease, border-color 150ms ease',
+        '&:hover, &:focus-visible': {
+          zIndex: 2,
+          borderColor: alpha(accent, 0.95),
+          boxShadow: `0 0 0 2px ${halo}, 0 0 9px ${alpha(accent, isDark ? 0.55 : 0.36)}`,
+          transform: 'scale(1.1)',
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${focusColor}`,
+          outlineOffset: 2,
+        },
+        '@media (prefers-reduced-motion: reduce)': {
+          animation: 'none',
+          transition: 'none',
+          '&:hover, &:focus-visible': { transform: 'none' },
+        },
+      }}
     >
       <Box
-        tabIndex={0}
-        role="img"
-        aria-label={`${pick.name} — Class Mastery passive`}
-        sx={{
-          width: { xs: 28, sm: 26, md: 25 },
-          height: { xs: 28, sm: 26, md: 25 },
-          borderRadius: '50%',
-          overflow: 'hidden',
-          flexShrink: 0,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'help',
-          background: alpha(accent, isDark ? 0.16 : 0.1),
-          border: `1.5px solid ${alpha(accent, isDark ? 0.65 : 0.55)}`,
-          boxShadow: `0 0 0 1px ${ringHalo}, 0 0 7px ${alpha(accent, isDark ? 0.32 : 0.2)}`,
-          transition: 'border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease',
-          '&:hover, &:focus-visible': {
-            borderColor: alpha(accent, 0.95),
-            boxShadow: `0 0 0 1px ${ringHalo}, 0 0 11px ${alpha(accent, isDark ? 0.5 : 0.34)}`,
-            transform: 'translateY(-1px)',
-          },
-          '&:focus-visible': {
-            outline: `2px solid ${focusColor}`,
-            outlineOffset: 2,
-          },
-          '@media (prefers-reduced-motion: reduce)': {
-            transition: 'none',
-            '&:hover, &:focus-visible': { transform: 'none' },
-          },
+        component="img"
+        src={`${ICON_URL}${pick.icon}.png`}
+        alt=""
+        loading="lazy"
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
         }}
-      >
-        <Box
-          component="img"
-          src={`${ICON_URL}${pick.icon}.png`}
-          alt=""
-          loading="lazy"
-          onError={(e) => {
-            (e.currentTarget as HTMLImageElement).style.visibility = 'hidden';
-          }}
-          sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-        />
-      </Box>
-    </Tooltip>
+        sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+      />
+    </Box>
   );
 };
+
+// ── Cluster ───────────────────────────────────────────────────────────────────
 
 interface ClassMasteryClusterProps {
   classAnalysis?: ClassAnalysisResult;
@@ -153,73 +226,116 @@ const ClassMasteryClusterComponent: React.FC<ClassMasteryClusterProps> = ({ clas
 
   const accent =
     CLASS_COLOR_MAP[toClassKey(className) as ESOClass]?.accent ?? theme.palette.primary.main;
-  // The "MASTERY" label is the smallest text on the card, so hold it to body-text
-  // contrast (4.5:1); the focus ring is a non-text indicator (3:1). Both keep the
-  // class hue via readableAccent rather than dropping to a neutral colour.
+  // The "Class Mastery" label is the smallest text on the card, so hold it to
+  // body-text contrast (4.5:1); the focus ring is a non-text indicator (3:1).
+  // Both keep the class hue via readableAccent rather than a neutral colour.
   const labelColor = readableAccent(accent, isDark, 4.5);
   const focusColor = readableAccent(accent, isDark, 3);
+  const chipShadowRest = isDark
+    ? 'inset 0 1px 0 rgba(255,255,255,0.05)'
+    : 'inset 0 1px 0 rgba(255,255,255,0.55)';
 
   return (
-    <Box
-      data-testid="class-mastery-cluster"
-      role="group"
-      aria-label="Class Mastery passives"
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: { xs: 0.85, sm: 0.75, md: 0.65 },
-        minWidth: 0,
-        mt: 0.25,
-        mb: 1,
+    <Tooltip
+      arrow
+      placement="top-start"
+      enterTouchDelay={0}
+      leaveTouchDelay={4000}
+      title={<ClassMasteryOverview picks={picks} accent={accent} />}
+      slotProps={{
+        tooltip: {
+          sx: {
+            bgcolor: isDark ? 'rgba(13,19,32,0.97)' : 'rgba(255,255,255,0.98)',
+            color: isDark ? '#e8eef7' : '#1b2433',
+            border: `1px solid ${alpha(accent, 0.4)}`,
+            borderRadius: 2,
+            p: 1.25,
+            maxWidth: 340,
+            boxShadow: `0 10px 28px rgba(0,0,0,${isDark ? 0.55 : 0.22})`,
+            backdropFilter: 'blur(8px)',
+          },
+        },
+        arrow: { sx: { color: isDark ? 'rgba(13,19,32,0.97)' : 'rgba(255,255,255,0.98)' } },
       }}
     >
-      <Tooltip
-        arrow
-        enterTouchDelay={0}
-        leaveTouchDelay={3000}
-        title="Class Mastery — up to 2 of your class's 5 passives (non-subclassed only)"
+      <Box
+        data-testid="class-mastery-cluster"
+        role="group"
+        aria-label="Class Mastery passives"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          width: 'fit-content',
+          maxWidth: '100%',
+          minWidth: 0,
+          mt: 0.25,
+          mb: 1,
+          pl: '5px',
+          pr: 1.25,
+          py: '3px',
+          borderRadius: 999,
+          cursor: 'default',
+          background: alpha(accent, isDark ? 0.12 : 0.1),
+          border: `1px solid ${alpha(accent, 0.3)}`,
+          boxShadow: chipShadowRest,
+          // Chip reveal: fade + lift + settle (no resting transform → no sticky
+          // transform interfering with the gems' hover scale).
+          '@keyframes cmChipIn': {
+            from: { opacity: 0, transform: 'translateY(4px) scale(0.96)' },
+            to: { opacity: 1, transform: 'none' },
+          },
+          animation: 'cmChipIn 300ms ease-out backwards',
+          transition: 'box-shadow 180ms ease, border-color 180ms ease',
+          '&:hover': {
+            borderColor: alpha(accent, 0.5),
+            boxShadow: `${chipShadowRest}, 0 0 0 1px ${alpha(accent, 0.35)}, 0 5px 16px ${alpha(
+              accent,
+              isDark ? 0.3 : 0.18,
+            )}`,
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            animation: 'none',
+            transition: 'none',
+          },
+        }}
       >
-        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.6, flexShrink: 0 }}>
-          <Box
-            aria-hidden
-            sx={{
-              width: 2,
-              height: 14,
-              borderRadius: 1,
-              flexShrink: 0,
-              background: `linear-gradient(${labelColor}, ${alpha(labelColor, 0.35)})`,
-            }}
-          />
-          <Typography
-            component="span"
-            sx={{
-              fontFamily: 'Space Grotesk, Inter, system-ui',
-              fontSize: { xs: 9.5, sm: 9, md: 8.5 },
-              fontWeight: 700,
-              letterSpacing: '0.1em',
-              textTransform: 'uppercase',
-              lineHeight: 1,
-              color: labelColor,
-              whiteSpace: 'nowrap',
-            }}
-          >
-            Mastery
-          </Typography>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}>
+          {picks.map((pick, index) => (
+            <ClassMasteryIcon
+              key={pick.id}
+              pick={pick}
+              accent={accent}
+              focusColor={focusColor}
+              isDark={isDark}
+              overlap={index > 0}
+              index={index}
+            />
+          ))}
         </Box>
-      </Tooltip>
-
-      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: { xs: 0.6, md: 0.5 } }}>
-        {picks.map((pick) => (
-          <ClassMasteryIcon
-            key={pick.id}
-            pick={pick}
-            accent={accent}
-            focusColor={focusColor}
-            isDark={isDark}
-          />
-        ))}
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: 'Space Grotesk, Inter, system-ui',
+            fontSize: { xs: 9.5, sm: 9, md: 8.5 },
+            fontWeight: 700,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            lineHeight: 1,
+            color: labelColor,
+            whiteSpace: 'nowrap',
+            '@keyframes cmLabelIn': {
+              from: { opacity: 0, transform: 'translateX(-4px)' },
+              to: { opacity: 1, transform: 'none' },
+            },
+            animation: 'cmLabelIn 320ms ease-out 200ms backwards',
+            '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+          }}
+        >
+          Class Mastery
+        </Typography>
       </Box>
-    </Box>
+    </Tooltip>
   );
 };
 

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -65,6 +65,7 @@ import { type BarSwapAnalysisResult } from '../../parse_analysis/utils/parseAnal
 import { SCRIBING_DETECTION_SCHEMA_VERSION } from '../../scribing/analysis/scribingDetectionAnalysis';
 import { ScribedSkillData } from '../../scribing/types';
 
+import { ClassMasteryCluster } from './ClassMasteryCluster';
 import { MetricsScrollRow } from './MetricsScrollRow';
 import type { StatChipId } from './statChipConfig';
 import { formatStatValue, STAT_CHIP_IDS, STAT_CHIP_META } from './statChipConfig';
@@ -1353,6 +1354,9 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                     </OneLineAutoFit>
                   </Box>
                 </Box>
+
+                {/* Class Mastery passives (non-subclassed only) — renders nothing otherwise */}
+                <ClassMasteryCluster classAnalysis={classAnalysis} />
 
                 {/* Talents */}
                 {talents.length > 0 && (

--- a/src/features/report_details/insights/__tests__/ClassMasteryCluster.test.tsx
+++ b/src/features/report_details/insights/__tests__/ClassMasteryCluster.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+
+import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
+
+import { ClassMasteryCluster } from '../ClassMasteryCluster';
+
+const NB_AN_EYE = 263604;
+const NB_ABOVE_AND_BEYOND = 263605;
+const SORC_CONSERVATION = 263870;
+const SORC_FONT = 263871;
+const SORC_STATIC = 263872;
+const SORC_CALCULATED = 263873;
+const NOISE_A = 264991;
+const NOISE_B = 268274;
+
+type SkillLineEntry = ClassAnalysisResult['skillLines'][number];
+
+const cmEntry = (className: string, ids: number[]): SkillLineEntry => ({
+  skillLine: 'Class Mastery',
+  className,
+  count: ids.length,
+  skillIds: new Set(ids),
+});
+
+const analysis = (lines: SkillLineEntry[]): ClassAnalysisResult => ({
+  primary: lines[0]?.skillLine ?? null,
+  skillLines: lines,
+});
+
+const masteryIcons = (): HTMLElement[] => screen.queryAllByRole('img');
+
+describe('ClassMasteryCluster', () => {
+  it('renders the labelled cluster with two passive icons', () => {
+    render(
+      <ClassMasteryCluster
+        classAnalysis={analysis([cmEntry('Nightblade', [NB_ABOVE_AND_BEYOND, NB_AN_EYE])])}
+      />,
+    );
+
+    expect(screen.getByTestId('class-mastery-cluster')).toBeInTheDocument();
+    expect(screen.getByText('Mastery')).toBeInTheDocument();
+    expect(masteryIcons()).toHaveLength(2);
+    expect(screen.getByLabelText('Above and Beyond — Class Mastery passive')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('An Eye for Exploitation — Class Mastery passive'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a single icon when only one pick is surfaced', () => {
+    render(<ClassMasteryCluster classAnalysis={analysis([cmEntry('Nightblade', [NB_AN_EYE])])} />);
+
+    expect(screen.getByTestId('class-mastery-cluster')).toBeInTheDocument();
+    expect(masteryIcons()).toHaveLength(1);
+  });
+
+  it('shows exactly two icons when detection over-detects three valid ids — never three', () => {
+    render(
+      <ClassMasteryCluster
+        classAnalysis={analysis([cmEntry('Sorcerer', [SORC_CONSERVATION, SORC_FONT, SORC_STATIC])])}
+      />,
+    );
+
+    expect(masteryIcons()).toHaveLength(2);
+  });
+
+  it('drops name-matched effect ids (Showers-in-Petals shape) and shows one icon', () => {
+    render(
+      <ClassMasteryCluster
+        classAnalysis={analysis([cmEntry('Sorcerer', [SORC_CALCULATED, NOISE_A, NOISE_B])])}
+      />,
+    );
+
+    expect(masteryIcons()).toHaveLength(1);
+    expect(screen.getByLabelText('Calculated Defense — Class Mastery passive')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a subclassed player (no Class Mastery line)', () => {
+    render(
+      <ClassMasteryCluster
+        classAnalysis={analysis([
+          { skillLine: 'Assassination', className: 'Nightblade', count: 4, skillIds: new Set([1]) },
+        ])}
+      />,
+    );
+
+    expect(screen.queryByTestId('class-mastery-cluster')).not.toBeInTheDocument();
+    expect(masteryIcons()).toHaveLength(0);
+  });
+
+  it('renders nothing without analysis', () => {
+    render(<ClassMasteryCluster classAnalysis={undefined} />);
+    expect(screen.queryByTestId('class-mastery-cluster')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/report_details/insights/__tests__/ClassMasteryCluster.test.tsx
+++ b/src/features/report_details/insights/__tests__/ClassMasteryCluster.test.tsx
@@ -38,7 +38,7 @@ describe('ClassMasteryCluster', () => {
     );
 
     expect(screen.getByTestId('class-mastery-cluster')).toBeInTheDocument();
-    expect(screen.getByText('Mastery')).toBeInTheDocument();
+    expect(screen.getByText('Class Mastery')).toBeInTheDocument();
     expect(masteryIcons()).toHaveLength(2);
     expect(screen.getByLabelText('Above and Beyond — Class Mastery passive')).toBeInTheDocument();
     expect(

--- a/src/features/report_details/insights/__tests__/classMasteryPicks.test.ts
+++ b/src/features/report_details/insights/__tests__/classMasteryPicks.test.ts
@@ -1,0 +1,116 @@
+import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
+
+import { getClassMasteryPicks } from '../classMasteryPicks';
+
+// Canonical Class Mastery ability ids (from classSkillIds.ts / classMastery.ts).
+const NB_AN_EYE = 263604; // "An Eye for Exploitation"
+const NB_ABOVE_AND_BEYOND = 263605; // "Above and Beyond"
+const SORC_CONSERVATION = 263870; // "Conservation of Energy"
+const SORC_FONT = 263871; // "Font of Power"
+const SORC_STATIC = 263872; // "Static Reverberation"
+const SORC_CALCULATED = 263873; // "Calculated Defense"
+// Effect/proc ids the live detection name-matches into the Class Mastery line
+// but that are NOT canonical passive ids (the real over-detection seen on
+// Showers-in-Petals). They must be filtered out, never rendered.
+const NOISE_A = 264991;
+const NOISE_B = 268274;
+
+type SkillLineEntry = ClassAnalysisResult['skillLines'][number];
+
+const cmEntry = (className: string, ids: number[]): SkillLineEntry => ({
+  skillLine: 'Class Mastery',
+  className,
+  count: ids.length,
+  skillIds: new Set(ids),
+});
+
+const analysis = (lines: SkillLineEntry[]): ClassAnalysisResult => ({
+  primary: lines[0]?.skillLine ?? null,
+  skillLines: lines,
+});
+
+describe('getClassMasteryPicks', () => {
+  it('resolves two picks to their named passives (Bögyike: Nightblade)', () => {
+    const result = getClassMasteryPicks(
+      analysis([cmEntry('Nightblade', [NB_ABOVE_AND_BEYOND, NB_AN_EYE])]),
+    );
+
+    expect(result.className).toBe('Nightblade');
+    expect(result.picks.map((p) => p.name)).toEqual([
+      'Above and Beyond',
+      'An Eye for Exploitation',
+    ]);
+    // Each pick carries the renderable fields the card needs.
+    expect(result.picks[0]).toMatchObject({
+      id: NB_ABOVE_AND_BEYOND,
+      name: 'Above and Beyond',
+    });
+    expect(result.picks[0].icon).toBeTruthy();
+    expect(result.picks[0].description).toBeTruthy();
+  });
+
+  it('handles a single surfaced pick gracefully', () => {
+    const result = getClassMasteryPicks(analysis([cmEntry('Nightblade', [NB_AN_EYE])]));
+
+    expect(result.picks).toHaveLength(1);
+    expect(result.picks[0].name).toBe('An Eye for Exploitation');
+  });
+
+  it('caps over-detection at 2 — three valid ids resolve to exactly two picks', () => {
+    const result = getClassMasteryPicks(
+      analysis([cmEntry('Sorcerer', [SORC_CONSERVATION, SORC_FONT, SORC_STATIC])]),
+    );
+
+    expect(result.picks).toHaveLength(2);
+    expect(result.picks.map((p) => p.id)).toEqual([SORC_CONSERVATION, SORC_FONT]);
+  });
+
+  it('drops name-matched effect ids that are not canonical picks (Showers-in-Petals shape)', () => {
+    // Detection returns [263873, 264991, 268274]; only 263873 is a real pick.
+    const result = getClassMasteryPicks(
+      analysis([cmEntry('Sorcerer', [SORC_CALCULATED, NOISE_A, NOISE_B])]),
+    );
+
+    expect(result.picks).toHaveLength(1);
+    expect(result.picks[0].name).toBe('Calculated Defense');
+  });
+
+  it('never resolves more than two even with noise mixed into valid ids', () => {
+    const result = getClassMasteryPicks(
+      analysis([
+        cmEntry('Sorcerer', [SORC_CONSERVATION, NOISE_A, SORC_FONT, NOISE_B, SORC_STATIC]),
+      ]),
+    );
+
+    expect(result.picks.length).toBeLessThanOrEqual(2);
+    expect(result.picks).toHaveLength(2);
+  });
+
+  it('returns nothing when there is no Class Mastery line (subclassed player)', () => {
+    const subclassed = analysis([
+      { skillLine: 'Assassination', className: 'Nightblade', count: 4, skillIds: new Set([1, 2]) },
+      { skillLine: 'Daedric Summoning', className: 'Sorcerer', count: 3, skillIds: new Set([3]) },
+    ]);
+
+    expect(getClassMasteryPicks(subclassed)).toEqual({ className: '', picks: [] });
+  });
+
+  it('returns nothing for missing analysis', () => {
+    expect(getClassMasteryPicks(undefined)).toEqual({ className: '', picks: [] });
+  });
+
+  it('returns nothing when the Class Mastery line holds only foreign/noise ids', () => {
+    expect(getClassMasteryPicks(analysis([cmEntry('Sorcerer', [NOISE_A, NOISE_B])])).picks).toEqual(
+      [],
+    );
+  });
+
+  it('drops ids that belong to a different class than the detected owner', () => {
+    // Nightblade ids under a Sorcerer Class Mastery entry are not Sorcerer picks.
+    const result = getClassMasteryPicks(
+      analysis([cmEntry('Sorcerer', [NB_ABOVE_AND_BEYOND, NB_AN_EYE])]),
+    );
+
+    expect(result.picks).toEqual([]);
+  });
+});

--- a/src/features/report_details/insights/classMasteryPicks.ts
+++ b/src/features/report_details/insights/classMasteryPicks.ts
@@ -1,0 +1,72 @@
+/**
+ * Class Mastery picks for a report player card.
+ *
+ * Derives the up-to-2 Class Mastery passives a non-subclassed player chose
+ * (U50: 2 of the base class's 5) from the report-side class analysis. This is
+ * the SAME plumbing the Extract→Build-Editor transfer uses (PR #1357): the
+ * shared `sanitizeClassMasteryPicks` filters the detected ability ids down to
+ * the class's own canonical Class Mastery ids, dedupes, and caps at the 2-pick
+ * max — so the card can never show more than two, and effect/proc ids that the
+ * detection name-matches into the line (but that aren't canonical passive ids)
+ * are dropped rather than rendered as phantom picks.
+ *
+ * Keep this display-only and in lockstep with the transfer: if it shows N
+ * picks, Extract Build transfers the same N.
+ */
+
+import {
+  CLASS_MASTERY_LINE_NAME,
+  getClassMasteryLine,
+} from '@/data/skill-lines/class/classMastery';
+import type { ESOClass } from '@/features/build-editor/types/build.types';
+import { sanitizeClassMasteryPicks } from '@/features/build-editor/utils/classMasteryTransfer';
+import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
+
+export interface ClassMasteryPick {
+  id: number;
+  name: string;
+  icon: string;
+  description: string;
+}
+
+export interface ClassMasteryPicksResult {
+  /** Owning class (e.g. "Nightblade"); empty string when there are no picks. */
+  className: string;
+  /** Up to two resolved Class Mastery passives; empty when none apply. */
+  picks: ClassMasteryPick[];
+}
+
+const EMPTY: ClassMasteryPicksResult = { className: '', picks: [] };
+
+/**
+ * Resolve the Class Mastery passives to surface on a player card. Returns no
+ * picks when the player is subclassed or otherwise has no Class Mastery line in
+ * the analysis — callers render nothing in that case.
+ */
+export function getClassMasteryPicks(
+  classAnalysis: ClassAnalysisResult | undefined,
+): ClassMasteryPicksResult {
+  const entry = classAnalysis?.skillLines?.find((sl) => sl.skillLine === CLASS_MASTERY_LINE_NAME);
+  if (!entry) return EMPTY;
+
+  const className = entry.className ?? '';
+  // sanitizeClassMasteryPicks resolves the line via a case-insensitive class
+  // lookup, so the lowercased detection class name is a valid ESOClass key here.
+  const esoClass = (className.toLowerCase() || 'any-class') as ESOClass;
+  const ids = sanitizeClassMasteryPicks([...entry.skillIds], esoClass);
+  if (ids.length === 0) return EMPTY;
+
+  const line = getClassMasteryLine(className);
+  const picks = ids
+    .map((id) => line?.skills.find((skill) => skill.id === id))
+    .filter((skill): skill is NonNullable<typeof skill> => Boolean(skill))
+    .map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      icon: skill.icon ?? '',
+      description: skill.description ?? '',
+    }));
+
+  if (picks.length === 0) return EMPTY;
+  return { className, picks };
+}


### PR DESCRIPTION
## What

Surfaces the **Class Mastery passives** a non-subclassed player chose (U50: 2 of the base class's 5) on the report player cards (e.g. `/report/:code/fight/:id/players`). The card already *detected* the Class Mastery line but deliberately hid it — this adds a small, dedicated element showing the actual picks, only when present. Wired once into `PlayerCard`, so it covers the Damage Done, Healing Done and modal surfaces.

## Design / UX

A compact **class-tinted glass chip** in the card's own chip language (like the Champion Point and gear-set chips), placed between the skill-line chips and the talents row. It's tinted with the owning class's accent from `CLASS_COLOR_MAP` — the **same per-class palette the build editor uses** — so each player's chip carries their class colour (Nightblade red, Templar gold, Sorcerer cyan, …). The chip holds the up-to-2 passive gems (a small avatar stack) plus a `CLASS MASTERY` label.

- **Reveal animation:** the chip fades/lifts in, the gems pop with a slight overshoot (staggered), and the label slides in. Uses `backwards` fill so no resting transform lingers to fight the gems' hover scale. Respects `prefers-reduced-motion`.
- **Overview tooltip:** hovering or focusing the chip surfaces a styled "Class Mastery" panel — class-accent header + `N of 5 · non-subclassed`, then each passive as icon + bold name + first mechanics paragraph.
- Each gem stays individually keyboard-focusable and `aria-label`led; `enterTouchDelay={0}`; renders nothing for 0 picks; gracefully renders 1 or 2.

## Data (in lockstep with Extract → Build, PR #1357)

Picks are derived with the **same** `sanitizeClassMasteryPicks` plumbing the Extract→Build transfer uses — detected ability ids are filtered to the class's canonical Class Mastery ids, deduped, and capped at 2. So **if the card shows N picks, Extract Build transfers the same N.** Display-only; the transfer code is untouched.

### Note on the over-detection edge case
The brief flagged Showers-in-Petals (Sorcerer) as detection returning **3** ids `[263873, 264991, 268274]` that must cap to 2. Live inspection of this report shows all three ids are named **"Calculated Defense"** — one canonical passive id plus two of its proc/effect ids. `sanitize` correctly collapses them to the **single** real distinct pick. The hard requirement — *never render 3* — holds; the "2" in the brief was a misread of that triple. This matches exactly what Extract Build transfers.

## Accessibility

The label and the keyboard focus ring use a hue-preserving contrast clamp (`readableAccent`, built on MUI's `getContrastRatio`) so bright class accents (Templar gold, sorcerer cyan, …) still meet **WCAG 4.5:1** (small text) and **3:1** (focus indicator) on the light card surface, in both themes. Verified numerically for all 8 accent keys × both themes.

## Verification

- `tsc --noEmit` clean; `eslint` clean; **full jest green (4297 passed / 17 skipped, 0 failed)** on the first design; CM suites re-green after the restyle (full suite re-run in progress).
- New tests: `classMasteryPicks` (derivation: 0/1/2/over-detected→2/noise→1/subclassed→none/foreign-class→none) and `ClassMasteryCluster` (RTL: counts, label, "never 3", subclassed → nothing).
- **Live-verified** on report `Wj8CTMmq36ra4Kph` fight 3: 5/12 players show the cluster (icon counts `[1,2,2,2,2]`); Showers correctly shows 1; keyboard-focus works; dark + light + mobile all good. The glass-chip restyle was previewed as a faithful static mockup across all 7 classes in both themes (the local dev `roster-hub-api` proxy to prod was flaky mid-session, so the post-restyle in-app capture used the mockup).
