### PR TITLE
feat(reports): show Kalpa ground-truth scribing scripts on the player card

### DIFF
--- a/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
+++ b/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CssBaseline } from '@mui/material';
+
+import { SkillTooltip } from './SkillTooltip';
+import type { SkillTooltipProps } from './SkillTooltip';
+
+jest.mock('../features/scribing/hooks/useScribingDetection', () => ({
+  useSkillScribingData: jest.fn(),
+}));
+
+jest.mock('../hooks/useLogger', () => ({
+  useLogger: () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn() }),
+}));
+
+import { useSkillScribingData } from '../features/scribing/hooks/useScribingDetection';
+
+const mockUseSkillScribingData = useSkillScribingData as jest.MockedFunction<
+  typeof useSkillScribingData
+>;
+
+const theme = createTheme({ palette: { mode: 'dark' } });
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    {children}
+  </ThemeProvider>
+);
+
+const baseProps: SkillTooltipProps = {
+  name: 'Leashing Soul',
+  abilityId: 217784,
+  iconSlug: 'ability_grimoire_soulmagic1',
+  lineText: 'Scribing — Wield Soul',
+};
+
+describe('SkillTooltip - Kalpa ground-truth scripts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('overrides inferred signature/affix with ground truth even when the skill was cast', () => {
+    // Inference DID run (wasCastInFight: true) and normally wins — but ground truth must
+    // still take precedence, since it is exact.
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: {
+        grimoireName: 'Wield Soul',
+        effects: [],
+        wasCastInFight: true,
+        signatureScript: {
+          name: 'Inferred Signature',
+          confidence: 0.6,
+          detectionMethod: 'effect-analysis',
+          evidence: ['guessed'],
+        },
+        affixScripts: [
+          {
+            id: 'inferred',
+            name: 'Inferred Affix',
+            description: '',
+            confidence: 0.5,
+            detectionMethod: 'effect-analysis',
+            evidence: { buffIds: [], debuffIds: [], abilityNames: [], occurrenceCount: 3 },
+          },
+        ],
+      },
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip
+          {...baseProps}
+          groundTruthScripts={{
+            focusScript: 'Pull',
+            signatureScript: 'Lingering Torment',
+            affixScript: 'Defile',
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    // Ground-truth values render...
+    expect(text).toContain('Lingering Torment');
+    expect(text).toContain('Defile');
+    expect(text).toContain('via Kalpa native evidence');
+    // ...and the inferred guesses are replaced, not shown.
+    expect(text).not.toContain('Inferred Signature');
+    expect(text).not.toContain('Inferred Affix');
+  });
+
+  it('renders ground-truth scripts even when the skill was never cast (no inference)', () => {
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: undefined,
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip
+          {...baseProps}
+          groundTruthScripts={{
+            focusScript: 'Pull',
+            signatureScript: 'Lingering Torment',
+            affixScript: 'Defile',
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Lingering Torment');
+    expect(text).toContain('Defile');
+    expect(text).toContain('via Kalpa native evidence');
+  });
+
+  it('leaves the inferred display untouched when there is no ground truth', () => {
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: {
+        grimoireName: 'Wield Soul',
+        effects: [],
+        wasCastInFight: true,
+        signatureScript: {
+          name: 'Inferred Signature',
+          confidence: 0.6,
+          detectionMethod: 'effect-analysis',
+          evidence: ['guessed'],
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip {...baseProps} />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Inferred Signature');
+    expect(text).not.toContain('via Kalpa native evidence');
+  });
+});

--- a/src/components/SkillTooltip.tsx
+++ b/src/components/SkillTooltip.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useLogger } from '@/hooks/useLogger';
 
 import { useSkillScribingData } from '../features/scribing/hooks/useScribingDetection';
-import type { ScribedSkillAffixInfo } from '../features/scribing/types';
+import type { ScribedSkillAffixInfo, ScribedSkillData } from '../features/scribing/types';
 import { highlightMetrics } from '../utils/highlightMetrics';
 
 export interface SkillStat {
@@ -40,6 +40,13 @@ export interface SkillTooltipProps {
   // Fight and player context for automatic scribing detection
   fightId?: string;
   playerId?: number;
+  // Ground-truth scripts recovered by Kalpa from the raw log (ABILITY_INFO). When
+  // present these override the inferred detection for the matching scribed skill.
+  groundTruthScripts?: {
+    focusScript?: string | null;
+    signatureScript?: string | null;
+    affixScript?: string | null;
+  };
 }
 
 type PaletteKey = 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info';
@@ -134,6 +141,61 @@ const nameGradientSx = (isDark: boolean): Record<string, unknown> => ({
   fontSize: { xs: '0.92rem', sm: '1rem' },
 });
 
+// Provenance label for Kalpa-sourced scripts. Renders as "via Kalpa native evidence",
+// matching how PlayerCard tags other sidecar-derived facts (food/race/CP).
+const KALPA_NATIVE_EVIDENCE_LABEL = 'Kalpa native evidence';
+
+type GroundTruthScripts = {
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
+};
+
+/**
+ * Overlay Kalpa's raw-log ground-truth signature/affix scripts onto the inferred scribing
+ * data. Ground truth wins because it is exact (the inference is probabilistic and may be
+ * absent when the skill was never cast). Returns the inferred data unchanged when there is
+ * no ground truth, so the existing display is byte-identical in that case. When there is
+ * ground truth but no inference at all, a minimal shell is synthesized so the scripts still
+ * render. (Focus is intentionally not surfaced — it is already encoded in the skill name.)
+ */
+function mergeGroundTruthScripts(
+  base: ScribedSkillData | null,
+  groundTruth: GroundTruthScripts | undefined,
+  name: string,
+): ScribedSkillData | null {
+  const hasGroundTruth = Boolean(
+    groundTruth && (groundTruth.signatureScript || groundTruth.affixScript),
+  );
+  if (!hasGroundTruth || !groundTruth) return base;
+
+  const next: ScribedSkillData = base
+    ? { ...base }
+    : { grimoireName: name.replace(/\s*\(.*\)\s*$/, '').trim() || name, effects: [] };
+
+  if (groundTruth.signatureScript) {
+    next.signatureScript = {
+      name: groundTruth.signatureScript,
+      confidence: 1,
+      detectionMethod: KALPA_NATIVE_EVIDENCE_LABEL,
+      evidence: [],
+    };
+  }
+  if (groundTruth.affixScript) {
+    next.affixScripts = [
+      {
+        id: 'kalpa-native-affix',
+        name: groundTruth.affixScript,
+        description: '',
+        confidence: 1,
+        detectionMethod: KALPA_NATIVE_EVIDENCE_LABEL,
+        evidence: { buffIds: [], debuffIds: [], abilityNames: [], occurrenceCount: 0 },
+      },
+    ];
+  }
+  return next;
+}
+
 /**
  * Minimal, reusable tooltip card for ESO skills. Designed to sit inside popovers/menus
  * but also works standalone in a column layout. Uses the app's dark theme and subtle
@@ -153,6 +215,7 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
   scribedSkillData,
   fightId,
   playerId,
+  groundTruthScripts,
 }) => {
   const theme = useTheme();
   const logger = useLogger();
@@ -167,10 +230,13 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
 
   // Prefer hook-detected data only when it has meaningful results (was actually cast),
   // otherwise the prop-based data from PlayerCard's worker detection is more accurate
-  const finalScribedData =
+  const baseScribedData =
     (detectedScribingData?.wasCastInFight ? detectedScribingData : null) ??
     scribedSkillData ??
     null;
+  // Kalpa's raw-log scripts are ground truth, so they win over inference (which can be
+  // probabilistic or missing entirely when a scribed skill was never cast in the fight).
+  const finalScribedData = mergeGroundTruthScripts(baseScribedData, groundTruthScripts, name);
 
   // Ensure at least one icon source is provided
   if (!iconUrl && !iconSlug) {

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -62,6 +62,7 @@ import { PlayerGearSetRecord } from '../../../utils/gearUtilities';
 import {
   kalpaRaceIdToLabel,
   type KalpaPlayerBuildEvidence,
+  type KalpaScribedSkillEvidence,
 } from '../../../utils/kalpaBuildEvidence';
 import { resolveActorName } from '../../../utils/resolveActorName';
 import { abbreviateSkillLine } from '../../../utils/skillLineDetectionUtils';
@@ -114,12 +115,32 @@ const LazyTalentTooltipContent: React.FC<{
   resolveScribedSkillData: (talentGuid: number, talentName: string) => ScribedSkillData | undefined;
   fightId?: string;
   playerId: number;
-}> = ({ talent, isUltimate, resolveProps, resolveScribedSkillData, fightId, playerId }) => {
+  kalpaScribedByAbilityId?: Map<number, KalpaScribedSkillEvidence>;
+}> = ({
+  talent,
+  isUltimate,
+  resolveProps,
+  resolveScribedSkillData,
+  fightId,
+  playerId,
+  kalpaScribedByAbilityId,
+}) => {
   const rich = resolveProps(talent);
   const base = {
     name: talent.name,
     description: `${talent.name} (ID: ${talent.guid})`,
   };
+
+  const groundTruth = kalpaScribedByAbilityId?.get(talent.guid);
+  const groundTruthScripts =
+    groundTruth &&
+    (groundTruth.focusScript || groundTruth.signatureScript || groundTruth.affixScript)
+      ? {
+          focusScript: groundTruth.focusScript,
+          signatureScript: groundTruth.signatureScript,
+          affixScript: groundTruth.affixScript,
+        }
+      : undefined;
 
   return (
     <SkillTooltip
@@ -130,6 +151,7 @@ const LazyTalentTooltipContent: React.FC<{
       scribedSkillData={rich?.scribedSkillData ?? resolveScribedSkillData(talent.guid, talent.name)}
       fightId={fightId}
       playerId={playerId}
+      groundTruthScripts={groundTruthScripts}
     />
   );
 };
@@ -383,6 +405,15 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
         name: food.name ?? `Food (${food.abilityId})`,
       };
     }, [kalpaBuildEvidence?.food]);
+    // Ground-truth scribing scripts from the Kalpa sidecar, keyed by ability id so the
+    // talent tooltip can prefer them over its inferred detection.
+    const kalpaScribedByAbilityId = React.useMemo(() => {
+      const byAbility = new Map<number, KalpaScribedSkillEvidence>();
+      for (const skill of kalpaBuildEvidence?.scribedSkills ?? []) {
+        if (Number.isInteger(skill.abilityId)) byAbility.set(skill.abilityId, skill);
+      }
+      return byAbility;
+    }, [kalpaBuildEvidence?.scribedSkills]);
     const effectiveFoodAura = foodAura ?? kalpaFoodAura;
     const foodEvidenceSource = foodAura
       ? 'combatant auras'
@@ -1492,6 +1523,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                     resolveScribedSkillData={resolveScribedSkillData}
                                     fightId={fightId || undefined}
                                     playerId={player.id}
+                                    kalpaScribedByAbilityId={kalpaScribedByAbilityId}
                                   />
                                 }
                                 placement="top-start"
@@ -1594,6 +1626,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                       resolveScribedSkillData={resolveScribedSkillData}
                                       fightId={fightId || undefined}
                                       playerId={player.id}
+                                      kalpaScribedByAbilityId={kalpaScribedByAbilityId}
                                     />
                                   }
                                   placement="top-start"


### PR DESCRIPTION
## Summary

Displays the **ground-truth scribing scripts** that Kalpa recovers from the raw log, preferring them over ESOTK's inferred detection. Stacked on #1373 (which persists/decodes the fields).

Today ESOTK infers a scribed skill's Signature/Affix scripts by correlating post-cast effects — probabilistic, and it gives up entirely when a skill was never cast in the fight. Kalpa reads the scripts straight from the `ABILITY_INFO` line (which ESO Logs strips from its API), so when the sidecar supplies them they are exact.

## Behaviour

- When the matched player's sidecar evidence has scripts for a scribed ability, the tooltip shows those **Signature / Affix** values, rendered as exact (no confidence %) and labelled **"via Kalpa native evidence"** — the same provenance style already used for food/race/CP.
- Ground truth wins **even when the skill was cast** (the case where inference normally takes over) — the override is applied after the hook-vs-prop selection in `SkillTooltip`, not just on the prop.
- It also renders when the skill was **never cast** (inference returns nothing).
- **No ground truth ⇒ the inferred display is byte-identical** (existing snapshots unchanged).

Focus script is intentionally not surfaced — it's already encoded in the skill's display name.

## Changes

- `SkillTooltip.tsx` — new `groundTruthScripts` prop; `mergeGroundTruthScripts()` overlays it onto the final scribing data.
- `PlayerCard.tsx` — builds an `abilityId → scribed-evidence` map from the matched player's `kalpaBuildEvidence.scribedSkills` and threads it to the talent tooltips (both bar render sites).
- New test: ground truth overrides inference even when cast; renders with no inference; inferred display untouched without ground truth.

## Testing (run locally)

- `tsc --noEmit` (frontend) — clean
- `eslint` (changed source files) — clean
- `prettier --check` (all changed files) — clean
- `SkillTooltip.kalpa-ground-truth.test.tsx` — 3 pass
- Existing `SkillTooltip.*` scribing/integration/unified/final-verification suites — 17 pass, snapshots unchanged

## Notes

- Base is #1373's branch (stacked). Merge #1373 first.
- Producing side: Kalpa PR #232 (`feat(uploader): recover scribing scripts from the log`).