### PR TITLE
feat(reports): fall back to Kalpa Mundus evidence when auras miss it

### DIFF
--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -253,9 +253,11 @@ function consolidateBuildIssues(buildIssues: BuildIssue[]): {
 
 interface MundusChipProps {
   mundusBuffs: Array<{ name: string; id: number }>;
+  // Provenance of the mundus, appended to the tooltip (e.g. "Kalpa native evidence").
+  source?: string;
 }
 
-const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs }) => {
+const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs, source }) => {
   if (mundusBuffs.length === 0) return null;
 
   // Since players can only have 1 mundus at a time, get the first/only one
@@ -263,7 +265,11 @@ const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs }) => {
   const mundusName = mundusBuff.name.replace(/^Boon:\s*/i, '').replace(/^The\s+/i, '');
 
   return (
-    <Tooltip title={`Mundus: ${mundusName}`} enterTouchDelay={0} leaveTouchDelay={3000}>
+    <Tooltip
+      title={`Mundus: ${mundusName}${source ? ` (${source})` : ''}`}
+      enterTouchDelay={0}
+      leaveTouchDelay={3000}
+    >
       <Box
         component="span"
         sx={{
@@ -420,6 +426,24 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       : kalpaFoodAura
         ? 'Kalpa native evidence'
         : undefined;
+
+    // Mundus fallback: ESO Logs derives the boon from combat auras, but that can be missed
+    // when it isn't re-applied in-window. Fall back to the Kalpa sidecar's exact PLAYER_INFO
+    // reading, mirroring the food fallback above.
+    const kalpaMundus = React.useMemo(() => {
+      const mundus = kalpaBuildEvidence?.mundus;
+      if (!mundus?.abilityId) return undefined;
+      return {
+        id: mundus.abilityId,
+        name: mundus.name ?? `Mundus (${mundus.abilityId})`,
+      };
+    }, [kalpaBuildEvidence?.mundus]);
+    const effectiveMundusBuffs = React.useMemo(
+      () => (mundusBuffs.length > 0 ? mundusBuffs : kalpaMundus ? [kalpaMundus] : []),
+      [mundusBuffs, kalpaMundus],
+    );
+    const mundusSource =
+      mundusBuffs.length === 0 && kalpaMundus ? 'Kalpa native evidence' : undefined;
     const kalpaRaceLabel = kalpaRaceIdToLabel(kalpaBuildEvidence?.raceId);
     const kalpaChampionPoints =
       Number.isInteger(kalpaBuildEvidence?.championPoints) &&
@@ -662,7 +686,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
           role: broadRole,
           gear: player?.combatantInfo?.gear ?? [],
           talents,
-          mundusBuffs,
+          mundusBuffs: effectiveMundusBuffs,
           championPoints,
           classAnalysis,
           kalpaBuildEvidence,
@@ -686,7 +710,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
     }, [
       player,
       talents,
-      mundusBuffs,
+      effectiveMundusBuffs,
       championPoints,
       classAnalysis,
       kalpaBuildEvidence,
@@ -959,8 +983,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
         );
       }
 
-      if (mundusBuffs.length > 0) {
-        add('mundus', <MundusChip mundusBuffs={mundusBuffs} />);
+      if (effectiveMundusBuffs.length > 0) {
+        add('mundus', <MundusChip mundusBuffs={effectiveMundusBuffs} source={mundusSource} />);
       }
 
       add(
@@ -1137,7 +1161,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       critDps,
       kalpaRaceLabel,
       kalpaChampionPoints,
-      mundusBuffs,
+      effectiveMundusBuffs,
+      mundusSource,
       effectiveFoodAura,
       foodEvidenceSource,
       foodInfo,


### PR DESCRIPTION
## Summary

Adds a **Mundus stone fallback** to the player card. Stacked on #1373 (which persists the `mundus` field).

ESO Logs derives the Mundus boon from combat auras, but that can be **missed** when the boon isn't re-applied in the analysis window (the player card then shows no Mundus). Kalpa reads the boon straight from the raw `PLAYER_INFO` long-term effects (distinctive `ability_mundusstones_*` icon), so the sidecar can supply it exactly.

This mirrors the existing **food** fallback pattern one-for-one.

## Behaviour

- Aura-based Mundus is still preferred. When it's empty for a player, the card falls back to `kalpaBuildEvidence.mundus`.
- The Mundus chip tooltip notes **"(Kalpa native evidence)"** when the fallback is used (same provenance style as food/race/CP).
- The **Extract Build** flow uses the effective Mundus too (it previously passed raw `mundusBuffs` while already passing the effective food).

## Changes

- `PlayerCard.tsx`: `MundusChip` gains an optional `source` for the provenance tooltip; a `kalpaMundus` memo + `effectiveMundusBuffs` (memoized) + `mundusSource` mirror the food fallback; the chip and build-export use the effective value.

## Testing

- `tsc --noEmit` — clean
- `eslint` (PlayerCard) — clean
- `prettier --check` — clean
- No PlayerCard render-test harness exists in the repo, so no unit test added (consistent with the file's current coverage); the persisted-field round-trip is covered by #1373's `kalpaBuildEvidence` test.

## Notes

- Base is #1373's branch (stacked). Merge #1373 first.
- Producing side: Kalpa `feat(uploader): recover the Mundus stone for the sidecar`.