### PR TITLE
feat(crit-damage): gate Fighting Finesse & Backstabber on companion CP

### DIFF
--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionCritEvidence.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionCritEvidence.test.ts
@@ -1,0 +1,106 @@
+import { ChampionPointAbilityId } from '@/types/champion-points';
+
+import {
+  buildCompanionCritEvidence,
+  critEvidenceFromSnapshot,
+} from '../esotkCompanionCritEvidence';
+import type { MatchableReport } from '../esotkCompanionMatcher';
+import type { CompanionSnapshot } from '../esotkCompanionParser';
+
+const REPORT_START_MS = 1_749_384_000_000;
+const REPORT_START_S = REPORT_START_MS / 1000;
+
+const report: MatchableReport = {
+  startTime: REPORT_START_MS,
+  endTime: REPORT_START_MS + 60 * 60 * 1000,
+  actors: [{ id: 1, name: 'Casts-A-Lot', server: 'NA' }],
+};
+
+function snap(slotted: Record<number, number>, names?: Record<number, string>): CompanionSnapshot {
+  return {
+    ts: REPORT_START_S + 60,
+    char: 'Casts-A-Lot',
+    server: 'NA',
+    championPoints: {
+      total: 3600,
+      disciplines: {},
+      slotted,
+      ...(names ? { names } : {}),
+    },
+  };
+}
+
+describe('critEvidenceFromSnapshot', () => {
+  it('detects Fighting Finesse by champion-skill id', () => {
+    expect(critEvidenceFromSnapshot(snap({ 5: ChampionPointAbilityId.FightingFinesse }))).toEqual({
+      fightingFinesseSlotted: true,
+      backstabberSlotted: false,
+    });
+  });
+
+  it('detects Backstabber by champion-skill id', () => {
+    expect(critEvidenceFromSnapshot(snap({ 6: ChampionPointAbilityId.Backstabber }))).toEqual({
+      fightingFinesseSlotted: false,
+      backstabberSlotted: true,
+    });
+  });
+
+  it('falls back to captured localized star names when ids are unrecognized', () => {
+    expect(
+      critEvidenceFromSnapshot(
+        snap({ 5: 999901, 6: 999902 }, { 999901: 'Fighting Finesse', 999902: 'Backstabber' }),
+      ),
+    ).toEqual({ fightingFinesseSlotted: true, backstabberSlotted: true });
+  });
+
+  it('returns false flags when neither star is slotted', () => {
+    expect(critEvidenceFromSnapshot(snap({ 5: ChampionPointAbilityId.DeadlyAim }))).toEqual({
+      fightingFinesseSlotted: false,
+      backstabberSlotted: false,
+    });
+  });
+
+  it('returns undefined when no slotted data was captured (assume-active fallback)', () => {
+    expect(
+      critEvidenceFromSnapshot({
+        ts: 1,
+        char: 'X',
+        championPoints: { disciplines: {}, slotted: {} },
+      }),
+    ).toBeUndefined();
+    expect(critEvidenceFromSnapshot({ ts: 1, char: 'X' })).toBeUndefined();
+  });
+});
+
+describe('buildCompanionCritEvidence', () => {
+  it('keys evidence by the matched numeric actor id', () => {
+    expect(
+      buildCompanionCritEvidence([snap({ 5: ChampionPointAbilityId.FightingFinesse })], report),
+    ).toEqual({ 1: { fightingFinesseSlotted: true, backstabberSlotted: false } });
+  });
+
+  it('omits actors with no matched snapshot', () => {
+    const anon: MatchableReport = { ...report, actors: [{ id: 9, name: 'Nobody' }] };
+    expect(
+      buildCompanionCritEvidence([snap({ 5: ChampionPointAbilityId.FightingFinesse })], anon),
+    ).toEqual({});
+  });
+
+  it('returns {} for empty snapshots or empty actors', () => {
+    expect(buildCompanionCritEvidence([], report)).toEqual({});
+    expect(
+      buildCompanionCritEvidence([snap({ 5: ChampionPointAbilityId.FightingFinesse })], {
+        ...report,
+        actors: [],
+      }),
+    ).toEqual({});
+  });
+
+  it('produces a plain Record of booleans (structured-clone safe for the worker)', () => {
+    const out = buildCompanionCritEvidence(
+      [snap({ 5: ChampionPointAbilityId.FightingFinesse, 6: ChampionPointAbilityId.Backstabber })],
+      report,
+    );
+    expect(JSON.parse(JSON.stringify(out))).toEqual(out);
+  });
+});

--- a/src/features/loadout-manager/utils/buildMatchableReport.ts
+++ b/src/features/loadout-manager/utils/buildMatchableReport.ts
@@ -1,0 +1,46 @@
+/**
+ * Build the minimal `MatchableReport` the ESOTK Companion matcher needs from the store's
+ * player roster + report registry entry. Extracted so every companion consumer (the
+ * Players-tab panel and the crit-damage graph) builds an identical report and therefore
+ * matches each snapshot to the same actor.
+ */
+
+import type { PlayerDetailsWithRole } from '@/store/player_data/playerDataSlice';
+import type { selectReportRegistryEntryForContext } from '@/store/report/reportSelectors';
+
+import type { MatchableReport } from './esotkCompanionMatcher';
+
+export function buildMatchableReport(
+  playersById: Record<string | number, PlayerDetailsWithRole>,
+  reportEntry: ReturnType<typeof selectReportRegistryEntryForContext>,
+): MatchableReport | null {
+  const data = reportEntry?.data;
+  if (!data?.startTime) return null;
+
+  const actors = Object.values(playersById)
+    .filter((player) => player.id !== undefined && player.name)
+    .map((player) => ({
+      id: player.id,
+      name: player.name,
+      server: player.server,
+    }));
+  if (actors.length === 0) return null;
+
+  const fights =
+    reportEntry?.fightIds
+      .map((fightId) => reportEntry.fightsById[fightId])
+      .filter((fight): fight is NonNullable<typeof fight> => Boolean(fight))
+      .map((fight) => ({
+        id: fight.id,
+        startTime: fight.startTime,
+        endTime: fight.endTime,
+        zoneId: fight.gameZone?.id,
+      })) ?? [];
+
+  return {
+    startTime: data.startTime,
+    endTime: data.endTime,
+    actors,
+    fights,
+  };
+}

--- a/src/features/loadout-manager/utils/esotkCompanionCritEvidence.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionCritEvidence.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-player crit-damage evidence from ESOTK Companion snapshots.
+ *
+ * The /critical-damage graph assumes Fighting Finesse (+8%) and Backstabber (+10%) for
+ * every player because those champion stars emit no event or aura and can't be seen in the
+ * log. When a companion snapshot matched a player, this derives whether each star is
+ * actually slotted so the graph can gate them per-player. Reuses the same matcher and
+ * targetFightId path as `buildCompanionBuildsForReport`, so the graph and the Players-tab
+ * companion panel always agree on which snapshot each actor got. Output is a POJO of
+ * booleans — structured-clone safe for the worker.
+ */
+
+import { ChampionPointAbilityId } from '@/types/champion-points';
+import type { CompanionCritEvidence } from '@/utils/CritDamageUtils';
+
+import {
+  matchCompanionSnapshots,
+  type MatchableReport,
+  type MatchCompanionSnapshotsOptions,
+} from './esotkCompanionMatcher';
+import type { CompanionSnapshot } from './esotkCompanionParser';
+
+/** Champion-skill id of Fighting Finesse (verified). */
+const FIGHTING_FINESSE_SKILL_ID = ChampionPointAbilityId.FightingFinesse;
+/** Champion-skill id of Backstabber (from DynamicCP data, cross-checked). */
+const BACKSTABBER_SKILL_ID = ChampionPointAbilityId.Backstabber;
+
+function normalizeStarName(name: string | undefined): string {
+  return (name ?? '').trim().toLowerCase();
+}
+
+/**
+ * Derive crit evidence from a single snapshot's slotted champion stars. Detection is by
+ * champion-skill id (primary) with the snapshot's captured localized star names as a
+ * fallback. Returns undefined when the snapshot carries no slotted data — a missing entry
+ * means "no evidence" downstream (assume-active), the correct default; emitting
+ * `{ false, false }` would wrongly zero a star we simply failed to capture.
+ *
+ * NOTE: gating is on the 12 *slotted* slots, not merely allocated points — both stars only
+ * grant their bonus while slotted, so `championPoints.slotted` is the correct signal.
+ */
+export function critEvidenceFromSnapshot(
+  snapshot: CompanionSnapshot,
+): CompanionCritEvidence | undefined {
+  const cp = snapshot.championPoints;
+  const slotted = cp?.slotted;
+  if (!slotted) return undefined;
+
+  const slottedIds = Object.values(slotted);
+  if (slottedIds.length === 0) return undefined;
+
+  const slottedIdSet = new Set(slottedIds);
+  const names = cp?.names;
+  const slottedNames = new Set(slottedIds.map((id) => normalizeStarName(names?.[id])));
+
+  return {
+    fightingFinesseSlotted:
+      slottedIdSet.has(FIGHTING_FINESSE_SKILL_ID) || slottedNames.has('fighting finesse'),
+    backstabberSlotted: slottedIdSet.has(BACKSTABBER_SKILL_ID) || slottedNames.has('backstabber'),
+  };
+}
+
+/**
+ * Match snapshots to a report and produce the per-player crit-evidence map keyed by numeric
+ * actor id (== player id). Actors with no match, or with a matched snapshot that carries no
+ * slotted data, are omitted so the worker treats them as "no evidence" (byte-identical to
+ * the pre-companion behaviour).
+ */
+export function buildCompanionCritEvidence(
+  snapshots: CompanionSnapshot[],
+  report: MatchableReport,
+  opts: MatchCompanionSnapshotsOptions = {},
+): Record<number, CompanionCritEvidence> {
+  const out: Record<number, CompanionCritEvidence> = {};
+  if (snapshots.length === 0 || report.actors.length === 0) return out;
+
+  const { matches } = matchCompanionSnapshots(snapshots, report, {
+    targetFightId: opts.targetFightId,
+  });
+  for (const [actorId, match] of matches) {
+    const evidence = critEvidenceFromSnapshot(match.snapshot);
+    const id = Number(actorId);
+    if (evidence && Number.isFinite(id)) {
+      out[id] = evidence;
+    }
+  }
+  return out;
+}

--- a/src/features/report_details/critical_damage/CriticalDamagePanel.tsx
+++ b/src/features/report_details/critical_damage/CriticalDamagePanel.tsx
@@ -8,6 +8,7 @@ import {
   useFightForContext,
 } from '../../../hooks';
 import type { PhaseTransitionInfo } from '../../../hooks/usePhaseTransitions';
+import { useCompanionCritEvidence } from '../../../hooks/workerTasks/useCompanionCritEvidence';
 import type { ReportFightContextInput } from '../../../store/contextTypes';
 import { getSkeletonForTab, TabId } from '../../../utils/getSkeletonForTab';
 
@@ -30,6 +31,9 @@ export const CriticalDamagePanel: React.FC<CriticalDamagePanelProps> = ({
   const { playerData, isPlayerDataLoading } = usePlayerData({ context: resolvedContext });
   const { criticalDamageData, isCriticalDamageLoading, criticalDamageError } =
     useCriticalDamageTask({ context: resolvedContext });
+  // Built from the SAME snapshots + resolvedContext the crit-damage worker uses, so the
+  // detail view's evidence-driven defaults agree with the worker's baked-in wasActive.
+  const companionCritEvidence = useCompanionCritEvidence(resolvedContext);
 
   const isLoading = isCriticalDamageLoading || isPlayerDataLoading || !fight;
 
@@ -99,6 +103,7 @@ export const CriticalDamagePanel: React.FC<CriticalDamagePanelProps> = ({
       phaseTransitionInfo={phaseTransitionInfo}
       globalFightingFinesseEnabled={globalFightingFinesseEnabled}
       onGlobalFightingFinesseToggle={handleGlobalFightingFinesseToggle}
+      companionCritEvidence={companionCritEvidence}
     />
   );
 };

--- a/src/features/report_details/critical_damage/CriticalDamagePanelView.tsx
+++ b/src/features/report_details/critical_damage/CriticalDamagePanelView.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import { FightFragment } from '../../../graphql/gql/graphql';
 import type { PhaseTransitionInfo } from '../../../hooks/usePhaseTransitions';
 import { PlayerDetailsWithRole } from '../../../store/player_data/playerDataSlice';
-import { CriticalDamageSourceWithActiveState } from '../../../utils/CritDamageUtils';
+import {
+  type CompanionCritEvidence,
+  CriticalDamageSourceWithActiveState,
+} from '../../../utils/CritDamageUtils';
 
 import { PlayerCriticalDamageDetails } from './PlayerCriticalDamageDetails';
 import { PlayerCriticalDamageData } from './PlayerCriticalDamageDetailsView';
@@ -24,6 +27,8 @@ interface CriticalDamagePanelProps {
   phaseTransitionInfo?: PhaseTransitionInfo;
   globalFightingFinesseEnabled: boolean;
   onGlobalFightingFinesseToggle: (enabled: boolean) => void;
+  /** Per-player companion crit evidence, keyed by player id; absent when no snapshot matched. */
+  companionCritEvidence?: Record<number, CompanionCritEvidence>;
 }
 
 /**
@@ -39,6 +44,7 @@ export const CriticalDamagePanelView: React.FC<CriticalDamagePanelProps> = ({
   phaseTransitionInfo,
   globalFightingFinesseEnabled,
   onGlobalFightingFinesseToggle,
+  companionCritEvidence,
 }) => {
   return (
     <Box sx={{ px: { xs: 0, sm: 2 }, py: 2 }}>
@@ -104,6 +110,7 @@ export const CriticalDamagePanelView: React.FC<CriticalDamagePanelProps> = ({
               isLoading={isLoading}
               phaseTransitionInfo={phaseTransitionInfo}
               globalFightingFinesseEnabled={globalFightingFinesseEnabled}
+              companionCritEvidence={companionCritEvidence?.[player.id]}
             />
           );
         })}

--- a/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
+++ b/src/features/report_details/critical_damage/PlayerCriticalDamageDetails.tsx
@@ -4,10 +4,13 @@ import { FightFragment } from '../../../graphql/gql/graphql';
 import { usePlayerData } from '../../../hooks';
 import type { PhaseTransitionInfo } from '../../../hooks/usePhaseTransitions';
 import { useSelectedReportAndFight } from '../../../ReportFightContext';
-import { CriticalDamageValues } from '../../../types/abilities';
 import { filterDataPointsByActiveCombat } from '../../../utils/activeCombatTimeUtils';
-import { CriticalDamageSourceWithActiveState } from '../../../utils/CritDamageUtils';
+import {
+  type CompanionCritEvidence,
+  CriticalDamageSourceWithActiveState,
+} from '../../../utils/CritDamageUtils';
 
+import { computeCritDamageAdjustment } from './critDamageAdjustment';
 import {
   PlayerCriticalDamageDetailsView,
   PlayerCriticalDamageData,
@@ -41,6 +44,13 @@ interface PlayerCriticalDamageDetailsProps {
   isLoading: boolean;
   phaseTransitionInfo?: PhaseTransitionInfo;
   globalFightingFinesseEnabled?: boolean;
+  /**
+   * Per-player ESOTK Companion evidence for this player, when a snapshot matched. Drives the
+   * Fighting Finesse default (slotted => on) and makes companion data authoritative over the
+   * report-wide toggle. The *subtract* still keys off the worker's baked-in `wasActive`, so
+   * both derive from the same evidence and never disagree.
+   */
+  companionCritEvidence?: CompanionCritEvidence;
 }
 
 export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsProps> = ({
@@ -53,6 +63,7 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
   isLoading,
   phaseTransitionInfo,
   globalFightingFinesseEnabled: globalFightingFinesseEnabledProp,
+  companionCritEvidence,
 }) => {
   const { playerData } = usePlayerData();
   const { reportId, fightId } = useSelectedReportAndFight();
@@ -77,6 +88,13 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
     );
   }, [criticalDamageData?.criticalDamageSources]);
 
+  // Whether the worker actually BAKED each star into staticCriticalDamage. This is the single
+  // source of truth for the subtract: when companion evidence proves a star isn't slotted the
+  // worker sets wasActive=false and excludes it, so we must not subtract it again. With no
+  // evidence, wasActive is true (assume-active) => included=true => pre-companion behaviour.
+  const fightingFinesseIncluded = fightingFinesseSource?.wasActive ?? false;
+  const backstabberIncluded = backstabberSource?.wasActive ?? false;
+
   const [localFightingFinesseEnabled, setLocalFightingFinesseEnabled] = React.useState<boolean>(
     FIGHTING_FINESSE_DEFAULT_ENABLED,
   );
@@ -91,38 +109,48 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
   // the global Fighting Finesse setting so an explicit global toggle still applies.
   // (We can't key on the always-on source's wasActive — it is always true and never changes.)
   React.useEffect(() => {
+    // When a companion snapshot matched this player, its slotted CP is authoritative: seed
+    // Fighting Finesse enabled only when it is actually slotted. Otherwise fall back to the
+    // report-wide global toggle so an explicit global setting still applies.
     setLocalFightingFinesseEnabled(
-      globalFightingFinesseEnabledProp ?? FIGHTING_FINESSE_DEFAULT_ENABLED,
+      companionCritEvidence
+        ? companionCritEvidence.fightingFinesseSlotted
+        : (globalFightingFinesseEnabledProp ?? FIGHTING_FINESSE_DEFAULT_ENABLED),
     );
+    // Backstabber depends on flanking, which is undetectable even with a snapshot, so it stays
+    // off by default; slotted only decides whether it was baked (and thus togglable).
     setBackstabberEnabled(BACKSTABBER_DEFAULT_ENABLED);
     // globalFightingFinesseEnabledProp is intentionally read but not a trigger here; the
     // effect below handles global-toggle changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reportId, fightId]);
+  }, [reportId, fightId, companionCritEvidence]);
 
-  // Sync local state with global state when global changes
+  // Sync local state with global state when global changes — unless companion evidence exists,
+  // in which case it is authoritative and the report-wide toggle must not fabricate Fighting
+  // Finesse for a player we know the truth of.
   React.useEffect(() => {
+    if (companionCritEvidence) return;
     if (globalFightingFinesseEnabledProp !== undefined) {
       setLocalFightingFinesseEnabled(globalFightingFinesseEnabledProp);
     }
-  }, [globalFightingFinesseEnabledProp]);
+  }, [globalFightingFinesseEnabledProp, companionCritEvidence]);
 
   // Individual state always takes priority (local state)
   const fightingFinesseEnabled = localFightingFinesseEnabled;
 
-  // Total critical damage to subtract for toggleable always-on sources that are
-  // currently disabled. Both Fighting Finesse and Backstabber are baked into the
-  // static critical damage, so turning either off removes its contribution.
-  const critDamageAdjustment = React.useMemo(() => {
-    let adjustment = 0;
-    if (fightingFinesseSource && !fightingFinesseEnabled) {
-      adjustment += CriticalDamageValues.FIGHTING_FINESSE;
-    }
-    if (backstabberSource && !backstabberEnabled) {
-      adjustment += CriticalDamageValues.BACKSTABBER;
-    }
-    return adjustment;
-  }, [fightingFinesseSource, fightingFinesseEnabled, backstabberSource, backstabberEnabled]);
+  // Total critical damage to subtract for toggleable always-on sources that are currently
+  // disabled — gated on whether the worker actually baked each star in (fightingFinesseIncluded
+  // / backstabberIncluded), so an evidence-excluded star is never subtracted twice.
+  const critDamageAdjustment = React.useMemo(
+    () =>
+      computeCritDamageAdjustment({
+        fightingFinesseIncluded,
+        fightingFinesseEnabled,
+        backstabberIncluded,
+        backstabberEnabled,
+      }),
+    [fightingFinesseIncluded, fightingFinesseEnabled, backstabberIncluded, backstabberEnabled],
+  );
 
   const adjustedCriticalDamageData = React.useMemo(() => {
     if (!criticalDamageData) {
@@ -176,31 +204,34 @@ export const PlayerCriticalDamageDetails: React.FC<PlayerCriticalDamageDetailsPr
       if (source.source === 'always_on' && source.name === FIGHTING_FINESSE_SOURCE_NAME) {
         return {
           ...source,
-          wasActive: fightingFinesseEnabled,
+          wasActive: fightingFinesseIncluded && fightingFinesseEnabled,
         };
       }
       if (source.source === 'always_on' && source.name === BACKSTABBER_SOURCE_NAME) {
         return {
           ...source,
-          wasActive: backstabberEnabled,
+          wasActive: backstabberIncluded && backstabberEnabled,
         };
       }
       return source;
     });
-  }, [criticalDamageData?.criticalDamageSources, fightingFinesseEnabled, backstabberEnabled]);
+  }, [
+    criticalDamageData?.criticalDamageSources,
+    fightingFinesseIncluded,
+    fightingFinesseEnabled,
+    backstabberIncluded,
+    backstabberEnabled,
+  ]);
 
+  // Only offer a toggle for stars the worker actually baked in (included). A star companion
+  // evidence proved isn't slotted is shown inactive but not togglable — the subtract-only model
+  // can't ADD back a contribution the worker never included.
   const toggleableSourceNames = React.useMemo(() => {
     const names = new Set<string>();
-    for (const source of adjustedCriticalDamageSources) {
-      if (
-        source.source === 'always_on' &&
-        (source.name === FIGHTING_FINESSE_SOURCE_NAME || source.name === BACKSTABBER_SOURCE_NAME)
-      ) {
-        names.add(source.name);
-      }
-    }
+    if (fightingFinesseIncluded) names.add(FIGHTING_FINESSE_SOURCE_NAME);
+    if (backstabberIncluded) names.add(BACKSTABBER_SOURCE_NAME);
     return names.size > 0 ? names : undefined;
-  }, [adjustedCriticalDamageSources]);
+  }, [fightingFinesseIncluded, backstabberIncluded]);
 
   const handleSourceToggle = React.useCallback((sourceName: string, nextValue: boolean) => {
     if (sourceName === FIGHTING_FINESSE_SOURCE_NAME) {

--- a/src/features/report_details/critical_damage/critDamageAdjustment.test.ts
+++ b/src/features/report_details/critical_damage/critDamageAdjustment.test.ts
@@ -1,0 +1,47 @@
+import { CriticalDamageValues } from '@/types/abilities';
+
+import { computeCritDamageAdjustment } from './critDamageAdjustment';
+
+describe('computeCritDamageAdjustment', () => {
+  it('subtracts both stars when included but disabled (pre-companion default)', () => {
+    expect(
+      computeCritDamageAdjustment({
+        fightingFinesseIncluded: true,
+        fightingFinesseEnabled: false,
+        backstabberIncluded: true,
+        backstabberEnabled: false,
+      }),
+    ).toBe(CriticalDamageValues.FIGHTING_FINESSE + CriticalDamageValues.BACKSTABBER);
+  });
+
+  it('does not subtract a star that is enabled', () => {
+    expect(
+      computeCritDamageAdjustment({
+        fightingFinesseIncluded: true,
+        fightingFinesseEnabled: true,
+        backstabberIncluded: true,
+        backstabberEnabled: false,
+      }),
+    ).toBe(CriticalDamageValues.BACKSTABBER);
+  });
+
+  it('never subtracts a star the worker did not bake in (double-subtract guard)', () => {
+    expect(
+      computeCritDamageAdjustment({
+        fightingFinesseIncluded: false,
+        fightingFinesseEnabled: false,
+        backstabberIncluded: false,
+        backstabberEnabled: false,
+      }),
+    ).toBe(0);
+    // Even if a not-included star is somehow marked enabled, it contributes nothing.
+    expect(
+      computeCritDamageAdjustment({
+        fightingFinesseIncluded: false,
+        fightingFinesseEnabled: true,
+        backstabberIncluded: false,
+        backstabberEnabled: true,
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/features/report_details/critical_damage/critDamageAdjustment.ts
+++ b/src/features/report_details/critical_damage/critDamageAdjustment.ts
@@ -1,0 +1,27 @@
+import { CriticalDamageValues } from '@/types/abilities';
+
+/**
+ * Critical damage to subtract from the displayed graph for the toggleable always-on stars
+ * (Fighting Finesse, Backstabber) that are currently switched off.
+ *
+ * The subtraction is gated on whether the worker actually BAKED the star into the static
+ * critical damage (`*Included`, derived from the source's `wasActive`). Once companion
+ * evidence proves a star isn't slotted, the worker excludes it (wasActive=false), so we must
+ * NOT subtract it again here — subtracting only when `included && !enabled` avoids that
+ * double-subtract while preserving the pre-companion behaviour (no evidence => included=true).
+ */
+export function computeCritDamageAdjustment(p: {
+  fightingFinesseIncluded: boolean;
+  fightingFinesseEnabled: boolean;
+  backstabberIncluded: boolean;
+  backstabberEnabled: boolean;
+}): number {
+  let adjustment = 0;
+  if (p.fightingFinesseIncluded && !p.fightingFinesseEnabled) {
+    adjustment += CriticalDamageValues.FIGHTING_FINESSE;
+  }
+  if (p.backstabberIncluded && !p.backstabberEnabled) {
+    adjustment += CriticalDamageValues.BACKSTABBER;
+  }
+  return adjustment;
+}

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { useLogger } from '@/contexts/LoggerContext';
-import type { MatchableReport } from '@/features/loadout-manager/utils/esotkCompanionMatcher';
-import {
-  parseESOTKCompanionSavedVariables,
-  type CompanionSnapshot,
-} from '@/features/loadout-manager/utils/esotkCompanionParser';
+import { buildMatchableReport } from '@/features/loadout-manager/utils/buildMatchableReport';
+import { parseESOTKCompanionSavedVariables } from '@/features/loadout-manager/utils/esotkCompanionParser';
 import {
   buildCompanionBuildsForReport,
   type CompanionBuildForPlayer,
@@ -17,6 +14,11 @@ import {
   type PlayerAbilityList,
 } from '@/features/scribing/analysis/scribingDetectionAnalysis';
 import { isScribingAbility } from '@/features/scribing/utils/Scribing';
+import {
+  companionSnapshotsUploaded,
+  selectCompanionSnapshots,
+  selectCompanionUpload,
+} from '@/store/companion';
 import { useAppDispatch } from '@/store/useAppDispatch';
 import {
   executeScribingDetectionsTask,
@@ -254,47 +256,6 @@ type CompanionBuildRenderProps = Pick<
   'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
 >;
 
-interface CompanionUploadState {
-  fileName?: string;
-  snapshotCount: number;
-  error?: string;
-}
-
-function buildMatchableReport(
-  playersById: Record<string | number, PlayerDetailsWithRole>,
-  reportEntry: ReturnType<typeof selectReportRegistryEntryForContext>,
-): MatchableReport | null {
-  const data = reportEntry?.data;
-  if (!data?.startTime) return null;
-
-  const actors = Object.values(playersById)
-    .filter((player) => player.id !== undefined && player.name)
-    .map((player) => ({
-      id: player.id,
-      name: player.name,
-      server: player.server,
-    }));
-  if (actors.length === 0) return null;
-
-  const fights =
-    reportEntry?.fightIds
-      .map((fightId) => reportEntry.fightsById[fightId])
-      .filter((fight): fight is NonNullable<typeof fight> => Boolean(fight))
-      .map((fight) => ({
-        id: fight.id,
-        startTime: fight.startTime,
-        endTime: fight.endTime,
-        zoneId: fight.gameZone?.id,
-      })) ?? [];
-
-  return {
-    startTime: data.startTime,
-    endTime: data.endTime,
-    actors,
-    fights,
-  };
-}
-
 interface PlayersPanelProps {
   context?: ReportFightContextInput;
 }
@@ -330,10 +291,8 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       >
     >
   >({});
-  const [companionSnapshots, setCompanionSnapshots] = React.useState<CompanionSnapshot[]>([]);
-  const [companionUpload, setCompanionUpload] = React.useState<CompanionUploadState>({
-    snapshotCount: 0,
-  });
+  const companionSnapshots = useSelector(selectCompanionSnapshots);
+  const companionUpload = useSelector(selectCompanionUpload);
 
   // Use hooks to get data
   const { reportMasterData, isMasterDataLoading } = useReportMasterData();
@@ -454,32 +413,38 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         const text = await file.text();
         const parsed = parseESOTKCompanionSavedVariables(text);
         if (!parsed || parsed.all.length === 0) {
-          setCompanionSnapshots([]);
-          setCompanionUpload({
-            fileName: file.name,
-            snapshotCount: 0,
-            error: 'No ESOTK Companion snapshots found',
-          });
+          dispatch(
+            companionSnapshotsUploaded({
+              snapshots: [],
+              fileName: file.name,
+              snapshotCount: 0,
+              error: 'No ESOTK Companion snapshots found',
+            }),
+          );
           return;
         }
 
-        setCompanionSnapshots(parsed.all);
-        setCompanionUpload({
-          fileName: file.name,
-          snapshotCount: parsed.all.length,
-        });
+        dispatch(
+          companionSnapshotsUploaded({
+            snapshots: parsed.all,
+            fileName: file.name,
+            snapshotCount: parsed.all.length,
+          }),
+        );
         logger.info('Loaded ESOTK Companion snapshots', {
           fileName: file.name,
           snapshotCount: parsed.all.length,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to read companion file';
-        setCompanionSnapshots([]);
-        setCompanionUpload({
-          fileName: file.name,
-          snapshotCount: 0,
-          error: message,
-        });
+        dispatch(
+          companionSnapshotsUploaded({
+            snapshots: [],
+            fileName: file.name,
+            snapshotCount: 0,
+            error: message,
+          }),
+        );
         logger.error(
           'Failed to load ESOTK Companion snapshots',
           error instanceof Error ? error : undefined,
@@ -490,7 +455,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         );
       }
     },
-    [logger],
+    [logger, dispatch],
   );
 
   const identityKalpaBuildEvidenceByPlayer = React.useMemo(() => {

--- a/src/hooks/workerTasks/useCompanionCritEvidence.ts
+++ b/src/hooks/workerTasks/useCompanionCritEvidence.ts
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { buildMatchableReport } from '@/features/loadout-manager/utils/buildMatchableReport';
+import { buildCompanionCritEvidence } from '@/features/loadout-manager/utils/esotkCompanionCritEvidence';
+import { selectCompanionSnapshots } from '@/store/companion';
+import { selectReportRegistryEntryForContext } from '@/store/report/reportSelectors';
+import type { RootState } from '@/store/storeWithHistory';
+import type { CompanionCritEvidence } from '@/utils/CritDamageUtils';
+
+import type { ReportFightContextInput } from '../../store/contextTypes';
+import { usePlayerData } from '../usePlayerData';
+import { useResolvedReportFightContext } from '../useResolvedReportFightContext';
+
+/**
+ * Bridge uploaded ESOTK Companion snapshots into the per-player crit-damage evidence map the
+ * crit-damage worker and graph consume. Reuses the same roster + report + targetFightId the
+ * Players-tab companion panel uses, so the worker's baked-in `wasActive` and the detail
+ * view's evidence-driven defaults never disagree. Returns undefined when there is nothing to
+ * gate, keeping the worker payload field undefined (byte-identical to the no-companion path).
+ */
+export function useCompanionCritEvidence(
+  context?: ReportFightContextInput,
+): Record<number, CompanionCritEvidence> | undefined {
+  const resolvedContext = useResolvedReportFightContext(context);
+  const snapshots = useSelector(selectCompanionSnapshots);
+  const { playerData } = usePlayerData({ context: resolvedContext });
+  const reportEntry = useSelector((state: RootState) =>
+    selectReportRegistryEntryForContext(state, resolvedContext),
+  );
+
+  const playersById = playerData?.playersById;
+  const fightId = resolvedContext.fightId;
+
+  return React.useMemo(() => {
+    if (!snapshots || snapshots.length === 0 || !playersById) return undefined;
+    const report = buildMatchableReport(playersById, reportEntry);
+    if (!report) return undefined;
+    const evidence = buildCompanionCritEvidence(snapshots, report, {
+      targetFightId: fightId ?? undefined,
+    });
+    return Object.keys(evidence).length > 0 ? evidence : undefined;
+  }, [snapshots, playersById, reportEntry, fightId]);
+}

--- a/src/hooks/workerTasks/useCriticalDamageTask.ts
+++ b/src/hooks/workerTasks/useCriticalDamageTask.ts
@@ -17,6 +17,7 @@ import { usePlayerData } from '../usePlayerData';
 import { useSelectedTargetIds } from '../useSelectedTargetIds';
 
 import { useBuffLookupTask } from './useBuffLookupTask';
+import { useCompanionCritEvidence } from './useCompanionCritEvidence';
 import { useDebuffLookupTask } from './useDebuffLookupTask';
 import { useWorkerTaskDependencies } from './useWorkerTaskDependencies';
 
@@ -39,6 +40,7 @@ export function useCriticalDamageTask(_options?: UseCriticalDamageTaskOptions): 
   const { debuffLookupData, isDebuffLookupLoading } = useDebuffLookupTask();
   const { damageEvents, isDamageEventsLoading } = useDamageEvents();
   const selectedTargetIds = useSelectedTargetIds();
+  const companionCritEvidence = useCompanionCritEvidence(_options?.context);
 
   // For now, we'll use placeholder data until the dependencies are properly integrated
   React.useEffect(() => {
@@ -66,6 +68,7 @@ export function useCriticalDamageTask(_options?: UseCriticalDamageTaskOptions): 
             debuffsLookup: debuffLookupData || { buffIntervals: {} },
             damageEvents: damageEvents,
             selectedTargetIds: Array.from(selectedTargetIds),
+            companionCritEvidence,
           }),
         );
         return () => {
@@ -84,6 +87,7 @@ export function useCriticalDamageTask(_options?: UseCriticalDamageTaskOptions): 
     damageEvents,
     isDamageEventsLoading,
     selectedTargetIds,
+    companionCritEvidence,
     isBuffLookupLoading,
     isDebuffLookupLoading,
     isCombatantInfoEventsLoading,

--- a/src/store/companion/companionSlice.test.ts
+++ b/src/store/companion/companionSlice.test.ts
@@ -1,0 +1,53 @@
+import type { CompanionSnapshot } from '@/features/loadout-manager/utils/esotkCompanionParser';
+
+import companionReducer, {
+  companionCleared,
+  companionSnapshotsUploaded,
+  type CompanionState,
+} from './companionSlice';
+
+const snap = (char: string): CompanionSnapshot => ({ ts: 1, char });
+
+describe('companionSlice', () => {
+  const initial: CompanionState = { snapshots: [], upload: { snapshotCount: 0 } };
+
+  it('stores uploaded snapshots and upload meta', () => {
+    const snaps = [snap('A'), snap('B')];
+    const state = companionReducer(
+      initial,
+      companionSnapshotsUploaded({
+        snapshots: snaps,
+        fileName: 'ESOTKCompanion.lua',
+        snapshotCount: 2,
+      }),
+    );
+    expect(state.snapshots).toBe(snaps);
+    expect(state.upload).toEqual({
+      fileName: 'ESOTKCompanion.lua',
+      snapshotCount: 2,
+      error: undefined,
+    });
+  });
+
+  it('records an error with no snapshots', () => {
+    const state = companionReducer(
+      initial,
+      companionSnapshotsUploaded({
+        snapshots: [],
+        fileName: 'bad.lua',
+        snapshotCount: 0,
+        error: 'No ESOTK Companion snapshots found',
+      }),
+    );
+    expect(state.snapshots).toEqual([]);
+    expect(state.upload.error).toBe('No ESOTK Companion snapshots found');
+  });
+
+  it('clears back to the initial state', () => {
+    const populated: CompanionState = {
+      snapshots: [snap('A')],
+      upload: { fileName: 'x', snapshotCount: 1 },
+    };
+    expect(companionReducer(populated, companionCleared())).toEqual(initial);
+  });
+});

--- a/src/store/companion/companionSlice.ts
+++ b/src/store/companion/companionSlice.ts
@@ -1,0 +1,60 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { CompanionSnapshot } from '@/features/loadout-manager/utils/esotkCompanionParser';
+import type { RootState } from '@/store/storeWithHistory';
+
+/** Upload-status metadata for the companion-file picker (mirrors the old PlayersPanel state). */
+export interface CompanionUploadMeta {
+  fileName?: string;
+  snapshotCount: number;
+  error?: string;
+}
+
+export interface CompanionState {
+  /**
+   * Snapshots parsed from the most recently uploaded ESOTK Companion file. Ephemeral, not
+   * persisted. Lifted out of PlayersPanel so the crit-damage graph (a separate component
+   * tree) can read them; matching is name + time scoped, so a file left over from another
+   * report simply yields no matches.
+   */
+  snapshots: CompanionSnapshot[];
+  upload: CompanionUploadMeta;
+}
+
+const initialState: CompanionState = {
+  snapshots: [],
+  upload: { snapshotCount: 0 },
+};
+
+const companionSlice = createSlice({
+  name: 'companion',
+  initialState,
+  reducers: {
+    companionSnapshotsUploaded: (
+      state,
+      action: PayloadAction<{
+        snapshots: CompanionSnapshot[];
+        fileName?: string;
+        snapshotCount: number;
+        error?: string;
+      }>,
+    ) => {
+      const { snapshots, fileName, snapshotCount, error } = action.payload;
+      state.snapshots = snapshots;
+      state.upload = { fileName, snapshotCount, error };
+    },
+    companionCleared: () => ({
+      snapshots: [],
+      upload: { snapshotCount: 0 },
+    }),
+  },
+});
+
+export const { companionSnapshotsUploaded, companionCleared } = companionSlice.actions;
+
+export const selectCompanionSnapshots = (state: RootState): CompanionSnapshot[] =>
+  state.companion.snapshots;
+export const selectCompanionUpload = (state: RootState): CompanionUploadMeta =>
+  state.companion.upload;
+
+export default companionSlice.reducer;

--- a/src/store/companion/index.ts
+++ b/src/store/companion/index.ts
@@ -1,0 +1,2 @@
+export { default as companionReducer } from './companionSlice';
+export * from './companionSlice';

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -23,6 +23,7 @@ import type { EsoLogsClient } from '@/esologsClient';
 import buildEditorReducer from '../features/build-editor/store/buildEditorSlice';
 import loadoutReducer from '../features/loadout-manager/store/loadoutSlice';
 
+import { companionReducer } from './companion';
 import dashboardReducer from './dashboard/dashboardSlice';
 import { eventsReducer } from './events_data';
 import masterDataReducer from './master_data/masterDataSlice';
@@ -38,6 +39,7 @@ import { workerResultsReducer } from './worker_results';
 // Root reducer - adding essential slices
 const rootReducer = combineReducers({
   buildEditor: buildEditorReducer,
+  companion: companionReducer,
   dashboard: dashboardReducer,
   events: eventsReducer,
   loadout: loadoutReducer,

--- a/src/store/worker_results/criticalDamageSlice.test.ts
+++ b/src/store/worker_results/criticalDamageSlice.test.ts
@@ -1,0 +1,59 @@
+import type { CriticalDamageCalculationTask } from '@/workers/calculations/CalculateCriticalDamage';
+
+import { criticalDamageInputHash } from './criticalDamageSlice';
+
+const base: CriticalDamageCalculationTask = {
+  fight: { startTime: 100, endTime: 200 },
+  players: {},
+  combatantInfoEvents: {},
+  friendlyBuffsLookup: { buffIntervals: {} },
+  debuffsLookup: { buffIntervals: {} },
+  damageEvents: [],
+};
+
+describe('criticalDamageInputHash — companion evidence', () => {
+  it('is byte-identical to the no-evidence key when evidence is absent', () => {
+    const withUndef: CriticalDamageCalculationTask = { ...base, companionCritEvidence: undefined };
+    expect(criticalDamageInputHash(withUndef)).toBe(criticalDamageInputHash(base));
+    expect(criticalDamageInputHash(base)).not.toContain('-cev:');
+  });
+
+  it('changes when companion evidence is present', () => {
+    const withEv: CriticalDamageCalculationTask = {
+      ...base,
+      companionCritEvidence: { 1: { fightingFinesseSlotted: true, backstabberSlotted: false } },
+    };
+    expect(criticalDamageInputHash(withEv)).not.toBe(criticalDamageInputHash(base));
+    expect(criticalDamageInputHash(withEv)).toContain('-cev:');
+  });
+
+  it('changes again when a single slotted flag flips', () => {
+    const a: CriticalDamageCalculationTask = {
+      ...base,
+      companionCritEvidence: { 1: { fightingFinesseSlotted: true, backstabberSlotted: false } },
+    };
+    const b: CriticalDamageCalculationTask = {
+      ...base,
+      companionCritEvidence: { 1: { fightingFinesseSlotted: false, backstabberSlotted: false } },
+    };
+    expect(criticalDamageInputHash(a)).not.toBe(criticalDamageInputHash(b));
+  });
+
+  it('is stable regardless of player-key ordering', () => {
+    const a: CriticalDamageCalculationTask = {
+      ...base,
+      companionCritEvidence: {
+        1: { fightingFinesseSlotted: true, backstabberSlotted: false },
+        2: { fightingFinesseSlotted: false, backstabberSlotted: true },
+      },
+    };
+    const b: CriticalDamageCalculationTask = {
+      ...base,
+      companionCritEvidence: {
+        2: { fightingFinesseSlotted: false, backstabberSlotted: true },
+        1: { fightingFinesseSlotted: true, backstabberSlotted: false },
+      },
+    };
+    expect(criticalDamageInputHash(a)).toBe(criticalDamageInputHash(b));
+  });
+});

--- a/src/store/worker_results/criticalDamageSlice.ts
+++ b/src/store/worker_results/criticalDamageSlice.ts
@@ -1,7 +1,12 @@
+import type { CriticalDamageCalculationTask } from '@/workers/calculations/CalculateCriticalDamage';
+
 import { createWorkerTaskSlice } from './workerTaskSliceFactory';
 
-// Create critical damage slice
-export const criticalDamageSlice = createWorkerTaskSlice('calculateCriticalDamageData', (input) => {
+/**
+ * Deduplication key for the crit-damage worker task. Exported for testing so the companion
+ * evidence contribution stays covered against silent regressions (a stale graph after upload).
+ */
+export function criticalDamageInputHash(input: CriticalDamageCalculationTask): string {
   const fightStart = input.fight?.startTime ?? 0;
   const fightEnd = input.fight?.endTime ?? 0;
   const playersCount = input.players ? Object.keys(input.players).length : 0;
@@ -16,8 +21,27 @@ export const criticalDamageSlice = createWorkerTaskSlice('calculateCriticalDamag
     : 0;
   const damageEventsCount = input.damageEvents?.length ?? 0;
   const selectedTargets = input.selectedTargetIds?.join(',') ?? '';
-  return `crit-dmg-${fightStart}-${fightEnd}-${playersCount}-${combatantInfoCount}-${buffIntervalsCount}-${debuffIntervalsCount}-${damageEventsCount}-${selectedTargets}`;
-});
+  const base = `crit-dmg-${fightStart}-${fightEnd}-${playersCount}-${combatantInfoCount}-${buffIntervalsCount}-${debuffIntervalsCount}-${damageEventsCount}-${selectedTargets}`;
+  // Fold in companion crit evidence so uploading/clearing a companion file re-runs the task.
+  // Appended only when present, so non-companion reports keep the exact key produced before.
+  const cev = input.companionCritEvidence;
+  const evidenceSig = cev
+    ? Object.keys(cev)
+        .sort()
+        .map((pid) => {
+          const e = cev[Number(pid)];
+          return `${pid}:${e.fightingFinesseSlotted ? 1 : 0}${e.backstabberSlotted ? 1 : 0}`;
+        })
+        .join('|')
+    : '';
+  return evidenceSig ? `${base}-cev:${evidenceSig}` : base;
+}
+
+// Create critical damage slice
+export const criticalDamageSlice = createWorkerTaskSlice(
+  'calculateCriticalDamageData',
+  criticalDamageInputHash,
+);
 
 // Export actions, thunk, and reducer
 export const criticalDamageActions = criticalDamageSlice.actions;

--- a/src/types/champion-points.test.ts
+++ b/src/types/champion-points.test.ts
@@ -1,0 +1,19 @@
+import {
+  CHAMPION_POINT_ABILITIES,
+  ChampionPointAbilityId,
+  ChampionPointTree,
+} from './champion-points';
+
+describe('ChampionPointAbilityId — crit-damage stars', () => {
+  it('locks the champion-skill ids the crit-damage gate relies on', () => {
+    // A wrong id would silently under-count every player with the star slotted.
+    expect(ChampionPointAbilityId.FightingFinesse).toBe(12);
+    expect(ChampionPointAbilityId.Backstabber).toBe(31);
+  });
+
+  it('maps Backstabber into the Warfare tree', () => {
+    const meta = CHAMPION_POINT_ABILITIES[ChampionPointAbilityId.Backstabber];
+    expect(meta?.name).toBe('Backstabber');
+    expect(meta?.tree).toBe(ChampionPointTree.Warfare);
+  });
+});

--- a/src/types/champion-points.ts
+++ b/src/types/champion-points.ts
@@ -32,6 +32,7 @@ export enum ChampionPointAbilityId {
   // === WARFARE (Blue) === ✅
   // Should be 33 total, only 21 mapped so far
   ArcaneSupremacy = 3,
+  Backstabber = 31,
   BitingAura = 23,
   Bulwark = 159,
   DeadlyAim = 25,
@@ -171,6 +172,14 @@ export const CHAMPION_POINT_ABILITIES: Partial<
     name: 'Fighting Finesse',
     tree: ChampionPointTree.Warfare,
     verified: true,
+  },
+  [ChampionPointAbilityId.Backstabber]: {
+    id: ChampionPointAbilityId.Backstabber,
+    name: 'Backstabber',
+    tree: ChampionPointTree.Warfare,
+    // id 31 sourced from DynamicCP convertDataIndices.lua + presetData.lua and cross-checked
+    // against five already-verified repo ids; not screenshot-verified, so `verified` stays false.
+    verified: false,
   },
   [ChampionPointAbilityId.ForceOfNature]: {
     id: ChampionPointAbilityId.ForceOfNature,

--- a/src/utils/CritDamageUtils.test.ts
+++ b/src/utils/CritDamageUtils.test.ts
@@ -24,6 +24,11 @@ import {
   ComputedCriticalDamageSources,
   CriticalDamageComputedSource,
   getCritDamageFromComputedSource,
+  isAlwaysOnSourceActive,
+  getAllCriticalDamageSourcesWithActiveState,
+  AlwaysOnCriticalDamageSources,
+  type CompanionCritEvidence,
+  type CriticalDamageAlwaysOnSource,
 } from './CritDamageUtils';
 
 describe('CritDamageUtils with BuffLookup', () => {
@@ -448,6 +453,110 @@ describe('CritDamageUtils with BuffLookup', () => {
             s.source === 'computed',
         ),
       ).toBe(true);
+    });
+  });
+});
+
+describe('CritDamageUtils — companion crit evidence gating', () => {
+  const alwaysOn = (key: AlwaysOnCriticalDamageSources): CriticalDamageAlwaysOnSource =>
+    CRITICAL_DAMAGE_SOURCES.find(
+      (s): s is CriticalDamageAlwaysOnSource => s.source === 'always_on' && s.key === key,
+    )!;
+  const ff = alwaysOn(AlwaysOnCriticalDamageSources.FIGHTING_FINESSE);
+  const bs = alwaysOn(AlwaysOnCriticalDamageSources.BACKSTABBER);
+  const dex = alwaysOn(AlwaysOnCriticalDamageSources.DEXTERITY);
+  const emptyLookup: BuffLookupData = { buffIntervals: {} };
+  const neither: CompanionCritEvidence = {
+    fightingFinesseSlotted: false,
+    backstabberSlotted: false,
+  };
+  const both: CompanionCritEvidence = { fightingFinesseSlotted: true, backstabberSlotted: true };
+
+  describe('isAlwaysOnSourceActive', () => {
+    it('assumes every always-on source active when there is no evidence', () => {
+      expect(isAlwaysOnSourceActive(ff)).toBe(true);
+      expect(isAlwaysOnSourceActive(bs)).toBe(true);
+      expect(isAlwaysOnSourceActive(dex)).toBe(true);
+    });
+
+    it('gates FF/Backstabber on evidence but never gates Dexterity', () => {
+      expect(isAlwaysOnSourceActive(ff, neither)).toBe(false);
+      expect(isAlwaysOnSourceActive(bs, neither)).toBe(false);
+      expect(isAlwaysOnSourceActive(dex, neither)).toBe(true);
+      expect(isAlwaysOnSourceActive(ff, both)).toBe(true);
+      expect(isAlwaysOnSourceActive(bs, both)).toBe(true);
+    });
+  });
+
+  describe('getCritDamageFromAlwaysOnSource', () => {
+    it('returns the star value with no evidence (byte-identical fallback)', () => {
+      expect(getCritDamageFromAlwaysOnSource(ff, null)).toBe(CriticalDamageValues.FIGHTING_FINESSE);
+      expect(getCritDamageFromAlwaysOnSource(bs, null)).toBe(CriticalDamageValues.BACKSTABBER);
+    });
+
+    it('returns 0 when evidence says the star is not slotted', () => {
+      expect(getCritDamageFromAlwaysOnSource(ff, null, neither)).toBe(0);
+      expect(getCritDamageFromAlwaysOnSource(bs, null, neither)).toBe(0);
+    });
+
+    it('returns the value when evidence says the star is slotted', () => {
+      expect(getCritDamageFromAlwaysOnSource(ff, null, both)).toBe(
+        CriticalDamageValues.FIGHTING_FINESSE,
+      );
+      expect(getCritDamageFromAlwaysOnSource(bs, null, both)).toBe(
+        CriticalDamageValues.BACKSTABBER,
+      );
+    });
+  });
+
+  describe('calculateStaticCriticalDamage', () => {
+    it('drops exactly FF+Backstabber when neither is slotted, vs the no-evidence baseline', () => {
+      const combatant = createMockCombatantInfoEvent({});
+      const baseline = calculateStaticCriticalDamage(combatant);
+      const gated = calculateStaticCriticalDamage(combatant, neither);
+      expect(baseline - gated).toBe(
+        CriticalDamageValues.FIGHTING_FINESSE + CriticalDamageValues.BACKSTABBER,
+      );
+    });
+
+    it('matches the baseline when both stars are slotted', () => {
+      const combatant = createMockCombatantInfoEvent({});
+      expect(calculateStaticCriticalDamage(combatant, both)).toBe(
+        calculateStaticCriticalDamage(combatant),
+      );
+    });
+  });
+
+  describe('getAllCriticalDamageSourcesWithActiveState', () => {
+    it('sets wasActive per evidence while keeping every source present', () => {
+      const combatant = createMockCombatantInfoEvent({});
+      const ev: CompanionCritEvidence = {
+        fightingFinesseSlotted: false,
+        backstabberSlotted: true,
+      };
+      const sources = getAllCriticalDamageSourcesWithActiveState(
+        emptyLookup,
+        emptyLookup,
+        combatant,
+        ev,
+      );
+      const ffOut = sources.find((s) => s.source === 'always_on' && s.name === 'Fighting Finesse')!;
+      const bsOut = sources.find((s) => s.source === 'always_on' && s.name === 'Backstabber')!;
+      expect(ffOut.wasActive).toBe(false);
+      expect(bsOut.wasActive).toBe(true);
+      // The sources remain in the list — they're shown inactive, not removed.
+      expect(sources.filter((s) => s.source === 'always_on')).toHaveLength(3);
+    });
+
+    it('keeps both stars active when there is no evidence (regression guard)', () => {
+      const combatant = createMockCombatantInfoEvent({});
+      const sources = getAllCriticalDamageSourcesWithActiveState(
+        emptyLookup,
+        emptyLookup,
+        combatant,
+      );
+      expect(sources.find((s) => s.name === 'Fighting Finesse')!.wasActive).toBe(true);
+      expect(sources.find((s) => s.name === 'Backstabber')!.wasActive).toBe(true);
     });
   });
 });

--- a/src/utils/CritDamageUtils.ts
+++ b/src/utils/CritDamageUtils.ts
@@ -106,6 +106,38 @@ export interface CriticalDamageAlwaysOnSource extends BaseCriticalDamageSource {
   source: 'always_on';
 }
 
+/**
+ * Per-player evidence from a matched ESOTK Companion snapshot for the two crit-damage
+ * champion stars that emit no event/aura and are otherwise assumed for every player.
+ * `undefined` (no matched snapshot) means "assume active", preserving the pre-companion
+ * behaviour byte-for-byte.
+ */
+export interface CompanionCritEvidence {
+  fightingFinesseSlotted: boolean;
+  backstabberSlotted: boolean;
+}
+
+/**
+ * Whether an always-on crit-damage source is active for a player. Fighting Finesse and
+ * Backstabber are gated on real slotted-CP evidence when a companion snapshot matched;
+ * every other always-on source (Dexterity, gear-derived) stays unconditionally active.
+ * With no evidence, all always-on sources are active — the assume-active default.
+ */
+export function isAlwaysOnSourceActive(
+  source: CriticalDamageAlwaysOnSource,
+  evidence?: CompanionCritEvidence,
+): boolean {
+  if (!evidence) return true;
+  switch (source.key) {
+    case AlwaysOnCriticalDamageSources.FIGHTING_FINESSE:
+      return evidence.fightingFinesseSlotted;
+    case AlwaysOnCriticalDamageSources.BACKSTABBER:
+      return evidence.backstabberSlotted;
+    default:
+      return true;
+  }
+}
+
 export enum ComputedCriticalDamageSources {
   FATED_FORTUNE,
   SUL_XAN_TORMENT,
@@ -359,6 +391,7 @@ export function getEnabledCriticalDamageSources(
   buffLookup: BuffLookupData,
   debuffLookup: BuffLookupData,
   combatantInfo: CombatantInfoEvent | null,
+  evidence?: CompanionCritEvidence,
 ): CriticalDamageSource[] {
   const result = [];
 
@@ -382,7 +415,7 @@ export function getEnabledCriticalDamageSources(
         isActive = isComputedSourceActive(combatantInfo, source, debuffLookup, buffLookup);
         break;
       case 'always_on':
-        isActive = true;
+        isActive = isAlwaysOnSourceActive(source, evidence);
         break;
     }
 
@@ -398,6 +431,7 @@ export function getAllCriticalDamageSourcesWithActiveState(
   buffLookup: BuffLookupData,
   debuffLookup: BuffLookupData,
   combatantInfo: CombatantInfoEvent | null,
+  evidence?: CompanionCritEvidence,
 ): CriticalDamageSourceWithActiveState[] {
   const result: CriticalDamageSourceWithActiveState[] = [];
 
@@ -421,7 +455,7 @@ export function getAllCriticalDamageSourcesWithActiveState(
         wasActive = isComputedSourceActive(combatantInfo, source, debuffLookup, buffLookup);
         break;
       case 'always_on':
-        wasActive = true;
+        wasActive = isAlwaysOnSourceActive(source, evidence);
         break;
     }
 
@@ -440,6 +474,7 @@ export function calculateCriticalDamageAtTimestamp(
   combatantInfo: CombatantInfoEvent,
   playerData: PlayerDetailsWithRole,
   timestamp: number,
+  evidence?: CompanionCritEvidence,
 ): number {
   const baseCriticalDamage = 50; // Base critical damage percentage
 
@@ -498,7 +533,7 @@ export function calculateCriticalDamageAtTimestamp(
         }
         break;
       case 'always_on':
-        alwaysOnCriticalDamage += getCritDamageFromAlwaysOnSource(source, combatantInfo);
+        alwaysOnCriticalDamage += getCritDamageFromAlwaysOnSource(source, combatantInfo, evidence);
         break;
     }
   }
@@ -514,7 +549,10 @@ export function calculateCriticalDamageAtTimestamp(
   );
 }
 
-export function calculateStaticCriticalDamage(combatantInfo: CombatantInfoEvent): number {
+export function calculateStaticCriticalDamage(
+  combatantInfo: CombatantInfoEvent,
+  evidence?: CompanionCritEvidence,
+): number {
   const baseCriticalDamage = 50; // Base critical damage percentage
 
   let gearCriticalDamage = 0;
@@ -538,7 +576,7 @@ export function calculateStaticCriticalDamage(combatantInfo: CombatantInfoEvent)
         }
         break;
       case 'always_on':
-        alwaysOnCriticalDamage += getCritDamageFromAlwaysOnSource(source, combatantInfo);
+        alwaysOnCriticalDamage += getCritDamageFromAlwaysOnSource(source, combatantInfo, evidence);
         break;
     }
   }
@@ -701,7 +739,11 @@ export function getCritDamageFromComputedSource(
 export function getCritDamageFromAlwaysOnSource(
   source: CriticalDamageAlwaysOnSource,
   combatantInfo: CombatantInfoEvent | null,
+  evidence?: CompanionCritEvidence,
 ): number {
+  // Companion evidence can prove Fighting Finesse / Backstabber aren't slotted for this
+  // player; when it does, the star contributes nothing. No evidence => assume active.
+  if (!isAlwaysOnSourceActive(source, evidence)) return 0;
   switch (source.key) {
     case AlwaysOnCriticalDamageSources.DEXTERITY: {
       const medPieces = combatantInfo?.gear?.filter(

--- a/src/workers/calculations/CalculateCriticalDamage.test.ts
+++ b/src/workers/calculations/CalculateCriticalDamage.test.ts
@@ -1,5 +1,5 @@
 import { calculateCriticalDamageData } from './CalculateCriticalDamage';
-import { KnownAbilities } from '../../types/abilities';
+import { CriticalDamageValues, KnownAbilities } from '../../types/abilities';
 import {
   createMockCombatantInfoEvent,
   createMockBuffEvent,
@@ -801,6 +801,71 @@ describe('CalculateCriticalDamage', () => {
 
         // Should have no inactive intervals
         expect(playerData.inactiveCombatIntervals).toHaveLength(0);
+      });
+    });
+
+    describe('companion crit evidence gating', () => {
+      const FF_PLUS_BS = CriticalDamageValues.FIGHTING_FINESSE + CriticalDamageValues.BACKSTABBER;
+
+      const run = (
+        companionCritEvidence?: Record<
+          number,
+          { fightingFinesseSlotted: boolean; backstabberSlotted: boolean }
+        >,
+      ) =>
+        calculateCriticalDamageData({
+          fight: { startTime: FIGHT_START, endTime: FIGHT_END },
+          players: { [PLAYER_ID]: createMockPlayer() },
+          combatantInfoEvents: {
+            [PLAYER_ID]: createMockCombatantInfoEvent({
+              sourceID: PLAYER_ID,
+              timestamp: FIGHT_START,
+            }),
+          },
+          friendlyBuffsLookup: createMockBuffLookupData({}),
+          debuffsLookup: createMockBuffLookupData({}),
+          damageEvents: createMockDamageEvents(),
+          selectedTargetIds: [TARGET_ID],
+          companionCritEvidence,
+        });
+
+      it('lowers static crit damage by FF+Backstabber when neither is slotted', () => {
+        const baseline = run().playerDataMap[PLAYER_ID];
+        const gated = run({
+          [PLAYER_ID]: { fightingFinesseSlotted: false, backstabberSlotted: false },
+        }).playerDataMap[PLAYER_ID];
+
+        expect(baseline.staticCriticalDamage - gated.staticCriticalDamage).toBe(FF_PLUS_BS);
+        // The gate flows into every datapoint.
+        expect(gated.dataPoints[0].criticalDamage).toBe(
+          baseline.dataPoints[0].criticalDamage - FF_PLUS_BS,
+        );
+      });
+
+      it('marks FF/Backstabber sources inactive when not slotted', () => {
+        const gated = run({
+          [PLAYER_ID]: { fightingFinesseSlotted: false, backstabberSlotted: false },
+        }).playerDataMap[PLAYER_ID];
+        const ff = gated.criticalDamageSources.find(
+          (s) => s.source === 'always_on' && s.name === 'Fighting Finesse',
+        )!;
+        const bs = gated.criticalDamageSources.find(
+          (s) => s.source === 'always_on' && s.name === 'Backstabber',
+        )!;
+        expect(ff.wasActive).toBe(false);
+        expect(bs.wasActive).toBe(false);
+      });
+
+      it('is byte-identical to the baseline when evidence is omitted', () => {
+        expect(run()).toEqual(run(undefined));
+      });
+
+      it('leaves a player untouched when evidence is keyed to a different player id', () => {
+        const baseline = run().playerDataMap[PLAYER_ID];
+        const other = run({
+          999: { fightingFinesseSlotted: false, backstabberSlotted: false },
+        }).playerDataMap[PLAYER_ID];
+        expect(other.staticCriticalDamage).toBe(baseline.staticCriticalDamage);
       });
     });
   });

--- a/src/workers/calculations/CalculateCriticalDamage.ts
+++ b/src/workers/calculations/CalculateCriticalDamage.ts
@@ -8,6 +8,7 @@ import { BuffLookupData } from '@/utils/BuffLookupUtils';
 import {
   calculateDynamicCriticalDamageAtTimestamp,
   calculateStaticCriticalDamage,
+  type CompanionCritEvidence,
   CriticalDamageSourceWithActiveState,
   getAllCriticalDamageSourcesWithActiveState,
 } from '@/utils/CritDamageUtils';
@@ -25,6 +26,12 @@ export interface CriticalDamageCalculationTask {
   debuffsLookup: BuffLookupData;
   damageEvents: DamageEvent[];
   selectedTargetIds?: number[];
+  /**
+   * Per-player ESOTK Companion evidence for the assumed crit-damage stars (Fighting
+   * Finesse / Backstabber), keyed by player id. Absent players fall back to assume-active,
+   * so non-companion reports are byte-identical. POJO of booleans — structured-clone safe.
+   */
+  companionCritEvidence?: Record<number, CompanionCritEvidence>;
 }
 
 export interface CriticalDamageDataPoint {
@@ -79,6 +86,7 @@ export function calculateCriticalDamageData(
     debuffsLookup,
     damageEvents,
     selectedTargetIds,
+    companionCritEvidence,
   } = data;
 
   // BuffLookupData is now a POJO, no deserialization needed
@@ -112,15 +120,19 @@ export function calculateCriticalDamageData(
         return null;
       }
 
+      // Companion evidence for the assumed crit stars, if this player matched a snapshot.
+      const critEvidence = companionCritEvidence?.[player.id];
+
       // Get all critical damage sources with active states for this player
       const allSources = getAllCriticalDamageSourcesWithActiveState(
         deserializedFriendlyBuffsLookup,
         deserializedDebuffsLookup,
         combatantInfo,
+        critEvidence,
       );
 
       // Calculate static critical damage for this player
-      const staticCriticalDamage = calculateStaticCriticalDamage(combatantInfo);
+      const staticCriticalDamage = calculateStaticCriticalDamage(combatantInfo, critEvidence);
 
       // Report progress
       onProgress?.((index + 1) / Object.keys(players).length);


### PR DESCRIPTION
Stacked on #1196 (base = its branch; retarget to `main` once #1196 merges).

## What
The `/critical-damage` graph assumed **Fighting Finesse (+8%)** and **Backstabber (+10%)** for *every* player, because those champion stars emit no event or aura and can't be seen in the log. When an ESOTK Companion snapshot matches a player, this reads their real slotted CP and gates the two stars per-player.

## How
- **Evidence** (`esotkCompanionCritEvidence.ts`): resolve the stars per-player from `championPoints.slotted` — Fighting Finesse id 12, Backstabber id 31 (added to `ChampionPointAbilityId`, sourced from DynamicCP data + cross-checked against 5 verified repo ids) — with a captured star-name fallback. Reuses the same matcher + `targetFightId` as the Players-tab companion panel so both agree on which snapshot each actor got.
- **Worker gate** (`CritDamageUtils.ts`, `CalculateCriticalDamage.ts`): `isAlwaysOnSourceActive` gates the four `always_on` branches + `getCritDamageFromAlwaysOnSource`. A not-slotted star contributes 0 and reports inactive; Dexterity (gear-derived) is never gated. **No evidence => assume-active => non-companion reports byte-identical.**
- **Shared store**: lift companion snapshots from `PlayersPanel` local state into a Redux `companion` slice so the crit-damage graph (a separate component tree) can read them; extract `buildMatchableReport` so both build one identical report. The worker cache key folds in the evidence so an upload re-runs the task.
- **Detail-view reconciliation** (`PlayerCriticalDamageDetails.tsx`): the manual FF/Backstabber toggle subtraction now keys off the worker's baked-in `wasActive` (no double-subtract), and toggle defaults seed from evidence (FF on when slotted; Backstabber stays a flanking toggle).

## Verify
`tsc --noEmit`, eslint (`--max-warnings 0`), and the companion + crit-damage jest suites are green. New tests cover the evidence builder, the gate, the cache key, the adjustment math, the slice, the id lock, and **byte-identical fallback guards** when evidence is absent.