### PR TITLE
Fix live player fallback data

### DIFF
--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -38,6 +38,11 @@ import { useBuffLookupTask } from '../../../hooks/workerTasks/useBuffLookupTask'
 import { usePlayerTravelDistanceTask } from '../../../hooks/workerTasks/usePlayerTravelDistanceTask';
 import type { ReportFightContextInput } from '../../../store/contextTypes';
 import {
+  buildFallbackPlayersFromMasterData,
+  hasPlayerEntries,
+} from '../../../store/player_data/playerDataFallback';
+import type { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
+import {
   KnownAbilities,
   MundusStones,
   RED_CHAMPION_POINTS,
@@ -72,6 +77,8 @@ import {
   type BarSwapAnalysisResult,
 } from '../../parse_analysis/utils/parseAnalysisUtils';
 
+import { PlayersPanelView } from './PlayersPanelView';
+
 // Recipe lookup stubs — full recipe resolution pending unified detection service
 const findScribingRecipe = async (_skillId: unknown, _skillName?: string): Promise<null> => null;
 const formatScribingRecipeForDisplay = (
@@ -93,8 +100,6 @@ const formatScribingRecipeForDisplay = (
   recipeSummary: '',
   tooltipInfo: '',
 });
-
-import { PlayersPanelView } from './PlayersPanelView';
 
 // This panel now uses report actors from masterData
 
@@ -133,7 +138,10 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
 
   // Use hooks to get data
   const { reportMasterData, isMasterDataLoading } = useReportMasterData();
-  const { playerData, isPlayerDataLoading } = usePlayerData({ context: resolvedContext });
+  const { playerData, isPlayerDataLoading } = usePlayerData({
+    context: resolvedContext,
+    includeFallback: false,
+  });
   const { combatantInfoEvents, isCombatantInfoEventsLoading } = useCombatantInfoEvents({
     context: resolvedContext,
   });
@@ -166,6 +174,25 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     combatantInfoEvents,
   });
 
+  const playersById = React.useMemo<Record<string | number, PlayerDetailsWithRole>>(() => {
+    if (hasPlayerEntries(playerData?.playersById)) {
+      return playerData.playersById;
+    }
+
+    return buildFallbackPlayersFromMasterData({
+      friendlyPlayerIds: fight?.friendlyPlayers ?? undefined,
+      actorsById: reportMasterData.actorsById,
+      combatantInfoEvents,
+      rolesByPlayerId,
+    });
+  }, [
+    playerData?.playersById,
+    fight?.friendlyPlayers,
+    reportMasterData.actorsById,
+    combatantInfoEvents,
+    rolesByPlayerId,
+  ]);
+
   const fightIdNumber = resolvedContext.fightId;
 
   const allBuffEvents = React.useMemo(
@@ -186,16 +213,16 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   );
 
   const scribingPlayerAbilities = React.useMemo<PlayerAbilityList[]>(() => {
-    if (!playerData?.playersById) {
+    if (!hasPlayerEntries(playersById)) {
       return [];
     }
 
-    const playerIds = new Set(Object.values(playerData.playersById).map((p) => p.id));
+    const playerIds = new Set(Object.values(playersById).map((p) => p.id));
 
     const abilitiesByPlayer = new Map<number, Set<number>>();
 
     // Scan talent GUIDs (works when ESO Logs provides the transformed ID)
-    Object.values(playerData.playersById).forEach((player) => {
+    Object.values(playersById).forEach((player) => {
       const talents = player.combatantInfo?.talents ?? [];
       talents.forEach((talent) => {
         if (typeof talent.guid === 'number' && isScribingAbility(talent.guid)) {
@@ -227,7 +254,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         abilityIds: Array.from(abilityIds),
       }))
       .filter((entry) => entry.abilityIds.length > 0);
-  }, [playerData, castEvents]);
+  }, [playersById, castEvents]);
 
   const existingScribingAbilities = React.useMemo(() => {
     if (!scribingResult || fightIdNumber === null || scribingResult.fightId !== fightIdNumber) {
@@ -383,9 +410,9 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   // Compute bar swap analysis (including bar setup pattern) per player
   const barSwapByPlayer = React.useMemo(() => {
     const result: Record<string, BarSwapAnalysisResult> = {};
-    if (!fight || !castEvents || !playerData?.playersById) return result;
+    if (!fight || !castEvents || !hasPlayerEntries(playersById)) return result;
     const { startTime, endTime } = fight;
-    for (const player of Object.values(playerData.playersById)) {
+    for (const player of Object.values(playersById)) {
       if (!player?.id) continue;
       result[String(player.id)] = analyzeBarSwaps(
         castEvents,
@@ -395,7 +422,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       );
     }
     return result;
-  }, [fight, castEvents, playerData?.playersById]);
+  }, [fight, castEvents, playersById]);
 
   const { abilitiesById } = reportMasterData;
 
@@ -478,8 +505,8 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       /^(?:Boon:|Bonus\s*\(2\):)?\s*The\s+(Warrior|Mage|Serpent|Thief|Lady|Steed|Lord|Apprentice|Ritual|Lover|Atronach|Shadow|Tower)\b/i;
 
     // Initialize arrays for each player
-    if (playerData) {
-      Object.values(playerData?.playersById).forEach((actor) => {
+    if (hasPlayerEntries(playersById)) {
+      Object.values(playersById).forEach((actor) => {
         if (actor?.id) {
           const playerId = String(actor.id);
           result[playerId] = [];
@@ -539,7 +566,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     }
 
     return result;
-  }, [combatantInfoEvents, abilitiesById, playerData, friendlyBuffEvents]);
+  }, [combatantInfoEvents, abilitiesById, playersById, friendlyBuffEvents]);
 
   // Classify each player's potion usage from the live fight event stream (Path B detection).
   const potionResultsByPlayer = React.useMemo((): Record<string, PotionStreamResult> => {
@@ -568,8 +595,8 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     ]);
 
     // Initialize arrays for each player
-    if (playerData) {
-      Object.values(playerData?.playersById).forEach((actor) => {
+    if (hasPlayerEntries(playersById)) {
+      Object.values(playersById).forEach((actor) => {
         if (actor?.id) {
           const playerId = String(actor.id);
           result[playerId] = [];
@@ -622,7 +649,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     }
 
     return result;
-  }, [combatantInfoEvents, abilitiesById, playerData]);
+  }, [combatantInfoEvents, abilitiesById, playersById]);
 
   // Compute CPM (casts per minute) per player for the current fight, including all casts
   const cpmByPlayer = React.useMemo(() => {
@@ -693,11 +720,11 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   const aurasByPlayer = React.useMemo(() => {
     const result: Record<string, Array<{ name: string; id: number; stacks?: number }>> = {};
 
-    if (!playerData?.playersById || !combatantInfoEvents || !abilitiesById) {
+    if (!hasPlayerEntries(playersById) || !combatantInfoEvents || !abilitiesById) {
       return result;
     }
 
-    Object.values(playerData.playersById).forEach((actor) => {
+    Object.values(playersById).forEach((actor) => {
       if (!actor?.id) {
         return;
       }
@@ -734,16 +761,16 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     });
 
     return result;
-  }, [abilitiesById, combatantInfoEvents, playerData?.playersById]);
+  }, [abilitiesById, combatantInfoEvents, playersById]);
 
   const playerGear = React.useMemo(() => {
     const result: Record<number, PlayerGearSetRecord[]> = {};
 
-    if (!playerData?.playersById) {
+    if (!hasPlayerEntries(playersById)) {
       return result;
     }
 
-    for (const player of Object.values(playerData.playersById)) {
+    for (const player of Object.values(playersById)) {
       const gear = player?.combatantInfo?.gear ?? [];
 
       const setDataByBase: Record<string, PlayerGearItemData> = {};
@@ -831,16 +858,16 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     }
 
     return result;
-  }, [playerData?.playersById]);
+  }, [playersById]);
 
   // Calculate max resources (health, stamina, magicka) per player using all resource events throughout the fight
   const maxResourcesByPlayer = React.useMemo(() => {
     const result: Record<string, { health: number; stamina: number; magicka: number }> = {};
 
-    if (!playerData?.playersById || !fight) return result;
+    if (!hasPlayerEntries(playersById) || !fight) return result;
 
     // Initialize with 0 for each player
-    Object.values(playerData.playersById).forEach((player) => {
+    Object.values(playersById).forEach((player) => {
       if (player?.id) {
         result[String(player.id)] = { health: 0, stamina: 0, magicka: 0 };
       }
@@ -937,7 +964,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     }
 
     return result;
-  }, [playerData?.playersById, resourceEvents, damageEvents, healingEvents, fight]);
+  }, [playersById, resourceEvents, damageEvents, healingEvents, fight]);
 
   // Extract individual max resources for backward compatibility
   const maxHealthByPlayer = React.useMemo(() => {
@@ -968,11 +995,16 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   const buildIssuesByPlayer = React.useMemo(() => {
     const result: Record<string, BuildIssue[]> = {};
 
-    if (!playerData?.playersById || !friendlyBuffLookup || !fight?.startTime || !fight?.endTime) {
+    if (
+      !hasPlayerEntries(playersById) ||
+      !friendlyBuffLookup ||
+      !fight?.startTime ||
+      !fight?.endTime
+    ) {
       return result;
     }
 
-    Object.values(playerData.playersById).forEach((player) => {
+    Object.values(playersById).forEach((player) => {
       if (!player?.id) return;
 
       const playerId = String(player.id);
@@ -1012,7 +1044,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
 
     return result;
   }, [
-    playerData?.playersById,
+    playersById,
     friendlyBuffLookup,
     fight?.startTime,
     fight?.endTime,
@@ -1073,7 +1105,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   const classAnalysisByPlayer = React.useMemo(() => {
     const result: Record<string, ClassAnalysisResult> = {};
 
-    if (!abilitiesById || !playerData?.playersById) {
+    if (!abilitiesById || !hasPlayerEntries(playersById)) {
       return result;
     }
 
@@ -1081,7 +1113,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     const classMapping = createSkillLineAbilityMapping(abilitiesById);
 
     // Analyze each player's class usage
-    Object.values(playerData.playersById).forEach((player) => {
+    Object.values(playersById).forEach((player) => {
       if (!player?.id) return;
 
       const playerId = String(player.id);
@@ -1108,7 +1140,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
     return result;
   }, [
     abilitiesById,
-    playerData?.playersById,
+    playersById,
     combatantInfoEvents,
     castEvents,
     damageEvents,
@@ -1227,10 +1259,10 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   }, [scribingSkillsByPlayer, scribingRecipes]);
 
   return (
-    <PlayerAvatarsProvider players={playerData?.playersById}>
+    <PlayerAvatarsProvider players={playersById}>
       <div data-testid="players-panel-loaded">
         <PlayersPanelView
-          playerActors={playerData?.playersById}
+          playerActors={playersById}
           mundusBuffsByPlayer={mundusBuffsByPlayer}
           championPointsByPlayer={championPointsByPlayer}
           scribingSkillsByPlayer={enhancedScribingSkillsByPlayer}

--- a/src/hooks/usePlayerData.ts
+++ b/src/hooks/usePlayerData.ts
@@ -3,11 +3,14 @@ import { useSelector } from 'react-redux';
 
 import { useEsoLogsClientInstance } from '../EsoLogsClientContext';
 import type { ReportFightContextInput } from '../store/contextTypes';
+import { hasPlayerEntries } from '../store/player_data/playerDataFallback';
 import {
   selectIsPlayerDataLoadingForContext,
   selectPlayerDataEntryForContext,
+  selectPlayersByIdForContext,
 } from '../store/player_data/playerDataSelectors';
-import { fetchPlayerData, PlayerDataEntry } from '../store/player_data/playerDataSlice';
+import { fetchPlayerData } from '../store/player_data/playerDataSlice';
+import type { PlayerDataEntry } from '../store/player_data/playerDataSlice';
 import type { RootState } from '../store/storeWithHistory';
 import { useAppDispatch } from '../store/useAppDispatch';
 
@@ -15,6 +18,7 @@ import { useResolvedReportFightContext } from './useResolvedReportFightContext';
 
 interface UsePlayerDataOptions {
   context?: ReportFightContextInput;
+  includeFallback?: boolean;
 }
 
 export function usePlayerData(options?: UsePlayerDataOptions): {
@@ -24,9 +28,13 @@ export function usePlayerData(options?: UsePlayerDataOptions): {
   const client = useEsoLogsClientInstance();
   const dispatch = useAppDispatch();
   const context = useResolvedReportFightContext(options?.context);
+  const includeFallback = options?.includeFallback ?? true;
 
   const playerData = useSelector((state: RootState) =>
     selectPlayerDataEntryForContext(state, context),
+  );
+  const playersById = useSelector((state: RootState) =>
+    selectPlayersByIdForContext(state, context),
   );
   const isPlayerDataLoading = useSelector((state: RootState) =>
     selectIsPlayerDataLoadingForContext(state, context),
@@ -40,8 +48,29 @@ export function usePlayerData(options?: UsePlayerDataOptions): {
     }
   }, [dispatch, context.reportCode, context.fightId, client]);
 
+  const effectivePlayerData = React.useMemo<PlayerDataEntry | null>(() => {
+    if (!includeFallback || hasPlayerEntries(playerData?.playersById)) {
+      return playerData ?? null;
+    }
+
+    if (!hasPlayerEntries(playersById)) {
+      return playerData ?? null;
+    }
+
+    return {
+      playersById,
+      status: playerData?.status ?? 'succeeded',
+      error: playerData?.error ?? null,
+      cacheMetadata: {
+        lastFetchedTimestamp: playerData?.cacheMetadata.lastFetchedTimestamp ?? null,
+        playerCount: Object.keys(playersById).length,
+      },
+      currentRequest: playerData?.currentRequest ?? null,
+    };
+  }, [includeFallback, playerData, playersById]);
+
   return React.useMemo(
-    () => ({ playerData: playerData ?? null, isPlayerDataLoading }),
-    [playerData, isPlayerDataLoading],
+    () => ({ playerData: effectivePlayerData, isPlayerDataLoading }),
+    [effectivePlayerData, isPlayerDataLoading],
   );
 }

--- a/src/store/player_data/index.ts
+++ b/src/store/player_data/index.ts
@@ -13,4 +13,5 @@ export type {
   PlayerDataPayload,
   PlayerDetailsWithRole,
 } from './playerDataSlice';
+export * from './playerDataFallback';
 export * from './playerDataSelectors';

--- a/src/store/player_data/playerDataFallback.test.ts
+++ b/src/store/player_data/playerDataFallback.test.ts
@@ -1,0 +1,109 @@
+import { DetectedRole, type PlayerRoleResult } from '@/features/role_detection';
+import type { ReportActorFragment } from '@/graphql/gql/graphql';
+import type { CombatantInfoEvent } from '@/types/combatlogEvents';
+
+import { buildFallbackPlayersFromMasterData } from './playerDataFallback';
+
+const actor = (overrides: Partial<ReportActorFragment>): ReportActorFragment => ({
+  __typename: 'ReportActor',
+  anonymous: false,
+  displayName: null,
+  gameID: null,
+  icon: null,
+  id: 1,
+  name: 'Player One',
+  petOwner: null,
+  server: 'NA Megaserver',
+  subType: 'Nightblade',
+  type: 'Player',
+  ...overrides,
+});
+
+const combatantInfo = (
+  sourceID: number,
+  timestamp: number,
+  gear: CombatantInfoEvent['gear'] = [],
+): CombatantInfoEvent => ({
+  timestamp,
+  type: 'combatantinfo',
+  fight: 12,
+  sourceID,
+  gear,
+  auras: [],
+});
+
+const role = (playerId: number, detectedRole: DetectedRole): PlayerRoleResult =>
+  ({
+    playerId,
+    playerName: `Player ${playerId}`,
+    role: detectedRole,
+    confidence: 100,
+    signals: {},
+  }) as PlayerRoleResult;
+
+describe('buildFallbackPlayersFromMasterData', () => {
+  it('creates player details from friendly master-data actors', () => {
+    const gear = [{ id: 10, setName: 'Test Set' }] as CombatantInfoEvent['gear'];
+    const players = buildFallbackPlayersFromMasterData({
+      friendlyPlayerIds: [1, 2, 96],
+      actorsById: {
+        1: actor({
+          id: 1,
+          name: "Grappa'Ko'Laid",
+          displayName: "@Spike'jo",
+          subType: 'Nightblade',
+          gameID: 123,
+        }),
+        2: actor({ id: 2, name: 'Archive NPC', type: 'NPC', subType: 'NPC' }),
+        96: actor({
+          id: 96,
+          name: 'Angair Doomfang',
+          displayName: '@blueblaze103',
+          subType: 'Necromancer',
+        }),
+      },
+      combatantInfoEvents: [
+        combatantInfo(1, 100, []),
+        combatantInfo(1, 200, gear),
+        combatantInfo(96, 150, []),
+      ],
+      rolesByPlayerId: {
+        96: role(96, DetectedRole.GroupHealer),
+      },
+    });
+
+    expect(Object.keys(players)).toEqual(['1', '96']);
+    expect(players[1]).toMatchObject({
+      id: 1,
+      name: "Grappa'Ko'Laid",
+      displayName: "@Spike'jo",
+      type: 'Nightblade',
+      role: 'dps',
+    });
+    expect(players[1].combatantInfo.gear).toBe(gear);
+    expect(players[96]).toMatchObject({
+      id: 96,
+      name: 'Angair Doomfang',
+      displayName: '@blueblaze103',
+      type: 'Necromancer',
+      role: 'healer',
+    });
+    expect(players[2]).toBeUndefined();
+  });
+
+  it('uses combatant-info source ids when fight friendly ids are unavailable', () => {
+    const players = buildFallbackPlayersFromMasterData({
+      actorsById: {
+        1: actor({ id: 1, name: 'Fallback Player', displayName: 'nil' }),
+      },
+      combatantInfoEvents: [combatantInfo(1, 100)],
+    });
+
+    expect(players[1]).toMatchObject({
+      id: 1,
+      name: 'Fallback Player',
+      displayName: '',
+      role: 'dps',
+    });
+  });
+});

--- a/src/store/player_data/playerDataFallback.ts
+++ b/src/store/player_data/playerDataFallback.ts
@@ -1,0 +1,138 @@
+import type { ReportActorFragment } from '@/graphql/gql/graphql';
+import type { CombatantInfoEvent } from '@/types/combatlogEvents';
+
+import type { PlayerDetailsWithRole } from './playerDataSlice';
+
+export const hasPlayerEntries = (
+  players: Record<string | number, PlayerDetailsWithRole> | null | undefined,
+): players is Record<string | number, PlayerDetailsWithRole> =>
+  Boolean(players && Object.keys(players).length > 0);
+
+interface RoleDetectionResultLike {
+  role: string;
+}
+
+interface BuildFallbackPlayersInput {
+  friendlyPlayerIds?: readonly (number | null | undefined)[];
+  actorsById: Record<string | number, ReportActorFragment>;
+  combatantInfoEvents: readonly CombatantInfoEvent[];
+  rolesByPlayerId?: Record<number, RoleDetectionResultLike>;
+}
+
+const normalizeDisplayName = (displayName: string | null | undefined): string => {
+  if (!displayName || displayName === 'nil') {
+    return '';
+  }
+  return displayName;
+};
+
+const toBroadRole = (role: string | undefined): PlayerDetailsWithRole['role'] => {
+  switch (role) {
+    case 'main_tank':
+    case 'off_tank':
+      return 'tank';
+    case 'group_healer':
+    case 'shield_healer':
+    case 'buff_healer':
+      return 'healer';
+    default:
+      return 'dps';
+  }
+};
+
+const getCandidatePlayerIds = ({
+  friendlyPlayerIds,
+  combatantInfoEvents,
+}: Pick<BuildFallbackPlayersInput, 'friendlyPlayerIds' | 'combatantInfoEvents'>): Set<number> => {
+  const ids = new Set<number>();
+
+  friendlyPlayerIds?.forEach((id) => {
+    if (typeof id === 'number') {
+      ids.add(id);
+    }
+  });
+
+  if (ids.size > 0) {
+    return ids;
+  }
+
+  combatantInfoEvents.forEach((event) => {
+    if (event.type === 'combatantinfo' && typeof event.sourceID === 'number') {
+      ids.add(event.sourceID);
+    }
+  });
+
+  return ids;
+};
+
+const getLatestCombatantInfoByPlayer = (
+  combatantInfoEvents: readonly CombatantInfoEvent[],
+  playerIds: Set<number>,
+): Map<number, CombatantInfoEvent> => {
+  const latestByPlayer = new Map<number, CombatantInfoEvent>();
+
+  combatantInfoEvents.forEach((event) => {
+    if (event.type !== 'combatantinfo' || !playerIds.has(event.sourceID)) {
+      return;
+    }
+
+    const current = latestByPlayer.get(event.sourceID);
+    if (!current || (event.timestamp ?? 0) >= (current.timestamp ?? 0)) {
+      latestByPlayer.set(event.sourceID, event);
+    }
+  });
+
+  return latestByPlayer;
+};
+
+export const buildFallbackPlayersFromMasterData = ({
+  friendlyPlayerIds,
+  actorsById,
+  combatantInfoEvents,
+  rolesByPlayerId = {},
+}: BuildFallbackPlayersInput): Record<string | number, PlayerDetailsWithRole> => {
+  const candidatePlayerIds = getCandidatePlayerIds({ friendlyPlayerIds, combatantInfoEvents });
+  if (candidatePlayerIds.size === 0) {
+    return {};
+  }
+
+  const latestCombatantInfoByPlayer = getLatestCombatantInfoByPlayer(
+    combatantInfoEvents,
+    candidatePlayerIds,
+  );
+  const playersById: Record<string | number, PlayerDetailsWithRole> = {};
+
+  candidatePlayerIds.forEach((playerId) => {
+    const actor = actorsById[playerId] ?? actorsById[String(playerId)];
+    if (!actor || actor.type !== 'Player') {
+      return;
+    }
+
+    const latestCombatantInfo = latestCombatantInfoByPlayer.get(playerId);
+    const className = actor.subType ?? 'Unknown';
+
+    playersById[playerId] = {
+      name: actor.name ?? `Player ${playerId}`,
+      id: playerId,
+      guid: typeof actor.gameID === 'number' ? actor.gameID : playerId,
+      type: className,
+      server: actor.server ?? '',
+      displayName: normalizeDisplayName(actor.displayName),
+      anonymous: Boolean(actor.anonymous),
+      icon: actor.icon ?? '',
+      specs: actor.subType ? [{ spec: actor.subType, count: 1 }] : [],
+      minItemLevel: undefined,
+      maxItemLevel: undefined,
+      potionUse: 0,
+      healthstoneUse: 0,
+      combatantInfo: {
+        stats: [],
+        talents: [],
+        gear: latestCombatantInfo?.gear ?? [],
+      },
+      role: toBroadRole(rolesByPlayerId[playerId]?.role),
+    };
+  });
+
+  return playersById;
+};

--- a/src/store/player_data/playerDataSelectors.test.ts
+++ b/src/store/player_data/playerDataSelectors.test.ts
@@ -1,0 +1,234 @@
+import type { FightFragment, ReportActorFragment } from '@/graphql/gql/graphql';
+import type { CombatantInfoEvent } from '@/types/combatlogEvents';
+
+import type { RootState } from '../storeWithHistory';
+import { resolveCacheKey } from '../utils/keyedCacheState';
+
+import { selectActivePlayersById, selectPlayersByIdForContext } from './playerDataSelectors';
+import type { PlayerDataEntry, PlayerDetailsWithRole } from './playerDataSlice';
+
+const actor = (overrides: Partial<ReportActorFragment>): ReportActorFragment => ({
+  __typename: 'ReportActor',
+  anonymous: false,
+  displayName: null,
+  gameID: null,
+  icon: null,
+  id: 1,
+  name: 'Player One',
+  petOwner: null,
+  server: 'NA Megaserver',
+  subType: 'Nightblade',
+  type: 'Player',
+  ...overrides,
+});
+
+const combatantInfo = (
+  sourceID: number,
+  timestamp: number,
+  gear: CombatantInfoEvent['gear'] = [],
+): CombatantInfoEvent => ({
+  timestamp,
+  type: 'combatantinfo',
+  fight: 12,
+  sourceID,
+  gear,
+  auras: [],
+});
+
+const player = (overrides: Partial<PlayerDetailsWithRole>): PlayerDetailsWithRole => ({
+  anonymous: false,
+  combatantInfo: {
+    gear: [],
+    stats: [],
+    talents: [],
+  },
+  displayName: '',
+  guid: 1,
+  healthstoneUse: 0,
+  icon: '',
+  id: 1,
+  maxItemLevel: undefined,
+  minItemLevel: undefined,
+  name: 'Player One',
+  potionUse: 0,
+  role: 'dps',
+  server: '',
+  specs: [],
+  type: 'Unknown',
+  ...overrides,
+});
+
+const playerDataEntry = (
+  playersById: Record<string | number, PlayerDetailsWithRole>,
+): PlayerDataEntry => ({
+  playersById,
+  status: 'succeeded',
+  error: null,
+  cacheMetadata: {
+    lastFetchedTimestamp: 123,
+    playerCount: Object.keys(playersById).length,
+  },
+  currentRequest: null,
+});
+
+const createState = ({
+  playersById = {},
+}: {
+  playersById?: Record<string | number, PlayerDetailsWithRole>;
+} = {}): RootState => {
+  const reportKey = resolveCacheKey({ reportCode: 'A' }).key;
+  const fightKey = resolveCacheKey({ reportCode: 'A', fightId: 12 }).key;
+  const gear = [{ id: 10, setName: 'Fallback Set' }] as CombatantInfoEvent['gear'];
+  const fight = {
+    id: 12,
+    startTime: 1000,
+    endTime: 2000,
+    friendlyPlayers: [1, 2, 96],
+    enemyNPCs: [],
+  } as unknown as FightFragment;
+
+  return {
+    events: {
+      combatantInfo: {
+        entries: {
+          [fightKey]: {
+            events: [combatantInfo(1, 100, []), combatantInfo(1, 200, gear)],
+            status: 'succeeded',
+            error: null,
+            cacheMetadata: {
+              lastFetchedTimestamp: 123,
+              eventCount: 2,
+              restrictToFightWindow: true,
+            },
+            currentRequest: null,
+          },
+        },
+        accessOrder: [fightKey],
+      },
+    },
+    masterData: {
+      entries: {
+        [reportKey]: {
+          actorsById: {
+            1: actor({
+              id: 1,
+              name: "Grappa'Ko'Laid",
+              displayName: "@Spike'jo",
+              subType: 'Nightblade',
+            }),
+            2: actor({ id: 2, name: 'Archive NPC', type: 'NPC', subType: 'NPC' }),
+            96: actor({
+              id: 96,
+              name: 'Angair Doomfang',
+              displayName: '@blueblaze103',
+              subType: 'Necromancer',
+            }),
+          },
+          abilitiesById: {},
+          status: 'succeeded',
+          error: null,
+          cacheMetadata: {
+            lastFetchedTimestamp: 123,
+            actorCount: 3,
+            abilityCount: 0,
+          },
+          currentRequest: null,
+        },
+      },
+      accessOrder: [reportKey],
+    },
+    playerData: {
+      entries: {
+        [fightKey]: playerDataEntry(playersById),
+      },
+      accessOrder: [fightKey],
+    },
+    report: {
+      entries: {
+        [reportKey]: {
+          data: null,
+          status: 'succeeded',
+          error: null,
+          fightsById: {
+            12: fight,
+          },
+          fightIds: [12],
+          cacheMetadata: {
+            lastFetchedTimestamp: 123,
+          },
+          currentRequest: null,
+        },
+      },
+      accessOrder: [reportKey],
+      activeContext: {
+        reportId: 'A',
+        fightId: 12,
+      },
+      reportId: 'A',
+      data: null,
+      loading: false,
+      error: null,
+      cacheMetadata: {
+        lastFetchedReportId: 'A',
+        lastFetchedTimestamp: 123,
+      },
+      fightIndexByReport: {
+        A: [12],
+      },
+    },
+  } as unknown as RootState;
+};
+
+describe('playerDataSelectors fallback players', () => {
+  it('builds fallback players when player details are empty', () => {
+    const players = selectPlayersByIdForContext(createState(), {
+      reportCode: 'A',
+      fightId: 12,
+    });
+
+    expect(Object.keys(players)).toEqual(['1', '96']);
+    expect(players[1]).toMatchObject({
+      id: 1,
+      name: "Grappa'Ko'Laid",
+      displayName: "@Spike'jo",
+      type: 'Nightblade',
+      role: 'dps',
+    });
+    expect(players[1].combatantInfo.gear).toEqual([{ id: 10, setName: 'Fallback Set' }]);
+    expect(players[96]).toMatchObject({
+      id: 96,
+      name: 'Angair Doomfang',
+      displayName: '@blueblaze103',
+      type: 'Necromancer',
+    });
+    expect(players[2]).toBeUndefined();
+  });
+
+  it('applies the same fallback to active player selectors', () => {
+    const players = selectActivePlayersById(createState());
+
+    expect(players[1]?.name).toBe("Grappa'Ko'Laid");
+    expect(players[96]?.displayName).toBe('@blueblaze103');
+  });
+
+  it('keeps real player details when the API provides them', () => {
+    const realPlayers = {
+      1: player({
+        id: 1,
+        name: 'API Player',
+        role: 'tank',
+      }),
+    };
+
+    const players = selectPlayersByIdForContext(createState({ playersById: realPlayers }), {
+      reportCode: 'A',
+      fightId: 12,
+    });
+
+    expect(players).toBe(realPlayers);
+    expect(players[1]).toMatchObject({
+      name: 'API Player',
+      role: 'tank',
+    });
+  });
+});

--- a/src/store/player_data/playerDataSelectors.ts
+++ b/src/store/player_data/playerDataSelectors.ts
@@ -1,10 +1,14 @@
 import { createSelector } from '@reduxjs/toolkit';
 
+import type { FightFragment, ReportActorFragment } from '../../graphql/gql/graphql';
+import type { CombatantInfoEvent } from '../../types/combatlogEvents';
 import type { ReportFightContext, ReportFightContextInput } from '../contextTypes';
+import type { ReportEntry } from '../report/reportSlice';
 import type { RootState } from '../storeWithHistory';
 import { createReportFightContextSelector } from '../utils/contextSelectors';
 import { resolveCacheKey } from '../utils/keyedCacheState';
 
+import { buildFallbackPlayersFromMasterData, hasPlayerEntries } from './playerDataFallback';
 import type { PlayerDataEntry, PlayerDataState, PlayerDetailsWithRole } from './playerDataSlice';
 
 export const selectPlayerDataState = (state: RootState): PlayerDataState => state.playerData;
@@ -20,6 +24,59 @@ const selectPlayerDataEntryByContext = (
   return state.playerData.entries[key] ?? null;
 };
 
+const selectReportEntryByContext = (
+  state: RootState,
+  context: ReportFightContext,
+): ReportEntry | null => {
+  const reportId =
+    context.reportCode ?? state.report.activeContext.reportId ?? state.report.reportId ?? null;
+  if (!reportId) {
+    return null;
+  }
+
+  const { key } = resolveCacheKey({ reportCode: reportId });
+  return state.report.entries[key] ?? null;
+};
+
+const selectFightByContext = (
+  state: RootState,
+  context: ReportFightContext,
+): FightFragment | null => {
+  if (context.fightId === null) {
+    return null;
+  }
+
+  const registryEntry = selectReportEntryByContext(state, context);
+  const registryFight = registryEntry?.fightsById[context.fightId] ?? null;
+  if (registryFight) {
+    return registryFight;
+  }
+
+  return state.report.data?.fights?.find((fight) => fight?.id === context.fightId) ?? null;
+};
+
+const selectActorsByIdByContext = (
+  state: RootState,
+  context: ReportFightContext,
+): Record<string | number, ReportActorFragment> => {
+  if (!context.reportCode) {
+    return {};
+  }
+  const { key } = resolveCacheKey({ reportCode: context.reportCode });
+  return state.masterData.entries[key]?.actorsById ?? {};
+};
+
+const selectCombatantInfoEventsByContext = (
+  state: RootState,
+  context: ReportFightContext,
+): CombatantInfoEvent[] => {
+  if (!context.reportCode) {
+    return [];
+  }
+  const { key } = resolveCacheKey(context);
+  return state.events.combatantInfo.entries[key]?.events ?? [];
+};
+
 export const selectPlayerDataEntryForContext = createReportFightContextSelector<
   RootState,
   [typeof selectPlayerDataEntryByContext],
@@ -28,9 +85,32 @@ export const selectPlayerDataEntryForContext = createReportFightContextSelector<
 
 export const selectPlayersByIdForContext = createReportFightContextSelector<
   RootState,
-  [typeof selectPlayerDataEntryByContext],
+  [
+    typeof selectPlayerDataEntryByContext,
+    typeof selectFightByContext,
+    typeof selectActorsByIdByContext,
+    typeof selectCombatantInfoEventsByContext,
+  ],
   Record<string | number, PlayerDetailsWithRole>
->([selectPlayerDataEntryByContext], (entry) => entry?.playersById ?? {});
+>(
+  [
+    selectPlayerDataEntryByContext,
+    selectFightByContext,
+    selectActorsByIdByContext,
+    selectCombatantInfoEventsByContext,
+  ],
+  (entry, fight, actorsById, combatantInfoEvents) => {
+    if (hasPlayerEntries(entry?.playersById)) {
+      return entry.playersById;
+    }
+
+    return buildFallbackPlayersFromMasterData({
+      friendlyPlayerIds: fight?.friendlyPlayers ?? undefined,
+      actorsById,
+      combatantInfoEvents,
+    });
+  },
+);
 
 export const selectIsPlayerDataLoadingForContext = createReportFightContextSelector<
   RootState,
@@ -72,11 +152,16 @@ type PlayerSelectorByContext = (
   context: ReportFightContextInput,
 ) => PlayerDataEntry['playersById'][string] | undefined;
 
+const selectEffectivePlayersByIdByContext = (
+  state: RootState,
+  context: ReportFightContext,
+): Record<string | number, PlayerDetailsWithRole> => selectPlayersByIdForContext(state, context);
+
 export const createSelectPlayerByIdForContext = (
   playerId: string | number,
 ): PlayerSelectorByContext =>
   createReportFightContextSelector<
     RootState,
-    [typeof selectPlayerDataEntryByContext],
+    [typeof selectEffectivePlayersByIdByContext],
     PlayerDataEntry['playersById'][string] | undefined
-  >([selectPlayerDataEntryByContext], (entry) => entry?.playersById[playerId]);
+  >([selectEffectivePlayersByIdByContext], (playersById) => playersById[playerId]);


### PR DESCRIPTION
## Summary

- Add a shared fallback player builder that derives player identity, class, display name, and latest gear from report master data plus combatant info events when ESO Logs omits `playerDetails`.
- Make shared player selectors and `usePlayerData` return fallback players when the API player payload is empty, while preserving real ESO Logs player details whenever present.
- Keep the Players panel's richer role-aware fallback and route all downstream panel calculations through the effective player map.

## Root Cause

Live reports can return an empty `playerDetails` payload even when `masterData.actors`, fight `friendlyPlayers`, and combatant info events already identify the real players. The first local fix covered the Players tab, but selector and hook consumers in other report panels could still see an empty `playersById` map.

## Validation

- `npx jest src/store/player_data/playerDataFallback.test.ts src/store/player_data/playerDataSelectors.test.ts --watchAll=false`
- `npm run typecheck`
- `npm run validate`
- `npm test -- --watchAll=false`
- `git diff --check`
- Browser smoke check on `http://127.0.0.1:3002/report/vNHkB9R6qTx34MLp/live`: Players tab showed `Showing 2 of 2 players` with `@blueblaze103` and `@Spike'jo`.