### PR TITLE
[DEMO – do not merge] All Kalpa sidecar displays combined (preview)

### DIFF
--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -47,6 +47,12 @@ interface KalpaAbilityEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
+  // Scribing scripts, only ever populated on scribed-skill entries (Kalpa reads them
+  // from the raw ABILITY_INFO line, which ESO Logs strips from its API). Food entries
+  // never carry these, so they serialize away as undefined.
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
 }
 
 type KalpaScribedSkillEvidence = KalpaAbilityEvidence;
@@ -130,6 +136,9 @@ function sanitizeAbilityEvidence(value: unknown): KalpaAbilityEvidence | undefin
     abilityId,
     name: boundedString(value.name, 96),
     icon: boundedString(value.icon, 64),
+    focusScript: boundedString(value.focusScript, 96),
+    signatureScript: boundedString(value.signatureScript, 96),
+    affixScript: boundedString(value.affixScript, 96),
   };
 }
 

--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -38,6 +38,7 @@ interface KalpaPlayerBuildEvidence {
   classMasteryPassives: number[];
   championPointPassives?: number[];
   food?: KalpaAbilityEvidence;
+  mundus?: KalpaAbilityEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
   evidence: string;
   confidence: string;
@@ -169,6 +170,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     MAX_CHAMPION_POINT_PASSIVES,
   );
   const food = sanitizeAbilityEvidence(value.food);
+  const mundus = sanitizeAbilityEvidence(value.mundus);
   const player: KalpaPlayerBuildEvidence = {
     unitId,
     unitOccurrenceId: boundedString(value.unitOccurrenceId, 48),
@@ -186,6 +188,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
   if (food) player.food = food;
+  if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;
   return player;
 }

--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -20,6 +20,7 @@ const MAX_PLAYERS = 300;
 const MAX_SCRIBED_SKILLS = 12;
 const MAX_CLASS_MASTERY_PICKS = 2;
 const MAX_CHAMPION_POINT_PASSIVES = 12;
+const MAX_PASSIVES = 256;
 const MAX_ABILITY_ID = 1_000_000;
 
 type ReportEvidenceContext = Context<{ Bindings: Env }>;
@@ -37,6 +38,7 @@ interface KalpaPlayerBuildEvidence {
   className?: string | null;
   classMasteryPassives: number[];
   championPointPassives?: number[];
+  passives?: number[];
   food?: KalpaAbilityEvidence;
   mundus?: KalpaAbilityEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
@@ -169,6 +171,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     value.championPointPassives,
     MAX_CHAMPION_POINT_PASSIVES,
   );
+  const passives = sanitizeNumberArray(value.passives, MAX_PASSIVES);
   const food = sanitizeAbilityEvidence(value.food);
   const mundus = sanitizeAbilityEvidence(value.mundus);
   const player: KalpaPlayerBuildEvidence = {
@@ -187,6 +190,7 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
     confidence: boundedString(value.confidence, 32) ?? '',
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
+  if (passives.length > 0) player.passives = passives;
   if (food) player.food = food;
   if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;

--- a/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
+++ b/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CssBaseline } from '@mui/material';
+
+import { SkillTooltip } from './SkillTooltip';
+import type { SkillTooltipProps } from './SkillTooltip';
+
+jest.mock('../features/scribing/hooks/useScribingDetection', () => ({
+  useSkillScribingData: jest.fn(),
+}));
+
+jest.mock('../hooks/useLogger', () => ({
+  useLogger: () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn() }),
+}));
+
+import { useSkillScribingData } from '../features/scribing/hooks/useScribingDetection';
+
+const mockUseSkillScribingData = useSkillScribingData as jest.MockedFunction<
+  typeof useSkillScribingData
+>;
+
+const theme = createTheme({ palette: { mode: 'dark' } });
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <CssBaseline />
+    {children}
+  </ThemeProvider>
+);
+
+const baseProps: SkillTooltipProps = {
+  name: 'Leashing Soul',
+  abilityId: 217784,
+  iconSlug: 'ability_grimoire_soulmagic1',
+  lineText: 'Scribing — Wield Soul',
+};
+
+describe('SkillTooltip - Kalpa ground-truth scripts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('overrides inferred signature/affix with ground truth even when the skill was cast', () => {
+    // Inference DID run (wasCastInFight: true) and normally wins — but ground truth must
+    // still take precedence, since it is exact.
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: {
+        grimoireName: 'Wield Soul',
+        effects: [],
+        wasCastInFight: true,
+        signatureScript: {
+          name: 'Inferred Signature',
+          confidence: 0.6,
+          detectionMethod: 'effect-analysis',
+          evidence: ['guessed'],
+        },
+        affixScripts: [
+          {
+            id: 'inferred',
+            name: 'Inferred Affix',
+            description: '',
+            confidence: 0.5,
+            detectionMethod: 'effect-analysis',
+            evidence: { buffIds: [], debuffIds: [], abilityNames: [], occurrenceCount: 3 },
+          },
+        ],
+      },
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip
+          {...baseProps}
+          groundTruthScripts={{
+            focusScript: 'Pull',
+            signatureScript: 'Lingering Torment',
+            affixScript: 'Defile',
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    // Ground-truth values render...
+    expect(text).toContain('Lingering Torment');
+    expect(text).toContain('Defile');
+    expect(text).toContain('via Kalpa native evidence');
+    // ...and the inferred guesses are replaced, not shown.
+    expect(text).not.toContain('Inferred Signature');
+    expect(text).not.toContain('Inferred Affix');
+  });
+
+  it('renders ground-truth scripts even when the skill was never cast (no inference)', () => {
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: undefined,
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip
+          {...baseProps}
+          groundTruthScripts={{
+            focusScript: 'Pull',
+            signatureScript: 'Lingering Torment',
+            affixScript: 'Defile',
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Lingering Torment');
+    expect(text).toContain('Defile');
+    expect(text).toContain('via Kalpa native evidence');
+  });
+
+  it('leaves the inferred display untouched when there is no ground truth', () => {
+    mockUseSkillScribingData.mockReturnValue({
+      scribedSkillData: {
+        grimoireName: 'Wield Soul',
+        effects: [],
+        wasCastInFight: true,
+        signatureScript: {
+          name: 'Inferred Signature',
+          confidence: 0.6,
+          detectionMethod: 'effect-analysis',
+          evidence: ['guessed'],
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TestWrapper>
+        <SkillTooltip {...baseProps} />
+      </TestWrapper>,
+    );
+
+    const text = container.textContent ?? '';
+    expect(text).toContain('Inferred Signature');
+    expect(text).not.toContain('via Kalpa native evidence');
+  });
+});

--- a/src/components/SkillTooltip.tsx
+++ b/src/components/SkillTooltip.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useLogger } from '@/hooks/useLogger';
 
 import { useSkillScribingData } from '../features/scribing/hooks/useScribingDetection';
-import type { ScribedSkillAffixInfo } from '../features/scribing/types';
+import type { ScribedSkillAffixInfo, ScribedSkillData } from '../features/scribing/types';
 import { highlightMetrics } from '../utils/highlightMetrics';
 
 export interface SkillStat {
@@ -40,6 +40,13 @@ export interface SkillTooltipProps {
   // Fight and player context for automatic scribing detection
   fightId?: string;
   playerId?: number;
+  // Ground-truth scripts recovered by Kalpa from the raw log (ABILITY_INFO). When
+  // present these override the inferred detection for the matching scribed skill.
+  groundTruthScripts?: {
+    focusScript?: string | null;
+    signatureScript?: string | null;
+    affixScript?: string | null;
+  };
 }
 
 type PaletteKey = 'primary' | 'secondary' | 'success' | 'warning' | 'error' | 'info';
@@ -134,6 +141,61 @@ const nameGradientSx = (isDark: boolean): Record<string, unknown> => ({
   fontSize: { xs: '0.92rem', sm: '1rem' },
 });
 
+// Provenance label for Kalpa-sourced scripts. Renders as "via Kalpa native evidence",
+// matching how PlayerCard tags other sidecar-derived facts (food/race/CP).
+const KALPA_NATIVE_EVIDENCE_LABEL = 'Kalpa native evidence';
+
+type GroundTruthScripts = {
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
+};
+
+/**
+ * Overlay Kalpa's raw-log ground-truth signature/affix scripts onto the inferred scribing
+ * data. Ground truth wins because it is exact (the inference is probabilistic and may be
+ * absent when the skill was never cast). Returns the inferred data unchanged when there is
+ * no ground truth, so the existing display is byte-identical in that case. When there is
+ * ground truth but no inference at all, a minimal shell is synthesized so the scripts still
+ * render. (Focus is intentionally not surfaced — it is already encoded in the skill name.)
+ */
+function mergeGroundTruthScripts(
+  base: ScribedSkillData | null,
+  groundTruth: GroundTruthScripts | undefined,
+  name: string,
+): ScribedSkillData | null {
+  const hasGroundTruth = Boolean(
+    groundTruth && (groundTruth.signatureScript || groundTruth.affixScript),
+  );
+  if (!hasGroundTruth || !groundTruth) return base;
+
+  const next: ScribedSkillData = base
+    ? { ...base }
+    : { grimoireName: name.replace(/\s*\(.*\)\s*$/, '').trim() || name, effects: [] };
+
+  if (groundTruth.signatureScript) {
+    next.signatureScript = {
+      name: groundTruth.signatureScript,
+      confidence: 1,
+      detectionMethod: KALPA_NATIVE_EVIDENCE_LABEL,
+      evidence: [],
+    };
+  }
+  if (groundTruth.affixScript) {
+    next.affixScripts = [
+      {
+        id: 'kalpa-native-affix',
+        name: groundTruth.affixScript,
+        description: '',
+        confidence: 1,
+        detectionMethod: KALPA_NATIVE_EVIDENCE_LABEL,
+        evidence: { buffIds: [], debuffIds: [], abilityNames: [], occurrenceCount: 0 },
+      },
+    ];
+  }
+  return next;
+}
+
 /**
  * Minimal, reusable tooltip card for ESO skills. Designed to sit inside popovers/menus
  * but also works standalone in a column layout. Uses the app's dark theme and subtle
@@ -153,6 +215,7 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
   scribedSkillData,
   fightId,
   playerId,
+  groundTruthScripts,
 }) => {
   const theme = useTheme();
   const logger = useLogger();
@@ -167,10 +230,13 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
 
   // Prefer hook-detected data only when it has meaningful results (was actually cast),
   // otherwise the prop-based data from PlayerCard's worker detection is more accurate
-  const finalScribedData =
+  const baseScribedData =
     (detectedScribingData?.wasCastInFight ? detectedScribingData : null) ??
     scribedSkillData ??
     null;
+  // Kalpa's raw-log scripts are ground truth, so they win over inference (which can be
+  // probabilistic or missing entirely when a scribed skill was never cast in the fight).
+  const finalScribedData = mergeGroundTruthScripts(baseScribedData, groundTruthScripts, name);
 
   // Ensure at least one icon source is provided
   if (!iconUrl && !iconSlug) {

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -231,9 +231,11 @@ function consolidateBuildIssues(buildIssues: BuildIssue[]): {
 
 interface MundusChipProps {
   mundusBuffs: Array<{ name: string; id: number }>;
+  // Provenance of the mundus, appended to the tooltip (e.g. "Kalpa native evidence").
+  source?: string;
 }
 
-const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs }) => {
+const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs, source }) => {
   if (mundusBuffs.length === 0) return null;
 
   // Since players can only have 1 mundus at a time, get the first/only one
@@ -241,7 +243,11 @@ const MundusChip: React.FC<MundusChipProps> = ({ mundusBuffs }) => {
   const mundusName = mundusBuff.name.replace(/^Boon:\s*/i, '').replace(/^The\s+/i, '');
 
   return (
-    <Tooltip title={`Mundus: ${mundusName}`} enterTouchDelay={0} leaveTouchDelay={3000}>
+    <Tooltip
+      title={`Mundus: ${mundusName}${source ? ` (${source})` : ''}`}
+      enterTouchDelay={0}
+      leaveTouchDelay={3000}
+    >
       <Box
         component="span"
         sx={{
@@ -389,6 +395,24 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       : kalpaFoodAura
         ? 'Kalpa native evidence'
         : undefined;
+
+    // Mundus fallback: ESO Logs derives the boon from combat auras, but that can be missed
+    // when it isn't re-applied in-window. Fall back to the Kalpa sidecar's exact PLAYER_INFO
+    // reading, mirroring the food fallback above.
+    const kalpaMundus = React.useMemo(() => {
+      const mundus = kalpaBuildEvidence?.mundus;
+      if (!mundus?.abilityId) return undefined;
+      return {
+        id: mundus.abilityId,
+        name: mundus.name ?? `Mundus (${mundus.abilityId})`,
+      };
+    }, [kalpaBuildEvidence?.mundus]);
+    const effectiveMundusBuffs = React.useMemo(
+      () => (mundusBuffs.length > 0 ? mundusBuffs : kalpaMundus ? [kalpaMundus] : []),
+      [mundusBuffs, kalpaMundus],
+    );
+    const mundusSource =
+      mundusBuffs.length === 0 && kalpaMundus ? 'Kalpa native evidence' : undefined;
     const kalpaRaceLabel = kalpaRaceIdToLabel(kalpaBuildEvidence?.raceId);
     const kalpaChampionPoints =
       Number.isInteger(kalpaBuildEvidence?.championPoints) &&
@@ -631,7 +655,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
           role: broadRole,
           gear: player?.combatantInfo?.gear ?? [],
           talents,
-          mundusBuffs,
+          mundusBuffs: effectiveMundusBuffs,
           championPoints,
           classAnalysis,
           kalpaBuildEvidence,
@@ -655,7 +679,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
     }, [
       player,
       talents,
-      mundusBuffs,
+      effectiveMundusBuffs,
       championPoints,
       classAnalysis,
       kalpaBuildEvidence,
@@ -928,8 +952,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
         );
       }
 
-      if (mundusBuffs.length > 0) {
-        add('mundus', <MundusChip mundusBuffs={mundusBuffs} />);
+      if (effectiveMundusBuffs.length > 0) {
+        add('mundus', <MundusChip mundusBuffs={effectiveMundusBuffs} source={mundusSource} />);
       }
 
       add(
@@ -1106,7 +1130,8 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
       critDps,
       kalpaRaceLabel,
       kalpaChampionPoints,
-      mundusBuffs,
+      effectiveMundusBuffs,
+      mundusSource,
       effectiveFoodAura,
       foodEvidenceSource,
       foodInfo,

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -62,6 +62,7 @@ import { PlayerGearSetRecord } from '../../../utils/gearUtilities';
 import {
   kalpaRaceIdToLabel,
   type KalpaPlayerBuildEvidence,
+  type KalpaScribedSkillEvidence,
 } from '../../../utils/kalpaBuildEvidence';
 import { resolveActorName } from '../../../utils/resolveActorName';
 import { abbreviateSkillLine } from '../../../utils/skillLineDetectionUtils';
@@ -114,12 +115,32 @@ const LazyTalentTooltipContent: React.FC<{
   resolveScribedSkillData: (talentGuid: number, talentName: string) => ScribedSkillData | undefined;
   fightId?: string;
   playerId: number;
-}> = ({ talent, isUltimate, resolveProps, resolveScribedSkillData, fightId, playerId }) => {
+  kalpaScribedByAbilityId?: Map<number, KalpaScribedSkillEvidence>;
+}> = ({
+  talent,
+  isUltimate,
+  resolveProps,
+  resolveScribedSkillData,
+  fightId,
+  playerId,
+  kalpaScribedByAbilityId,
+}) => {
   const rich = resolveProps(talent);
   const base = {
     name: talent.name,
     description: `${talent.name} (ID: ${talent.guid})`,
   };
+
+  const groundTruth = kalpaScribedByAbilityId?.get(talent.guid);
+  const groundTruthScripts =
+    groundTruth &&
+    (groundTruth.focusScript || groundTruth.signatureScript || groundTruth.affixScript)
+      ? {
+          focusScript: groundTruth.focusScript,
+          signatureScript: groundTruth.signatureScript,
+          affixScript: groundTruth.affixScript,
+        }
+      : undefined;
 
   return (
     <SkillTooltip
@@ -130,6 +151,7 @@ const LazyTalentTooltipContent: React.FC<{
       scribedSkillData={rich?.scribedSkillData ?? resolveScribedSkillData(talent.guid, talent.name)}
       fightId={fightId}
       playerId={playerId}
+      groundTruthScripts={groundTruthScripts}
     />
   );
 };
@@ -383,6 +405,15 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
         name: food.name ?? `Food (${food.abilityId})`,
       };
     }, [kalpaBuildEvidence?.food]);
+    // Ground-truth scribing scripts from the Kalpa sidecar, keyed by ability id so the
+    // talent tooltip can prefer them over its inferred detection.
+    const kalpaScribedByAbilityId = React.useMemo(() => {
+      const byAbility = new Map<number, KalpaScribedSkillEvidence>();
+      for (const skill of kalpaBuildEvidence?.scribedSkills ?? []) {
+        if (Number.isInteger(skill.abilityId)) byAbility.set(skill.abilityId, skill);
+      }
+      return byAbility;
+    }, [kalpaBuildEvidence?.scribedSkills]);
     const effectiveFoodAura = foodAura ?? kalpaFoodAura;
     const foodEvidenceSource = foodAura
       ? 'combatant auras'
@@ -1492,6 +1523,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                     resolveScribedSkillData={resolveScribedSkillData}
                                     fightId={fightId || undefined}
                                     playerId={player.id}
+                                    kalpaScribedByAbilityId={kalpaScribedByAbilityId}
                                   />
                                 }
                                 placement="top-start"
@@ -1594,6 +1626,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                                       resolveScribedSkillData={resolveScribedSkillData}
                                       fightId={fightId || undefined}
                                       playerId={player.id}
+                                      kalpaScribedByAbilityId={kalpaScribedByAbilityId}
                                     />
                                   }
                                   placement="top-start"

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -911,6 +911,13 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       for (const abilityId of kalpaBuildEvidenceByPlayer[playerId]?.championPointPassives ?? []) {
         addChampionPoint(abilityId);
       }
+      // Kalpa's full passives list carries every slotted long-term effect. addChampionPoint
+      // filters each id through the authoritative CP classifier (championPointColorForId),
+      // so this picks up CP stars beyond the legacy championPointPassives subset while
+      // silently skipping non-CP passives — no false positives.
+      for (const abilityId of kalpaBuildEvidenceByPlayer[playerId]?.passives ?? []) {
+        addChampionPoint(abilityId);
+      }
 
       sortChampionPointEntries(result[playerId]);
     });

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -413,6 +413,22 @@ describe('kalpaBuildEvidence', () => {
     expect(decodeKalpaBuildEvidenceParam(encodeEvidence(mundusEvidence))).toEqual(mundusEvidence);
   });
 
+  it('round-trips the full passives list', () => {
+    const passivesEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          passives: [142079, 999999, 45301],
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(passivesEvidence))).toEqual(
+      passivesEvidence,
+    );
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -370,6 +370,31 @@ describe('kalpaBuildEvidence', () => {
     );
   });
 
+  it('round-trips ground-truth focus/signature/affix scripts on scribed skills', () => {
+    const scribingEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          scribedSkills: [
+            {
+              abilityId: 217784,
+              name: 'Leashing Soul',
+              icon: 'ability_grimoire_soulmagic1',
+              focusScript: 'Pull',
+              signatureScript: 'Lingering Torment',
+              affixScript: 'Defile',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(scribingEvidence))).toEqual(
+      scribingEvidence,
+    );
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -395,6 +395,24 @@ describe('kalpaBuildEvidence', () => {
     );
   });
 
+  it('round-trips the Mundus stone evidence', () => {
+    const mundusEvidence: KalpaBuildEvidence = {
+      ...evidence,
+      players: [
+        {
+          ...evidence.players[0],
+          mundus: {
+            abilityId: 13984,
+            name: 'Boon: The Shadow',
+            icon: 'ability_mundusstones_012',
+          },
+        },
+      ],
+    };
+
+    expect(decodeKalpaBuildEvidenceParam(encodeEvidence(mundusEvidence))).toEqual(mundusEvidence);
+  });
+
   it('maps native race ids to build editor ids and labels', () => {
     expect(kalpaRaceIdToBuildRace(9)).toBe('khajiit');
     expect(kalpaRaceIdToLabel(9)).toBe('Khajiit');

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -45,6 +45,10 @@ export interface KalpaScribedSkillEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
+  /** Ground-truth equipped scripts, recovered by Kalpa from the raw ABILITY_INFO line. */
+  focusScript?: string | null;
+  signatureScript?: string | null;
+  affixScript?: string | null;
 }
 
 export interface KalpaBuildEvidence {
@@ -451,6 +455,10 @@ function sanitizeScribedSkills(value: unknown): KalpaScribedSkillEvidence[] {
         abilityId: entry.abilityId as number,
         name: typeof entry.name === 'string' ? entry.name : undefined,
         icon: typeof entry.icon === 'string' ? entry.icon : undefined,
+        focusScript: typeof entry.focusScript === 'string' ? entry.focusScript : undefined,
+        signatureScript:
+          typeof entry.signatureScript === 'string' ? entry.signatureScript : undefined,
+        affixScript: typeof entry.affixScript === 'string' ? entry.affixScript : undefined,
       };
     })
     .filter((entry): entry is KalpaScribedSkillEvidence => entry != null);

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -30,12 +30,19 @@ export interface KalpaPlayerBuildEvidence {
   classMasteryPassives: number[];
   championPointPassives?: number[];
   food?: KalpaFoodEvidence;
+  mundus?: KalpaMundusEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
   evidence: string;
   confidence: string;
 }
 
 export interface KalpaFoodEvidence {
+  abilityId: number;
+  name?: string | null;
+  icon?: string | null;
+}
+
+export interface KalpaMundusEvidence {
   abilityId: number;
   name?: string | null;
   icon?: string | null;
@@ -408,6 +415,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
   const classMasteryPassives = sanitizeNumberArray(value.classMasteryPassives);
   const championPointPassives = sanitizeNumberArray(value.championPointPassives);
   const food = sanitizeFoodEvidence(value.food);
+  const mundus = sanitizeMundusEvidence(value.mundus);
   const scribedSkills = sanitizeScribedSkills(value.scribedSkills);
   const player: KalpaPlayerBuildEvidence = {
     unitId: value.unitId,
@@ -429,11 +437,24 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
   if (food) player.food = food;
+  if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;
   return player;
 }
 
 function sanitizeFoodEvidence(value: unknown): KalpaFoodEvidence | undefined {
+  if (!isRecord(value) || !Number.isInteger(value.abilityId) || (value.abilityId as number) <= 0) {
+    return undefined;
+  }
+
+  return {
+    abilityId: value.abilityId as number,
+    name: typeof value.name === 'string' ? value.name : undefined,
+    icon: typeof value.icon === 'string' ? value.icon : undefined,
+  };
+}
+
+function sanitizeMundusEvidence(value: unknown): KalpaMundusEvidence | undefined {
   if (!isRecord(value) || !Number.isInteger(value.abilityId) || (value.abilityId as number) <= 0) {
     return undefined;
   }

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -29,6 +29,8 @@ export interface KalpaPlayerBuildEvidence {
   className?: string | null;
   classMasteryPassives: number[];
   championPointPassives?: number[];
+  /** Full long-term-effect ability ids from the raw PLAYER_INFO (classified client-side). */
+  passives?: number[];
   food?: KalpaFoodEvidence;
   mundus?: KalpaMundusEvidence;
   scribedSkills?: KalpaScribedSkillEvidence[];
@@ -414,6 +416,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
 
   const classMasteryPassives = sanitizeNumberArray(value.classMasteryPassives);
   const championPointPassives = sanitizeNumberArray(value.championPointPassives);
+  const passives = sanitizeNumberArray(value.passives);
   const food = sanitizeFoodEvidence(value.food);
   const mundus = sanitizeMundusEvidence(value.mundus);
   const scribedSkills = sanitizeScribedSkills(value.scribedSkills);
@@ -436,6 +439,7 @@ function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence |
     confidence: typeof value.confidence === 'string' ? value.confidence : '',
   };
   if (championPointPassives.length > 0) player.championPointPassives = championPointPassives;
+  if (passives.length > 0) player.passives = passives;
   if (food) player.food = food;
   if (mundus) player.mundus = mundus;
   if (scribedSkills.length > 0) player.scribedSkills = scribedSkills;


### PR DESCRIPTION
**Draft, not for merge.** Combines the three stacked display PRs (#1374 scribing tooltip, #1375 Mundus fallback, #1376 CP stars from full passives) onto the persist branch (#1373) so a **single dev-preview** shows every Kalpa sidecar feature at once.

Merge the real PRs (#1373 → #1374/#1375/#1376) individually; this branch only exists to produce a combined preview build.