### PR TITLE
feat(reports): surface more CP stars from Kalpa's full passives

### DIFF
--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -47,6 +47,12 @@ interface KalpaAbilityEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
+  // Scribing scripts, only ever populated on scribed-skill entries (Kalpa reads them
+  // from the raw ABILITY_INFO line, which ESO Logs strips from its API). Food entries
+  // never carry these, so they serialize away as undefined.
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
 }
 
 type KalpaScribedSkillEvidence = KalpaAbilityEvidence;
@@ -130,6 +136,9 @@ function sanitizeAbilityEvidence(value: unknown): KalpaAbilityEvidence | undefin
     abilityId,
     name: boundedString(value.name, 96),
     icon: boundedString(value.icon, 64),
+    focusScript: boundedString(value.focusScript, 96),
+    signatureScript: boundedString(value.signatureScript, 96),
+    affixScript: boundedString(value.affixScript, 96),
   };
 }
 

--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -38,6 +38,7 @@ interface KalpaPlayerBuildEvidence {
   classMasteryPassives: number[];
   championPointPassives?: number[];
   food?: KalpaAbilityEvidence;
+  mundus?: KalpaAbilityEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
   evidence: string;
   confidence: string;
@@ -169,6 +170,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     MAX_CHAMPION_POINT_PASSIVES,
   );
   const food = sanitizeAbilityEvidence(value.food);
+  const mundus = sanitizeAbilityEvidence(value.mundus);
   const player: KalpaPlayerBuildEvidence = {
     unitId,
     unitOccurrenceId: boundedString(value.unitOccurrenceId, 48),
@@ -186,6 +188,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
   if (food) player.food = food;
+  if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;
   return player;
 }

--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -20,6 +20,7 @@ const MAX_PLAYERS = 300;
 const MAX_SCRIBED_SKILLS = 12;
 const MAX_CLASS_MASTERY_PICKS = 2;
 const MAX_CHAMPION_POINT_PASSIVES = 12;
+const MAX_PASSIVES = 256;
 const MAX_ABILITY_ID = 1_000_000;
 
 type ReportEvidenceContext = Context<{ Bindings: Env }>;
@@ -37,6 +38,7 @@ interface KalpaPlayerBuildEvidence {
   className?: string | null;
   classMasteryPassives: number[];
   championPointPassives?: number[];
+  passives?: number[];
   food?: KalpaAbilityEvidence;
   mundus?: KalpaAbilityEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
@@ -169,6 +171,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     value.championPointPassives,
     MAX_CHAMPION_POINT_PASSIVES,
   );
+  const passives = sanitizeNumberArray(value.passives, MAX_PASSIVES);
   const food = sanitizeAbilityEvidence(value.food);
   const mundus = sanitizeAbilityEvidence(value.mundus);
   const player: KalpaPlayerBuildEvidence = {
@@ -187,6 +190,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     confidence: boundedString(value.confidence, 32) ?? '',
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
+  if (passives.length > 0) player.passives = passives;
   if (food) player.food = food;
   if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -911,6 +911,13 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       for (const abilityId of kalpaBuildEvidenceByPlayer[playerId]?.championPointPassives ?? []) {
         addChampionPoint(abilityId);
       }
+      // Kalpa's full passives list carries every slotted long-term effect. addChampionPoint
+      // filters each id through the authoritative CP classifier (championPointColorForId),
+      // so this picks up CP stars beyond the legacy championPointPassives subset while
+      // silently skipping non-CP passives — no false positives.
+      for (const abilityId of kalpaBuildEvidenceByPlayer[playerId]?.passives ?? []) {
+        addChampionPoint(abilityId);
+      }
 
       sortChampionPointEntries(result[playerId]);
     });

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -413,6 +413,22 @@ describe('kalpaBuildEvidence', () => {
     expect(decodeKalpaBuildEvidenceParam(encodeEvidence(mundusEvidence))).toEqual(mundusEvidence);
   });
 
+  it('round-trips the full passives list', () => {
+    const passivesEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          passives: [142079, 999999, 45301],
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(passivesEvidence))).toEqual(
+      passivesEvidence,
+    );
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -370,6 +370,31 @@ describe('kalpaBuildEvidence', () => {
     );
   });
 
+  it('round-trips ground-truth focus/signature/affix scripts on scribed skills', () => {
+    const scribingEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          scribedSkills: [
+            {
+              abilityId: 217784,
+              name: 'Leashing Soul',
+              icon: 'ability_grimoire_soulmagic1',
+              focusScript: 'Pull',
+              signatureScript: 'Lingering Torment',
+              affixScript: 'Defile',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(scribingEvidence))).toEqual(
+      scribingEvidence,
+    );
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -395,6 +395,24 @@ describe('kalpaBuildEvidence', () => {
     );
   });
 
+  it('round-trips the Mundus stone evidence', () => {
+    const mundusEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          mundus: {
+            abilityId: 13984,
+            name: 'Boon: The Shadow',
+            icon: 'ability_mundusstones_012',
+          },
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(mundusEvidence))).toEqual(mundusEvidence);
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -45,6 +45,10 @@ export interface KalpaScribedSkillEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
+  /** Ground-truth equipped scripts, recovered by Kalpa from the raw ABILITY_INFO line. */
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
 }
 
 export interface KalpaBuildEvidence {
@@ -451,6 +455,10 @@ function sanitizeScribedSkills(value: unknown): KalpaScribedSkillEvidence[] {
         abilityId: entry.abilityId as number,
         name: typeof entry.name === 'string' ? entry.name : undefined,
         icon: typeof entry.icon === 'string' ? entry.icon : undefined,
+        focusScript: typeof entry.focusScript === 'string' ? entry.focusScript : undefined,
+        signatureScript:
+          typeof entry.signatureScript === 'string' ? entry.signatureScript : undefined,
+        affixScript: typeof entry.affixScript === 'string' ? entry.affixScript : undefined,
       };
     })
     .filter((entry): entry is KalpaScribedSkillEvidence => entry != null);

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -30,12 +30,19 @@ export interface KalpaPlayerBuildEvidence {
   classMasteryPassives: number[];
   championPointPassives?: number[];
   food?: KalpaFoodEvidence;
+  mundus?: KalpaMundusEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
   evidence: string;
   confidence: string;
 }
 
 export interface KalpaFoodEvidence {
+  abilityId: number;
+  name?: string | null;
+  icon?: string | null;
+}
+
+export interface KalpaMundusEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
@@ -408,6 +415,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
   const classMasteryPassives = sanitizeNumberArray(value.classMasteryPassives);
   const championPointPassives = sanitizeNumberArray(value.championPointPassives);
   const food = sanitizeFoodEvidence(value.food);
+  const mundus = sanitizeMundusEvidence(value.mundus);
   const scribedSkills = sanitizeScribedSkills(value.scribedSkills);
   const player: KalpaPlayerBuildEvidence = {
     unitId: value.unitId,
@@ -429,11 +437,24 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
   if (food) player.food = food;
+  if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;
   return player;
 }
 
 function sanitizeFoodEvidence(value: unknown): KalpaFoodEvidence | undefined {
+  if (!isRecord(value) || !Number.isInteger(value.abilityId) || (value.abilityId as number) <= 0) {
+    return undefined;
+  }
+
+  return {
+    abilityId: value.abilityId as number,
+    name: typeof value.name === 'string' ? value.name : undefined,
+    icon: typeof value.icon === 'string' ? value.icon : undefined,
+  };
+}
+
+function sanitizeMundusEvidence(value: unknown): KalpaMundusEvidence | undefined {
   if (!isRecord(value) || !Number.isInteger(value.abilityId) || (value.abilityId as number) <= 0) {
     return undefined;
   }

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -29,6 +29,8 @@ export interface KalpaPlayerBuildEvidence {
   className?: string | null;
   classMasteryPassives: number[];
   championPointPassives?: number[];
+  /** Full long-term-effect ability ids from the raw PLAYER_INFO (classified client-side). */
+  passives?: number[];
   food?: KalpaFoodEvidence;
   mundus?: KalpaMundusEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
@@ -414,6 +416,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
 
   const classMasteryPassives = sanitizeNumberArray(value.classMasteryPassives);
   const championPointPassives = sanitizeNumberArray(value.championPointPassives);
+  const passives = sanitizeNumberArray(value.passives);
   const food = sanitizeFoodEvidence(value.food);
   const mundus = sanitizeMundusEvidence(value.mundus);
   const scribedSkills = sanitizeScribedSkills(value.scribedSkills);
@@ -436,6 +439,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
     confidence: typeof value.confidence === 'string' ? value.confidence : '',
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
+  if (passives.length > 0) player.passives = passives;
   if (food) player.food = food;
   if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;


### PR DESCRIPTION
## Summary

Surfaces **CP stars that a regular ESO Logs upload never exposes**, using the full passive list Kalpa now sends. Stacked on #1373 (which persists the `passives` field).

A regular upload's `combatantInfo.talents` is just the two ability bars — it contains **no passives at all**. Champion Point stars are only recovered today from (a) observable combat auras and (b) Kalpa's legacy 31-id `championPointPassives` subset (capped at 12). Kalpa now forwards the player's **entire** long-term-effects list from the raw `PLAYER_INFO`.

## How it works (zero false-positive risk)

The full passives list is fed through the same `addChampionPoint` → `buildChampionPointEntry` path already used for `championPointPassives`. That runs each id through `championPointColorForId`, which checks the authoritative `RED/BLUE/GREEN_CHAMPION_POINTS` sets and returns `undefined` for anything that isn't a CP star. So:
- Every CP star esotk recognizes (beyond the legacy 31-id subset) now shows.
- Non-CP passives (class/skill-line passives, mundus, food, buffs) are silently skipped.
- Deduped against auras and the legacy list.

The classification lives here — where the CP database is maintained — so Kalpa doesn't have to guess which ids are CP stars (they share generic icons and can't be identified from the log alone).

## Changes

- `PlayersPanel.tsx`: one extra loop in `championPointsByPlayer` over `kalpaBuildEvidence.passives`.

## Testing

- `tsc --noEmit`, `eslint`, `prettier --check` — clean
- `PlayersPanel.test.tsx` — 5 pass (incl. the existing `buildChampionPointEntry` contract test: a real CP star classifies, `999999` is skipped — the exact non-CP id Kalpa's test forwards in `passives`)

## Notes

- Base is #1373's branch (stacked). Merge #1373 first.
- Producing side: Kalpa `feat(uploader): forward the full passive list for the sidecar`.
- The full `passives` data now flows end-to-end, so a general "Passives" display section (beyond CP stars) is a straightforward follow-up if wanted.