### PR TITLE
feat(insights): surface class mastery uptimes

### DIFF
--- a/documentation/features/u50-game-data-update.md
+++ b/documentation/features/u50-game-data-update.md
@@ -76,22 +76,22 @@ addon (`tools/eso-tooltip-dump` on `feat/tooltip-data-pipeline`) will supply exa
 2. **Class Mastery passives (35 new, 5 per class)**: new passive-only skill line per class for
    non-subclassed characters (2 of 5 active via Class Mastery Points). **IDs SELF-SOURCED
    2026-06-10** from the U50 in-game tooltip dump (skill-tree walk enumerates them; exact names
-   + descriptions in `data/tooltip-dump.json`; ESO Logs `gameData.ability` still returns null
-   for them). Grouped by class:
-   - Dragonknight: 238232 Inexorable Descent, 240268 Booming Voice, 259224 Wildfire Embers,
+   - descriptions in `data/tooltip-dump.json`; ESO Logs `gameData.ability` still returns null
+     for them). Grouped by class:
+   * Dragonknight: 238232 Inexorable Descent, 240268 Booming Voice, 259224 Wildfire Embers,
      263220 Resolute Defense, 263247 Lead from the Front
-   - Arcanist: 263316 Abyssal Emergence, 263398 Fate Realigned, 263410 Unbound Potential,
+   * Arcanist: 263316 Abyssal Emergence, 263398 Fate Realigned, 263410 Unbound Potential,
      263412 Erudite's Rigor, 263416 Ink-Scribe's Verve
-   - Necromancer: 263448 Nothing Wasted, 263465 Malevolent Promise, 263509 Cycle Unending,
+   * Necromancer: 263448 Nothing Wasted, 263465 Malevolent Promise, 263509 Cycle Unending,
      263549 Pound of Flesh, 263554 Veil's Forfeit
-   - Warden: 263519 Tundra's Maw, 263520 Wild Adaptation, 263521 Glacial Obstinance,
+   * Warden: 263519 Tundra's Maw, 263520 Wild Adaptation, 263521 Glacial Obstinance,
      263522 Green-Keeper's Hide, 263523 Bountiful Harvest (patch notes called it
      "Nature's Bounty")
-   - Templar: 263585 Bastion of Light, 263586 Devout Guardian, 263587 Bright Harbinger,
+   * Templar: 263585 Bastion of Light, 263586 Devout Guardian, 263587 Bright Harbinger,
      263588 Judgment's Brand, 263589 Steadfast Candescence
-   - Nightblade: 263603 Nocturnal Inspiration, 263604 An Eye for Exploitation,
+   * Nightblade: 263603 Nocturnal Inspiration, 263604 An Eye for Exploitation,
      263605 Above and Beyond, 263606 Cutthroat's Focus, 263607 Share the Spoils
-   - Sorcerer: 263870 Conservation of Energy, 263871 Font of Power, 263872 Static
+   * Sorcerer: 263870 Conservation of Energy, 263871 Font of Power, 263872 Static
      Reverberation, 263873 Calculated Defense, 263874 Sphere of Influence
 
    **Skill-line data entries SHIPPED 2026-06-10**: `src/data/skill-lines/class/classMastery.ts`
@@ -112,14 +112,16 @@ addon (`tools/eso-tooltip-dump` on `feat/tooltip-data-pipeline`) will supply exa
    exclude it; picks live in their own slice field, not `setup.passives`).
 
    **Buff tracking for the group-buff passives** (Lead from the Front 263247:
-   Major Berserk 61745 + Major Protection; Bountiful Harvest 263523: Major
-   Heroism 61709; Ink-Scribe's Verve 263416: Major Force 61747; Tundra's Maw
-   263519: Major Brittle 145977 via Chilled): the granted buffs use the existing
-   tracked Major effect IDs, and every consumer (buff-uptime panels, stat
-   engines `CritDamageUtils`/`damageReductionUtils`/`PenetrationUtils`,
-   locked-player live stats) keys on the BUFF effect ID, not the granting
-   ability — uptime and stat modeling work with no code change. **TODO (needs
-   the first real U50 log containing these passives — none exists yet):**
+   Major Berserk 61745 + Major Protection 61722; Erudite's Rigor 263412:
+   Major Vitality 61713 + Minor Cowardice 46202; Bountiful Harvest 263523:
+   Major Heroism 61709; Ink-Scribe's Verve 263416: Major Force 61747; Tundra's
+   Maw 263519: Major Brittle 145977 via Chilled): the granted buffs use tracked
+   Major/Minor effect IDs, and consumers should key on the buff/debuff effect
+   ID when modeling the group-facing effect. **Insights default curation shipped
+   2026-06-29**: `BuffUptimesPanel` / `DebuffUptimesPanel` now include both the
+   known Class Mastery source/proc rows and the granted named effect rows so
+   they are visible without toggling "Show All". **TODO (needs more real U50
+   logs containing these passives):**
 
    1. Role detection: `OFFENSIVE_BUFF_CATEGORIES`
       (`src/features/role_detection/constants.ts`) counts group applications of
@@ -137,6 +139,7 @@ addon (`tools/eso-tooltip-dump` on `feat/tooltip-data-pipeline`) will supply exa
    3. Tundra's Maw: verify the Warden applying Chilled gets debuff-applied
       credit for Major Brittle 145977 (insights debuff attribution uses event
       `sourceID`).
+
 3. **The Prowler's Talisman set ID**: not yet in ESO Logs `gameData.item_sets`
    (scanned 2026-06-09). Add to `KnownSetIDs` when it appears (post-July 8).
 4. **Season One wave (July 8, 2026)**: Thieves Guild questline, Dynamic Encounters,

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -52,8 +52,8 @@ module.exports = {
 
   // Test file patterns
   testMatch: [
-    '<rootDir>/src/**/__tests__/**/*.(test|spec).{js,jsx,ts,tsx}',
-    '<rootDir>/src/**/*.(test|spec).{js,jsx,ts,tsx}',
+    '**/src/**/__tests__/**/*.{test,spec}.{js,jsx,ts,tsx}',
+    '**/src/**/*.{test,spec}.{js,jsx,ts,tsx}',
   ],
 
   // Module file extensions
@@ -115,6 +115,7 @@ module.exports = {
   testPathIgnorePatterns: [
     'node_modules',
     '<rootDir>/build/',
+    'discord-bot/',
     'scribing-e2e\\.(test|spec)\\.(ts|tsx)$',
   ],
   transformIgnorePatterns: [

--- a/src/features/report_details/insights/BuffUptimesPanel.test.ts
+++ b/src/features/report_details/insights/BuffUptimesPanel.test.ts
@@ -8,8 +8,9 @@
  */
 
 import { KnownAbilities } from '../../../types/abilities';
+import { ClassSkillId } from '../../loadout-manager/data/classSkillIds';
 
-import { IMPORTANT_BUFF_ABILITIES } from './BuffUptimesPanel';
+import { CLASS_MASTERY_BUFF_ABILITIES, IMPORTANT_BUFF_ABILITIES } from './BuffUptimesPanel';
 
 describe('BuffUptimesPanel', () => {
   describe('IMPORTANT_BUFF_ABILITIES', () => {
@@ -47,13 +48,20 @@ describe('BuffUptimesPanel', () => {
         KnownAbilities.MINOR_BRUTALITY,
         KnownAbilities.MAJOR_BRUTALITY,
         KnownAbilities.MINOR_FORCE,
+        KnownAbilities.MAJOR_FORCE,
         KnownAbilities.MINOR_SLAYER,
         KnownAbilities.MAJOR_SLAYER,
         KnownAbilities.GRAND_REJUVENATION,
         KnownAbilities.MAJOR_BERSERK,
+        KnownAbilities.MAJOR_PROTECTION,
+        KnownAbilities.MAJOR_VITALITY,
         KnownAbilities.PILLAGERS_PROFIT_BUFF,
         KnownAbilities.OZEZANS_PLATING,
         KnownAbilities.AGGRESSIVE_HORN_BUFF,
+        ClassSkillId.DRAGONKNIGHT_LEAD_FROM_THE_FRONT,
+        ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+        ClassSkillId.ARCANIST_INK_SCRIBE_S_VERVE,
+        ClassSkillId.WARDEN_BOUNTIFUL_HARVEST,
       ];
 
       expectedBuffs.forEach((buff) => {
@@ -68,6 +76,25 @@ describe('BuffUptimesPanel', () => {
       expect(IMPORTANT_BUFF_ABILITIES.has(KnownAbilities.MAJOR_BREACH)).toBe(false);
       expect(IMPORTANT_BUFF_ABILITIES.has(KnownAbilities.MINOR_BREACH)).toBe(false);
       expect(IMPORTANT_BUFF_ABILITIES.has(KnownAbilities.NAZARAY_DEBUFF)).toBe(false);
+    });
+
+    it('should include U50 Class Mastery group buff sources and granted effects', () => {
+      const expectedClassMasteryBuffs = [
+        ClassSkillId.DRAGONKNIGHT_LEAD_FROM_THE_FRONT,
+        ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+        ClassSkillId.ARCANIST_INK_SCRIBE_S_VERVE,
+        ClassSkillId.WARDEN_BOUNTIFUL_HARVEST,
+        KnownAbilities.MAJOR_BERSERK,
+        KnownAbilities.MAJOR_FORCE,
+        KnownAbilities.MAJOR_HEROISM,
+        KnownAbilities.MAJOR_PROTECTION,
+        KnownAbilities.MAJOR_VITALITY,
+      ];
+
+      expectedClassMasteryBuffs.forEach((buff) => {
+        expect(CLASS_MASTERY_BUFF_ABILITIES.has(buff)).toBe(true);
+        expect(IMPORTANT_BUFF_ABILITIES.has(buff)).toBe(true);
+      });
     });
 
     it("should have correct ability ID for Pillager's Profit buff", () => {

--- a/src/features/report_details/insights/BuffUptimesPanel.tsx
+++ b/src/features/report_details/insights/BuffUptimesPanel.tsx
@@ -11,6 +11,7 @@ import {
   computeBuffUptimes,
   computeBuffUptimesWithGroupAverage,
 } from '../../../utils/buffUptimeCalculator';
+import { ClassSkillId } from '../../loadout-manager/data/classSkillIds';
 
 import { BuffUptimesView } from './BuffUptimesView';
 import { EffectUptimeTimelineModal } from './EffectUptimeTimelineModal';
@@ -21,8 +22,22 @@ interface BuffUptimesPanelProps {
   selectedPlayerId?: number | null; // Optional: if provided, show per-player uptimes with group average deltas
 }
 
-// Define the specific status effect debuff abilities to track
-export const IMPORTANT_BUFF_ABILITIES = new Set([
+export const CLASS_MASTERY_BUFF_ABILITIES = new Set<number>([
+  // U50 group-facing Class Mastery passives. Include both the source/proc row
+  // when ESO Logs exposes it and the granted named effect row players compare.
+  ClassSkillId.DRAGONKNIGHT_LEAD_FROM_THE_FRONT,
+  ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+  ClassSkillId.ARCANIST_INK_SCRIBE_S_VERVE,
+  ClassSkillId.WARDEN_BOUNTIFUL_HARVEST,
+  KnownAbilities.MAJOR_BERSERK,
+  KnownAbilities.MAJOR_FORCE,
+  KnownAbilities.MAJOR_HEROISM,
+  KnownAbilities.MAJOR_PROTECTION,
+  KnownAbilities.MAJOR_VITALITY,
+]);
+
+// Define the specific status effect buff abilities to track
+export const IMPORTANT_BUFF_ABILITIES = new Set<number>([
   KnownAbilities.MINOR_SAVAGERY,
   KnownAbilities.MAJOR_SAVAGERY,
   KnownAbilities.MINOR_SORCERY,
@@ -58,6 +73,7 @@ export const IMPORTANT_BUFF_ABILITIES = new Set([
   KnownAbilities.PILLAGERS_PROFIT_BUFF,
   KnownAbilities.OZEZANS_PLATING,
   KnownAbilities.AGGRESSIVE_HORN_BUFF,
+  ...CLASS_MASTERY_BUFF_ABILITIES,
 ]);
 
 /**

--- a/src/features/report_details/insights/DebuffUptimesPanel.test.ts
+++ b/src/features/report_details/insights/DebuffUptimesPanel.test.ts
@@ -11,8 +11,9 @@ import { KnownAbilities } from '../../../types/abilities';
 import { computeBuffUptimes } from '../../../utils/buffUptimeCalculator';
 import { createDebuffLookup } from '../../../utils/BuffLookupUtils';
 import { DebuffEvent } from '../../../types/combatlogEvents';
+import { ClassSkillId } from '../../loadout-manager/data/classSkillIds';
 
-import { IMPORTANT_DEBUFF_ABILITIES } from './DebuffUptimesPanel';
+import { CLASS_MASTERY_DEBUFF_ABILITIES, IMPORTANT_DEBUFF_ABILITIES } from './DebuffUptimesPanel';
 
 describe('DebuffUptimesPanel', () => {
   describe('IMPORTANT_DEBUFF_ABILITIES', () => {
@@ -27,10 +28,12 @@ describe('DebuffUptimesPanel', () => {
         KnownAbilities.ENGULFING_FLAMES_BUFF,
         KnownAbilities.HEAT_SHOCK,
         KnownAbilities.MAJOR_BREACH,
+        KnownAbilities.MAJOR_BRITTLE,
         KnownAbilities.MAJOR_COWARDICE,
         KnownAbilities.MAJOR_VULNERABILITY,
         KnownAbilities.MINOR_BREACH,
         KnownAbilities.MINOR_BRITTLE,
+        KnownAbilities.MINOR_COWARDICE,
         KnownAbilities.MINOR_LIFESTEAL,
         KnownAbilities.MINOR_VULNERABILITY,
         KnownAbilities.NAZARAY_DEBUFF,
@@ -38,6 +41,8 @@ describe('DebuffUptimesPanel', () => {
         KnownAbilities.RUNIC_SUNDER_DEBUFF,
         KnownAbilities.STAGGER, // Pre-U49 legacy debuff ID
         KnownAbilities.TOUCH_OF_ZEN,
+        ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+        ClassSkillId.WARDEN_TUNDRA_S_MAW,
       ];
 
       expectedDebuffs.forEach((debuff) => {
@@ -52,6 +57,20 @@ describe('DebuffUptimesPanel', () => {
       expect(IMPORTANT_DEBUFF_ABILITIES.has(KnownAbilities.MAJOR_COURAGE)).toBe(false);
       expect(IMPORTANT_DEBUFF_ABILITIES.has(KnownAbilities.MAJOR_RESOLVE)).toBe(false);
       expect(IMPORTANT_DEBUFF_ABILITIES.has(KnownAbilities.EMPOWER)).toBe(false);
+    });
+
+    it('should include U50 Class Mastery debuff sources and granted effects', () => {
+      const expectedClassMasteryDebuffs = [
+        ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+        ClassSkillId.WARDEN_TUNDRA_S_MAW,
+        KnownAbilities.MAJOR_BRITTLE,
+        KnownAbilities.MINOR_COWARDICE,
+      ];
+
+      expectedClassMasteryDebuffs.forEach((debuff) => {
+        expect(CLASS_MASTERY_DEBUFF_ABILITIES.has(debuff)).toBe(true);
+        expect(IMPORTANT_DEBUFF_ABILITIES.has(debuff)).toBe(true);
+      });
     });
   });
 

--- a/src/features/report_details/insights/DebuffUptimesPanel.tsx
+++ b/src/features/report_details/insights/DebuffUptimesPanel.tsx
@@ -28,6 +28,7 @@ import {
 import { calculateElementalWeaknessStacks } from '../../../workers/calculations/CalculateElementalWeaknessStacks';
 import { calculateStaggerStacks } from '../../../workers/calculations/CalculateStaggerStacks';
 import { calculateTouchOfZenStacks } from '../../../workers/calculations/CalculateTouchOfZenStacks';
+import { ClassSkillId } from '../../loadout-manager/data/classSkillIds';
 
 import { DebuffUptimesView } from './DebuffUptimesView';
 import { EffectUptimeTimelineModal } from './EffectUptimeTimelineModal';
@@ -38,8 +39,17 @@ interface DebuffUptimesPanelProps {
   selectedPlayerId?: number | null; // Optional: if provided, show per-player uptimes with group average deltas
 }
 
+export const CLASS_MASTERY_DEBUFF_ABILITIES = new Set<number>([
+  // U50 Class Mastery debuffs. Include source/passive rows when ESO Logs emits
+  // them and the named debuff rows used for group uptime comparisons.
+  ClassSkillId.ARCANIST_ERUDITE_S_RIGOR,
+  ClassSkillId.WARDEN_TUNDRA_S_MAW,
+  KnownAbilities.MAJOR_BRITTLE,
+  KnownAbilities.MINOR_COWARDICE,
+]);
+
 // Define the specific status effect debuff abilities to track
-export const IMPORTANT_DEBUFF_ABILITIES = new Set([
+export const IMPORTANT_DEBUFF_ABILITIES = new Set<number>([
   KnownAbilities.BURNING,
   KnownAbilities.CRUSHER,
   KnownAbilities.ENGULFING_FLAMES_BUFF,
@@ -56,6 +66,7 @@ export const IMPORTANT_DEBUFF_ABILITIES = new Set([
   KnownAbilities.HEAT_SHOCK,
   KnownAbilities.STAGGER, // Pre-U49 legacy debuff ID
   KnownAbilities.TOUCH_OF_ZEN,
+  ...CLASS_MASTERY_DEBUFF_ABILITIES,
 ]);
 
 /**

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -397,10 +397,12 @@ export enum KnownAbilities {
   MAJOR_EVASION = 61716,
   MAJOR_EXPEDITION = 61736,
   MAJOR_HEROISM = 61709,
+  MAJOR_PROTECTION = 61722,
   MAJOR_RESOLVE = 61694,
   MAJOR_SAVAGERY = 61667, // Fixed: was incorrectly 61898 (which is Minor Savagery)
   MAJOR_SLAYER = 93109,
   MAJOR_SORCERY = 61687, // Major Sorcery buff (was incorrectly 61685 which is "Minor Sorcery")
+  MAJOR_VITALITY = 61713,
   MAJOR_VULNERABILITY = 106754,
 
   // Minor Buffs and Debuffs
@@ -409,6 +411,7 @@ export enum KnownAbilities {
   MINOR_BRITTLE = 146697,
   MINOR_BRUTALITY = 61662,
   MINOR_COURAGE = 121878,
+  MINOR_COWARDICE = 46202,
   MINOR_EVASION = 61715,
   MINOR_EXPEDITION = 61735,
   MINOR_FORCE = 61746,


### PR DESCRIPTION
## Summary

Adds U50 Class Mastery uptime coverage to the existing Insights buff and debuff uptime panels.

## Jira Ticket

None. User-requested maintenance change.

## Problem

Class Mastery effects introduced around U50 can show up in report data, but several of the group-facing uptime rows were not part of the default curated Insights lists. That meant useful effects such as Major Force, Major Brittle, Major Protection, Major Vitality, and Minor Cowardice could require "Show All" or be missed entirely in the normal Insights view.

## Root Cause

The Insights uptime panels use explicit curated ability ID sets for default buff/debuff rows. The existing U50 data work added Class Mastery definitions, but the curated Insights sets did not include every relevant Class Mastery source/proc row and granted named effect row.

## Changes Made

- Adds Class Mastery-specific curated buff and debuff ability sets.
- Includes both source/proc IDs and granted effect IDs where ESO Logs may expose either row.
- Adds missing known ability IDs for Major Protection, Major Vitality, and Minor Cowardice.
- Updates uptime panel tests to assert Class Mastery coverage.
- Fixes Jest test discovery in this Windows `.codex` worktree while excluding the sibling `discord-bot` Vitest suite.
- Updates U50 documentation to record the Insights uptime curation behavior.

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Focused uptime tests pass (`npx jest --config jest.config.cjs --testPathPatterns "BuffUptimesPanel|DebuffUptimesPanel" --watchAll=false --runInBand`)
- [x] Touched-file formatting passes (`npx prettier --check ...`)
- [x] Whitespace check passes (`git diff --check`)
- [ ] Repo-wide format gate passes (`npm run validate`)
  - Fails on the existing repo-wide Prettier baseline: 1346 unrelated `src` files are reported.
- [ ] Full unit suite completes (`npm test -- --watchAll=false`)
  - Timed out locally after 10 minutes without emitting a suite summary.
