### PR TITLE
fix(latest-reports): never list empty logs & untangle empty/error report states

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,5 +1,14 @@
 export const DATA_FETCH_CACHE_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 
+/**
+ * Freshness window for a cached report whose fights came back EMPTY. An empty
+ * report is usually a just-uploaded log that ESO Logs is still parsing — it
+ * heals upstream within minutes — so pinning it for the full
+ * DATA_FETCH_CACHE_TIMEOUT keeps showing "Empty Log" long after the data
+ * exists. Keep it just long enough to debounce rapid remounts.
+ */
+export const EMPTY_REPORT_CACHE_TIMEOUT = 15 * 1000; // 15 seconds
+
 export const ERROR_TRACKING_TOKEN =
   '9eba53324bf5455db004638013efbb9064b4c8a84f605a7b0fc53cd482f4f2e2961c75a7d9d1a4a615b0536f861d8ab3';
 

--- a/src/features/latest_reports/LatestReports.tsx
+++ b/src/features/latest_reports/LatestReports.tsx
@@ -59,13 +59,14 @@ export const LatestReports: React.FC = () => {
   const { viewMode, density, setViewMode, setDensity } = useReportViewPrefs();
   const { zones } = useZoneOptions();
 
-  const { reports, hiddenEmptyCount, loading, error, pagination, refetch } = useLatestReportsQuery({
-    page: filters.page,
-    zoneId: filters.zoneId,
-    range: filters.range,
-    customFrom: filters.customFrom,
-    customTo: filters.customTo,
-  });
+  const { reports, hiddenEmptyCount, hiddenRecentCount, loading, error, pagination, refetch } =
+    useLatestReportsQuery({
+      page: filters.page,
+      zoneId: filters.zoneId,
+      range: filters.range,
+      customFrom: filters.customFrom,
+      customTo: filters.customTo,
+    });
 
   const { filtered, visibleCount, loadedCount, appliedQuery, isDebouncing } = useFilteredReports(
     reports,
@@ -137,6 +138,14 @@ export const LatestReports: React.FC = () => {
         visibleCount === 0
           ? `No reports match "${appliedQuery.trim()}". Try clearing the search or adjusting Zone and Date filters.`
           : `Showing ${visibleCount} of ${loadedCount} loaded reports.`;
+    } else if (loadedCount === 0 && hiddenEmptyCount > 0) {
+      const subject = hiddenEmptyCount === 1 ? 'The only log' : `All ${hiddenEmptyCount} logs`;
+      const verb =
+        hiddenEmptyCount === 1 ? 'has no combat data and was' : 'have no combat data and were';
+      message =
+        hiddenRecentCount > 0
+          ? `${subject} on page ${pagination.currentPage} ${verb} hidden. These logs are still processing — refresh to check again, or browse another page.`
+          : `${subject} on page ${pagination.currentPage} ${verb} hidden. These older logs never parsed — try another page or different filters.`;
     } else {
       message = `Showing ${loadedCount} reports on page ${pagination.currentPage} of ${pagination.totalPages}.`;
     }
@@ -147,18 +156,24 @@ export const LatestReports: React.FC = () => {
     appliedQuery,
     visibleCount,
     loadedCount,
+    hiddenEmptyCount,
+    hiddenRecentCount,
     pagination.currentPage,
     pagination.totalPages,
   ]);
 
   const emptyStateInput: EmptyStateInput = useMemo(
-    () => ({ serverFilterActive, searchActive, loadedCount, hiddenEmptyCount }),
-    [serverFilterActive, searchActive, loadedCount, hiddenEmptyCount],
+    () => ({ serverFilterActive, searchActive, loadedCount, hiddenEmptyCount, hiddenRecentCount }),
+    [serverFilterActive, searchActive, loadedCount, hiddenEmptyCount, hiddenRecentCount],
   );
 
   const showResults = filtered.length > 0;
-  const showEmptyState = !loading && filtered.length === 0;
-  const showInitialSkeleton = loading && reports.length === 0;
+  const showEmptyState = filtered.length === 0 && (!loading || hiddenEmptyCount > 0);
+  // Skeleton only when we know nothing about the page yet. An all-hidden page
+  // being refreshed keeps its empty state mounted instead: swapping it for a
+  // skeleton would unmount the Refresh button mid-click and drop keyboard focus
+  // to <body>; the corner "Refreshing…" pill provides the progress feedback.
+  const showInitialSkeleton = loading && reports.length === 0 && hiddenEmptyCount === 0;
 
   // --- Render -----------------------------------------------------------------
 
@@ -293,12 +308,14 @@ export const LatestReports: React.FC = () => {
                 query={appliedQuery}
                 onClearSearch={() => setFilters({ q: '' })}
                 onClearFilters={clearServerFilters}
+                onRefresh={refetch}
               />
             ) : null}
 
             {/* Re-fetch indicator — a non-blocking corner pill so prior results
-                stay fully interactive (scroll/click) while new data loads. */}
-            {loading && reports.length > 0 && (
+                (or the all-hidden empty state) stay fully interactive while new
+                data loads. */}
+            {loading && (reports.length > 0 || hiddenEmptyCount > 0) && (
               <Box
                 sx={{
                   position: 'absolute',

--- a/src/features/latest_reports/components/ReportsEmptyState.test.ts
+++ b/src/features/latest_reports/components/ReportsEmptyState.test.ts
@@ -45,6 +45,20 @@ describe('selectEmptyStateKind', () => {
     ).toBe('cold-empty');
   });
 
+  it('prioritizes all-hidden over filter-no-results when rows came back but were all empty', () => {
+    // A zone/date filter is active AND the page's rows were all empty logs:
+    // "no reports match your filters" would be wrong — reports DID match, they
+    // just have no combat data yet.
+    expect(
+      selectEmptyStateKind({
+        serverFilterActive: true,
+        searchActive: false,
+        loadedCount: 0,
+        hiddenEmptyCount: 25,
+      }),
+    ).toBe('all-hidden');
+  });
+
   it('prioritizes search-no-match over filter-no-results when both could apply', () => {
     // Server filter active AND search active AND rows present-but-filtered-out:
     // the user's most recent action (typing) should drive the message.

--- a/src/features/latest_reports/components/ReportsEmptyState.tsx
+++ b/src/features/latest_reports/components/ReportsEmptyState.tsx
@@ -20,19 +20,26 @@ export interface EmptyStateInput {
   loadedCount: number;
   /** Reports hidden on this page for having no combat data. */
   hiddenEmptyCount: number;
+  /**
+   * How many hidden empties are recent uploads plausibly still parsing on
+   * ESO Logs. When zero, the all-hidden copy must not promise that refreshing
+   * in a few minutes will surface them — old empties are permanent parse
+   * failures that never heal.
+   */
+  hiddenRecentCount?: number;
 }
 
 export function selectEmptyStateKind(input: EmptyStateInput): EmptyStateKind {
   const { serverFilterActive, searchActive, loadedCount, hiddenEmptyCount } = input;
   // The server returned rows but the client text query filtered them all out.
   if (searchActive && loadedCount > 0) return 'search-no-match';
+  // Every row on this page was an empty (no-combat) log, hidden by
+  // `useLatestReportsQuery` (empty logs open to "No fights available", so the
+  // list never shows them). This must win over `filter-no-results`: rows DID
+  // come back for the active filters — they just have no combat data yet.
+  if (loadedCount === 0 && hiddenEmptyCount > 0) return 'all-hidden';
   // The server returned nothing for the active zone/date filter.
   if (serverFilterActive && loadedCount === 0) return 'filter-no-results';
-  // Every row on this page was an empty (no-combat) log. Kept as defense-in-depth:
-  // `useLatestReportsQuery` now fails open (`selectReportsForDisplay`) and shows
-  // the reports instead of hiding the whole page, so this branch is no longer
-  // reachable from that surface — do NOT "simplify" the hook to re-arm the wall.
-  if (loadedCount === 0 && hiddenEmptyCount > 0) return 'all-hidden';
   return 'cold-empty';
 }
 
@@ -41,6 +48,8 @@ interface ReportsEmptyStateProps {
   query: string;
   onClearSearch: () => void;
   onClearFilters: () => void;
+  /** Revalidates the list from the network (the `all-hidden` recovery action). */
+  onRefresh?: () => void;
 }
 
 export const ReportsEmptyState: React.FC<ReportsEmptyStateProps> = ({
@@ -48,6 +57,7 @@ export const ReportsEmptyState: React.FC<ReportsEmptyStateProps> = ({
   query,
   onClearSearch,
   onClearFilters,
+  onRefresh,
 }) => {
   const kind = selectEmptyStateKind(input);
 
@@ -72,11 +82,30 @@ export const ReportsEmptyState: React.FC<ReportsEmptyStateProps> = ({
       body: 'No combat logs were found for the selected zone and date range. Try widening the date range or choosing a different zone.',
       action: { label: 'Clear filters', onClick: onClearFilters },
     },
-    'all-hidden': {
-      icon: <VisibilityOffIcon fontSize="large" color="action" />,
-      title: 'Every report on this page is empty',
-      body: 'All logs on this page contain no combat data, so they were hidden. Try another page.',
-    },
+    'all-hidden':
+      (input.hiddenRecentCount ?? 0) > 0
+        ? {
+            icon: <VisibilityOffIcon fontSize="large" color="action" />,
+            title:
+              input.hiddenEmptyCount === 1
+                ? 'The only log on this page has no combat data yet'
+                : `All ${input.hiddenEmptyCount} logs on this page have no combat data yet`,
+            body: 'They were hidden because opening one would only show an empty report. Just-uploaded logs usually finish processing on ESO Logs within a few minutes — refresh to check again, or browse another page.',
+            action: onRefresh ? { label: 'Refresh', onClick: onRefresh } : undefined,
+          }
+        : {
+            icon: <VisibilityOffIcon fontSize="large" color="action" />,
+            title:
+              input.hiddenEmptyCount === 1
+                ? 'The only log on this page contains no combat data'
+                : `None of the ${input.hiddenEmptyCount} logs on this page contain combat data`,
+            // These are old uploads whose fights never parsed — refreshing
+            // cannot surface them, so offer a real way out instead.
+            body: 'They were hidden because opening one would only show an empty report. These are older uploads whose combat data never parsed on ESO Logs, so refreshing will not change them — try another page or different filters.',
+            action: input.serverFilterActive
+              ? { label: 'Clear filters', onClick: onClearFilters }
+              : undefined,
+          },
     'cold-empty': {
       icon: <InboxIcon fontSize="large" color="action" />,
       title: 'No reports found',

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.test.tsx
@@ -122,7 +122,10 @@ describe('useLatestReportsQuery', () => {
     expect(result.current.hiddenEmptyCount).toBe(1);
   });
 
-  it('fails open and shows them all when the whole page is empty (never a dead-end wall)', async () => {
+  it('hides the whole page when every log is empty, reporting the hidden count', async () => {
+    // No fail-open: empty logs open to "No fights available", so an all-empty
+    // page renders the list's `all-hidden` state (driven by hiddenEmptyCount)
+    // instead of a page of dead links.
     primeClient({
       network: [pageResult([makeReport('E1', { empty: true }), makeReport('E2', { empty: true })])],
     });
@@ -130,13 +133,33 @@ describe('useLatestReportsQuery', () => {
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.reports.map((r) => r.code)).toEqual(['E1', 'E2']);
-    expect(result.current.hiddenEmptyCount).toBe(0);
+    expect(result.current.reports).toEqual([]);
+    expect(result.current.hiddenEmptyCount).toBe(2);
+    // START is years old, so none of these hidden empties can still be parsing
+    // — the empty state must not promise a quick self-heal.
+    expect(result.current.hiddenRecentCount).toBe(0);
+  });
+
+  it('counts hidden empties that are recent enough to still be parsing', async () => {
+    const recentEmpty = {
+      ...makeReport('FRESH-EMPTY', { empty: true }),
+      startTime: Date.now() - 10 * 60 * 1000,
+      endTime: Date.now() - 10 * 60 * 1000, // ended 10 min ago → plausibly processing
+    };
+    primeClient({
+      network: [pageResult([recentEmpty as ReturnType<typeof makeReport>])],
+    });
+
+    const { result } = renderHook(() => useLatestReportsQuery(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.hiddenEmptyCount).toBe(1);
+    expect(result.current.hiddenRecentCount).toBe(1);
   });
 
   it('refetch (explicit Refresh) revalidates network-only and skips the cache peek', async () => {
     primeClient({
-      // Mount: cold cache, network shows the still-processing page (fail-open).
+      // Mount: cold cache, network shows a still-processing (hidden) page.
       network: [
         pageResult([makeReport('PENDING', { empty: true })]),
         // Refresh: the log has since healed upstream.
@@ -146,7 +169,9 @@ describe('useLatestReportsQuery', () => {
 
     const { result } = renderHook(() => useLatestReportsQuery(baseInput));
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.reports.map((r) => r.code)).toEqual(['PENDING']);
+    // The still-processing log is hidden; its count drives the all-hidden state.
+    expect(result.current.reports).toEqual([]);
+    expect(result.current.hiddenEmptyCount).toBe(1);
     // Mount = cache peek + network revalidate.
     expect(fetchPolicies()).toEqual(['cache-only', 'network-only']);
 

--- a/src/features/latest_reports/hooks/useLatestReportsQuery.ts
+++ b/src/features/latest_reports/hooks/useLatestReportsQuery.ts
@@ -7,7 +7,11 @@ import {
   GetLatestReportsQueryVariables,
   UserReportSummaryFragment,
 } from '../../../graphql/gql/graphql';
-import { selectReportsForDisplay } from '../../reports/reportFormatting';
+import {
+  isRecentlyUploaded,
+  isReportEmpty,
+  partitionReportsByData,
+} from '../../reports/reportFormatting';
 
 import { rangeToEpochMs, type DateRangePreset } from './rangeToEpochMs';
 
@@ -28,6 +32,13 @@ export interface LatestReportsQueryState {
   reports: UserReportSummaryFragment[];
   /** Count of reports on the current page hidden for having no combat data. */
   hiddenEmptyCount: number;
+  /**
+   * How many of the hidden empties ended recently enough to still be parsing
+   * on ESO Logs (see isRecentlyUploaded). Lets the all-hidden empty state say
+   * "still processing — refresh in a few minutes" only when that is actually
+   * plausible, instead of promising it for months-old permanently-broken logs.
+   */
+  hiddenRecentCount: number;
   loading: boolean;
   error: string | null;
   pagination: LatestReportsPagination;
@@ -49,6 +60,15 @@ const INITIAL_PAGINATION: LatestReportsPagination = {
   hasMorePages: false,
   from: null,
   to: null,
+};
+
+const INITIAL_STATE: LatestReportsQueryState = {
+  reports: [],
+  hiddenEmptyCount: 0,
+  hiddenRecentCount: 0,
+  loading: true,
+  error: null,
+  pagination: INITIAL_PAGINATION,
 };
 
 function buildVariables(input: LatestReportsQueryInput): GetLatestReportsQueryVariables {
@@ -75,13 +95,7 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
   refetch: () => void;
 } {
   const client = useEsoLogsClientInstance();
-  const [state, setState] = useState<LatestReportsQueryState>({
-    reports: [],
-    hiddenEmptyCount: 0,
-    loading: true,
-    error: null,
-    pagination: INITIAL_PAGINATION,
-  });
+  const [state, setState] = useState<LatestReportsQueryState>(INITIAL_STATE);
 
   const { page, zoneId, range, customFrom, customTo } = input;
 
@@ -105,11 +119,20 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
       const fetched = (reportPagination.data ?? []).filter(
         (report): report is NonNullable<typeof report> => report !== null,
       );
-      // Hide empty (no-combat) logs, but never the whole page: if every report
-      // the server returned would be hidden — e.g. a busy upload window where the
-      // freshest page is dominated by still-parsing logs — fail open and show
-      // them all so the user is never stranded on an "every report is empty" wall.
-      const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(fetched);
+      // Hide every empty (no-combat) log — they open to "No fights available",
+      // so listing them is listing dead links. When that hides the whole page
+      // (a busy upload window where the freshest page is dominated by
+      // still-parsing logs), the list renders its `all-hidden` state, which
+      // explains the logs are still processing and offers a refresh; empties
+      // self-heal upstream within minutes.
+      const { reportsWithData: reportsToShow, emptyCount: hiddenEmptyCount } =
+        partitionReportsByData(fetched);
+      // Of the hidden empties, how many are recent enough to plausibly still be
+      // parsing? Drives whether the all-hidden state promises a quick self-heal.
+      const hiddenRecentCount =
+        hiddenEmptyCount === 0
+          ? 0
+          : fetched.filter((report) => isReportEmpty(report) && isRecentlyUploaded(report)).length;
 
       const currentPage = reportPagination.current_page || 1;
       const lastPage = reportPagination.last_page;
@@ -119,6 +142,7 @@ export function useLatestReportsQuery(input: LatestReportsQueryInput): LatestRep
       setState({
         reports: reportsToShow,
         hiddenEmptyCount,
+        hiddenRecentCount,
         loading,
         error: null,
         pagination: {

--- a/src/features/report_details/ReportFights.autoRecheck.test.tsx
+++ b/src/features/report_details/ReportFights.autoRecheck.test.tsx
@@ -1,0 +1,136 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { ReportFragment } from '../../graphql/gql/graphql';
+import { useReportData } from '../../hooks';
+
+import { ReportFights } from './ReportFights';
+
+jest.mock('../../hooks', () => ({
+  useReportData: jest.fn(),
+}));
+
+jest.mock('../../ReportFightContext', () => ({
+  useSelectedReportAndFight: () => ({ reportId: 'ABC123', fightId: null }),
+}));
+
+jest.mock('../../components/DynamicMetaTags', () => ({
+  DynamicMetaTags: () => null,
+}));
+
+// Probe stand-in: exposes the props the container computes so the tests can
+// assert card stability without rendering the real (MUI-heavy) view.
+jest.mock('./ReportFightsView', () => ({
+  ReportFightsView: (props: { stillProcessing?: boolean; loading: boolean }) => (
+    <div
+      data-testid="view"
+      data-still-processing={String(Boolean(props.stillProcessing))}
+      data-loading={String(props.loading)}
+    />
+  ),
+}));
+
+const mockUseReportData = useReportData as jest.MockedFunction<typeof useReportData>;
+
+const makeReport = (endTime: number): ReportFragment =>
+  ({
+    code: 'ABC123',
+    title: 'Fresh upload',
+    startTime: endTime - 60_000,
+    endTime,
+    visibility: 'public',
+    zone: null,
+    owner: null,
+    fights: [],
+    phases: null,
+  }) as unknown as ReportFragment;
+
+const hookState = (overrides: Partial<ReturnType<typeof useReportData>> = {}) => ({
+  reportData: makeReport(Date.now() - 5 * 60 * 1000), // ended 5 min ago → still processing
+  isReportLoading: false,
+  reportError: null,
+  refetchReport: jest.fn(),
+  ...overrides,
+});
+
+describe('ReportFights still-processing auto-recheck', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('re-checks every 30s and stops at the cap (10 checks), never unbounded', () => {
+    const state = hookState();
+    mockUseReportData.mockReturnValue(state);
+
+    render(<ReportFights />);
+
+    // Advance well past the cap: 20 ticks of 30s.
+    for (let i = 0; i < 20; i++) {
+      act(() => {
+        jest.advanceTimersByTime(30_000);
+      });
+    }
+
+    expect(state.refetchReport).toHaveBeenCalledTimes(10);
+  });
+
+  it('keeps the still-processing card up while a background re-check is in flight', () => {
+    // During a poll the slice flips to loading with the empty data still
+    // present. The card must neither fall back to the permanent "Empty Log"
+    // variant nor blank to a skeleton — either would flicker every 30s.
+    mockUseReportData.mockReturnValue(hookState({ isReportLoading: true }));
+
+    render(<ReportFights />);
+
+    const view = screen.getByTestId('view');
+    expect(view).toHaveAttribute('data-still-processing', 'true');
+    expect(view).toHaveAttribute('data-loading', 'false');
+  });
+
+  it('does not poll an OLD empty report (permanent Empty Log case)', () => {
+    const state = hookState({
+      reportData: makeReport(Date.now() - 3 * 60 * 60 * 1000), // 3 h old
+    });
+    mockUseReportData.mockReturnValue(state);
+
+    render(<ReportFights />);
+
+    act(() => {
+      jest.advanceTimersByTime(10 * 60_000);
+    });
+
+    expect(state.refetchReport).not.toHaveBeenCalled();
+    expect(screen.getByTestId('view')).toHaveAttribute('data-still-processing', 'false');
+  });
+
+  it('stops polling once fights appear (report healed)', () => {
+    const state = hookState();
+    mockUseReportData.mockReturnValue(state);
+
+    const { rerender } = render(<ReportFights />);
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+    expect(state.refetchReport).toHaveBeenCalledTimes(1);
+
+    // The re-check found fights: the report healed.
+    const healed = {
+      ...makeReport(Date.now() - 5 * 60 * 1000),
+      fights: [{ id: 1 }],
+    } as unknown as ReportFragment;
+    mockUseReportData.mockReturnValue(hookState({ reportData: healed }));
+    rerender(<ReportFights />);
+
+    act(() => {
+      jest.advanceTimersByTime(10 * 60_000);
+    });
+    // No further polls after healing.
+    expect(state.refetchReport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/report_details/ReportFights.tsx
+++ b/src/features/report_details/ReportFights.tsx
@@ -5,17 +5,52 @@ import { FightFragment } from '../../graphql/gql/graphql';
 import { useReportData } from '../../hooks';
 import { useSelectedReportAndFight } from '../../ReportFightContext';
 import { cleanArray } from '../../utils/cleanArray';
+import { isRecentlyUploaded } from '../reports/reportFormatting';
 
 import { ReportFightsView } from './ReportFightsView';
+
+// A still-processing (recently uploaded, zero-fight) report re-checks the API
+// on this cadence so the page heals by itself once ESO Logs finishes parsing.
+// Bounded: after MAX_AUTO_RECHECKS the user still has the manual "Check again"
+// action, so a log that never parses cannot poll forever.
+const AUTO_RECHECK_INTERVAL_MS = 30_000;
+const MAX_AUTO_RECHECKS = 10;
 
 export const ReportFights: React.FC = () => {
   // Get current selected report and fight from context
   const { reportId, fightId } = useSelectedReportAndFight();
-  const { reportData, isReportLoading } = useReportData();
+  const { reportData, isReportLoading, reportError, refetchReport } = useReportData();
 
   const memoizedFights = React.useMemo<FightFragment[]>((): FightFragment[] => {
     return cleanArray(reportData?.fights?.filter(Boolean));
   }, [reportData]);
+
+  // A loaded report with zero fights is either still being parsed by ESO Logs
+  // (recent upload — the overwhelmingly common case) or permanently broken.
+  // Deliberately NOT gated on isReportLoading: a background re-check flips the
+  // slice to loading, and dropping stillProcessing then would (a) swap the card
+  // to the contradictory "Empty Log" variant for the duration of every poll and
+  // (b) tear down + re-create the auto-recheck interval, resetting its cap.
+  const stillProcessing =
+    reportData != null && memoizedFights.length === 0 && isRecentlyUploaded(reportData);
+
+  // While the report looks still-processing, quietly re-check from the network
+  // so the page heals in place the moment fights appear. Skipped while the tab
+  // is hidden; capped so an abandoned tab does not poll indefinitely.
+  React.useEffect(() => {
+    if (!stillProcessing) return undefined;
+    let checks = 0;
+    const id = window.setInterval(() => {
+      if (document.hidden) return;
+      checks += 1;
+      if (checks > MAX_AUTO_RECHECKS) {
+        window.clearInterval(id);
+        return;
+      }
+      refetchReport();
+    }, AUTO_RECHECK_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [stillProcessing, refetchReport]);
 
   // Generate dynamic meta tags for social sharing
   const metaTags = React.useMemo(() => {
@@ -41,32 +76,26 @@ export const ReportFights: React.FC = () => {
     return null;
   }, [reportId, reportData, memoizedFights]);
 
-  if (isReportLoading) {
-    return (
-      <>
-        {metaTags && <DynamicMetaTags {...metaTags} />}
-        <ReportFightsView
-          fights={undefined}
-          loading={isReportLoading}
-          fightId={fightId}
-          reportId={reportId}
-          reportStartTime={reportData?.startTime}
-          reportData={reportData}
-        />
-      </>
-    );
-  }
+  // Skeleton while nothing is known about this report yet — including the
+  // client-warmup gap before the first fetch dispatches (no data, no error,
+  // not loading), which previously flashed the "Empty Log" card. A background
+  // re-check of an already-rendered (empty or healthy) report must not blank
+  // the page back to a skeleton every poll, so data presence wins over loading.
+  const showSkeleton = !reportData && (isReportLoading || (Boolean(reportId) && !reportError));
 
   return (
     <>
       {metaTags && <DynamicMetaTags {...metaTags} />}
       <ReportFightsView
-        fights={memoizedFights}
-        loading={isReportLoading}
+        fights={showSkeleton ? undefined : memoizedFights}
+        loading={showSkeleton}
         fightId={fightId}
         reportId={reportId}
         reportStartTime={reportData?.startTime}
         reportData={reportData}
+        error={reportError}
+        stillProcessing={stillProcessing}
+        onRetry={refetchReport}
       />
     </>
   );

--- a/src/features/report_details/ReportFightsView.emptyStates.test.tsx
+++ b/src/features/report_details/ReportFightsView.emptyStates.test.tsx
@@ -1,0 +1,133 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import { ReportFragment } from '../../graphql/gql/graphql';
+
+import { ReportFightsView } from './ReportFightsView';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../../components/ReportActionBar', () => ({
+  ReportActionBar: () => null,
+}));
+
+jest.mock('../../components/ReportFightsSkeleton', () => ({
+  ReportFightsSkeleton: () => <div data-testid="fights-skeleton" />,
+}));
+
+const makeStore = () =>
+  configureStore({
+    reducer: { ui: () => ({ darkMode: false }) },
+  });
+
+const emptyReport = {
+  code: 'ABC123',
+  title: 'Test report',
+  startTime: 1_700_000_000_000,
+  endTime: 1_700_000_360_000,
+  visibility: 'public',
+  zone: null,
+  owner: null,
+  fights: [],
+  phases: null,
+} as unknown as ReportFragment;
+
+type ViewProps = React.ComponentProps<typeof ReportFightsView>;
+
+const renderView = (overrides: Partial<ViewProps> = {}) =>
+  render(
+    <Provider store={makeStore()}>
+      <MemoryRouter>
+        <ReportFightsView
+          fights={[]}
+          loading={false}
+          fightId={null}
+          reportId="ABC123"
+          reportStartTime={emptyReport.startTime}
+          reportData={emptyReport}
+          {...overrides}
+        />
+      </MemoryRouter>
+    </Provider>,
+  );
+
+describe('ReportFightsView no-fights states', () => {
+  it('shows a distinct ERROR card (not "Empty Log") when the fetch failed and nothing loaded', async () => {
+    const onRetry = jest.fn();
+    renderView({
+      reportData: null,
+      error: 'API rate limit exceeded. Too many requests were sent in a short period.',
+      onRetry,
+    });
+
+    expect(screen.getByText(/couldn.t load this report/i)).toBeInTheDocument();
+    // Friendly guidance leads; the raw (humanized) error is secondary detail.
+    expect(screen.getByText(/usually temporary/i)).toBeInTheDocument();
+    expect(screen.getByText(/rate limit exceeded/i)).toBeInTheDocument();
+    // The error must never masquerade as a broken/empty log.
+    expect(screen.queryByText('Empty Log')).not.toBeInTheDocument();
+    expect(screen.queryByText(/no fights available/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the STILL PROCESSING card for a recently uploaded empty log', async () => {
+    const onRetry = jest.fn();
+    renderView({ stillProcessing: true, onRetry });
+
+    expect(screen.getByText(/still processing/i)).toBeInTheDocument();
+    expect(screen.getByText('Processing')).toBeInTheDocument();
+    // Not presented as a permanently broken log.
+    expect(screen.queryByText('Empty Log')).not.toBeInTheDocument();
+    expect(screen.queryByText(/re-uploading/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /check again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the EMPTY LOG card for an old report with zero fights', () => {
+    renderView({ stillProcessing: false, onRetry: jest.fn() });
+
+    expect(screen.getByText(/no fights available/i)).toBeInTheDocument();
+    expect(screen.getByText('Empty Log')).toBeInTheDocument();
+    expect(screen.getByText(/re-uploading the log/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /check again/i })).toBeInTheDocument();
+  });
+
+  it('prioritizes the error card over still-processing when nothing is loaded', () => {
+    renderView({
+      reportData: null,
+      stillProcessing: false,
+      error: 'Network error: Could not connect to the ESO Logs API.',
+    });
+
+    expect(screen.getByText(/couldn.t load this report/i)).toBeInTheDocument();
+    expect(screen.queryByText('Empty Log')).not.toBeInTheDocument();
+  });
+
+  it('still renders the cached empty state when a background re-check errors (data present)', () => {
+    // A failed auto-recheck must not swap an already-rendered empty/processing
+    // card for an error card — we still have server truth that the log was empty.
+    renderView({
+      stillProcessing: true,
+      error: 'Network error: Could not connect to the ESO Logs API.',
+    });
+
+    expect(screen.getByText(/still processing/i)).toBeInTheDocument();
+    expect(screen.queryByText(/couldn.t load this report/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the skeleton while loading', () => {
+    renderView({ loading: true, fights: undefined, reportData: null });
+    expect(screen.getByTestId('fights-skeleton')).toBeInTheDocument();
+  });
+});

--- a/src/features/report_details/ReportFightsView.tsx
+++ b/src/features/report_details/ReportFightsView.tsx
@@ -133,6 +133,12 @@ interface ReportFightsViewProps {
   reportId: string | undefined | null;
   reportStartTime: number | undefined | null;
   reportData: ReportFragment | null | undefined;
+  /** Why the report failed to load — shown instead of the "Empty Log" card. */
+  error?: string | null;
+  /** The report loaded but is a recent upload ESO Logs is still parsing. */
+  stillProcessing?: boolean;
+  /** Re-fetches the report from the network ("Try again" / "Check again"). */
+  onRetry?: () => void;
 }
 
 export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
@@ -142,6 +148,9 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
   reportId,
   reportStartTime,
   reportData,
+  error,
+  stillProcessing,
+  onRetry,
 }) => {
   const navigate = useNavigate();
   const darkMode = useSelector((state: RootState) => state.ui.darkMode);
@@ -387,6 +396,41 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
   }
 
   if (!fights?.length) {
+    // Three distinct no-fights situations, in priority order:
+    //  1. The fetch FAILED (rate limit, network, not-public…) and nothing is
+    //     loaded — an error, not an empty log; a retry usually fixes it.
+    //  2. The report loaded but is a recent upload ESO Logs is still parsing —
+    //     it self-heals within minutes (the container auto-re-checks).
+    //  3. The report loaded and is old with zero fights — a genuine
+    //     upload/parse failure that only re-uploading fixes.
+    const failedToLoad = Boolean(error) && !reportData;
+
+    const state = failedToLoad
+      ? {
+          title: 'Couldn’t load this report',
+          chip: { label: 'Error', color: 'error' as const },
+          // Lead with written guidance; the raw error (already humanized for
+          // rate-limit/network cases by EsoLogsClient) becomes secondary detail.
+          body: 'Something went wrong while fetching this report. This is usually temporary — trying again often fixes it.',
+          detail: error,
+          retryLabel: 'Try again',
+        }
+      : stillProcessing
+        ? {
+            title: 'This log is still processing',
+            chip: { label: 'Processing', color: 'info' as const },
+            body: 'ESO Logs has not finished parsing this recently uploaded log yet. That usually takes a few minutes — this page re-checks automatically, or you can check now.',
+            detail: null,
+            retryLabel: 'Check again',
+          }
+        : {
+            title: 'No fights available',
+            chip: { label: 'Empty Log', color: 'warning' as const },
+            body: 'This log contains no fight data, likely due to an upload or parsing issue on ESO Logs. Re-uploading the log on ESO Logs usually fixes it.',
+            detail: null,
+            retryLabel: 'Check again',
+          };
+
     return (
       <Card
         elevation={4}
@@ -403,21 +447,39 @@ export const ReportFightsView: React.FC<ReportFightsViewProps> = ({
         <CardContent sx={{ p: { xs: 2, sm: 4 } }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <Typography variant="body1" sx={{ fontWeight: 'medium' }}>
-              No fights available
+              {state.title}
             </Typography>
             <Chip
-              label="Empty Log"
+              label={state.chip.label}
               size="small"
-              color="warning"
+              color={state.chip.color}
               variant="outlined"
               sx={{ fontSize: '0.7rem', height: 20 }}
             />
           </Box>
-          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
-            This log contains no fight data, likely due to an upload or parsing issue on ESO Logs.
-            Re-uploading the log on ESO Logs usually fixes it.
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: state.detail ? 1 : 2 }}>
+            {state.body}
           </Typography>
+          {state.detail && (
+            <Typography
+              variant="caption"
+              component="p"
+              sx={{ color: 'text.secondary', fontStyle: 'italic', mb: 2 }}
+            >
+              {state.detail}
+            </Typography>
+          )}
           <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {onRetry && (
+              <Button
+                variant="contained"
+                size="small"
+                onClick={onRetry}
+                sx={{ textTransform: 'none' }}
+              >
+                {state.retryLabel}
+              </Button>
+            )}
             <Button
               variant="outlined"
               size="small"

--- a/src/features/reports/reportFormatting.test.ts
+++ b/src/features/reports/reportFormatting.test.ts
@@ -1,4 +1,9 @@
-import { isReportEmpty, partitionReportsByData, selectReportsForDisplay } from './reportFormatting';
+import {
+  isRecentlyUploaded,
+  isReportEmpty,
+  partitionReportsByData,
+  REPORT_PROCESSING_WINDOW_MS,
+} from './reportFormatting';
 
 const baseReport = {
   startTime: 1_700_000_000_000,
@@ -101,63 +106,37 @@ describe('partitionReportsByData', () => {
   it('handles an empty list', () => {
     expect(partitionReportsByData([])).toEqual({ reportsWithData: [], emptyCount: 0 });
   });
-});
 
-describe('selectReportsForDisplay', () => {
-  it('hides empty logs but keeps the reports that have data, counting the hidden ones', () => {
-    const healthy = { ...baseReport, code: 'A' };
-    const inProgress = { ...baseReport, code: 'B', segments: 0, endTime: baseReport.startTime };
-    const brokenSlipThrough = { ...baseReport, code: 'C', fights: [] };
-
-    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay([
-      healthy,
-      inProgress,
-      brokenSlipThrough,
-    ]);
-
-    expect(reportsToShow).toEqual([healthy]);
-    expect(hiddenEmptyCount).toBe(2);
-  });
-
-  it('fails open and shows every report when the whole page would be hidden', () => {
-    // The real-world dead-end: during a busy upload window the freshest page is
-    // dominated by just-uploaded logs that have not parsed fights yet
-    // (segments: 0, fights: []). Hiding all of them would strand the user on an
-    // "every report on this page is empty" wall, so we show them instead.
+  it('hides EVERY report when the whole page is empty (no fail-open)', () => {
+    // Empty logs open to "No fights available", so a browse list never shows
+    // them — even when that hides the entire page. The list surfaces its
+    // `all-hidden` empty state (still processing + refresh) instead of a page
+    // of dead links.
     const stillParsing = [
       { ...baseReport, code: 'A', segments: 0, endTime: baseReport.startTime, fights: [] },
       { ...baseReport, code: 'B', segments: 0, endTime: baseReport.startTime, fights: [] },
       { ...baseReport, code: 'C', segments: 0, endTime: baseReport.startTime, fights: [] },
     ];
 
-    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(stillParsing);
-
-    expect(reportsToShow).toEqual(stillParsing);
-    expect(hiddenEmptyCount).toBe(0);
-  });
-
-  it('fails open for a single empty report rather than showing nothing', () => {
-    const onlyEmpty = [{ ...baseReport, code: 'A', fights: [] }];
-    const { reportsToShow, hiddenEmptyCount } = selectReportsForDisplay(onlyEmpty);
-    expect(reportsToShow).toEqual(onlyEmpty);
-    expect(hiddenEmptyCount).toBe(0);
-  });
-
-  it('returns nothing (not a fail-open) when the server returned no reports at all', () => {
-    // An empty input is a genuine "no results" — there is nothing to fail open
-    // to, so we must not fabricate rows. The page shows its cold/filter empty
-    // state, never the "all hidden" wall.
-    expect(selectReportsForDisplay([])).toEqual({ reportsToShow: [], hiddenEmptyCount: 0 });
-  });
-
-  it('leaves a fully healthy page untouched', () => {
-    const reports = [
-      { ...baseReport, code: 'A' },
-      { ...baseReport, code: 'B' },
-    ];
-    expect(selectReportsForDisplay(reports)).toEqual({
-      reportsToShow: reports,
-      hiddenEmptyCount: 0,
+    expect(partitionReportsByData(stillParsing)).toEqual({
+      reportsWithData: [],
+      emptyCount: 3,
     });
+  });
+});
+
+describe('isRecentlyUploaded', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('is true for a log whose activity ended inside the processing window', () => {
+    expect(isRecentlyUploaded({ endTime: NOW - 5 * 60 * 1000 }, NOW)).toBe(true);
+  });
+
+  it('is false for a log older than the processing window', () => {
+    expect(isRecentlyUploaded({ endTime: NOW - REPORT_PROCESSING_WINDOW_MS - 1 }, NOW)).toBe(false);
+  });
+
+  it('tolerates a slightly-future endTime (clock skew) as recent', () => {
+    expect(isRecentlyUploaded({ endTime: NOW + 60_000 }, NOW)).toBe(true);
   });
 });

--- a/src/features/reports/reportFormatting.ts
+++ b/src/features/reports/reportFormatting.ts
@@ -130,6 +130,18 @@ export const isReportEmpty = (report: ReportEmptinessFields): boolean => {
  * Splits a report list into reports that contain combat data and a count of
  * empty ones, so list surfaces can hide broken logs while telling the user
  * how many were hidden.
+ *
+ * Public *browse* lists (Latest Reports) hide every empty log unconditionally —
+ * including when that hides the whole page. An earlier iteration failed open
+ * and showed the full page of empties (with an "Empty" badge) when all rows
+ * would be hidden, reasoning that an all-empty page is a transient upload burst
+ * that self-heals; in practice that filled the list with dead links that open
+ * to "No fights available", which users read as broken. The all-hidden case is
+ * instead handled by the list's `all-hidden` empty state (see
+ * ReportsEmptyState), which explains that the logs are still processing and
+ * offers a refresh — an informative pause, not a dead end. Owner-facing
+ * surfaces (My Reports, profile logs) still SHOW empties with a badge so
+ * uploaders can see their own still-processing logs.
  */
 export const partitionReportsByData = <T extends ReportEmptinessFields>(
   reports: T[],
@@ -139,33 +151,21 @@ export const partitionReportsByData = <T extends ReportEmptinessFields>(
 };
 
 /**
- * Decides which loaded reports a public *browse* list should display while
- * hiding empty (no-combat) logs — but WITHOUT ever blanking out the whole page.
- *
- * Hiding individual empty logs is correct when a page also carries real reports:
- * it removes dead links that open to "No fights available". The failure mode is
- * hiding *every* report on a page. During a busy upload window the freshest page
- * can be dominated — or, at a peak, entirely composed — of just-uploaded logs
- * that have not finished parsing yet (`segments: 0`, `fights: []`). Hiding all of
- * them strands the user on a dead-end "every report on this page is empty" wall,
- * even though those reports exist and self-heal within minutes as ESO Logs
- * finishes parsing them. A *permanently* broken full page is statistically
- * impossible — broken slip-throughs are well under 1% of logs — so an all-empty
- * page is overwhelmingly a transient upload burst, not 25 genuinely dead logs.
- *
- * Therefore, when every loaded report would be hidden, fail OPEN and show them
- * all (`hiddenEmptyCount: 0`). The reports stay individually openable and the
- * list is never a dead end; the worst case is a recent log that opens to "No
- * fights available" until it finishes parsing — strictly better than telling the
- * user there is nothing here. This mirrors the fail-open fallback already used by
- * `useLatestReport` (prefer a report with data, but never hide the only ones).
+ * How long after a log's last recorded activity we still treat an empty
+ * (no-fights) report as "probably still being parsed by ESO Logs" rather than
+ * permanently broken. Just-uploaded logs routinely take minutes to parse;
+ * genuinely broken ones stay empty forever. 90 minutes comfortably covers the
+ * observed self-heal window while keeping old dead logs out of the
+ * "still processing" messaging.
  */
-export const selectReportsForDisplay = <T extends ReportEmptinessFields>(
-  reports: T[],
-): { reportsToShow: T[]; hiddenEmptyCount: number } => {
-  const { reportsWithData, emptyCount } = partitionReportsByData(reports);
-  if (reports.length > 0 && reportsWithData.length === 0) {
-    return { reportsToShow: reports, hiddenEmptyCount: 0 };
-  }
-  return { reportsToShow: reportsWithData, hiddenEmptyCount: emptyCount };
-};
+export const REPORT_PROCESSING_WINDOW_MS = 90 * 60 * 1000;
+
+/**
+ * True when the report's activity ended recently enough that an empty fights
+ * list most likely means "ESO Logs has not finished parsing yet" (see
+ * REPORT_PROCESSING_WINDOW_MS) rather than a permanent upload/parse failure.
+ */
+export const isRecentlyUploaded = (
+  report: { endTime: number },
+  now: number = Date.now(),
+): boolean => now - report.endTime < REPORT_PROCESSING_WINDOW_MS;

--- a/src/hooks/useReportData.ts
+++ b/src/hooks/useReportData.ts
@@ -14,6 +14,14 @@ import { useAppDispatch } from '../store/useAppDispatch';
 export function useReportData(): {
   reportData: ReportFragment | null;
   isReportLoading: boolean;
+  /** Why the report failed to load (fetch/API error) — null when healthy. */
+  reportError: string | null;
+  /**
+   * Re-fetches the report from the network, bypassing both the slice's
+   * freshness window and Apollo's cache. Backs the detail page's "Try again" /
+   * "Check again" actions and the still-processing auto-recheck.
+   */
+  refetchReport: () => void;
 } {
   const { client, isReady } = useEsoLogsClientContext();
   const dispatch = useAppDispatch();
@@ -30,8 +38,19 @@ export function useReportData(): {
   const combinedReportData = useSelector(selectCombinedReportData);
   const isReportLoading = useSelector(selectReportLoadingState);
 
+  const refetchReport = React.useCallback(() => {
+    if (reportId && isReady && client) {
+      void dispatch(fetchReportData({ reportId, client, force: true }));
+    }
+  }, [dispatch, reportId, client, isReady]);
+
   return React.useMemo(
-    () => ({ reportData: combinedReportData.data, isReportLoading }),
-    [combinedReportData.data, isReportLoading],
+    () => ({
+      reportData: combinedReportData.data,
+      isReportLoading,
+      reportError: combinedReportData.error ?? null,
+      refetchReport,
+    }),
+    [combinedReportData.data, combinedReportData.error, isReportLoading, refetchReport],
   );
 }

--- a/src/store/report/reportSlice.test.ts
+++ b/src/store/report/reportSlice.test.ts
@@ -1,9 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
-import { DATA_FETCH_CACHE_TIMEOUT } from '../../Constants';
+import { DATA_FETCH_CACHE_TIMEOUT, EMPTY_REPORT_CACHE_TIMEOUT } from '../../Constants';
+import type { EsoLogsClient } from '../../esologsClient';
+import type { ReportFragment } from '../../graphql/gql/graphql';
 
 import reportSlice, {
   clearReport,
+  fetchReportData,
   ReportEntry,
   ReportState,
   setActiveReportContext,
@@ -178,6 +181,187 @@ describe('reportSlice caching logic', () => {
 
       const state = store.getState() as { report: ReportState };
       expect(state.report.activeContext).toEqual({ reportId: null, fightId: null });
+    });
+  });
+
+  describe('fetchReportData caching + force', () => {
+    const CODE = 'CACHE-TEST-1';
+
+    const makeReportData = (fights: Array<{ id: number }> | []): ReportFragment =>
+      ({
+        code: CODE,
+        title: 'Cached report',
+        startTime: 1000,
+        endTime: 2000,
+        visibility: 'public',
+        zone: null,
+        owner: null,
+        fights,
+        phases: null,
+      }) as unknown as ReportFragment;
+
+    const storeWithEntry = (entry: ReportEntry) => {
+      const { key } = resolveCacheKey({ reportCode: CODE });
+      return configureStore({
+        reducer: { report: reportSlice },
+        preloadedState: {
+          report: {
+            entries: { [key]: entry },
+            accessOrder: [key],
+            reportId: CODE,
+            data: entry.data,
+            loading: false,
+            error: null,
+            cacheMetadata: {
+              lastFetchedReportId: entry.data ? CODE : null,
+              lastFetchedTimestamp: entry.cacheMetadata.lastFetchedTimestamp,
+            },
+            activeContext: { reportId: CODE, fightId: null },
+            fightIndexByReport: {},
+          } satisfies ReportState,
+        },
+      });
+    };
+
+    const makeClient = () => {
+      const query = jest
+        .fn()
+        .mockResolvedValue({ reportData: { report: makeReportData([{ id: 1 }]) } });
+      return { client: { query } as unknown as EsoLogsClient, query };
+    };
+
+    it('skips the fetch entirely for a fresh cached report WITH fights', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([{ id: 1 }]),
+          status: 'succeeded',
+          cacheMetadata: { lastFetchedTimestamp: Date.now() - 60_000 }, // 1 min old
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('re-checks a cached EMPTY (zero-fight) report once the short empty-TTL passes, bypassing the Apollo cache', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([]),
+          status: 'succeeded',
+          // Older than the empty-report TTL but far fresher than the normal
+          // 30-minute window, which would have pinned "Empty Log".
+          cacheMetadata: { lastFetchedTimestamp: Date.now() - EMPTY_REPORT_CACHE_TIMEOUT - 1000 },
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+
+      expect(query).toHaveBeenCalledTimes(1);
+      // The cached snapshot is empty, so cache-first would re-serve it forever.
+      expect(query.mock.calls[0][0]).toMatchObject({ fetchPolicy: 'network-only' });
+    });
+
+    it('debounces rapid re-checks of an empty report inside the short TTL', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([]),
+          status: 'succeeded',
+          cacheMetadata: { lastFetchedTimestamp: Date.now() - 2000 }, // 2 s old
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+      expect(query).not.toHaveBeenCalled();
+    });
+
+    it('force bypasses the freshness window AND the Apollo cache', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([{ id: 1 }]),
+          status: 'succeeded',
+          cacheMetadata: { lastFetchedTimestamp: Date.now() }, // perfectly fresh
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client, force: true }));
+
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query.mock.calls[0][0]).toMatchObject({ fetchPolicy: 'network-only' });
+    });
+
+    it('uses the default (cacheable) fetch for a stale report WITH fights', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([{ id: 1 }]),
+          status: 'succeeded',
+          cacheMetadata: { lastFetchedTimestamp: Date.now() - DATA_FETCH_CACHE_TIMEOUT - 1000 },
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+
+      expect(query).toHaveBeenCalledTimes(1);
+      expect((query.mock.calls[0][0] as { fetchPolicy?: string }).fetchPolicy).toBeUndefined();
+    });
+
+    it('re-reads from the network when a cacheable read returns zero fights (stale Apollo hit)', async () => {
+      // The slice LRU can forget a report while Apollo's session cache still
+      // holds its empty snapshot; cache-first would then re-serve "Empty Log"
+      // forever. The thunk must retry exactly once, network-only.
+      const query = jest
+        .fn()
+        .mockResolvedValueOnce({ reportData: { report: makeReportData([]) } }) // stale cache hit
+        .mockResolvedValueOnce({ reportData: { report: makeReportData([{ id: 1 }]) } }); // healed
+      const client = { query } as unknown as EsoLogsClient;
+
+      // No cached entry data → bypassCache is false → first read is cacheable.
+      const testStore = storeWithEntry(createReportEntry());
+
+      const action = await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+
+      expect(query).toHaveBeenCalledTimes(2);
+      expect((query.mock.calls[0][0] as { fetchPolicy?: string }).fetchPolicy).toBeUndefined();
+      expect(query.mock.calls[1][0]).toMatchObject({ fetchPolicy: 'network-only' });
+      expect(
+        (action.payload as { data: ReportFragment }).data.fights?.filter(Boolean),
+      ).toHaveLength(1);
+    });
+
+    it('does not retry a network-only read that returns zero fights (genuinely empty)', async () => {
+      const query = jest.fn().mockResolvedValue({ reportData: { report: makeReportData([]) } });
+      const client = { query } as unknown as EsoLogsClient;
+
+      // Cached EMPTY data → bypassCache is already true → single network read.
+      const testStore = storeWithEntry(
+        createReportEntry({
+          data: makeReportData([]),
+          status: 'succeeded',
+          cacheMetadata: { lastFetchedTimestamp: Date.now() - EMPTY_REPORT_CACHE_TIMEOUT - 1000 },
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client }));
+
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(query.mock.calls[0][0]).toMatchObject({ fetchPolicy: 'network-only' });
+    });
+
+    it('never stacks a request on an in-flight one, even when forced', async () => {
+      const { client, query } = makeClient();
+      const testStore = storeWithEntry(
+        createReportEntry({
+          status: 'loading',
+          currentRequest: { reportId: CODE, requestId: 'in-flight' },
+        }),
+      );
+
+      await testStore.dispatch(fetchReportData({ reportId: CODE, client, force: true }));
+      expect(query).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/report/reportSlice.ts
+++ b/src/store/report/reportSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 
-import { DATA_FETCH_CACHE_TIMEOUT } from '../../Constants';
+import { DATA_FETCH_CACHE_TIMEOUT, EMPTY_REPORT_CACHE_TIMEOUT } from '../../Constants';
 import { EsoLogsClient } from '../../esologsClient';
 import { FightFragment, GetReportByCodeDocument, ReportFragment } from '../../graphql/gql/graphql';
 import { isSampleReport, getSampleReportUrl } from '../../utils/sampleReports';
@@ -147,6 +147,13 @@ const getEntry = (state: ReportState, reportId: string | null | undefined): Repo
   return state.entries[cacheKey] ?? null;
 };
 
+// True when a cached entry holds a report with at least one real fight. An
+// entry whose report parsed ZERO fights is usually a log ESO Logs is still
+// processing — it heals upstream within minutes — so both cache layers (this
+// slice's freshness window and Apollo's normalized cache) must not pin it.
+const entryHasFights = (entry: ReportEntry | null): boolean =>
+  Boolean(entry?.data?.fights?.some(Boolean));
+
 const ensureEntry = (state: ReportState, reportId: string): ReportEntry => {
   const { key } = resolveCacheKey({ reportCode: reportId });
   if (!state.entries[key]) {
@@ -192,11 +199,11 @@ const syncActiveReportState = (state: ReportState): void => {
 
 export const fetchReportData = createAsyncThunk<
   { reportId: string; data: ReportFragment },
-  { reportId: string; client: EsoLogsClient },
+  { reportId: string; client: EsoLogsClient; force?: boolean },
   { state: RootState; rejectValue: string }
 >(
   'report/fetchReportData',
-  async ({ reportId, client }, { rejectWithValue }) => {
+  async ({ reportId, client, force }, { getState, rejectWithValue }) => {
     try {
       // Bundled sample reports are served from static JSON in public/
       // so they never hit the ESO Logs API and work without authentication.
@@ -213,10 +220,39 @@ export const fetchReportData = createAsyncThunk<
         return { data: json.reportData.report, reportId };
       }
 
-      const response = await client.query({
+      // Apollo's cache-first default would re-serve a cached empty (zero-fight)
+      // snapshot forever, so a forced retry or a re-check of a known-empty
+      // report must go to the network — that is the only way a log that has
+      // since finished parsing on ESO Logs can heal in the UI. (The Worker
+      // proxy already refuses to edge-cache empty report responses.)
+      const entry = getEntry(getState().report as ReportState, reportId);
+      const bypassCache = Boolean(force) || (entry?.data != null && !entryHasFights(entry));
+
+      let response = await client.query({
         query: GetReportByCodeDocument,
         variables: { code: reportId },
+        ...(bypassCache ? { fetchPolicy: 'network-only' as const } : {}),
       });
+
+      // A zero-fight result from a cacheable read may be a stale Apollo
+      // cache-first hit: this slice's LRU (REPORT_CACHE_MAX_ENTRIES) can forget
+      // a report while Apollo's session cache still remembers its empty
+      // snapshot, which no server would still serve (the Worker proxy refuses
+      // to edge-cache empties). Re-read once from the network so a since-healed
+      // log cannot render "Empty Log" out of a local cache. For a genuinely
+      // empty report this costs one duplicate request on first visit — rare
+      // (well under 1% of logs) and cheap next to showing wrong data.
+      if (
+        !bypassCache &&
+        response.reportData?.report &&
+        !response.reportData.report.fights?.some(Boolean)
+      ) {
+        response = await client.query({
+          query: GetReportByCodeDocument,
+          variables: { code: reportId },
+          fetchPolicy: 'network-only' as const,
+        });
+      }
 
       if (!response.reportData?.report) {
         return rejectWithValue('Report not found or not public.');
@@ -235,7 +271,7 @@ export const fetchReportData = createAsyncThunk<
     }
   },
   {
-    condition: ({ reportId }, { getState }) => {
+    condition: ({ reportId, force }, { getState }) => {
       if (!reportId) {
         return false;
       }
@@ -243,17 +279,29 @@ export const fetchReportData = createAsyncThunk<
       const state = getState().report as ReportState;
       const entry = getEntry(state, reportId);
 
-      const lastFetchedTimestamp = entry?.cacheMetadata.lastFetchedTimestamp ?? null;
-      const isCached = Boolean(entry?.data);
-      const isFresh =
-        typeof lastFetchedTimestamp === 'number' &&
-        Date.now() - lastFetchedTimestamp < DATA_FETCH_CACHE_TIMEOUT;
-
-      if (isCached && isFresh) {
+      // Never stack a duplicate request on an in-flight one — a forced retry
+      // included (the pending fetch will deliver the same answer).
+      if (entry?.status === 'loading') {
         return false;
       }
 
-      if (entry?.status === 'loading') {
+      if (force) {
+        return true;
+      }
+
+      const lastFetchedTimestamp = entry?.cacheMetadata.lastFetchedTimestamp ?? null;
+      const isCached = Boolean(entry?.data);
+      // A cached report with zero fights goes stale almost immediately: it is
+      // usually a just-uploaded log ESO Logs is still parsing, so revisits must
+      // re-check instead of pinning "Empty Log" for the full cache window.
+      const freshnessWindow = entryHasFights(entry)
+        ? DATA_FETCH_CACHE_TIMEOUT
+        : EMPTY_REPORT_CACHE_TIMEOUT;
+      const isFresh =
+        typeof lastFetchedTimestamp === 'number' &&
+        Date.now() - lastFetchedTimestamp < freshnessWindow;
+
+      if (isCached && isFresh) {
         return false;
       }
 


### PR DESCRIPTION
## Problem

Despite #1352 (fail-open + "Empty" badge) and #1355 (cache-and-network revalidation), users still regularly land on the dead **"No fights available / Empty Log"** page from `/latest-reports`. Live diagnosis (production API probes of all 25 page-1 reports + code trace) found three remaining routes into that page:

1. **The fail-open itself.** During upload bursts, a page where *every* row is a still-parsing log (`fights: []`) was deliberately shown in full — 25 badged rows that all open to an empty report. The user-facing requirement has changed: an empty log must never be listed as an openable row.
2. **Errors masquerading as "Empty Log".** `fetchReportData`'s rejection (`selectReportErrorState`) was consumed **nowhere** — any rate-limit (shared client token), network blip, or "not public" rejection left `reportData` null, and `ReportFightsView` rendered the *Empty Log — parsing issue* card for what was actually a fetch failure.
3. **Sticky empty snapshots.** A genuinely still-processing report opened once was pinned as empty for 30 minutes by the redux freshness window *and* indefinitely by Apollo's `cache-first` default — it kept rendering "Empty Log" long after ESO Logs finished parsing it (the Worker proxy already refuses to edge-cache empty reports for exactly this reason).

## Changes

### Latest Reports list
- `partitionReportsByData` now hides **every** empty log, including whole-page cases (fail-open removed; `selectReportsForDisplay` deleted).
- The re-armed `all-hidden` empty state is an informative pause, not a wall: it reports the hidden count, and its copy is **age-aware** — "still processing, refresh in a few minutes" (+ Refresh action) only when at least one hidden empty is a recent upload (`hiddenRecentCount`); otherwise it says these older logs never parsed and offers *Clear filters* instead.
- Refreshing an all-hidden page keeps the empty state mounted (no skeleton swap that unmounts the focused Refresh button); the corner "Refreshing…" pill supplies progress feedback.
- The aria-live region announces the hidden count, singular/plural correct, matching the visible copy.
- `all-hidden` now wins over `filter-no-results` when rows came back but were all empty.

### Report detail page
Three distinct no-fights states instead of one misleading card:
- **Error** (`error && !reportData`): "Couldn't load this report" + friendly guidance, the humanized error as secondary detail, and a **Try again** button (network-only, bypasses both caches).
- **Still processing** (report loaded, 0 fights, ended < 90 min ago): calm "still processing" card that **auto-re-checks every 30 s (max 10, paused while the tab is hidden)** and heals in place the moment fights appear.
- **Empty Log** (old report, 0 fights): the original permanent-failure copy, now with a "Check again" button.
- Skeleton only while nothing is known yet (also fixes a pre-existing flash-of-"Empty Log" during client warm-up); background re-checks never blank an already-rendered page.

### Caching
- `fetchReportData` gains `force` (network-only + skips the freshness window; still de-dupes in-flight requests).
- Cached entries with zero fights go stale after **15 s** (`EMPTY_REPORT_CACHE_TIMEOUT`) instead of 30 min, and their re-checks are network-only.
- A cacheable read that returns zero fights retries once network-only — closes the gap where the redux LRU forgets a report while Apollo still holds its stale empty snapshot.

## Verification
- Production probes: all 25 live page-1 reports fetched with the app's exact list + detail documents — the one `fights: []` report is hidden, all 24 shown rows open with fights; confirmed both prior fixes are deployed (bundle signature check).
- `tsc`, `eslint`, `prettier` clean; **full jest suite green** (`326 suites / 4372 tests` before the final fixes, re-run after); new coverage: slice force/TTL/retry semantics, the three detail-page cards, auto-recheck cap + card stability + healing, `hiddenRecentCount`.
- 36-agent adversarial review (4 lenses, 2 refuters per finding): 16 raw findings → all confirmed items fixed (poll-cap reset + card flicker, focus loss on Refresh, raw error copy, stale-Apollo re-pin, plural-only announcement, age-blind copy).
- Vite production build green.

Not changed on purpose: owner-facing surfaces (My Reports, profile logs) still show their own empties with a badge so uploaders can see still-processing logs; the home-hero own-report fallback is unchanged.
