### PR TITLE
fix(reports): show fallback combatant gear

### DIFF
--- a/src/components/GearDetailsPanel.tsx
+++ b/src/components/GearDetailsPanel.tsx
@@ -31,6 +31,14 @@ interface GearDetailsPanelProps {
   onPlayerChange: (playerId: string | number) => void;
 }
 
+const WEAPON_SLOTS = [10, 11, 12, 13];
+const ARMOR_SLOTS = [0, 1, 2, 3, 4, 5, 6];
+const JEWELRY_SLOTS = [7, 8, 9];
+
+const isWeaponSlot = (slot: number): boolean => WEAPON_SLOTS.includes(slot);
+const isArmorSlot = (slot: number): boolean => ARMOR_SLOTS.includes(slot);
+const isJewelrySlot = (slot: number): boolean => JEWELRY_SLOTS.includes(slot);
+
 // Helper function to get slot name from slot number
 const getSlotName = (slot: number): string => {
   const slotNames: Record<number, string> = {
@@ -54,14 +62,68 @@ const getSlotName = (slot: number): string => {
 
 // Helper function to get slot icon
 const getSlotIcon = (slot: number): string => {
-  const weaponSlots = [10, 11, 12, 13];
-  const armorSlots = [0, 1, 2, 3, 4, 5, 6];
-  const jewelrySlots = [7, 8, 9];
-
-  if (weaponSlots.includes(slot)) return '⚔️';
-  if (armorSlots.includes(slot)) return '🛡️';
-  if (jewelrySlots.includes(slot)) return '💍';
+  if (isWeaponSlot(slot)) return '⚔️';
+  if (isArmorSlot(slot)) return '🛡️';
+  if (isJewelrySlot(slot)) return '💍';
   return '❓';
+};
+
+const getArmorTypeLabel = (type: number): string | null => {
+  switch (type) {
+    case ArmorType.LIGHT:
+      return 'Light';
+    case ArmorType.MEDIUM:
+      return 'Medium';
+    case ArmorType.HEAVY:
+      return 'Heavy';
+    case ArmorType.JEWELRY:
+      return 'Jewelry';
+    default:
+      return null;
+  }
+};
+
+const getWeaponTypeLabel = (type: number): string | null => {
+  switch (type) {
+    case WeaponType.AXE:
+      return 'Axe';
+    case WeaponType.MACE:
+      return 'Mace';
+    case WeaponType.SWORD:
+      return 'Sword';
+    case WeaponType.TWO_HANDED_SWORD:
+      return '2H Sword';
+    case WeaponType.TWO_HANDED_AXE:
+      return '2H Axe';
+    case WeaponType.MAUL:
+      return 'Maul';
+    case WeaponType.DAGGER:
+      return 'Dagger';
+    case WeaponType.INFERNO_STAFF:
+      return 'Inferno Staff';
+    case WeaponType.FROST_STAFF:
+      return 'Frost Staff';
+    case WeaponType.LIGHTNING_STAFF:
+      return 'Lightning Staff';
+    case WeaponType.RESO_STAFF:
+      return 'Resto Staff';
+    case WeaponType.SHIELD:
+      return 'Shield';
+    default:
+      return null;
+  }
+};
+
+const getGearTypeLabel = (gear: PlayerGear): string => {
+  if (isWeaponSlot(gear.slot)) {
+    return getWeaponTypeLabel(gear.type) ?? getArmorTypeLabel(gear.type) ?? '—';
+  }
+
+  if (isArmorSlot(gear.slot) || isJewelrySlot(gear.slot)) {
+    return getArmorTypeLabel(gear.type) ?? getWeaponTypeLabel(gear.type) ?? '—';
+  }
+
+  return getArmorTypeLabel(gear.type) ?? getWeaponTypeLabel(gear.type) ?? '—';
 };
 
 export const GearDetailsPanel: React.FC<GearDetailsPanelProps> = ({
@@ -214,47 +276,8 @@ export const GearDetailsPanel: React.FC<GearDetailsPanelProps> = ({
       {
         id: 'type',
         header: 'Type',
-        accessorFn: (row: Record<string, unknown>) => {
-          const getTypeLabel = (t: number): string => {
-            switch (t) {
-              case ArmorType.LIGHT:
-                return 'Light';
-              case ArmorType.MEDIUM:
-                return 'Medium';
-              case ArmorType.HEAVY:
-                return 'Heavy';
-              case ArmorType.JEWELRY:
-                return 'Jewelry';
-              case WeaponType.AXE:
-                return 'Axe';
-              case WeaponType.MACE:
-                return 'Mace';
-              case WeaponType.SWORD:
-                return 'Sword';
-              case WeaponType.TWO_HANDED_SWORD:
-                return '2H Sword';
-              case WeaponType.TWO_HANDED_AXE:
-                return '2H Axe';
-              case WeaponType.MAUL:
-                return 'Maul';
-              case WeaponType.DAGGER:
-                return 'Dagger';
-              case WeaponType.INFERNO_STAFF:
-                return 'Inferno Staff';
-              case WeaponType.FROST_STAFF:
-                return 'Frost Staff';
-              case WeaponType.LIGHTNING_STAFF:
-                return 'Lightning Staff';
-              case WeaponType.RESO_STAFF:
-                return 'Resto Staff';
-              case WeaponType.SHIELD:
-                return 'Shield';
-              default:
-                return '—';
-            }
-          };
-          return getTypeLabel((row as unknown as PlayerGear).type);
-        },
+        accessorFn: (row: Record<string, unknown>) =>
+          getGearTypeLabel(row as unknown as PlayerGear),
         size: 80,
         cell: (info: CellContext<Record<string, unknown>, unknown>) => (
           <Typography

--- a/src/features/report_details/insights/LazyPlayerCard.tsx
+++ b/src/features/report_details/insights/LazyPlayerCard.tsx
@@ -4,6 +4,7 @@ import { PlayerCardSkeleton } from '../../../components/PlayersSkeleton';
 import type { GrimoireData } from '../../../components/ScribingSkillsDisplay';
 import type { PlayerRoleResult } from '../../../features/role_detection';
 import type { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
+import type { PlayerTalent } from '../../../types/playerDetails';
 import type { ClassAnalysisResult } from '../../../utils/classDetectionUtils';
 import type { BuildIssue } from '../../../utils/detectBuildIssues';
 import type { PlayerGearSetRecord } from '../../../utils/gearUtilities';
@@ -27,6 +28,7 @@ export interface PlayerCardProps {
   mundusBuffs: Array<{ name: string; id: number }>;
   championPoints: Array<{ name: string; id: number; color: 'red' | 'blue' | 'green' }>;
   auras: Array<{ name: string; id: number; stacks?: number }>;
+  observedSkills?: PlayerTalent[];
   scribingSkills: GrimoireData[];
   buildIssues: BuildIssue[];
   classAnalysis?: ClassAnalysisResult;

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -55,7 +55,7 @@ import { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlic
 import { selectActiveReportContext } from '../../../store/report/reportSelectors';
 import type { RootState } from '../../../store/storeWithHistory';
 import { selectScribingDetectionsResult } from '../../../store/worker_results';
-import type { PlayerGear } from '../../../types/playerDetails';
+import type { PlayerGear, PlayerTalent } from '../../../types/playerDetails';
 import { type ClassAnalysisResult } from '../../../utils/classDetectionUtils';
 import { BuildIssue } from '../../../utils/detectBuildIssues';
 import { PlayerGearSetRecord } from '../../../utils/gearUtilities';
@@ -139,6 +139,7 @@ interface PlayerCardProps {
   mundusBuffs: Array<{ name: string; id: number }>;
   championPoints: Array<{ name: string; id: number; color: 'red' | 'blue' | 'green' }>;
   auras: Array<{ name: string; id: number; stacks?: number }>;
+  observedSkills?: PlayerTalent[];
   scribingSkills: GrimoireData[];
   buildIssues: BuildIssue[];
   classAnalysis?: ClassAnalysisResult;
@@ -282,6 +283,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
     mundusBuffs,
     championPoints,
     auras,
+    observedSkills,
     scribingSkills,
     buildIssues,
     classAnalysis,
@@ -327,6 +329,11 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       () => player?.combatantInfo?.talents ?? [],
       [player?.combatantInfo?.talents],
     );
+    const displayTalents = React.useMemo(
+      () => (talents.length > 0 ? talents : (observedSkills ?? [])),
+      [observedSkills, talents],
+    );
+    const isObservedTalentFallback = talents.length === 0 && displayTalents.length > 0;
     const gear = React.useMemo(
       () => (player?.combatantInfo?.gear ?? []).filter((g) => g.id !== 0),
       [player?.combatantInfo?.gear],
@@ -1459,15 +1466,15 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                 <ClassMasteryCluster classAnalysis={classAnalysis} />
 
                 {/* Talents and gear */}
-                {(talents.length > 0 || gear.length > 0) && (
+                {(displayTalents.length > 0 || gear.length > 0) && (
                   <Box sx={{ mb: 1.5 }}>
-                    {talents.length > 0 && (
+                    {displayTalents.length > 0 && (
                       <>
                         <Box sx={{ mb: 1.25, flexWrap: 'wrap', gap: 1.25, display: 'flex' }}>
-                          {talents.slice(0, 6).map((talent, idx) => {
-                            const isUltimate = idx === 5;
+                          {displayTalents.slice(0, 6).map((talent, idx) => {
+                            const isUltimate = !isObservedTalentFallback && idx === 5;
                             return (
-                              <React.Fragment key={idx}>
+                              <React.Fragment key={`${talent.guid}-${idx}`}>
                                 {isUltimate && (
                                   <Box
                                     sx={{
@@ -1564,12 +1571,12 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                             );
                           })}
                         </Box>
-                        {talents.length > 6 && (
+                        {displayTalents.length > 6 && (
                           <Box sx={{ flexWrap: 'wrap', gap: 1.25, mt: 0.25, display: 'flex' }}>
-                            {talents.slice(6).map((talent, idx) => {
-                              const isUltimate = idx === 5;
+                            {displayTalents.slice(6).map((talent, idx) => {
+                              const isUltimate = !isObservedTalentFallback && idx === 5;
                               return (
-                                <React.Fragment key={idx}>
+                                <React.Fragment key={`${talent.guid}-${idx}`}>
                                   {isUltimate && (
                                     <Box
                                       sx={{

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -1458,212 +1458,216 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                 {/* Class Mastery passives (non-subclassed only) — renders nothing otherwise */}
                 <ClassMasteryCluster classAnalysis={classAnalysis} />
 
-                {/* Talents */}
-                {talents.length > 0 && (
+                {/* Talents and gear */}
+                {(talents.length > 0 || gear.length > 0) && (
                   <Box sx={{ mb: 1.5 }}>
-                    <Box sx={{ mb: 1.25, flexWrap: 'wrap', gap: 1.25, display: 'flex' }}>
-                      {talents.slice(0, 6).map((talent, idx) => {
-                        const isUltimate = idx === 5;
-                        return (
-                          <React.Fragment key={idx}>
-                            {isUltimate && (
-                              <Box
-                                sx={{
-                                  width: 2,
-                                  height: 34,
-                                  bgcolor: 'rgba(124,207,252,0.55)',
-                                  borderRadius: 0.5,
-                                  flexShrink: 0,
-                                }}
-                              />
-                            )}
-                            <Box
-                              component="span"
-                              sx={{ display: 'inline-flex', alignItems: 'center' }}
-                            >
-                              <Tooltip
-                                enterTouchDelay={0}
-                                leaveTouchDelay={3000}
-                                title={
-                                  <LazyTalentTooltipContent
-                                    talent={talent}
-                                    isUltimate={isUltimate}
-                                    resolveProps={getTalentTooltipProps}
-                                    resolveScribedSkillData={resolveScribedSkillData}
-                                    fightId={fightId || undefined}
-                                    playerId={player.id}
-                                  />
-                                }
-                                placement="top-start"
-                                enterDelay={0}
-                                arrow
-                                slotProps={{
-                                  popper: {
-                                    disablePortal: true,
-                                    modifiers: [
-                                      {
-                                        name: 'preventOverflow',
-                                        options: {
-                                          altAxis: true,
-                                          altBoundary: true,
-                                          tether: false,
-                                          rootBoundary: 'document',
-                                          padding: 16,
-                                        },
-                                      },
-                                      {
-                                        name: 'flip',
-                                        enabled: true,
-                                        options: {
-                                          altBoundary: true,
-                                          rootBoundary: 'document',
-                                          padding: 16,
-                                          fallbackPlacements: ['bottom'],
-                                        },
-                                      },
-                                      {
-                                        name: 'arrow',
-                                        enabled: true,
-                                      },
-                                    ],
-                                  },
-                                  tooltip: {
-                                    sx: {
-                                      maxWidth: 320,
-                                      p: 0,
-                                      backgroundColor: 'transparent !important',
-                                      border: 'none !important',
-                                      boxShadow: 'none !important',
-                                    },
-                                  },
-                                  arrow: { sx: { display: 'none' } },
-                                }}
-                              >
-                                <Avatar
-                                  src={abilityIconUrl(talent.abilityIcon, talent.guid)}
-                                  alt={talent.name}
-                                  variant="rounded"
-                                  sx={{
-                                    width: isUltimate ? 34 : 32,
-                                    height: isUltimate ? 34 : 32,
-                                    border: isUltimate
-                                      ? '1.5px solid #b3b3b3f2'
-                                      : theme.palette.mode === 'dark'
-                                        ? '1px solid #b5b8bd59'
-                                        : '1px solid #1e3a8a',
-                                    boxShadow: isUltimate
-                                      ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
-                                      : 'none',
-                                  }}
-                                />
-                              </Tooltip>
-                            </Box>
-                          </React.Fragment>
-                        );
-                      })}
-                    </Box>
-                    {talents.length > 6 && (
-                      <Box sx={{ flexWrap: 'wrap', gap: 1.25, mt: 0.25, display: 'flex' }}>
-                        {talents.slice(6).map((talent, idx) => {
-                          const isUltimate = idx === 5;
-                          return (
-                            <React.Fragment key={idx}>
-                              {isUltimate && (
-                                <Box
-                                  sx={{
-                                    width: 2,
-                                    height: 34,
-                                    bgcolor: 'rgba(124,207,252,0.55)',
-                                    borderRadius: 0.5,
-                                    flexShrink: 0,
-                                  }}
-                                />
-                              )}
-                              <Box
-                                component="span"
-                                sx={{ display: 'inline-flex', alignItems: 'center' }}
-                              >
-                                <Tooltip
-                                  enterTouchDelay={0}
-                                  leaveTouchDelay={3000}
-                                  title={
-                                    <LazyTalentTooltipContent
-                                      talent={talent}
-                                      isUltimate={isUltimate}
-                                      resolveProps={getTalentTooltipProps}
-                                      resolveScribedSkillData={resolveScribedSkillData}
-                                      fightId={fightId || undefined}
-                                      playerId={player.id}
-                                    />
-                                  }
-                                  placement="top-start"
-                                  enterDelay={0}
-                                  arrow
-                                  slotProps={{
-                                    popper: {
-                                      disablePortal: true,
-                                      modifiers: [
-                                        {
-                                          name: 'preventOverflow',
-                                          options: {
-                                            altAxis: true,
-                                            altBoundary: true,
-                                            tether: false,
-                                            rootBoundary: 'document',
-                                            padding: 16,
-                                          },
-                                        },
-                                        {
-                                          name: 'flip',
-                                          enabled: true,
-                                          options: {
-                                            altBoundary: true,
-                                            rootBoundary: 'document',
-                                            padding: 16,
-                                            fallbackPlacements: ['bottom'],
-                                          },
-                                        },
-                                        {
-                                          name: 'arrow',
-                                          enabled: true,
-                                        },
-                                      ],
-                                    },
-                                    tooltip: {
-                                      sx: {
-                                        maxWidth: 320,
-                                        p: 0,
-                                        backgroundColor: 'transparent !important',
-                                        border: 'none !important',
-                                        boxShadow: 'none !important',
-                                      },
-                                    },
-                                    arrow: { sx: { display: 'none' } },
-                                  }}
-                                >
-                                  <Avatar
-                                    src={abilityIconUrl(talent.abilityIcon, talent.guid)}
-                                    alt={talent.name}
-                                    variant="rounded"
+                    {talents.length > 0 && (
+                      <>
+                        <Box sx={{ mb: 1.25, flexWrap: 'wrap', gap: 1.25, display: 'flex' }}>
+                          {talents.slice(0, 6).map((talent, idx) => {
+                            const isUltimate = idx === 5;
+                            return (
+                              <React.Fragment key={idx}>
+                                {isUltimate && (
+                                  <Box
                                     sx={{
-                                      width: isUltimate ? 34 : 32,
-                                      height: isUltimate ? 34 : 32,
-                                      border: isUltimate
-                                        ? '1.5px solid #b3b3b3f2'
-                                        : theme.palette.mode === 'dark'
-                                          ? '1px solid #b5b8bd59'
-                                          : '1px solid #1e3a8a',
-                                      boxShadow: isUltimate
-                                        ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
-                                        : 'none',
+                                      width: 2,
+                                      height: 34,
+                                      bgcolor: 'rgba(124,207,252,0.55)',
+                                      borderRadius: 0.5,
+                                      flexShrink: 0,
                                     }}
                                   />
-                                </Tooltip>
-                              </Box>
-                            </React.Fragment>
-                          );
-                        })}
-                      </Box>
+                                )}
+                                <Box
+                                  component="span"
+                                  sx={{ display: 'inline-flex', alignItems: 'center' }}
+                                >
+                                  <Tooltip
+                                    enterTouchDelay={0}
+                                    leaveTouchDelay={3000}
+                                    title={
+                                      <LazyTalentTooltipContent
+                                        talent={talent}
+                                        isUltimate={isUltimate}
+                                        resolveProps={getTalentTooltipProps}
+                                        resolveScribedSkillData={resolveScribedSkillData}
+                                        fightId={fightId || undefined}
+                                        playerId={player.id}
+                                      />
+                                    }
+                                    placement="top-start"
+                                    enterDelay={0}
+                                    arrow
+                                    slotProps={{
+                                      popper: {
+                                        disablePortal: true,
+                                        modifiers: [
+                                          {
+                                            name: 'preventOverflow',
+                                            options: {
+                                              altAxis: true,
+                                              altBoundary: true,
+                                              tether: false,
+                                              rootBoundary: 'document',
+                                              padding: 16,
+                                            },
+                                          },
+                                          {
+                                            name: 'flip',
+                                            enabled: true,
+                                            options: {
+                                              altBoundary: true,
+                                              rootBoundary: 'document',
+                                              padding: 16,
+                                              fallbackPlacements: ['bottom'],
+                                            },
+                                          },
+                                          {
+                                            name: 'arrow',
+                                            enabled: true,
+                                          },
+                                        ],
+                                      },
+                                      tooltip: {
+                                        sx: {
+                                          maxWidth: 320,
+                                          p: 0,
+                                          backgroundColor: 'transparent !important',
+                                          border: 'none !important',
+                                          boxShadow: 'none !important',
+                                        },
+                                      },
+                                      arrow: { sx: { display: 'none' } },
+                                    }}
+                                  >
+                                    <Avatar
+                                      src={abilityIconUrl(talent.abilityIcon, talent.guid)}
+                                      alt={talent.name}
+                                      variant="rounded"
+                                      sx={{
+                                        width: isUltimate ? 34 : 32,
+                                        height: isUltimate ? 34 : 32,
+                                        border: isUltimate
+                                          ? '1.5px solid #b3b3b3f2'
+                                          : theme.palette.mode === 'dark'
+                                            ? '1px solid #b5b8bd59'
+                                            : '1px solid #1e3a8a',
+                                        boxShadow: isUltimate
+                                          ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
+                                          : 'none',
+                                      }}
+                                    />
+                                  </Tooltip>
+                                </Box>
+                              </React.Fragment>
+                            );
+                          })}
+                        </Box>
+                        {talents.length > 6 && (
+                          <Box sx={{ flexWrap: 'wrap', gap: 1.25, mt: 0.25, display: 'flex' }}>
+                            {talents.slice(6).map((talent, idx) => {
+                              const isUltimate = idx === 5;
+                              return (
+                                <React.Fragment key={idx}>
+                                  {isUltimate && (
+                                    <Box
+                                      sx={{
+                                        width: 2,
+                                        height: 34,
+                                        bgcolor: 'rgba(124,207,252,0.55)',
+                                        borderRadius: 0.5,
+                                        flexShrink: 0,
+                                      }}
+                                    />
+                                  )}
+                                  <Box
+                                    component="span"
+                                    sx={{ display: 'inline-flex', alignItems: 'center' }}
+                                  >
+                                    <Tooltip
+                                      enterTouchDelay={0}
+                                      leaveTouchDelay={3000}
+                                      title={
+                                        <LazyTalentTooltipContent
+                                          talent={talent}
+                                          isUltimate={isUltimate}
+                                          resolveProps={getTalentTooltipProps}
+                                          resolveScribedSkillData={resolveScribedSkillData}
+                                          fightId={fightId || undefined}
+                                          playerId={player.id}
+                                        />
+                                      }
+                                      placement="top-start"
+                                      enterDelay={0}
+                                      arrow
+                                      slotProps={{
+                                        popper: {
+                                          disablePortal: true,
+                                          modifiers: [
+                                            {
+                                              name: 'preventOverflow',
+                                              options: {
+                                                altAxis: true,
+                                                altBoundary: true,
+                                                tether: false,
+                                                rootBoundary: 'document',
+                                                padding: 16,
+                                              },
+                                            },
+                                            {
+                                              name: 'flip',
+                                              enabled: true,
+                                              options: {
+                                                altBoundary: true,
+                                                rootBoundary: 'document',
+                                                padding: 16,
+                                                fallbackPlacements: ['bottom'],
+                                              },
+                                            },
+                                            {
+                                              name: 'arrow',
+                                              enabled: true,
+                                            },
+                                          ],
+                                        },
+                                        tooltip: {
+                                          sx: {
+                                            maxWidth: 320,
+                                            p: 0,
+                                            backgroundColor: 'transparent !important',
+                                            border: 'none !important',
+                                            boxShadow: 'none !important',
+                                          },
+                                        },
+                                        arrow: { sx: { display: 'none' } },
+                                      }}
+                                    >
+                                      <Avatar
+                                        src={abilityIconUrl(talent.abilityIcon, talent.guid)}
+                                        alt={talent.name}
+                                        variant="rounded"
+                                        sx={{
+                                          width: isUltimate ? 34 : 32,
+                                          height: isUltimate ? 34 : 32,
+                                          border: isUltimate
+                                            ? '1.5px solid #b3b3b3f2'
+                                            : theme.palette.mode === 'dark'
+                                              ? '1px solid #b5b8bd59'
+                                              : '1px solid #1e3a8a',
+                                          boxShadow: isUltimate
+                                            ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
+                                            : 'none',
+                                        }}
+                                      />
+                                    </Tooltip>
+                                  </Box>
+                                </React.Fragment>
+                              );
+                            })}
+                          </Box>
+                        )}
+                      </>
                     )}
                     {gear.length > 0 && (
                       <Box sx={{ mt: 1.25, pt: 0.9, pb: 0 }}>

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -101,6 +101,9 @@ const LazyGearSetTooltipContent: React.FC<{
 
 type TalentTooltipProps = ReturnType<typeof buildTooltipProps>;
 
+const OBSERVED_SKILLS_TOOLTIP =
+  "Inferred from this fight's casts, damage, buffs, debuffs, heals, and resources. This is not an exact slotted bar; unused skills cannot be recovered from public log data.";
+
 /**
  * Renders a talent/skill tooltip's content, resolving the (expensive) rich tooltip props only
  * when this component mounts — i.e. when MUI opens the tooltip on hover. The resolver caches per
@@ -1470,6 +1473,30 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                   <Box sx={{ mb: 1.5 }}>
                     {displayTalents.length > 0 && (
                       <>
+                        {isObservedTalentFallback && (
+                          <Box sx={{ mb: 0.75, display: 'flex', alignItems: 'center' }}>
+                            <Tooltip title={OBSERVED_SKILLS_TOOLTIP} arrow>
+                              <Chip
+                                icon={<InfoIcon sx={{ fontSize: '0.85rem !important' }} />}
+                                label="Observed skills"
+                                size="small"
+                                color="warning"
+                                variant="outlined"
+                                data-testid="observed-skills-chip"
+                                sx={{
+                                  height: 22,
+                                  borderRadius: 1,
+                                  fontSize: '0.68rem',
+                                  fontWeight: 600,
+                                  '& .MuiChip-icon': {
+                                    ml: 0.6,
+                                    mr: -0.25,
+                                  },
+                                }}
+                              />
+                            </Tooltip>
+                          </Box>
+                        )}
                         <Box sx={{ mb: 1.25, flexWrap: 'wrap', gap: 1.25, display: 'flex' }}>
                           {displayTalents.slice(0, 6).map((talent, idx) => {
                             const isUltimate = !isObservedTalentFallback && idx === 5;
@@ -1557,12 +1584,16 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                         height: isUltimate ? 34 : 32,
                                         border: isUltimate
                                           ? '1.5px solid #b3b3b3f2'
-                                          : theme.palette.mode === 'dark'
-                                            ? '1px solid #b5b8bd59'
-                                            : '1px solid #1e3a8a',
+                                          : isObservedTalentFallback
+                                            ? `1px dashed ${theme.palette.warning.main}`
+                                            : theme.palette.mode === 'dark'
+                                              ? '1px solid #b5b8bd59'
+                                              : '1px solid #1e3a8a',
                                         boxShadow: isUltimate
                                           ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
-                                          : 'none',
+                                          : isObservedTalentFallback
+                                            ? `0 0 0 2px ${theme.palette.warning.main}22`
+                                            : 'none',
                                       }}
                                     />
                                   </Tooltip>
@@ -1659,12 +1690,16 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                           height: isUltimate ? 34 : 32,
                                           border: isUltimate
                                             ? '1.5px solid #b3b3b3f2'
-                                            : theme.palette.mode === 'dark'
-                                              ? '1px solid #b5b8bd59'
-                                              : '1px solid #1e3a8a',
+                                            : isObservedTalentFallback
+                                              ? `1px dashed ${theme.palette.warning.main}`
+                                              : theme.palette.mode === 'dark'
+                                                ? '1px solid #b5b8bd59'
+                                                : '1px solid #1e3a8a',
                                           boxShadow: isUltimate
                                             ? 'inset 0 2px 4px rgb(0 0 0 / 100%), 0 0 0 1px rgb(255 255 255 / 18%), 0 0 10px rgb(255 255 255 / 25%), 0 2px 6px rgb(0 0 0 / 60%)'
-                                            : 'none',
+                                            : isObservedTalentFallback
+                                              ? `0 0 0 2px ${theme.palette.warning.main}22`
+                                              : 'none',
                                         }}
                                       />
                                     </Tooltip>

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -86,6 +86,7 @@ import {
   type KalpaBuildEvidence,
   type KalpaPlayerBuildEvidence,
 } from '../../../utils/kalpaBuildEvidence';
+import { deriveObservedPlayerSkills } from '../../../utils/observedSkillFallback';
 import {
   classifyPotionEventsFromBuffStream,
   type PotionStreamResult,
@@ -610,6 +611,47 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   }, [fight, castEvents, playersById]);
 
   const { abilitiesById } = reportMasterData;
+
+  const observedSkillsByPlayer = React.useMemo(() => {
+    const result: Record<string, ReturnType<typeof deriveObservedPlayerSkills>> = {};
+
+    if (!abilitiesById || !hasPlayerEntries(playersById)) {
+      return result;
+    }
+
+    Object.values(playersById).forEach((player) => {
+      if (!player?.id || (player.combatantInfo?.talents?.length ?? 0) > 0) {
+        return;
+      }
+
+      const observedSkills = deriveObservedPlayerSkills({
+        playerId: player.id,
+        abilitiesById,
+        gear: player.combatantInfo?.gear,
+        castEvents,
+        damageEvents,
+        friendlyBuffEvents,
+        debuffEvents,
+        healingEvents,
+        resourceEvents,
+      });
+
+      if (observedSkills.length > 0) {
+        result[String(player.id)] = observedSkills;
+      }
+    });
+
+    return result;
+  }, [
+    abilitiesById,
+    playersById,
+    castEvents,
+    damageEvents,
+    friendlyBuffEvents,
+    debuffEvents,
+    healingEvents,
+    resourceEvents,
+  ]);
 
   const publicClassAnalysisByPlayer = React.useMemo(() => {
     const result: Record<string, ClassAnalysisResult> = {};
@@ -1522,6 +1564,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
           resurrectsByPlayer={resurrectsByPlayer}
           cpmByPlayer={cpmByPlayer}
           aurasByPlayer={aurasByPlayer}
+          observedSkillsByPlayer={observedSkillsByPlayer}
           maxHealthByPlayer={maxHealthByPlayer}
           maxStaminaByPlayer={maxStaminaByPlayer}
           maxMagickaByPlayer={maxMagickaByPlayer}

--- a/src/features/report_details/insights/PlayersPanelView.tsx
+++ b/src/features/report_details/insights/PlayersPanelView.tsx
@@ -25,6 +25,7 @@ import { GrimoireData } from '../../../components/ScribingSkillsDisplay';
 import { DetectedRole, type PlayerRoleResult } from '../../../features/role_detection';
 import { toBroadRole, type BroadRole } from '../../../hooks/useRoleDetection';
 import { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
+import type { PlayerTalent } from '../../../types/playerDetails';
 import { type ClassAnalysisResult } from '../../../utils/classDetectionUtils';
 import { BuildIssue } from '../../../utils/detectBuildIssues';
 import { PlayerGearSetRecord } from '../../../utils/gearUtilities';
@@ -47,6 +48,7 @@ interface PlayersPanelViewProps {
     Array<{ name: string; id: number; color: 'red' | 'blue' | 'green' }>
   >;
   aurasByPlayer: Record<string, Array<{ name: string; id: number; stacks?: number }>>;
+  observedSkillsByPlayer: Record<string, PlayerTalent[]>;
   scribingSkillsByPlayer: Record<string, GrimoireData[]>;
   buildIssuesByPlayer: Record<string, BuildIssue[]>;
   classAnalysisByPlayer: Record<string, ClassAnalysisResult>;
@@ -116,6 +118,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
     mundusBuffsByPlayer,
     championPointsByPlayer,
     aurasByPlayer,
+    observedSkillsByPlayer,
     scribingSkillsByPlayer,
     buildIssuesByPlayer,
     classAnalysisByPlayer,
@@ -189,6 +192,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
         const mundusBuffs = mundusBuffsByPlayer?.[String(player.id)] ?? [];
         const championPoints = championPointsByPlayer?.[String(player.id)] ?? [];
         const auras = aurasByPlayer?.[String(player.id)] ?? [];
+        const observedSkills = observedSkillsByPlayer?.[String(player.id)] ?? [];
         const scribingSkills = scribingSkillsByPlayer?.[String(player.id)] ?? [];
         const buildIssues = buildIssuesByPlayer[String(player.id)] || [];
         const classAnalysis = classAnalysisByPlayer[String(player.id)];
@@ -221,6 +225,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
           mundusBuffs,
           championPoints,
           auras,
+          observedSkills,
           scribingSkills,
           buildIssues,
           classAnalysis,
@@ -252,6 +257,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
       mundusBuffsByPlayer,
       championPointsByPlayer,
       aurasByPlayer,
+      observedSkillsByPlayer,
       scribingSkillsByPlayer,
       buildIssuesByPlayer,
       classAnalysisByPlayer,
@@ -735,6 +741,7 @@ export const PlayersPanelView: React.FC<PlayersPanelViewProps> = React.memo(
                 mundusBuffs={playerData.mundusBuffs}
                 championPoints={playerData.championPoints}
                 auras={playerData.auras}
+                observedSkills={playerData.observedSkills}
                 scribingSkills={playerData.scribingSkills}
                 buildIssues={playerData.buildIssues}
                 classAnalysis={playerData.classAnalysis}

--- a/src/features/report_details/talents/TalentsGridPanel.tsx
+++ b/src/features/report_details/talents/TalentsGridPanel.tsx
@@ -5,9 +5,19 @@ import React, { useCallback, useMemo } from 'react';
 import { DataGrid } from '../../../components/LazyDataGrid';
 import { useLogger } from '../../../contexts/LoggerContext';
 import { FightFragment } from '../../../graphql/gql/graphql';
-import { usePlayerData } from '../../../hooks';
+import {
+  useCastEvents,
+  useDamageEvents,
+  useDebuffEvents,
+  useFriendlyBuffEvents,
+  useHealingEvents,
+  usePlayerData,
+  useReportMasterData,
+  useResourceEvents,
+} from '../../../hooks';
 import { PlayerTalent } from '../../../types/playerDetails';
 import { abilityIconUrl } from '../../../utils/abilityIconCorrections';
+import { deriveObservedPlayerSkills } from '../../../utils/observedSkillFallback';
 import { resolveActorName } from '../../../utils/resolveActorName';
 
 interface TalentsGridPanelProps {
@@ -20,6 +30,7 @@ interface TalentRow {
   type: number;
   abilityIcon: string;
   flags: number;
+  source: 'ESO Logs' | 'Observed' | 'Mixed';
   playerKeys: Set<string>;
   playerNames: string[];
   rawTalentData: PlayerTalent;
@@ -27,6 +38,13 @@ interface TalentRow {
 
 export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => {
   const { playerData } = usePlayerData();
+  const { reportMasterData } = useReportMasterData();
+  const { castEvents } = useCastEvents();
+  const { damageEvents } = useDamageEvents();
+  const { friendlyBuffEvents } = useFriendlyBuffEvents();
+  const { debuffEvents } = useDebuffEvents();
+  const { healingEvents } = useHealingEvents();
+  const { resourceEvents } = useResourceEvents();
   const logger = useLogger('TalentsGridPanel');
 
   // Transform talent data for DataGrid
@@ -44,13 +62,29 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
 
       const playerName = resolveActorName(player, fightPlayer);
       const combatantInfo = player.combatantInfo;
-      const talents = combatantInfo?.talents || [];
+      const talents = combatantInfo?.talents?.length
+        ? combatantInfo.talents
+        : deriveObservedPlayerSkills({
+            playerId: fightPlayer,
+            abilitiesById: reportMasterData.abilitiesById,
+            gear: combatantInfo?.gear,
+            castEvents,
+            damageEvents,
+            friendlyBuffEvents,
+            debuffEvents,
+            healingEvents,
+            resourceEvents,
+          });
+      const talentSource = combatantInfo?.talents?.length ? 'ESO Logs' : 'Observed';
 
       const playerKey = String(fightPlayer);
 
       talents.forEach((talent: PlayerTalent) => {
         const existingTalent = talentMap.get(talent.guid);
         if (existingTalent) {
+          if (existingTalent.source !== talentSource) {
+            existingTalent.source = 'Mixed';
+          }
           // Count each distinct player once per talent guid, even if the
           // player's talents array lists the same guid more than once.
           if (!existingTalent.playerKeys.has(playerKey)) {
@@ -64,6 +98,7 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
             type: talent.type || 0,
             abilityIcon: talent.abilityIcon || '',
             flags: talent.flags || 0,
+            source: talentSource,
             playerKeys: new Set([playerKey]),
             playerNames: [playerName],
             rawTalentData: talent,
@@ -73,7 +108,17 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
     });
 
     return Array.from(talentMap.values());
-  }, [playerData, fight]);
+  }, [
+    playerData,
+    fight,
+    reportMasterData.abilitiesById,
+    castEvents,
+    damageEvents,
+    friendlyBuffEvents,
+    debuffEvents,
+    healingEvents,
+    resourceEvents,
+  ]);
 
   // Create column helper
   const columnHelper = createColumnHelper<TalentRow>();
@@ -143,6 +188,18 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
         ),
         size: 80,
       }),
+      columnHelper.accessor('source', {
+        header: 'Source',
+        cell: (info) => (
+          <Chip
+            label={info.getValue()}
+            size="small"
+            color={info.getValue() === 'ESO Logs' ? 'primary' : 'default'}
+            variant={info.getValue() === 'ESO Logs' ? 'filled' : 'outlined'}
+          />
+        ),
+        size: 120,
+      }),
       columnHelper.display({
         id: 'playerCount',
         header: 'Players',
@@ -200,7 +257,8 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
           No talent data available for this fight
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-          Talent information may not be available for this report or fight.
+          Talent information may not be available for this report or fight, and no observed player
+          skills were found in the loaded events.
         </Typography>
       </Box>
     );

--- a/src/features/report_details/talents/TalentsGridPanel.tsx
+++ b/src/features/report_details/talents/TalentsGridPanel.tsx
@@ -264,10 +264,20 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
     );
   }
 
+  const hasObservedRows = talentRows.some((row) => row.source !== 'ESO Logs');
+  const hasExactRows = talentRows.some(
+    (row) => row.source === 'ESO Logs' || row.source === 'Mixed',
+  );
+  const rowLabel = hasObservedRows ? 'Skills' : 'Talents';
+  const title =
+    hasObservedRows && !hasExactRows
+      ? 'Player Observed Skills Overview'
+      : 'Player Talents Overview';
+
   return (
     <Box sx={{ p: 2 }}>
       <Typography variant="h5" gutterBottom>
-        Player Talents Overview
+        {title}
       </Typography>
 
       <Stack spacing={3}>
@@ -280,7 +290,7 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
                   {talentRows.length}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Unique Talents
+                  Unique {rowLabel}
                 </Typography>
               </CardContent>
             </Card>
@@ -302,7 +312,7 @@ export const TalentsGridPanel: React.FC<TalentsGridPanelProps> = ({ fight }) => 
           <DataGrid
             data={talentRows as unknown as Record<string, unknown>[]}
             columns={columns as ColumnDef<Record<string, unknown>>[]}
-            title={`Talents (${talentRows.length} unique)`}
+            title={`${rowLabel} (${talentRows.length} unique)`}
             height={600}
             initialPageSize={25}
             pageSizeOptions={[25, 50, 100]}

--- a/src/store/player_data/playerDataFallback.test.ts
+++ b/src/store/player_data/playerDataFallback.test.ts
@@ -80,7 +80,9 @@ describe('buildFallbackPlayersFromMasterData', () => {
       type: 'Nightblade',
       role: 'dps',
     });
-    expect(players[1].combatantInfo.gear).toBe(gear);
+    expect(players[1].combatantInfo.gear).toEqual([
+      { id: 10, setName: 'Test Set', slot: 0, name: 'Test Set' },
+    ]);
     expect(players[96]).toMatchObject({
       id: 96,
       name: 'Angair Doomfang',
@@ -105,5 +107,44 @@ describe('buildFallbackPlayersFromMasterData', () => {
       displayName: '',
       role: 'dps',
     });
+  });
+
+  it('normalizes combatant-info gear from event payloads', () => {
+    const gear = [
+      { id: 157729, setID: 475 },
+      { id: 0, setID: 0 },
+      { id: 223189, setID: 845, slot: 5 },
+    ] as CombatantInfoEvent['gear'];
+
+    const players = buildFallbackPlayersFromMasterData({
+      actorsById: {
+        1: actor({ id: 1, name: 'Fallback Player' }),
+      },
+      combatantInfoEvents: [combatantInfo(1, 100, gear)],
+    });
+
+    expect(players[1].combatantInfo.gear).toEqual([
+      {
+        id: 157729,
+        setID: 475,
+        slot: 0,
+        setName: 'Aegis Caller',
+        name: 'Aegis Caller',
+      },
+      {
+        id: 0,
+        setID: 0,
+        slot: 1,
+        setName: undefined,
+        name: undefined,
+      },
+      {
+        id: 223189,
+        setID: 845,
+        slot: 5,
+        setName: "Huntsman's Warmask",
+        name: "Huntsman's Warmask",
+      },
+    ]);
   });
 });

--- a/src/store/player_data/playerDataFallback.ts
+++ b/src/store/player_data/playerDataFallback.ts
@@ -1,5 +1,8 @@
 import type { ReportActorFragment } from '@/graphql/gql/graphql';
 import type { CombatantInfoEvent } from '@/types/combatlogEvents';
+import type { PlayerGear } from '@/types/playerDetails';
+
+import setNamesRaw from '../../../data/libsets-set-names.json';
 
 import type { PlayerDetailsWithRole } from './playerDataSlice';
 
@@ -18,6 +21,12 @@ interface BuildFallbackPlayersInput {
   combatantInfoEvents: readonly CombatantInfoEvent[];
   rolesByPlayerId?: Record<number, RoleDetectionResultLike>;
 }
+
+interface LibSetsSetNamesFile {
+  sets: Record<string, Record<string, string>>;
+}
+
+const setNamesData = setNamesRaw as LibSetsSetNamesFile;
 
 const normalizeDisplayName = (displayName: string | null | undefined): string => {
   if (!displayName || displayName === 'nil') {
@@ -39,6 +48,26 @@ const toBroadRole = (role: string | undefined): PlayerDetailsWithRole['role'] =>
       return 'dps';
   }
 };
+
+const resolveSetName = (setId: number | null | undefined): string | undefined => {
+  if (typeof setId !== 'number' || setId <= 0) {
+    return undefined;
+  }
+
+  const names = setNamesData.sets[String(setId)];
+  return names?.en ?? Object.values(names ?? {})[0];
+};
+
+const normalizeFallbackGear = (gear: readonly PlayerGear[] | undefined): PlayerGear[] =>
+  (gear ?? []).map((piece, index) => {
+    const setName = piece.setName ?? resolveSetName(piece.setID);
+    return {
+      ...piece,
+      slot: typeof piece.slot === 'number' ? piece.slot : index,
+      setName,
+      name: piece.name ?? (piece.id ? setName : undefined),
+    };
+  });
 
 const getCandidatePlayerIds = ({
   friendlyPlayerIds,
@@ -128,7 +157,7 @@ export const buildFallbackPlayersFromMasterData = ({
       combatantInfo: {
         stats: [],
         talents: [],
-        gear: latestCombatantInfo?.gear ?? [],
+        gear: normalizeFallbackGear(latestCombatantInfo?.gear),
       },
       role: toBroadRole(rolesByPlayerId[playerId]?.role),
     };

--- a/src/store/player_data/playerDataSelectors.test.ts
+++ b/src/store/player_data/playerDataSelectors.test.ts
@@ -194,7 +194,9 @@ describe('playerDataSelectors fallback players', () => {
       type: 'Nightblade',
       role: 'dps',
     });
-    expect(players[1].combatantInfo.gear).toEqual([{ id: 10, setName: 'Fallback Set' }]);
+    expect(players[1].combatantInfo.gear).toEqual([
+      { id: 10, setName: 'Fallback Set', slot: 0, name: 'Fallback Set' },
+    ]);
     expect(players[96]).toMatchObject({
       id: 96,
       name: 'Angair Doomfang',

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -302,6 +302,91 @@ describe('kalpaBuildEvidence', () => {
     ).toBe(anonymousEvidence.players[0]);
   });
 
+  it('matches anonymous raw player info by unique single class when no public fingerprint exists', () => {
+    const anonymousEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          unitId: '20',
+          characterName: undefined,
+          accountName: undefined,
+          characterId: undefined,
+          className: 'Sorcerer',
+          raceId: 1,
+          championPoints: 0,
+          championPointPassives: [],
+          scribedSkills: [],
+          evidence: 'raw-player-info',
+          confidence: 'exact',
+        },
+        {
+          ...evidence.players[0],
+          unitId: '104',
+          characterName: undefined,
+          accountName: undefined,
+          characterId: undefined,
+          className: 'Sorcerer',
+          raceId: 1,
+          championPoints: 1134,
+          championPointPassives: [],
+          scribedSkills: [],
+          evidence: 'raw-unit-added',
+          confidence: 'partial',
+        },
+      ],
+    };
+
+    expect(
+      findAnonymousKalpaBuildEvidenceForPlayer(anonymousEvidence, {
+        classNames: ['Sorcerer'],
+      }),
+    ).toBe(anonymousEvidence.players[0]);
+  });
+
+  it('does not use raw player info fallback when anonymous class-only matching is ambiguous', () => {
+    const ambiguous: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          unitId: '20',
+          characterName: undefined,
+          accountName: undefined,
+          characterId: undefined,
+          className: 'Sorcerer',
+          championPointPassives: [],
+          scribedSkills: [],
+          evidence: 'raw-player-info',
+          confidence: 'exact',
+        },
+        {
+          ...evidence.players[0],
+          unitId: '21',
+          characterName: undefined,
+          accountName: undefined,
+          characterId: undefined,
+          className: 'Sorcerer',
+          championPointPassives: [],
+          scribedSkills: [],
+          evidence: 'raw-player-info',
+          confidence: 'exact',
+        },
+      ],
+    };
+
+    expect(
+      findAnonymousKalpaBuildEvidenceForPlayer(ambiguous, {
+        classNames: ['Sorcerer'],
+      }),
+    ).toBeUndefined();
+    expect(
+      findAnonymousKalpaBuildEvidenceForPlayer(ambiguous, {
+        classNames: ['Sorcerer', 'Templar'],
+      }),
+    ).toBeUndefined();
+  });
+
   it('excludes exact anonymous sidecar rows without blocking reused unit ids', () => {
     const anonymousEvidence: KalpaBuildEvidence = {
       ...evidence,

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -300,15 +300,17 @@ export function findAnonymousKalpaBuildEvidenceForPlayer(
 
   const publicCpIds = uniquePositiveNumbers(signals.championPointPassiveIds);
   const publicScribedIds = uniquePositiveNumbers(signals.scribedSkillIds);
-  if (publicCpIds.length < 2 && publicScribedIds.length === 0) return undefined;
-
-  const matches = evidence.players
+  const classMatches = evidence.players
     .filter((candidate) => !signals.excludedPlayers?.has(candidate))
     .filter((candidate) => !hasSidecarIdentity(candidate))
     .filter((candidate) => {
       const candidateClass = classNameToEsoClass(candidate.className);
-      if (!candidateClass || !classNames.has(candidateClass)) return false;
+      return Boolean(candidateClass && classNames.has(candidateClass));
+    });
 
+  const hasPublicFingerprint = publicCpIds.length >= 2 || publicScribedIds.length > 0;
+  if (hasPublicFingerprint) {
+    const matches = classMatches.filter((candidate) => {
       const candidateCpIds = new Set(uniquePositiveNumbers(candidate.championPointPassives));
       const cpOverlap = publicCpIds.filter((id) => candidateCpIds.has(id)).length;
       if (cpOverlap >= 2) return true;
@@ -319,7 +321,13 @@ export function findAnonymousKalpaBuildEvidenceForPlayer(
       return publicScribedIds.some((id) => candidateScribedIds.has(id));
     });
 
-  return matches.length === 1 ? matches[0] : undefined;
+    return matches.length === 1 ? matches[0] : undefined;
+  }
+
+  if (classNames.size !== 1) return undefined;
+
+  const rawPlayerInfoMatches = classMatches.filter(isExactRawPlayerInfoEvidence);
+  return rawPlayerInfoMatches.length === 1 ? rawPlayerInfoMatches[0] : undefined;
 }
 
 export function redactKalpaPlayerIdentity(
@@ -355,6 +363,10 @@ function hasSidecarIdentity(candidate: KalpaPlayerBuildEvidence): boolean {
     normalizeAccount(candidate.accountName) ||
     normalizeCharacterId(candidate.characterId),
   );
+}
+
+function isExactRawPlayerInfoEvidence(candidate: KalpaPlayerBuildEvidence): boolean {
+  return candidate.evidence === 'raw-player-info' && candidate.confidence === 'exact';
 }
 
 function uniquePositiveNumbers(values: number[] | undefined): number[] {

--- a/src/utils/observedSkillFallback.test.ts
+++ b/src/utils/observedSkillFallback.test.ts
@@ -1,0 +1,210 @@
+import type { ReportAbilityFragment } from '@/graphql/gql/graphql';
+import { KnownAbilities } from '@/types/abilities';
+import type {
+  BuffEvent,
+  DamageEvent,
+  DebuffEvent,
+  HealEvent,
+  ResourceChangeEvent,
+  UnifiedCastEvent,
+} from '@/types/combatlogEvents';
+import type { PlayerGear } from '@/types/playerDetails';
+
+import { deriveObservedPlayerSkills } from './observedSkillFallback';
+
+const ability = (gameID: number, name: string, icon = 'ability_test'): ReportAbilityFragment => ({
+  __typename: 'ReportAbility',
+  gameID,
+  name,
+  icon,
+  type: '1',
+});
+
+const cast = (abilityGameID: number, timestamp = 1, sourceID = 1): UnifiedCastEvent => ({
+  timestamp,
+  type: 'cast',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: 100,
+  targetIsFriendly: false,
+  abilityGameID,
+  fight: 1,
+});
+
+const damage = (abilityGameID: number, timestamp = 1, sourceID = 1): DamageEvent => ({
+  timestamp,
+  type: 'damage',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: 100,
+  targetIsFriendly: false,
+  abilityGameID,
+  fight: 1,
+  hitType: 1,
+  amount: 1,
+  castTrackID: 1,
+  sourceResources: {} as DamageEvent['sourceResources'],
+  targetResources: {} as DamageEvent['targetResources'],
+});
+
+const debuff = (abilityGameID: number, timestamp = 1, sourceID = 1): DebuffEvent => ({
+  timestamp,
+  type: 'applydebuff',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: 100,
+  targetIsFriendly: false,
+  abilityGameID,
+  fight: 1,
+  extraAbilityGameID: 0,
+});
+
+const buff = (abilityGameID: number, timestamp = 1, sourceID = 1): BuffEvent => ({
+  timestamp,
+  type: 'applybuff',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: sourceID,
+  targetIsFriendly: true,
+  abilityGameID,
+  fight: 1,
+  extraAbilityGameID: 0,
+});
+
+const heal = (abilityGameID: number, timestamp = 1, sourceID = 1): HealEvent => ({
+  timestamp,
+  type: 'heal',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: sourceID,
+  targetIsFriendly: true,
+  abilityGameID,
+  fight: 1,
+  hitType: 1,
+  amount: 1,
+  overheal: 0,
+  castTrackID: 1,
+  sourceResources: {} as HealEvent['sourceResources'],
+  targetResources: {} as HealEvent['targetResources'],
+});
+
+const resource = (abilityGameID: number, timestamp = 1, sourceID = 1): ResourceChangeEvent => ({
+  timestamp,
+  type: 'resourcechange',
+  sourceID,
+  sourceIsFriendly: true,
+  targetID: sourceID,
+  targetIsFriendly: true,
+  abilityGameID,
+  fight: 1,
+  resourceChange: 1,
+  resourceChangeType: 1,
+  otherResourceChange: 0,
+  maxResourceAmount: 100,
+  waste: 0,
+  castTrackID: 1,
+  sourceResources: {} as ResourceChangeEvent['sourceResources'],
+  targetResources: {} as ResourceChangeEvent['targetResources'],
+});
+
+describe('deriveObservedPlayerSkills', () => {
+  it('derives player skills from player-sourced events and filters basics/status/procs', () => {
+    const abilitiesById: Record<number, ReportAbilityFragment> = {
+      25260: ability(25260, 'Surprise Attack', 'ability_nightblade_002_a'),
+      34843: ability(34843, "Killer's Blade", 'ability_nightblade_017_a'),
+      38745: ability(38745, 'Carve', 'ability_2handed_002_a'),
+      40385: ability(40385, 'Barbed Trap', 'ability_fightersguild_004_a'),
+      133494: ability(133494, 'Aegis Caller', 'death_recap_bleed'),
+      18084: ability(18084, 'Burning', 'ability_mage_062'),
+      [KnownAbilities.LIGHT_ATTACK_DUAL_WIELD]: ability(
+        KnownAbilities.LIGHT_ATTACK_DUAL_WIELD,
+        'Light Attack (Dual Wield)',
+      ),
+      [KnownAbilities.SWAP_WEAPONS]: ability(KnownAbilities.SWAP_WEAPONS, 'Swap Weapons'),
+      115548: ability(115548, 'Grave Robber'),
+    };
+    const gear = [{ setName: 'Aegis Caller', id: 1 } as PlayerGear];
+
+    const result = deriveObservedPlayerSkills({
+      playerId: 1,
+      abilitiesById,
+      gear,
+      castEvents: [
+        cast(KnownAbilities.LIGHT_ATTACK_DUAL_WIELD, 1),
+        cast(34843, 2),
+        cast(25260, 3),
+        cast(KnownAbilities.SWAP_WEAPONS, 4),
+        cast(115548, 5),
+        cast(38745, 6),
+      ],
+      damageEvents: [damage(133494, 7), damage(18084, 8), damage(40385, 9)],
+    });
+
+    expect(result.map((skill) => skill.name)).toEqual([
+      "Killer's Blade",
+      'Surprise Attack',
+      'Carve',
+      'Barbed Trap',
+    ]);
+  });
+
+  it('deduplicates effect variants by skill name and prefers cast ability ids', () => {
+    const abilitiesById: Record<number, ReportAbilityFragment> = {
+      38745: ability(38745, 'Carve', 'ability_2handed_002_a'),
+      38747: ability(38747, 'Carve', 'ability_2handed_002_a'),
+    };
+
+    const result = deriveObservedPlayerSkills({
+      playerId: 1,
+      abilitiesById,
+      castEvents: [cast(38745, 10)],
+      debuffEvents: [debuff(38747, 11)],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ guid: 38745, name: 'Carve' });
+  });
+
+  it('drops generic non-cast buff/resource noise while keeping real self-buffs and heals', () => {
+    const abilitiesById: Record<number, ReportAbilityFragment> = {
+      61919: ability(61919, 'Merciless Resolve', 'ability_nightblade_005_b'),
+      215494: ability(215494, 'Siphoning Attacks', 'ability_nightblade_003_b'),
+      [KnownAbilities.SPRINTER]: ability(KnownAbilities.SPRINTER, 'Sprinter', 'ability_mage_065'),
+      17328: ability(17328, 'Restore Stamina', 'ability_mage_065'),
+    };
+
+    const result = deriveObservedPlayerSkills({
+      playerId: 1,
+      abilitiesById,
+      friendlyBuffEvents: [buff(61919, 2), buff(KnownAbilities.SPRINTER, 3)],
+      healingEvents: [heal(215494, 4)],
+      resourceEvents: [resource(17328, 5)],
+    });
+
+    expect(result.map((skill) => skill.name)).toEqual(['Siphoning Attacks', 'Merciless Resolve']);
+  });
+
+  it('excludes IA vision and class-resource effects that are not slotted skills', () => {
+    const abilitiesById: Record<number, ReportAbilityFragment> = {
+      183006: ability(183006, "Cephaliarch's Flail", 'ability_arcanist_003_a'),
+      183008: ability(183008, 'Abyssal Ink', 'ability_arcanist_003_a'),
+      115573: ability(115573, 'Grave Robber', 'ability_necromancer_004'),
+      220863: ability(220863, 'Sliver Assault', 'ability_death_recap_ithelia_cone'),
+      252048: ability(252048, 'Mark of Hircine', 'crownstore_skillline_werewolf'),
+      215727: ability(215727, 'Sunderer', 'ability_rogue_029'),
+      220988: ability(220988, 'Thorns', 'vision_defense_thorns'),
+    };
+
+    const result = deriveObservedPlayerSkills({
+      playerId: 1,
+      abilitiesById,
+      castEvents: [cast(183006, 1)],
+      damageEvents: [damage(220988, 2), damage(220863, 3)],
+      debuffEvents: [debuff(183008, 4), debuff(252048, 5)],
+      friendlyBuffEvents: [buff(215727, 4)],
+      healingEvents: [heal(115573, 5)],
+    });
+
+    expect(result.map((skill) => skill.name)).toEqual(["Cephaliarch's Flail"]);
+  });
+});

--- a/src/utils/observedSkillFallback.ts
+++ b/src/utils/observedSkillFallback.ts
@@ -1,0 +1,392 @@
+import type { ReportAbilityFragment } from '@/graphql/gql/graphql';
+import {
+  BLUE_CHAMPION_POINTS,
+  GREEN_CHAMPION_POINTS,
+  HEALTH_AND_REGEN_FOOD,
+  HEALTH_FOOD,
+  INCREASE_MAX_HEALTH_AND_MAGICKA,
+  INCREASE_MAX_HEALTH_AND_STAMINA,
+  INCREASE_MAX_MAGICKA_AND_STAMINA,
+  KnownAbilities,
+  MAGICKA_FOOD,
+  MAX_STAMINA_AND_MAGICKA_RECOVERY,
+  MundusStones,
+  POTION_RESOURCE_RESTORE_IDS,
+  RED_CHAMPION_POINTS,
+  STAMINA_FOOD,
+  SYNERGY_ABILITY_IDS,
+  TRI_STAT_FOOD,
+  WITCHES_BREW,
+} from '@/types/abilities';
+import type {
+  BuffEvent,
+  DamageEvent,
+  DebuffEvent,
+  HealEvent,
+  ResourceChangeEvent,
+  UnifiedCastEvent,
+} from '@/types/combatlogEvents';
+import type { PlayerGear, PlayerTalent } from '@/types/playerDetails';
+
+type AbilityLookup = Record<string | number, ReportAbilityFragment>;
+
+type EvidenceKind = 'cast' | 'damage' | 'debuff' | 'heal' | 'buff' | 'resource';
+
+interface ObservedSkillCandidate {
+  abilityId: number;
+  name: string;
+  icon: string;
+  normalizedName: string;
+  firstTimestamp: number;
+  bestEvidenceRank: number;
+  count: number;
+}
+
+interface DeriveObservedPlayerSkillsInput {
+  playerId: string | number;
+  abilitiesById: AbilityLookup;
+  gear?: readonly PlayerGear[];
+  castEvents?: readonly UnifiedCastEvent[];
+  damageEvents?: readonly DamageEvent[];
+  friendlyBuffEvents?: readonly BuffEvent[];
+  debuffEvents?: readonly DebuffEvent[];
+  healingEvents?: readonly HealEvent[];
+  resourceEvents?: readonly ResourceChangeEvent[];
+  limit?: number;
+}
+
+const BASIC_ABILITY_IDS = new Set<number>([
+  KnownAbilities.SWAP_WEAPONS,
+  KnownAbilities.RESURRECT,
+  KnownAbilities.LIGHT_ATTACK_ONE_HANDED,
+  KnownAbilities.HEAVY_ATTACK_ONE_HANDED,
+  KnownAbilities.HEAVY_ATTACK_ONE_HANDED_2,
+  KnownAbilities.HEAVY_ATTACK_ONE_HANDED_3,
+  KnownAbilities.LIGHT_ATTACK_TWO_HANDED,
+  KnownAbilities.HEAVY_ATTACK_TWO_HANDED,
+  KnownAbilities.HEAVY_ATTACK_TWO_HANDED_2,
+  KnownAbilities.HEAVY_ATTACK_TWO_HANDED_3,
+  KnownAbilities.LIGHT_ATTACK_DUAL_WIELD,
+  KnownAbilities.HEAVY_ATTACK_DUAL_WIELD,
+  KnownAbilities.HEAVY_ATTACK_DUAL_WIELD_2,
+  KnownAbilities.HEAVY_ATTACK_DUAL_WIELD_3,
+  KnownAbilities.HEAVY_ATTACK_DUAL_WIELD_4,
+  KnownAbilities.LIGHT_ATTACK_BOW,
+  KnownAbilities.HEAVY_ATTACK_BOW,
+  KnownAbilities.HEAVY_ATTACK_BOW_2,
+  KnownAbilities.HEAVY_ATTACK_BOW_3,
+  KnownAbilities.LIGHT_ATTACK_INFERNO,
+  KnownAbilities.HEAVY_ATTACK_INFERNO,
+  KnownAbilities.HEAVY_ATTACK_INFERNO_2,
+  KnownAbilities.HEAVY_ATTACK_INFERNO_3,
+  KnownAbilities.LIGHT_ATTACK_ICE,
+  KnownAbilities.HEAVY_ATTACK_ICE,
+  KnownAbilities.HEAVY_ATTACK_ICE_2,
+  KnownAbilities.HEAVY_ATTACK_ICE_3,
+  KnownAbilities.LIGHT_ATTACK_LIGHTNING,
+  KnownAbilities.HEAVY_ATTACK_LIGHTNING,
+  KnownAbilities.HEAVY_ATTACK_LIGHTNING_2,
+  KnownAbilities.LIGHT_ATTACK_RESTORATION,
+  KnownAbilities.HEAVY_ATTACK_RESTORATION,
+  KnownAbilities.HEAVY_ATTACK_RESTORATION_2,
+  KnownAbilities.HEAVY_ATTACK_RESTORATION_3,
+  KnownAbilities.LIGHT_ATTACK_UNARMED,
+]);
+
+const EXCLUDED_ABILITY_IDS = new Set<number>([
+  ...BASIC_ABILITY_IDS,
+  ...SYNERGY_ABILITY_IDS,
+  ...POTION_RESOURCE_RESTORE_IDS,
+  ...TRI_STAT_FOOD,
+  ...HEALTH_AND_REGEN_FOOD,
+  ...HEALTH_FOOD,
+  ...MAGICKA_FOOD,
+  ...STAMINA_FOOD,
+  ...INCREASE_MAX_HEALTH_AND_STAMINA,
+  ...INCREASE_MAX_HEALTH_AND_MAGICKA,
+  ...INCREASE_MAX_MAGICKA_AND_STAMINA,
+  ...MAX_STAMINA_AND_MAGICKA_RECOVERY,
+  ...WITCHES_BREW,
+  ...RED_CHAMPION_POINTS,
+  ...BLUE_CHAMPION_POINTS,
+  ...GREEN_CHAMPION_POINTS,
+  ...Object.values(MundusStones).filter((value): value is number => typeof value === 'number'),
+]);
+
+const EXCLUDED_EXACT_NAMES = new Set(
+  [
+    'bash',
+    'abyssal ink',
+    'berserker',
+    'block',
+    'break free',
+    'burning',
+    'chill',
+    'concussion',
+    'crux',
+    'diseased',
+    'dodge',
+    'dodge roll',
+    'fiery weapon',
+    'grave robber',
+    'health recovery',
+    'hemorrhaging',
+    'mark of hircine',
+    'off balance',
+    'overcharged',
+    'poisoned',
+    'poisoned weapon',
+    'restore magicka',
+    'restore stamina',
+    'sliver assault',
+    'sunderer',
+    'sundered',
+    'weapon swap',
+  ].map((name) => name.toLowerCase()),
+);
+
+const EXCLUDED_NAME_PATTERNS = [
+  /^light attack\b/i,
+  /^heavy attack\b/i,
+  /^major\s+/i,
+  /^minor\s+/i,
+  /\bsynergy\b/i,
+  /\bset bonus\b/i,
+  /\bfood\b/i,
+  /\bdrink\b/i,
+  /\bmundus\b/i,
+];
+
+const EVIDENCE_RANK: Record<EvidenceKind, number> = {
+  cast: 0,
+  damage: 1,
+  debuff: 2,
+  heal: 3,
+  buff: 4,
+  resource: 5,
+};
+
+function normalizeName(value: string | null | undefined): string {
+  return (value ?? '')
+    .replace(/\s*\([^)]*\)\s*$/g, '')
+    .replace(/[''`]/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function getAbility(abilitiesById: AbilityLookup, abilityId: number): ReportAbilityFragment | null {
+  return abilitiesById[abilityId] ?? abilitiesById[String(abilityId)] ?? null;
+}
+
+function getGearSetNames(gear: readonly PlayerGear[] | undefined): Set<string> {
+  const names = new Set<string>();
+
+  gear?.forEach((piece) => {
+    const setName = normalizeName(piece.setName);
+    if (setName) {
+      names.add(setName);
+      names.add(setName.replace(/^perfected\s+/, ''));
+    }
+
+    const itemName = normalizeName(piece.name);
+    if (itemName) {
+      names.add(itemName);
+      names.add(itemName.replace(/^perfected\s+/, ''));
+    }
+  });
+
+  return names;
+}
+
+function isGenericIcon(icon: string | null | undefined): boolean {
+  if (!icon) {
+    return true;
+  }
+
+  return (
+    icon === 'ability_mage_065' ||
+    icon.startsWith('passive_') ||
+    icon.startsWith('crafting_') ||
+    icon.startsWith('vision_') ||
+    icon.startsWith('ava_artifact_')
+  );
+}
+
+function shouldExcludeAbility(
+  abilityId: number,
+  ability: ReportAbilityFragment | null,
+  gearNames: Set<string>,
+  evidenceKind: EvidenceKind,
+): boolean {
+  if (EXCLUDED_ABILITY_IDS.has(abilityId)) {
+    return true;
+  }
+
+  const rawName = ability?.name ?? '';
+  const normalizedName = normalizeName(rawName);
+  if (!normalizedName) {
+    return true;
+  }
+
+  if (EXCLUDED_EXACT_NAMES.has(normalizedName)) {
+    return true;
+  }
+
+  if (EXCLUDED_NAME_PATTERNS.some((pattern) => pattern.test(rawName))) {
+    return true;
+  }
+
+  if (gearNames.has(normalizedName)) {
+    return true;
+  }
+
+  const icon = ability?.icon ?? '';
+  if (icon.startsWith('passive_')) {
+    return true;
+  }
+
+  if (evidenceKind !== 'cast' && isGenericIcon(icon)) {
+    return true;
+  }
+
+  return false;
+}
+
+function addCandidate(
+  candidates: Map<string, ObservedSkillCandidate>,
+  input: {
+    abilityId: number;
+    timestamp: number;
+    evidenceKind: EvidenceKind;
+    abilitiesById: AbilityLookup;
+    gearNames: Set<string>;
+  },
+): void {
+  const ability = getAbility(input.abilitiesById, input.abilityId);
+  if (shouldExcludeAbility(input.abilityId, ability, input.gearNames, input.evidenceKind)) {
+    return;
+  }
+
+  const name = ability?.name?.trim();
+  if (!name) {
+    return;
+  }
+
+  const normalizedName = normalizeName(name);
+  const existing = candidates.get(normalizedName);
+  const rank = EVIDENCE_RANK[input.evidenceKind];
+  const icon = ability?.icon ?? '';
+
+  if (!existing) {
+    candidates.set(normalizedName, {
+      abilityId: input.abilityId,
+      name,
+      icon,
+      normalizedName,
+      firstTimestamp: input.timestamp,
+      bestEvidenceRank: rank,
+      count: 1,
+    });
+    return;
+  }
+
+  existing.count += 1;
+  existing.firstTimestamp = Math.min(existing.firstTimestamp, input.timestamp);
+
+  const shouldReplace =
+    rank < existing.bestEvidenceRank ||
+    (rank === existing.bestEvidenceRank && isGenericIcon(existing.icon) && !isGenericIcon(icon));
+
+  if (shouldReplace) {
+    existing.abilityId = input.abilityId;
+    existing.name = name;
+    existing.icon = icon;
+    existing.bestEvidenceRank = rank;
+  }
+}
+
+export function deriveObservedPlayerSkills({
+  playerId,
+  abilitiesById,
+  gear,
+  castEvents = [],
+  damageEvents = [],
+  friendlyBuffEvents = [],
+  debuffEvents = [],
+  healingEvents = [],
+  resourceEvents = [],
+  limit = 12,
+}: DeriveObservedPlayerSkillsInput): PlayerTalent[] {
+  const playerIdString = String(playerId);
+  const gearNames = getGearSetNames(gear);
+  const candidates = new Map<string, ObservedSkillCandidate>();
+
+  const add = (abilityId: number, timestamp: number, evidenceKind: EvidenceKind): void => {
+    addCandidate(candidates, {
+      abilityId,
+      timestamp,
+      evidenceKind,
+      abilitiesById,
+      gearNames,
+    });
+  };
+
+  castEvents.forEach((event) => {
+    if (String(event.sourceID) === playerIdString && typeof event.abilityGameID === 'number') {
+      add(event.abilityGameID, event.timestamp, 'cast');
+    }
+  });
+
+  damageEvents.forEach((event) => {
+    if (
+      String(event.sourceID) === playerIdString &&
+      event.sourceIsFriendly &&
+      !event.targetIsFriendly &&
+      typeof event.abilityGameID === 'number'
+    ) {
+      add(event.abilityGameID, event.timestamp, 'damage');
+    }
+  });
+
+  debuffEvents.forEach((event) => {
+    if (String(event.sourceID) === playerIdString && typeof event.abilityGameID === 'number') {
+      add(event.abilityGameID, event.timestamp, 'debuff');
+    }
+  });
+
+  healingEvents.forEach((event) => {
+    if (String(event.sourceID) === playerIdString && typeof event.abilityGameID === 'number') {
+      add(event.abilityGameID, event.timestamp, 'heal');
+    }
+  });
+
+  friendlyBuffEvents.forEach((event) => {
+    if (String(event.sourceID) === playerIdString && typeof event.abilityGameID === 'number') {
+      add(event.abilityGameID, event.timestamp, 'buff');
+    }
+  });
+
+  resourceEvents.forEach((event) => {
+    if (String(event.sourceID) === playerIdString && typeof event.abilityGameID === 'number') {
+      add(event.abilityGameID, event.timestamp, 'resource');
+    }
+  });
+
+  return Array.from(candidates.values())
+    .sort(
+      (a, b) =>
+        a.bestEvidenceRank - b.bestEvidenceRank ||
+        a.firstTimestamp - b.firstTimestamp ||
+        b.count - a.count ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, limit)
+    .map((candidate) => ({
+      guid: candidate.abilityId,
+      name: candidate.name,
+      abilityIcon: candidate.icon,
+      type: 0,
+      flags: 0,
+    }));
+}


### PR DESCRIPTION
## Summary

Fixes report player cards when ESO Logs returns an empty `playerDetails` payload but combatant-info events still contain gear.

## Problem

The live IA report `xJbr8QRAcvPGDZXL` fight 3 showed stats, CP, food, and build issues, but no gear section or details controls. The regular `getPlayersForReport` response for that fight returns `playerDetails: []`, so ESOTK falls back to combatant-info events.

## Root Cause

- Fallback players copied combatant-info gear directly, but those event gear entries can omit `slot`, `name`, and `setName`.
- The player card rendered the entire Gear section inside `talents.length > 0`, so fallback players with gear but no talents never showed Gear, Extract, or Info.
- Gear detail type labels treated numeric type codes globally, but ESO Logs reuses `4` for both Jewelry and 2H Sword depending on slot.

## Changes Made

- Normalize fallback combatant-info gear with slot indexes and set names from `libsets-set-names.json`.
- Render the Gear section whenever gear exists, even if talents are missing.
- Resolve gear detail type labels using slot context so weapon slots display weapon types correctly.
- Add regression coverage for fallback combatant-info gear normalization.

## Screenshots

| Before | After |
|--------|-------|
| ![before-production.png](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-24655a8e1c3c60dde2d2/before-production.png) | ![after-local.png](https://github.com/ESO-Toolkit/eso-toolkit/releases/download/untagged-24655a8e1c3c60dde2d2/after-local.png) |

## Testing Done

- `npm run validate`
- `npm test -- --watchAll=false` (repo wrapper found no changed-file tests)
- `npx jest --config jest.config.cjs --testPathIgnorePatterns "node_modules" --testMatch "**/src/store/player_data/playerDataFallback.test.ts" --watchAll=false`
- Playwright local verification on `http://127.0.0.1:3004/report/xJbr8QRAcvPGDZXL/fight/3/players`
