### PR TITLE
feat(companion): surface matched-build provenance + fix tie-break

### DIFF
--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionMatcher.test.ts
@@ -55,6 +55,22 @@ describe('matchCompanionSnapshots', () => {
     expect(matches.get(1)?.snapshot).toBe(near);
   });
 
+  it('prefers a combat-end capture over a manual one at equal distance', () => {
+    // Both inside f1's window (distance 0). The manual snapshot is newer, but a combat-end
+    // capture is the canonical end-of-fight build and should win the tie despite being older.
+    const combatEnd = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', reason: 'combatEnd' });
+    const manual = snap({ ts: REPORT_START_S + 120, char: 'Casts-A-Lot', reason: 'manual' });
+    const { matches } = matchCompanionSnapshots([manual, combatEnd], report);
+    expect(matches.get(1)?.snapshot).toBe(combatEnd);
+  });
+
+  it('falls back to the newer snapshot when reason and distance both tie', () => {
+    const older = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', reason: 'combatEnd' });
+    const newer = snap({ ts: REPORT_START_S + 120, char: 'Casts-A-Lot', reason: 'combatEnd' });
+    const { matches } = matchCompanionSnapshots([older, newer], report);
+    expect(matches.get(1)?.snapshot).toBe(newer);
+  });
+
   it('rejects a provable region conflict (EU Megaserver ↔ PC-NA)', () => {
     const s = snap({ ts: REPORT_START_S + 60, char: 'Casts-A-Lot', server: 'EU Megaserver' });
     const { matches, unmatched } = matchCompanionSnapshots([s], report);

--- a/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionMatcher.ts
@@ -107,6 +107,32 @@ function snapshotMs(snapshot: CompanionSnapshot): number {
   return snapshot.ts * 1000;
 }
 
+/**
+ * Rank a snapshot's capture reason for tie-breaking. A combat-end capture is the canonical
+ * end-of-fight build; a manual `/esotk` snapshot may have been taken mid-adjustment, so it
+ * only wins a tie when no combat-end capture is equally close.
+ */
+function reasonRank(snapshot: CompanionSnapshot): number {
+  return snapshot.reason === 'combatEnd' ? 1 : 0;
+}
+
+/**
+ * Whether a candidate snapshot is a better match for an actor than the current best. Prefer
+ * the smaller time distance; on a distance tie prefer a combat-end capture over a manual one;
+ * on a further tie prefer the newer snapshot.
+ */
+function isPreferredMatch(
+  candidateSnapshot: CompanionSnapshot,
+  candidateDistanceMs: number,
+  best: CompanionMatch,
+): boolean {
+  if (candidateDistanceMs !== best.distanceMs) return candidateDistanceMs < best.distanceMs;
+  const candidateReason = reasonRank(candidateSnapshot);
+  const bestReason = reasonRank(best.snapshot);
+  if (candidateReason !== bestReason) return candidateReason > bestReason;
+  return snapshotMs(candidateSnapshot) > snapshotMs(best.snapshot);
+}
+
 function withinWindow(tsMs: number, start: number, end: number): boolean {
   return tsMs >= start - WINDOW_SLOP_MS && tsMs <= end + WINDOW_SLOP_MS;
 }
@@ -205,11 +231,7 @@ export function matchCompanionSnapshots(
       const candidate = candidateDistance(tsMs, report, snapshot, opts);
       if (!candidate) continue;
 
-      if (
-        !best ||
-        candidate.distanceMs < best.distanceMs ||
-        (candidate.distanceMs === best.distanceMs && tsMs > snapshotMs(best.snapshot))
-      ) {
+      if (!best || isPreferredMatch(snapshot, candidate.distanceMs, best)) {
         best = {
           actor,
           snapshot,

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -39,6 +39,12 @@ export interface CompanionBuildForPlayer {
   snapshot: CompanionSnapshot;
   /** The fight the snapshot best matched, if any. */
   fightId?: number | string;
+  /**
+   * How far (ms) the matched snapshot sits outside the report/fight window — 0 when the
+   * capture is inside it. A large value means the build was borrowed from an adjacent pull,
+   * so the UI can flag it as approximate ("nearest capture, N min away").
+   */
+  distanceMs: number;
 }
 
 export interface BuildCompanionBuildsOptions {
@@ -70,6 +76,7 @@ export function buildCompanionBuildsForReport(
       scribing: match.snapshot.scribing,
       snapshot: match.snapshot,
       fightId: match.fightId,
+      distanceMs: match.distanceMs,
     });
   }
   return out;

--- a/src/features/report_details/insights/CompanionBuildPanel.tsx
+++ b/src/features/report_details/insights/CompanionBuildPanel.tsx
@@ -43,7 +43,15 @@ export interface CompanionBuildPanelProps {
   effects?: CompanionEffect[];
   /** Scribed skills captured directly from the add-on action bar snapshot. */
   scribing?: CompanionScribedSkill[];
+  /**
+   * How far (ms) the matched capture sits outside this fight's window. When it's more than a
+   * minute away the build was borrowed from an adjacent pull, so we flag it as approximate.
+   */
+  distanceMs?: number;
 }
+
+/** Only badge a borrowed build once the capture is at least this far from the fight window. */
+const BORROWED_BUILD_THRESHOLD_MS = 60_000;
 
 const SECTION_TITLE_SX = {
   fontWeight: 'bold',
@@ -248,6 +256,7 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
   stats,
   effects,
   scribing,
+  distanceMs,
 }) => {
   const theme = useTheme();
   const rows = React.useMemo(() => statRows(stats), [stats]);
@@ -269,8 +278,28 @@ export const CompanionBuildPanel: React.FC<CompanionBuildPanelProps> = ({
   const hasScribing = capturedScribing.length > 0;
   if (!hasCp && !hasCoaching && !hasStats && !hasConsumables && !hasScribing) return null;
 
+  // When no capture landed inside this fight's window, the build was borrowed from the
+  // nearest adjacent pull — flag it so it isn't read as the exact build used in this fight.
+  const borrowedMinutes =
+    distanceMs && distanceMs >= BORROWED_BUILD_THRESHOLD_MS ? Math.round(distanceMs / 60_000) : 0;
+
   return (
     <Box sx={{ mt: 1 }} data-testid="companion-build-panel">
+      {borrowedMinutes > 0 && (
+        <Tooltip
+          title={`No ESOTK Companion capture landed inside this fight — showing the nearest snapshot, about ${borrowedMinutes} min away. It may not reflect the build used in this fight.`}
+          placement="top-start"
+        >
+          <Chip
+            size="small"
+            variant="outlined"
+            color="warning"
+            icon={<WarningIcon />}
+            label={`Nearest capture · ${borrowedMinutes} min away`}
+            sx={{ mb: 1, '& .MuiChip-label': { fontSize: '0.58rem' } }}
+          />
+        </Tooltip>
+      )}
       {hasCp && championPoints && (
         <Box sx={{ mb: hasConsumables || hasScribing || hasStats || hasCoaching ? 2 : 0 }}>
           <Typography variant="body2" sx={SECTION_TITLE_SX}>

--- a/src/features/report_details/insights/LazyPlayerCard.tsx
+++ b/src/features/report_details/insights/LazyPlayerCard.tsx
@@ -74,7 +74,7 @@ export interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
   >;
   /** Test ID for testing */
   'data-testid'?: string;

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -211,7 +211,7 @@ interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
   >;
 }
 
@@ -2184,6 +2184,7 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                       stats={companionBuild.stats}
                       effects={companionBuild.effects}
                       scribing={companionBuild.scribing}
+                      distanceMs={companionBuild.distanceMs}
                     />
                   )}
                 </Box>

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -256,7 +256,7 @@ export function classAnalysisFromKalpaEvidence(
 
 type CompanionBuildRenderProps = Pick<
   CompanionBuildForPlayer,
-  'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'
+  'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
 >;
 
 interface PlayersPanelProps {
@@ -412,6 +412,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         stats: build.stats,
         effects: build.effects,
         scribing: build.scribing,
+        distanceMs: build.distanceMs,
       };
     });
     return byPlayer;

--- a/src/features/report_details/insights/PlayersPanelView.tsx
+++ b/src/features/report_details/insights/PlayersPanelView.tsx
@@ -88,7 +88,10 @@ interface PlayersPanelViewProps {
   /** Per-player companion build data parsed from an uploaded ESOTKCompanion SavedVariables file */
   companionBuildsByPlayer?: Record<
     string,
-    Pick<CompanionBuildForPlayer, 'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing'>
+    Pick<
+      CompanionBuildForPlayer,
+      'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
+    >
   >;
   /** Current companion upload status for the toolbar chip */
   companionUpload?: {

--- a/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
+++ b/src/features/report_details/insights/__tests__/CompanionBuildPanel.test.tsx
@@ -120,4 +120,16 @@ describe('CompanionBuildPanel', () => {
     expect(screen.getByText('Physical Pen: 12,345')).toBeInTheDocument();
     expect(screen.queryByText('Stable')).toBeNull();
   });
+
+  it('flags a build borrowed from an adjacent pull', () => {
+    render(
+      <CompanionBuildPanel championPoints={cpViewModel} coaching={[]} distanceMs={5 * 60 * 1000} />,
+    );
+    expect(screen.getByText(/Nearest capture · 5 min away/)).toBeInTheDocument();
+  });
+
+  it('does not flag a build captured inside the fight window', () => {
+    render(<CompanionBuildPanel championPoints={cpViewModel} coaching={[]} distanceMs={0} />);
+    expect(screen.queryByText(/Nearest capture/)).toBeNull();
+  });
 });


### PR DESCRIPTION
Phase E of the ESOTK Companion work — matcher provenance. Makes it clear when a player's companion build was **borrowed from an adjacent pull** rather than captured in the shown fight, and picks the more trustworthy snapshot on ties.

## Changes
- **Matcher tie-break** (`esotkCompanionMatcher.ts`): on an equal time-distance tie, prefer a **combat-end** capture (the canonical end-of-fight build) over a manual `/esotk` snapshot, then the newer snapshot. Previously only newer-wins.
- **Carry `distanceMs`** (`esotkCompanionReportAdapter.ts`): the matched snapshot's distance-from-window was computed then discarded; it now flows through into the per-player render props.
- **Borrowed-build badge** (`CompanionBuildPanel.tsx`, threaded via PlayerCard/LazyPlayerCard/PlayersPanel[View]): when the nearest capture is more than a minute outside the fight window, show `Nearest capture · N min away` with a tooltip so it isn't read as the exact build used in that fight.

## Verify
`tsc --noEmit` + eslint (`--max-warnings 0`) + prettier clean; 38 tests across the matcher/panel/adapter/view/parser suites green (new: two tie-break tests + two badge tests).

## Not included (documented follow-ups from the handoff's Phase E)
Fight-relative `WINDOW_SLOP_MS` (needs neighbor-fight-gap awareness), the "All fights" report-scope label, and making the addon's 200-snapshot ring per-character (a change to the live-validated addon) — each is separable and lower-value; happy to follow up.