### PR TITLE
fix(companion-addon): decouple SavedVars storage version from parse-schema

### DIFF
--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -24,7 +24,13 @@
 
 local ADDON = {
   name = "ESOTKCompanion",
-  schemaVersion = 1,
+  schemaVersion = 1,       -- payload parse-schema (ESOTK reads this); may bump across seasons
+  -- ZO_SavedVars storage version. PINNED to 1 forever and DECOUPLED from schemaVersion above:
+  -- bumping the NewAccountWide version arg makes ZO_SavedVars DESTROY every stored snapshot, so
+  -- a schema bump must never ride it. The payload's own schemaVersion carries the parse-schema
+  -- instead, so it can change without wiping users' captured builds. Only ever bump this if a
+  -- deliberate, one-time wipe of all stored snapshots is actually intended.
+  savedVarsVersion = 1,
   season = "U50",          -- bump per ESO season; ESOTK uses this to pick the right caps/data
   maxSnapshots = 200,      -- ring buffer; oldest dropped beyond this
   snapshotMode = "combatEnd",
@@ -338,7 +344,9 @@ local function OnAddOnLoaded(_, addonName)
   if addonName ~= ADDON.name then return end
   EVENT_MANAGER:UnregisterForEvent(ADDON.name, EVENT_ADD_ON_LOADED)
 
-  SV = ZO_SavedVars:NewAccountWide("ESOTKCompanionSV", ADDON.schemaVersion, nil, {
+  -- Storage version is the pinned savedVarsVersion (NOT schemaVersion) so a parse-schema bump
+  -- never triggers ZO_SavedVars' destroy-on-version-change and wipes stored snapshots.
+  SV = ZO_SavedVars:NewAccountWide("ESOTKCompanionSV", ADDON.savedVarsVersion, nil, {
     schemaVersion = ADDON.schemaVersion,
     season        = ADDON.season,
     enabled       = true,


### PR DESCRIPTION
Phase G prerequisite — the handoff's "**First** decouple the addon's `schemaVersion` from the `ZO_SavedVars` destroy-gate" before publishing to ESOUI.

## Why
`ZO_SavedVars:NewAccountWide(name, VERSION, ...)` **destroys all stored data** whenever `VERSION` changes. The addon was passing `ADDON.schemaVersion` there, so any future parse-schema bump would wipe every user's captured snapshots.

## Change
Introduce a separate `ADDON.savedVarsVersion` pinned to `1` (the storage/destroy-gate version) and pass **that** to `NewAccountWide`. `schemaVersion` stays the payload parse-schema (what ESOTK reads) and can now evolve across seasons without wiping data. **No-op today** — both values are `1`, so current behavior is byte-identical; it only changes future-bump semantics.

## Note
This is the code prerequisite for Phase G. The actual ESOUI publish (uploading the addon to esoui.com) is an external action that needs an ESOUI account — handed to you.