### PR TITLE
feat(companion): capture true Class Mastery from the live client

### DIFF
--- a/addon/ESOTKCompanion/ESOTKCompanion.lua
+++ b/addon/ESOTKCompanion/ESOTKCompanion.lua
@@ -258,6 +258,41 @@ local function captureScribing()
   return scribing
 end
 
+-- Class Mastery (U50 skill line id 351): a non-subclassed character slots 2 of 5 of its
+-- class's passives via Class Mastery Points (both points granted on unlock). The encounter
+-- log is combat-event-driven and UNDER-REPORTS these - a passive that hasn't registered in
+-- a session is simply absent, so the log frequently shows only 1 of the 2 slotted. We read
+-- the TRUE allocation from the client: find the Class Mastery line and keep the passives the
+-- player has actually purchased (allocated a point to). Language-agnostic - raw ability ids
+-- plus client names, like every other capture. Returns nil when the line is absent
+-- (subclassed, which disables it, or pre-U50), letting ESOTK fall back to the log.
+local CLASS_MASTERY_LINE_ID = 351
+local function captureClassMastery()
+  local skillTypeClass = _G["SKILL_TYPE_CLASS"]
+  if skillTypeClass == nil then return nil end
+  local numLines = call("GetNumSkillLines", skillTypeClass) or 0
+  for lineIndex = 1, numLines do
+    if call("GetSkillLineId", skillTypeClass, lineIndex) == CLASS_MASTERY_LINE_ID then
+      local picks, names = {}, {}
+      local numAbilities = call("GetNumSkillAbilities", skillTypeClass, lineIndex) or 0
+      for abilityIndex = 1, numAbilities do
+        -- GetSkillAbilityInfo => name, texture, earnedRank, passive, ultimate, purchased, ...
+        local name, _, _, passive, _, purchased =
+          call("GetSkillAbilityInfo", skillTypeClass, lineIndex, abilityIndex)
+        if passive and purchased then
+          local abilityId = call("GetSkillAbilityId", skillTypeClass, lineIndex, abilityIndex, false)
+          if abilityId and abilityId ~= 0 then
+            picks[#picks + 1] = abilityId
+            names[abilityId] = name
+          end
+        end
+      end
+      return { lineId = CLASS_MASTERY_LINE_ID, picks = picks, names = names }
+    end
+  end
+  return nil
+end
+
 -- ----------------------------------------------------------------------------
 -- snapshot
 -- ----------------------------------------------------------------------------
@@ -301,6 +336,7 @@ local function Snapshot(reason)
     effects   = tryCapture("longTermEffects", captureLongTermEffects),
     bars      = tryCapture("bars", captureBars),
     scribing  = tryCapture("scribing", captureScribing),
+    classMastery = tryCapture("classMastery", captureClassMastery),
   }
 
   if not snap.ts or not snap.char then
@@ -375,7 +411,7 @@ local function OnAddOnLoaded(_, addonName)
     end
   end
 
-  d("[ESOTK] Companion loaded. Capturing champion points, stats and scribing on combat end. Type /esotk to snapshot now.")
+  d("[ESOTK] Companion loaded. Capturing champion points, stats, scribing and class mastery on combat end. Type /esotk to snapshot now.")
 end
 
 EVENT_MANAGER:RegisterForEvent(ADDON.name, EVENT_ADD_ON_LOADED, OnAddOnLoaded)

--- a/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/esotkCompanionParser.test.ts
@@ -238,6 +238,32 @@ describe('normalizeCompanionSnapshots', () => {
     expect(snapshots[0].stats?.physicalPen).toBe(7778);
   });
 
+  it('normalizes the true Class Mastery allocation the log under-reports (raw Kalpa forward shape)', () => {
+    const raw = [
+      {
+        ts: 1749384000,
+        char: 'Grappa',
+        // Kalpa forwards Lua sequences/maps as numeric-string-keyed objects.
+        classMastery: {
+          lineId: 351,
+          picks: { '1': 263872, '2': 263873 },
+          names: { '263872': 'Static Reverberation', '263873': 'Calculated Defense' },
+        },
+      },
+    ];
+    const [snap] = normalizeCompanionSnapshots(raw);
+    expect(snap.classMastery?.lineId).toBe(351);
+    expect(snap.classMastery?.picks).toEqual([263872, 263873]);
+    expect(snap.classMastery?.names?.[263872]).toBe('Static Reverberation');
+  });
+
+  it('drops an empty Class Mastery capture (subclassed / pre-U50 → falls back to the log)', () => {
+    const [snap] = normalizeCompanionSnapshots([
+      { ts: 1, char: 'X', classMastery: { lineId: 351, picks: {} } },
+    ]);
+    expect(snap.classMastery).toBeUndefined();
+  });
+
   it('returns an empty array for empty input', () => {
     expect(normalizeCompanionSnapshots([])).toEqual([]);
   });

--- a/src/features/loadout-manager/utils/esotkCompanionParser.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionParser.ts
@@ -98,6 +98,21 @@ export interface CompanionScribedSkill {
   scripts: Record<number, CompanionScribingScript>;
 }
 
+/**
+ * Class Mastery allocation read live from the client (U50 skill line 351). The encounter
+ * log under-reports these (it's combat-event-driven, so it often surfaces only 1 of the 2
+ * slotted), so the companion carries the TRUE purchased picks — prefer these over the
+ * log-derived picks when a snapshot is matched.
+ */
+export interface CompanionClassMastery {
+  /** In-game Class Mastery skill line id (351 on U50). */
+  lineId?: number;
+  /** Ability ids the player has actually purchased (allocated a Class Mastery Point to). */
+  picks: number[];
+  /** Client-provided passive names keyed by ability id (localized ground truth). */
+  names?: Record<number, string>;
+}
+
 /** One captured build snapshot, taken on combat end or on demand. */
 export interface CompanionSnapshot {
   schemaVersion?: number;
@@ -126,6 +141,7 @@ export interface CompanionSnapshot {
   effects?: CompanionEffect[];
   bars?: { front?: Record<number, number>; back?: Record<number, number> };
   scribing?: CompanionScribedSkill[];
+  classMastery?: CompanionClassMastery;
 }
 
 /** Parsed companion file: snapshots grouped by account. */
@@ -297,6 +313,27 @@ function normalizeScribing(v: LuaValue | undefined): CompanionScribedSkill[] | u
   return out.length > 0 ? out : undefined;
 }
 
+function normalizeClassMastery(v: LuaValue | undefined): CompanionClassMastery | undefined {
+  if (!isRecord(v)) return undefined;
+  // picks is a Lua sequence of ability ids; dedupe defensively (order preserved).
+  const seen = new Set<number>();
+  const picks: number[] = [];
+  for (const val of luaArray(v.picks)) {
+    const n = asNumber(val);
+    if (typeof n === 'number' && n > 0 && !seen.has(n)) {
+      seen.add(n);
+      picks.push(n);
+    }
+  }
+  if (picks.length === 0) return undefined;
+  const names = numericStringMap(v.names);
+  return {
+    lineId: asNumber(v.lineId),
+    picks,
+    ...(Object.keys(names).length > 0 ? { names } : {}),
+  };
+}
+
 interface SnapshotDefaults {
   account?: string;
   schemaVersion?: number;
@@ -346,6 +383,7 @@ function normalizeSnapshot(v: LuaValue, defaults: SnapshotDefaults = {}): Compan
     effects: normalizeEffects(v.effects),
     bars,
     scribing: normalizeScribing(v.scribing),
+    classMastery: normalizeClassMastery(v.classMastery),
   };
 }
 

--- a/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
+++ b/src/features/loadout-manager/utils/esotkCompanionReportAdapter.ts
@@ -35,6 +35,8 @@ export interface CompanionBuildForPlayer {
   effects?: CompanionSnapshot['effects'];
   /** Scribed skills captured authoritatively from the local action bars. */
   scribing?: CompanionSnapshot['scribing'];
+  /** True Class Mastery allocation read live from the client (the log under-reports it). */
+  classMastery?: CompanionSnapshot['classMastery'];
   /** The snapshot this was built from (raw stats/effects/scribing available for detail views). */
   snapshot: CompanionSnapshot;
   /** The fight the snapshot best matched, if any. */
@@ -74,6 +76,7 @@ export function buildCompanionBuildsForReport(
       stats: match.snapshot.stats,
       effects: match.snapshot.effects,
       scribing: match.snapshot.scribing,
+      classMastery: match.snapshot.classMastery,
       snapshot: match.snapshot,
       fightId: match.fightId,
       distanceMs: match.distanceMs,

--- a/src/features/report_details/insights/ClassMasteryCluster.tsx
+++ b/src/features/report_details/insights/ClassMasteryCluster.tsx
@@ -19,10 +19,15 @@ import React from 'react';
 
 import { CLASS_COLOR_MAP } from '@/features/build-editor/theme/classColorMap';
 import type { ESOClass } from '@/features/build-editor/types/build.types';
+import type { CompanionClassMastery } from '@/features/loadout-manager/utils/esotkCompanionParser';
 import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
 import { toClassKey } from '@/utils/classNameUtils';
 
-import { getClassMasteryPicks, type ClassMasteryPick } from './classMasteryPicks';
+import {
+  getClassMasteryPicks,
+  getCompanionClassMasteryPicks,
+  type ClassMasteryPick,
+} from './classMasteryPicks';
 
 const ICON_URL = 'https://assets.rpglogs.com/img/eso/abilities/';
 
@@ -55,10 +60,11 @@ const firstMechanicsParagraph = (description: string): string =>
 
 // ── Overview tooltip ──────────────────────────────────────────────────────────
 
-const ClassMasteryOverview: React.FC<{ picks: ClassMasteryPick[]; accent: string }> = ({
-  picks,
-  accent,
-}) => (
+const ClassMasteryOverview: React.FC<{
+  picks: ClassMasteryPick[];
+  accent: string;
+  fromCompanion: boolean;
+}> = ({ picks, accent, fromCompanion }) => (
   <Box sx={{ maxWidth: 320 }}>
     <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, mb: 0.25 }}>
       <Typography
@@ -74,7 +80,7 @@ const ClassMasteryOverview: React.FC<{ picks: ClassMasteryPick[]; accent: string
         Class Mastery
       </Typography>
       <Typography sx={{ fontSize: 9.5, opacity: 0.6, letterSpacing: '0.02em' }}>
-        {picks.length} of 5 · non-subclassed
+        {picks.length} of 5 · {fromCompanion ? 'Companion' : 'non-subclassed'}
       </Typography>
     </Box>
     <Divider sx={{ borderColor: alpha(accent, 0.35), mb: 0.75 }} />
@@ -211,16 +217,28 @@ const ClassMasteryIcon: React.FC<ClassMasteryIconProps> = ({
 
 interface ClassMasteryClusterProps {
   classAnalysis?: ClassAnalysisResult;
+  /**
+   * The player's true Class Mastery picks from the ESOTK Companion capture, when a snapshot
+   * was matched. Preferred over the log-derived picks: the encounter log under-reports Class
+   * Mastery (combat-event-driven), so it can miss the 2nd of the 2 slotted passives.
+   */
+  companionClassMastery?: CompanionClassMastery;
 }
 
-const ClassMasteryClusterComponent: React.FC<ClassMasteryClusterProps> = ({ classAnalysis }) => {
+const ClassMasteryClusterComponent: React.FC<ClassMasteryClusterProps> = ({
+  classAnalysis,
+  companionClassMastery,
+}) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
 
-  const { className, picks } = React.useMemo(
-    () => getClassMasteryPicks(classAnalysis),
-    [classAnalysis],
-  );
+  // Prefer the companion's live-client capture (authoritative + complete); fall back to the
+  // log-derived picks when there's no matched snapshot.
+  const { className, picks, fromCompanion } = React.useMemo(() => {
+    const companion = getCompanionClassMasteryPicks(companionClassMastery?.picks);
+    if (companion.picks.length > 0) return { ...companion, fromCompanion: true };
+    return { ...getClassMasteryPicks(classAnalysis), fromCompanion: false };
+  }, [classAnalysis, companionClassMastery]);
 
   if (picks.length === 0) return null;
 
@@ -241,7 +259,7 @@ const ClassMasteryClusterComponent: React.FC<ClassMasteryClusterProps> = ({ clas
       placement="top-start"
       enterTouchDelay={0}
       leaveTouchDelay={4000}
-      title={<ClassMasteryOverview picks={picks} accent={accent} />}
+      title={<ClassMasteryOverview picks={picks} accent={accent} fromCompanion={fromCompanion} />}
       slotProps={{
         tooltip: {
           sx: {

--- a/src/features/report_details/insights/LazyPlayerCard.tsx
+++ b/src/features/report_details/insights/LazyPlayerCard.tsx
@@ -74,7 +74,7 @@ export interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'classMastery' | 'distanceMs'
   >;
   /** Test ID for testing */
   'data-testid'?: string;

--- a/src/features/report_details/insights/PlayerCard.tsx
+++ b/src/features/report_details/insights/PlayerCard.tsx
@@ -211,7 +211,7 @@ interface PlayerCardProps {
    */
   companionBuild?: Pick<
     CompanionBuildForPlayer,
-    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
+    'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'classMastery' | 'distanceMs'
   >;
 }
 
@@ -1523,8 +1523,12 @@ export const PlayerCard: React.FC<PlayerCardProps> = React.memo(
                   </Box>
                 </Box>
 
-                {/* Class Mastery passives (non-subclassed only) — renders nothing otherwise */}
-                <ClassMasteryCluster classAnalysis={classAnalysis} />
+                {/* Class Mastery passives (non-subclassed only) — renders nothing otherwise.
+                    Prefers the Companion's true capture over the log's under-reported picks. */}
+                <ClassMasteryCluster
+                  classAnalysis={classAnalysis}
+                  companionClassMastery={companionBuild?.classMastery}
+                />
 
                 {/* Talents */}
                 {talents.length > 0 && (

--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -256,7 +256,7 @@ export function classAnalysisFromKalpaEvidence(
 
 type CompanionBuildRenderProps = Pick<
   CompanionBuildForPlayer,
-  'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
+  'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'classMastery' | 'distanceMs'
 >;
 
 interface PlayersPanelProps {
@@ -412,6 +412,7 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
         stats: build.stats,
         effects: build.effects,
         scribing: build.scribing,
+        classMastery: build.classMastery,
         distanceMs: build.distanceMs,
       };
     });

--- a/src/features/report_details/insights/PlayersPanelView.tsx
+++ b/src/features/report_details/insights/PlayersPanelView.tsx
@@ -90,7 +90,13 @@ interface PlayersPanelViewProps {
     string,
     Pick<
       CompanionBuildForPlayer,
-      'championPoints' | 'coaching' | 'stats' | 'effects' | 'scribing' | 'distanceMs'
+      | 'championPoints'
+      | 'coaching'
+      | 'stats'
+      | 'effects'
+      | 'scribing'
+      | 'classMastery'
+      | 'distanceMs'
     >
   >;
   /** Current companion upload status for the toolbar chip */

--- a/src/features/report_details/insights/__tests__/classMasteryPicks.test.ts
+++ b/src/features/report_details/insights/__tests__/classMasteryPicks.test.ts
@@ -1,6 +1,6 @@
 import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
 
-import { getClassMasteryPicks } from '../classMasteryPicks';
+import { getClassMasteryPicks, getCompanionClassMasteryPicks } from '../classMasteryPicks';
 
 // Canonical Class Mastery ability ids (from classSkillIds.ts / classMastery.ts).
 const NB_AN_EYE = 263604; // "An Eye for Exploitation"
@@ -112,5 +112,41 @@ describe('getClassMasteryPicks', () => {
     );
 
     expect(result.picks).toEqual([]);
+  });
+});
+
+describe('getCompanionClassMasteryPicks (live-client capture, preferred over the log)', () => {
+  it('resolves the true two purchased picks, deriving the class from the ids alone', () => {
+    const result = getCompanionClassMasteryPicks([SORC_STATIC, SORC_CALCULATED]);
+
+    expect(result.className).toBe('Sorcerer');
+    expect(result.picks.map((p) => p.name)).toEqual(['Static Reverberation', 'Calculated Defense']);
+    expect(result.picks[0].icon).toBeTruthy();
+    expect(result.picks[0].description).toBeTruthy();
+  });
+
+  it('recovers the full pair the encounter log under-reports (log often surfaces only one)', () => {
+    const result = getCompanionClassMasteryPicks([NB_AN_EYE, NB_ABOVE_AND_BEYOND]);
+
+    expect(result.picks).toHaveLength(2);
+    expect(result.picks.map((p) => p.id)).toEqual([NB_AN_EYE, NB_ABOVE_AND_BEYOND]);
+  });
+
+  it('caps at two and drops non-canonical noise ids', () => {
+    const result = getCompanionClassMasteryPicks([
+      SORC_CONSERVATION,
+      NOISE_A,
+      SORC_FONT,
+      SORC_STATIC,
+    ]);
+
+    expect(result.picks).toHaveLength(2);
+    expect(result.picks.map((p) => p.id)).toEqual([SORC_CONSERVATION, SORC_FONT]);
+  });
+
+  it('returns nothing for empty, undefined, or all-noise input', () => {
+    expect(getCompanionClassMasteryPicks(undefined)).toEqual({ className: '', picks: [] });
+    expect(getCompanionClassMasteryPicks([])).toEqual({ className: '', picks: [] });
+    expect(getCompanionClassMasteryPicks([NOISE_A, NOISE_B])).toEqual({ className: '', picks: [] });
   });
 });

--- a/src/features/report_details/insights/classMasteryPicks.ts
+++ b/src/features/report_details/insights/classMasteryPicks.ts
@@ -19,7 +19,10 @@ import {
   getClassMasteryLine,
 } from '@/data/skill-lines/class/classMastery';
 import type { ESOClass } from '@/features/build-editor/types/build.types';
-import { sanitizeClassMasteryPicks } from '@/features/build-editor/utils/classMasteryTransfer';
+import {
+  classFromMasteryIds,
+  sanitizeClassMasteryPicks,
+} from '@/features/build-editor/utils/classMasteryTransfer';
 import type { ClassAnalysisResult } from '@/utils/classDetectionUtils';
 
 export interface ClassMasteryPick {
@@ -69,4 +72,41 @@ export function getClassMasteryPicks(
 
   if (picks.length === 0) return EMPTY;
   return { className, picks };
+}
+
+/**
+ * Resolve Class Mastery picks from the ESOTK Companion's live-client capture — the TRUE
+ * purchased allocation. Prefer this over {@link getClassMasteryPicks} whenever a companion
+ * snapshot is matched: the encounter log is combat-event-driven and under-reports Class
+ * Mastery (it often surfaces only 1 of the 2 slotted), whereas the add-on reads the two
+ * purchased passives straight from the client.
+ *
+ * The owning class is derived from the ability ids themselves (each of the 35 ids belongs to
+ * exactly one class), so this doesn't depend on log-side class detection. Cross-class noise,
+ * duplicates, and >2 picks are dropped by the shared sanitizer.
+ */
+export function getCompanionClassMasteryPicks(
+  ids: readonly number[] | undefined,
+): ClassMasteryPicksResult {
+  if (!ids || ids.length === 0) return EMPTY;
+  const esoClass = classFromMasteryIds([...ids]);
+  if (!esoClass) return EMPTY;
+
+  const validIds = sanitizeClassMasteryPicks([...ids], esoClass);
+  if (validIds.length === 0) return EMPTY;
+
+  const line = getClassMasteryLine(esoClass);
+  const picks = validIds
+    .map((id) => line?.skills.find((skill) => skill.id === id))
+    .filter((skill): skill is NonNullable<typeof skill> => Boolean(skill))
+    .map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      icon: skill.icon ?? '',
+      description: skill.description ?? '',
+    }));
+
+  if (picks.length === 0) return EMPTY;
+  // line.class is proper-cased ("Nightblade"), matching getClassMasteryPicks' className.
+  return { className: line?.class ?? '', picks };
 }


### PR DESCRIPTION
## Why

The ESO **encounter log under-reports Class Mastery.** `PLAYER_INFO` is combat-event-driven, so a Class Mastery passive that hasn't registered in a session is simply absent from the log. In practice that means a non-subclassed player who runs **2** of their 2 slotted passives frequently logs only **1** — verified across three independent logs (~2:1 ratio of 1-pick to 2-pick), including the same character showing a stable 2-pick state in one log and a 1-pick state in another.

Authoritative sources (ESO Hub, UESP, ZOS support) confirm a non-subclassed level-50 character gets **2 Class Mastery Points, both granted on unlock**, and slots 2. So "1 pick" on a report card is a log artifact, not a real build — the extractor is faithful, the raw log just doesn't carry the 2nd.

The log can't be fixed after the fact. The live client can.

## What

Read the **true** Class Mastery allocation live from the game client and prefer it on the report card — the same "beats the log ceiling" pattern already used for champion points, Mundus, and crit.

- **Addon** (`ESOTKCompanion.lua`): `captureClassMastery()` finds the Class Mastery skill line (in-game line id **351**) and records the passives the player has actually **purchased** (`GetSkillAbilityInfo` → `purchased`). Language-agnostic (raw ability ids + client names); returns nothing when subclassed / pre-U50 so the card falls back to the log. Flows through the existing companion sidecar block — no Kalpa or worker change needed (the worker persists snapshots opaquely).
- **Parser**: normalizes a `classMastery { lineId, picks[], names }` block into a typed field.
- **Adapter**: surfaces `classMastery` per matched player.
- **Card** (`ClassMasteryCluster`): prefers the companion's picks over the log-derived picks when a snapshot is matched, resolving the owning class from the ids themselves (reusing `classFromMasteryIds` + `sanitizeClassMasteryPicks`), and tags the tooltip **"Companion"** so the provenance is clear.

## Caveat

The addon reads the **local** client, so it captures the **logging player's own** character authoritatively. Other group members stay log-limited unless they also run the Companion addon.

## Checks

- `tsc --noEmit`: clean
- jest (card chain + companion suites): **55 passing**, incl. new `getCompanionClassMasteryPicks` + parser `classMastery` tests
- eslint (source) + prettier: clean