### PR TITLE
feat(companion): accept forwarded companion snapshots from the sidecar

### DIFF
--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -60,12 +60,19 @@ interface KalpaAbilityEvidence {
 
 type KalpaScribedSkillEvidence = KalpaAbilityEvidence;
 
+interface KalpaCompanionEvidence {
+  // Raw ESOTK Companion snapshot tables forwarded by Kalpa (each a JSON object mirroring the
+  // Lua snapshot). Persisted opaquely — the frontend normalizes them via esotkCompanionParser.
+  snapshots: Record<string, unknown>[];
+}
+
 interface KalpaBuildEvidence {
   schemaVersion: number;
   extractorVersion?: number | null;
   source: string;
   reportCode: string;
   players: KalpaPlayerBuildEvidence[];
+  companion?: KalpaCompanionEvidence;
 }
 
 interface ReportOwnerResponse {
@@ -197,6 +204,17 @@ function validatePlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | null
   return player;
 }
 
+/** Cap forwarded companion snapshots (the overall payload is already size-bounded). */
+const MAX_COMPANION_SNAPSHOTS = 40;
+
+function validateCompanion(value: unknown): KalpaCompanionEvidence | undefined {
+  if (!isRecord(value) || !Array.isArray(value.snapshots)) return undefined;
+  const snapshots = value.snapshots
+    .filter((snapshot): snapshot is Record<string, unknown> => isRecord(snapshot))
+    .slice(0, MAX_COMPANION_SNAPSHOTS);
+  return snapshots.length > 0 ? { snapshots } : undefined;
+}
+
 function validateEvidence(value: unknown, reportCode: string): KalpaBuildEvidence | null {
   if (!isRecord(value)) return null;
   if (value.schemaVersion !== SCHEMA_VERSION || value.source !== SOURCE) return null;
@@ -216,12 +234,15 @@ function validateEvidence(value: unknown, reportCode: string): KalpaBuildEvidenc
 
   if (players.length === 0) return null;
 
+  const companion = validateCompanion(value.companion);
+
   return {
     schemaVersion: SCHEMA_VERSION,
     extractorVersion: boundedInteger(value.extractorVersion, 1, 10_000),
     source: SOURCE,
     reportCode,
     players,
+    ...(companion ? { companion } : {}),
   };
 }
 

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -1,4 +1,8 @@
-import { isESOTKCompanionFormat, parseESOTKCompanionSavedVariables } from '../esotkCompanionParser';
+import {
+  isESOTKCompanionFormat,
+  normalizeCompanionSnapshots,
+  parseESOTKCompanionSavedVariables,
+} from '../esotkCompanionParser';
 
 const SAMPLE = `
 ESOTKCompanionSV =
@@ -209,5 +213,32 @@ describe('parseESOTKCompanionSavedVariables', () => {
     `;
     // both snapshots are unusable (one lacks ts, one lacks char) → no result
     expect(parseESOTKCompanionSavedVariables(broken)).toBeNull();
+  });
+});
+
+describe('normalizeCompanionSnapshots', () => {
+  it('normalizes raw snapshot tables (e.g. forwarded by Kalpa) into typed snapshots', () => {
+    const raw = [
+      {
+        ts: 1749384000,
+        char: 'Grappa',
+        server: 'NA',
+        cp: { total: 3600, slotted: { '5': 25, '6': 31 } },
+        stats: { physicalPen: 7778 },
+      },
+      { ts: 1749380000, char: 'Grappa' },
+      { nonsense: true }, // no ts/char → dropped
+    ];
+    const snapshots = normalizeCompanionSnapshots(raw);
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0].char).toBe('Grappa');
+    expect(snapshots[0].championPoints?.total).toBe(3600);
+    // Numeric Lua slot keys survive the raw JSON → typed round-trip (Backstabber id 31 in slot 6).
+    expect(snapshots[0].championPoints?.slotted[6]).toBe(31);
+    expect(snapshots[0].stats?.physicalPen).toBe(7778);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(normalizeCompanionSnapshots([])).toEqual([]);
   });
 });

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -355,6 +355,20 @@ export function isESOTKCompanionFormat(luaContent: string): boolean {
 }
 
 /**
+ * Normalize raw companion snapshot tables into typed snapshots. Used for snapshots that
+ * arrive already parsed (e.g. forwarded JSON from Kalpa's build-evidence sidecar) rather than
+ * as a raw Lua file — each entry is the same table shape `normalizeSnapshot` expects.
+ */
+export function normalizeCompanionSnapshots(raw: readonly unknown[]): CompanionSnapshot[] {
+  const out: CompanionSnapshot[] = [];
+  for (const item of raw) {
+    const snapshot = normalizeSnapshot(item as LuaValue);
+    if (snapshot) out.push(snapshot);
+  }
+  return out;
+}
+
+/**
  * Parse an `ESOTKCompanionSV` saved-variables file into typed snapshots.
  * Returns `null` when the file is not an ESOTK Companion save.
  */

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 
 import { useLogger } from '@/contexts/LoggerContext';
 import { buildMatchableReport } from '@/features/loadout-manager/utils/buildMatchableReport';
-import { parseESOTKCompanionSavedVariables } from '@/features/loadout-manager/utils/esotkCompanionParser';
+import {
+  normalizeCompanionSnapshots,
+  parseESOTKCompanionSavedVariables,
+} from '@/features/loadout-manager/utils/esotkCompanionParser';
 import {
   buildCompanionBuildsForReport,
   type CompanionBuildForPlayer,
@@ -324,6 +327,20 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
       cancelled = true;
     };
   }, [reportId]);
+
+  // Kalpa forwards the logger's ESOTK Companion snapshots inside the build-evidence sidecar.
+  // When they arrive, feed them into the shared companion store so the companion panel and the
+  // crit-damage graph pick them up automatically — exactly like a manual file upload. Skip when
+  // snapshots are already loaded (e.g. a manual upload) so we never clobber an explicit choice.
+  React.useEffect(() => {
+    const raw = kalpaBuildEvidence?.companion?.snapshots;
+    if (!raw?.length || companionSnapshots.length > 0) return;
+    const snapshots = normalizeCompanionSnapshots(raw);
+    if (snapshots.length > 0) {
+      dispatch(companionSnapshotsUploaded({ snapshots, snapshotCount: snapshots.length }));
+    }
+  }, [kalpaBuildEvidence, companionSnapshots.length, dispatch]);
+
   const { combatantInfoEvents, isCombatantInfoEventsLoading } = useCombatantInfoEvents({
     context: resolvedContext,
   });

--- a/src/utils/kalpaBuildEvidence.test.ts
+++ b/src/utils/kalpaBuildEvidence.test.ts
@@ -149,6 +149,18 @@ describe('kalpaBuildEvidence', () => {
     );
   });
 
+  it('passes an ESOTK Companion block through validation', () => {
+    const withCompanion = {
+      ...evidence,
+      companion: {
+        snapshots: [{ ts: 1749384000, char: 'Casts-A-Lot', cp: { total: 3600 } }],
+      },
+    };
+    const decoded = decodeKalpaBuildEvidenceParam(encodeEvidence(withCompanion));
+    expect(decoded?.companion?.snapshots).toHaveLength(1);
+    expect(decoded?.companion?.snapshots?.[0]).toMatchObject({ char: 'Casts-A-Lot' });
+  });
+
   it('persists matching report evidence in session storage and reloads it without the URL param', () => {
     const encoded = encodeEvidence(evidence);
     const first = loadKalpaBuildEvidenceForReport('REPORT123', {

--- a/src/utils/kalpaBuildEvidence.ts
+++ b/src/utils/kalpaBuildEvidence.ts
@@ -60,12 +60,18 @@ export interface KalpaScribedSkillEvidence {
   affixScript?: string | null;
 }
 
+/** ESOTK Companion snapshots forwarded by Kalpa (raw tables the companion parser normalizes). */
+export interface KalpaCompanionEvidence {
+  snapshots: Array<Record<string, unknown>>;
+}
+
 export interface KalpaBuildEvidence {
   schemaVersion: number;
   extractorVersion?: number | null;
   source: string;
   reportCode?: string | null;
   players: KalpaPlayerBuildEvidence[];
+  companion?: KalpaCompanionEvidence;
 }
 
 export interface KalpaAnonymousMatchSignals {
@@ -408,7 +414,16 @@ function validateKalpaBuildEvidence(value: unknown): KalpaBuildEvidence | undefi
     source: KALPA_BUILD_EVIDENCE_SOURCE,
     reportCode: typeof value.reportCode === 'string' ? value.reportCode : undefined,
     players,
+    companion: validateCompanionEvidence(value.companion),
   };
+}
+
+function validateCompanionEvidence(value: unknown): KalpaCompanionEvidence | undefined {
+  if (!isRecord(value) || !Array.isArray(value.snapshots)) return undefined;
+  const snapshots = value.snapshots.filter((snapshot): snapshot is Record<string, unknown> =>
+    isRecord(snapshot),
+  );
+  return snapshots.length > 0 ? { snapshots } : undefined;
 }
 
 function validateKalpaPlayerEvidence(value: unknown): KalpaPlayerBuildEvidence | undefined {


### PR DESCRIPTION
Consumer side of the Kalpa auto-forward (Kalpa PR ESO-Toolkit/kalpa#237). Kalpa now attaches the logging player's ESOTK Companion snapshots to the build-evidence sidecar; this accepts and surfaces them so the companion panel + the `/critical-damage` graph light up automatically — no manual file upload.

## Changes
- **Worker** (`roster-hub-api/src/report-build-evidence.ts`): validate + persist the additive `companion` block. Both the worker and the client rebuild evidence from an allowlist, so the field was silently dropped before. **schemaVersion stays 1** (additive), so this can't affect existing sidecars.
- **Client validator** (`kalpaBuildEvidence.ts`): pass the `companion` block through.
- **Normalizer** (`esotkCompanionParser.ts` `normalizeCompanionSnapshots`): turn the raw forwarded snapshot tables into typed `CompanionSnapshot[]` via the existing parser — no Lua re-parse.
- **Consumption** (`PlayersPanel.tsx`): when the sidecar carries companion snapshots, dispatch them into the shared companion store (added in #1378), skipping when a manual upload is already loaded so an explicit choice is never clobbered. That single dispatch feeds both the companion panel and the crit-damage graph.

## Verify
Frontend `tsc --noEmit` + worker `tsc --noEmit` clean; eslint (`--max-warnings 0`) + prettier clean; companion/kalpaBuildEvidence/PlayersPanel jest suites green (new tests: `normalizeCompanionSnapshots` round-trip and the client companion passthrough).

## ⚠️ Deploy note
The `roster-hub-api` worker change needs a **manual worker deploy** to take effect (Actions → "Deploy Cloudflare Worker" → `roster-hub-api`; NOT kalpa-pack-hub). The frontend deploys via GitHub Pages on merge. Until the worker is deployed it drops the `companion` field, so the end-to-end feature is gated on that deploy.