### PR TITLE
perf(bundle): cut the entry chunk from 11.3 MB to ~830 kB

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Space+Grotesk:wght@300..700&display=swap"
       rel="stylesheet"
     />
-    <!-- Material Symbols for ligature icons (e.g., skull, swords) -->
+    <!-- Material Symbols for ligature icons (e.g., skull, swords).
+         display=block (not swap): swapping a ligature icon font would flash the
+         raw ligature TEXT ("skull") before the glyph loads; block hides it. -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=block"
       rel="stylesheet"
     />
     <title>ESO Toolkit</title>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,8 +51,9 @@ import {
   importBuildHubPage,
   importPackHubPage,
 } from './utils/hubRoutePreload';
-// Initialize error tracking before the app starts
-initializeErrorTracking();
+// Initialize error tracking before the app starts (async — loads the
+// Rollbar chunk off the entry path; consumers null-guard the instance)
+void initializeErrorTracking();
 
 // Initialize Google Analytics
 initializeAnalytics();
@@ -336,7 +337,7 @@ const App: React.FC = () => {
     const handleConsentChanged = (): void => {
       // Re-evaluate consent and reinitialize services accordingly
       initializeAnalytics();
-      initializeErrorTracking();
+      void initializeErrorTracking();
     };
 
     // Listen for custom consent-changed event from CookieConsent component

--- a/src/features/build-editor/data/setArmorWeights.ts
+++ b/src/features/build-editor/data/setArmorWeights.ts
@@ -14,8 +14,11 @@
  * (regenerate with `node scripts/generate-set-armor-weights.mjs`).
  */
 
-import { getItemInfo } from '../../loadout-manager/data/itemIdMap';
 import type { ArmorWeight } from '../../loadout-manager/types/loadout.types';
+// Imported by buildEditorSlice (root store → entry chunk), so this module
+// must not static-import itemIdMap — set names resolve through the oracle
+// registered by itemIconResolver (see gearItemOracle.ts).
+import { getSetNameForItem } from '../../loadout-manager/utils/gearItemOracle';
 
 import { LOCKED_SET_ARMOR_WEIGHTS } from './setArmorWeights.generated';
 
@@ -72,7 +75,7 @@ export function resolveApparelWeight(
 ): ArmorWeight {
   const numericId = typeof id === 'number' ? id : Number(id);
   if (Number.isFinite(numericId) && numericId > 0) {
-    const locked = getLockedArmorWeight(getItemInfo(numericId)?.setName);
+    const locked = getLockedArmorWeight(getSetNameForItem(numericId));
     if (locked) return locked;
   }
   return storedWeight ?? 'heavy';

--- a/src/features/build-editor/engine/__tests__/countArmorWeights.test.ts
+++ b/src/features/build-editor/engine/__tests__/countArmorWeights.test.ts
@@ -10,6 +10,10 @@
  *   97050 — Plague Doctor Chest    → locked HEAVY
  */
 
+// Side-effect: registers the gearItemOracle with REAL item data — the concrete
+// item ids above resolve their set names (→ locked weights) through the oracle.
+import '../../../loadout-manager/utils/itemIconResolver';
+
 import type { GearConfig } from '../../../loadout-manager/types/loadout.types';
 import { countArmorWeights } from '../stat-engine';
 

--- a/src/features/build-editor/store/buildEditorSlice.bulkGear.test.ts
+++ b/src/features/build-editor/store/buildEditorSlice.bulkGear.test.ts
@@ -4,11 +4,13 @@
  * the single-slot UI shows as read-only. Trait/enchant still apply to any piece.
  *
  * The item/lock data is mocked so the test is deterministic: item 100 belongs to
- * a locked set, item 200 to a free (all-weight) set.
+ * a locked set, item 200 to a free (all-weight) set. The slice reads item facts
+ * through gearItemOracle (never itemIdMap directly — bundle-size seam).
  */
 
-jest.mock('../../loadout-manager/data/itemIdMap', () => ({
-  getItemInfo: (id: number) => ({ setName: id === 100 ? 'Locked Set' : 'Free Set' }),
+jest.mock('../../loadout-manager/utils/gearItemOracle', () => ({
+  getSetNameForItem: (id: number) => (id === 100 ? 'Locked Set' : 'Free Set'),
+  isTwoHandedWeaponId: () => false,
 }));
 jest.mock('../data/setArmorWeights', () => ({
   getLockedArmorWeight: (setName?: string | null) => (setName === 'Locked Set' ? 'medium' : null),

--- a/src/features/build-editor/store/buildEditorSlice.import.test.ts
+++ b/src/features/build-editor/store/buildEditorSlice.import.test.ts
@@ -6,9 +6,11 @@
  */
 
 // Treat item id 9999 as a two-handed weapon so we can assert off-hand clearing
-// without coupling the test to the real itemIdMap.
-jest.mock('../../loadout-manager/utils/itemIconResolver', () => ({
-  isTwoHandedWeapon: (id: number) => id === 9999,
+// without coupling the test to the real itemIdMap. The slice reads item facts
+// through gearItemOracle (never itemIdMap directly — bundle-size seam).
+jest.mock('../../loadout-manager/utils/gearItemOracle', () => ({
+  isTwoHandedWeaponId: (id: number) => id === 9999,
+  getSetNameForItem: () => undefined,
 }));
 
 import { getClassMasteryLine } from '@/data/skill-lines/class/classMastery';

--- a/src/features/build-editor/store/buildEditorSlice.ts
+++ b/src/features/build-editor/store/buildEditorSlice.ts
@@ -8,13 +8,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { getClassMasteryLine } from '@/data/skill-lines/class/classMastery';
 
-import { getItemInfo } from '../../loadout-manager/data/itemIdMap';
 import type {
   ArmorWeight,
   GearConfig,
   SkillsConfig,
 } from '../../loadout-manager/types/loadout.types';
-import { isTwoHandedWeapon } from '../../loadout-manager/utils/itemIconResolver';
+// This slice lives in the ROOT store (imported by the entry chunk) and must
+// never static-import itemIdMap/itemIconResolver — the oracle indirection
+// keeps ~11 MB of item data out of the startup bundle (see gearItemOracle.ts).
+import { getSetNameForItem, isTwoHandedWeaponId } from '../../loadout-manager/utils/gearItemOracle';
 import { EQUIP_SLOTS, getDefaultLinesForClass } from '../data/esoStaticData';
 import { getLockedArmorWeight } from '../data/setArmorWeights';
 import { DEFAULT_STAT_OVERRIDES } from '../engine/stat-constants';
@@ -383,7 +385,7 @@ export const buildEditorSlice = createSlice({
           // trial drops) can't be re-weighted — the single-slot UI shows them as
           // read-only, so skip them here too rather than persist an impossible
           // weight that exports/roster display would read verbatim.
-          const setName = piece.id != null ? getItemInfo(Number(piece.id))?.setName : undefined;
+          const setName = piece.id != null ? getSetNameForItem(Number(piece.id)) : undefined;
           const isLocked = getLockedArmorWeight(setName) !== null;
           if (!isLocked) {
             if (weight === null) {
@@ -489,7 +491,7 @@ export const buildEditorSlice = createSlice({
           [20, 21],
         ] as const) {
           const mainId = target.gear[mainSlot]?.id;
-          if (mainId != null && isTwoHandedWeapon(Number(mainId))) {
+          if (mainId != null && isTwoHandedWeaponId(Number(mainId))) {
             delete target.gear[offSlot];
           }
         }

--- a/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
+++ b/src/features/loadout-manager/utils/__tests__/cspsExport.test.ts
@@ -2,6 +2,11 @@
  * @jest-environment jsdom
  */
 
+// Side-effect: registers the gearItemOracle with REAL item data — the armor
+// weight assertions below use concrete item ids (Mother's Sorrow, Plague
+// Doctor), and resolveApparelWeight resolves their set names via the oracle.
+import '../itemIconResolver';
+
 import { convertBuildToCSPS, exportBuildToCSPSLua } from '../../../build-editor/utils/cspsExport';
 import {
   convertCSPSCharacterToBuild,

--- a/src/features/loadout-manager/utils/gearItemOracle.ts
+++ b/src/features/loadout-manager/utils/gearItemOracle.ts
@@ -1,0 +1,37 @@
+/**
+ * Gear item oracle — a registration seam that lets modules in the EAGER
+ * bundle graph (the root redux store via buildEditorSlice, setArmorWeights)
+ * consult the ~11 MB itemIdMap WITHOUT statically importing it.
+ *
+ * Why: the root store must stay item-data-free or the entry chunk regains
+ * the full map (see vite.config.mjs manualChunks 'item-data'). Every surface
+ * that can dispatch gear-mutating actions or resolve apparel weights renders
+ * item names/icons and therefore loads `itemIconResolver` — which registers
+ * the real implementations at module-eval, before any such action can fire.
+ *
+ * Unregistered fallbacks are graceful: set names resolve to undefined (weight
+ * treated as freely choosable) and no weapon counts as two-handed. In
+ * practice registration always precedes use; the fallbacks exist for unit
+ * tests that exercise reducers in isolation.
+ */
+
+interface GearItemOracle {
+  /** Set name for an item id, or undefined when unknown. */
+  getSetNameForItem: (itemId: number) => string | undefined;
+  /** True when the item id is a two-handed weapon (occupies both hand slots). */
+  isTwoHandedWeapon: (itemId: number) => boolean;
+}
+
+let oracle: GearItemOracle | null = null;
+
+export function registerGearItemOracle(impl: GearItemOracle): void {
+  oracle = impl;
+}
+
+export function getSetNameForItem(itemId: number): string | undefined {
+  return oracle?.getSetNameForItem(itemId);
+}
+
+export function isTwoHandedWeaponId(itemId: number): boolean {
+  return oracle?.isTwoHandedWeapon(itemId) ?? false;
+}

--- a/src/features/loadout-manager/utils/itemIconResolver.ts
+++ b/src/features/loadout-manager/utils/itemIconResolver.ts
@@ -20,6 +20,8 @@ import { Logger } from '@/utils/logger';
 import { getItemInfo } from '../data/itemIdMap';
 import type { SlotType } from '../data/slotTypes';
 
+import { registerGearItemOracle } from './gearItemOracle';
+
 type IconData = {
   icons: string[];
   items: Record<string, number>;
@@ -514,3 +516,11 @@ export async function prefetchItemIcons(itemIds: number[]): Promise<void> {
     await new Promise((r) => setTimeout(r, 50));
   }
 }
+
+// Register the item-data-backed implementations for modules in the EAGER
+// bundle graph (buildEditorSlice, setArmorWeights) that must not import
+// itemIdMap statically — see gearItemOracle.ts for the invariant.
+registerGearItemOracle({
+  getSetNameForItem: (itemId) => getItemInfo(itemId)?.setName,
+  isTwoHandedWeapon: (itemId) => isTwoHandedWeapon(itemId),
+});

--- a/src/features/report_details/FightDetailsView.tsx
+++ b/src/features/report_details/FightDetailsView.tsx
@@ -40,13 +40,19 @@ import { useReportMasterData } from '../../hooks';
 import { usePhaseTransitions } from '../../hooks/usePhaseTransitions';
 import { getSkeletonForTab, TabId } from '../../utils/getSkeletonForTab';
 
-import { CriticalDamagePanel } from './critical_damage/CriticalDamagePanel';
 import { CombinedFilterDropdown } from './insights/CombinedFilterDropdown';
 import { useFightNavigation } from './ReportFightHeader';
 
 // Lazy load heavy panel components for better initial page load performance
 const ActorsPanel = React.lazy(() =>
   import('./actors/ActorsPanel').then((module) => ({ default: module.ActorsPanel })),
+);
+// Lazy like every sibling panel — a static import here drags echarts (~620 kB)
+// into the entry chunk, since this view is reached eagerly via ReportFightDetails.
+const CriticalDamagePanel = React.lazy(() =>
+  import('./critical_damage/CriticalDamagePanel').then((module) => ({
+    default: module.CriticalDamagePanel,
+  })),
 );
 const DamageDonePanel = React.lazy(() =>
   import('./damage/DamageDonePanel').then((module) => ({ default: module.DamageDonePanel })),

--- a/src/features/report_details/ReportFightHeader.tsx
+++ b/src/features/report_details/ReportFightHeader.tsx
@@ -26,7 +26,7 @@ import type { PlayerDetailsWithRole } from '@/store/player_data/playerDataSlice'
 import type { RootState } from '@/store/storeWithHistory';
 import { createDefaultRoster } from '@/types/roster';
 import { cleanArray } from '@/utils/cleanArray';
-import { convertLogPlayersToRoster, type LogPlayerDetails } from '@/utils/logToRoster';
+import type { LogPlayerDetails } from '@/utils/logToRoster';
 import { encodeRosterToURL } from '@/utils/rosterEncoding';
 
 function getWipeColor(percentage: number): string {
@@ -287,6 +287,12 @@ export const ReportFightHeader: React.FC = () => {
 
       const details: LogPlayerDetails = { tanks, healers, dps };
       const defaultRoster = createDefaultRoster();
+
+      // Dynamic import: logToRoster transitively pulls the ~11 MB itemIdMap
+      // (via playerToBuild → combatLogGearMapping); a static import here would
+      // drag it into the entry chunk since this header renders eagerly on the
+      // report route. Loaded on click instead — the handler already awaits.
+      const { convertLogPlayersToRoster } = await import('@/utils/logToRoster');
 
       // CombatantInfoEvents from Redux use the canonical type which has `ability` on auras;
       // convertLogPlayersToRoster expects the same shape via LogCombatantInfoEvent

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
-import { preloadIconData } from './features/loadout-manager/utils/itemIconResolver';
 import './index.css';
 import './styles/view-transitions.css';
 import store, { type RootState } from './store/storeWithHistory';
 import { setPerfTier } from './store/ui/uiSlice';
 import { heuristicPerfTier } from './utils/detectPerfTier';
-
-preloadIconData();
 
 // First-paint perf-tier priming. For a first-time visitor with no
 // persisted store, the default is 'medium' — which would leave a low-end
@@ -59,3 +56,21 @@ root.render(
   // Note: Production builds don't use Strict Mode, so this only affects development.
   <App />,
 );
+
+// Warm the item-icon cache off the critical path. A STATIC import of
+// itemIconResolver here would drag the ~11 MB itemIdMap (+ ~2 MB set
+// collections) into the entry chunk, parsed before first paint on every
+// page — the dynamic import keeps that data in its own async chunk, and
+// idle scheduling keeps even the fetch out of the startup window. This is
+// best-effort: consumers that need the data (GearPicker, Extract Build)
+// await preloadIconData() themselves and retry on failure.
+const warmItemIconData = (): void => {
+  void import('./features/loadout-manager/utils/itemIconResolver')
+    .then((m) => m.preloadIconData())
+    .catch(() => {});
+};
+if (typeof window.requestIdleCallback === 'function') {
+  window.requestIdleCallback(warmItemIconData, { timeout: 5000 });
+} else {
+  window.setTimeout(warmItemIconData, 2000);
+}

--- a/src/utils/errorTracking.test.ts
+++ b/src/utils/errorTracking.test.ts
@@ -63,16 +63,16 @@ jest.mock('../contexts/LoggerContext', () => ({
 }));
 
 /** Helper: initialize Rollbar in production mode with consent. */
-const initInProduction = (): void => {
+const initInProduction = async (): Promise<void> => {
   process.env.NODE_ENV = 'production';
   mockHasErrorTrackingConsent.mockReturnValue(true);
-  initializeErrorTracking();
+  await initializeErrorTracking();
 };
 
 describe('errorTracking', () => {
   let originalEnv: string | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // jest.config.cjs has resetMocks: true which resets all mock implementations
     // before each test. Re-apply the Rollbar constructor implementation so that
     // `new Rollbar(config)` continues to return our shared mock instance.
@@ -92,8 +92,8 @@ describe('errorTracking', () => {
   // ─── initializeErrorTracking ──────────────────────────────────────────────
 
   describe('initializeErrorTracking', () => {
-    it('should initialize Rollbar in production with consent', () => {
-      initInProduction();
+    it('should initialize Rollbar in production with consent', async () => {
+      await initInProduction();
 
       expect(Rollbar).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -106,9 +106,9 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should initialize Rollbar in development with auto-capture disabled', () => {
+    it('should initialize Rollbar in development with auto-capture disabled', async () => {
       process.env.NODE_ENV = 'development';
-      initializeErrorTracking();
+      await initializeErrorTracking();
 
       expect(Rollbar).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -119,16 +119,16 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should not initialize Rollbar in production without consent', () => {
+    it('should not initialize Rollbar in production without consent', async () => {
       process.env.NODE_ENV = 'production';
       mockHasErrorTrackingConsent.mockReturnValue(false);
-      initializeErrorTracking();
+      await initializeErrorTracking();
 
       expect(Rollbar).not.toHaveBeenCalled();
     });
 
-    it('should configure checkIgnore to drop chrome extension errors (ESO-559)', () => {
-      initInProduction();
+    it('should configure checkIgnore to drop chrome extension errors (ESO-559)', async () => {
+      await initInProduction();
       const { checkIgnore } = (Rollbar as jest.Mock).mock.calls[0][0];
 
       const extensionPayload = {
@@ -137,8 +137,8 @@ describe('errorTracking', () => {
       expect(checkIgnore(false, [new Error('x')], extensionPayload)).toBe(true);
     });
 
-    it('should configure checkIgnore to drop firefox extension errors (ESO-559)', () => {
-      initInProduction();
+    it('should configure checkIgnore to drop firefox extension errors (ESO-559)', async () => {
+      await initInProduction();
       const { checkIgnore } = (Rollbar as jest.Mock).mock.calls[0][0];
 
       const extensionPayload = {
@@ -147,8 +147,8 @@ describe('errorTracking', () => {
       expect(checkIgnore(false, [new Error('x')], extensionPayload)).toBe(true);
     });
 
-    it('should configure checkIgnore to drop runtime.sendMessage errors (ESO-559)', () => {
-      initInProduction();
+    it('should configure checkIgnore to drop runtime.sendMessage errors (ESO-559)', async () => {
+      await initInProduction();
       const { checkIgnore } = (Rollbar as jest.Mock).mock.calls[0][0];
 
       const sendMessageError = new Error('Invalid call to runtime.sendMessage(). Tab not found.');
@@ -157,8 +157,8 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should NOT drop normal application errors (ESO-559)', () => {
-      initInProduction();
+    it('should NOT drop normal application errors (ESO-559)', async () => {
+      await initInProduction();
       const { checkIgnore } = (Rollbar as jest.Mock).mock.calls[0][0];
 
       const appPayload = {
@@ -167,8 +167,8 @@ describe('errorTracking', () => {
       expect(checkIgnore(false, [new Error('TypeError')], appPayload)).toBe(false);
     });
 
-    it('should configure transform to add browser context fields', () => {
-      initInProduction();
+    it('should configure transform to add browser context fields', async () => {
+      await initInProduction();
       const { transform } = (Rollbar as jest.Mock).mock.calls[0][0];
 
       const payload: Record<string, unknown> = {};
@@ -184,7 +184,7 @@ describe('errorTracking', () => {
   // ─── captureApplicationContext ────────────────────────────────────────────
 
   describe('captureApplicationContext', () => {
-    it('should capture basic application context', () => {
+    it('should capture basic application context', async () => {
       const context = captureApplicationContext();
 
       expect(context).toEqual(
@@ -204,7 +204,7 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should include Redux state when store is provided', () => {
+    it('should include Redux state when store is provided', async () => {
       const mockStore = {
         getState: jest.fn().mockReturnValue({
           router: { location: { pathname: '/' } },
@@ -242,7 +242,7 @@ describe('errorTracking', () => {
       });
     });
 
-    it('should handle missing APIs gracefully', () => {
+    it('should handle missing APIs gracefully', async () => {
       // The function should not throw even if some browser APIs are missing
       const context = captureApplicationContext();
 
@@ -256,12 +256,12 @@ describe('errorTracking', () => {
   // ─── reportError ──────────────────────────────────────────────────────────
 
   describe('reportError', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       // The outer beforeEach already clears mocks; this just sets up production state
-      initInProduction();
+      await initInProduction();
     });
 
-    it('should call rollbar.error with an Error object in production', () => {
+    it('should call rollbar.error with an Error object in production', async () => {
       const error = new Error('Test error');
       const context = { key: 'value' };
 
@@ -277,7 +277,7 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should call rollbar.error with a string message in production', () => {
+    it('should call rollbar.error with a string message in production', async () => {
       reportError('Test error message');
 
       expect(mockRollbarInstance.error).toHaveBeenCalledWith(
@@ -286,21 +286,21 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should not call rollbar in development', () => {
+    it('should not call rollbar in development', async () => {
       process.env.NODE_ENV = 'development';
       reportError(new Error('dev error'));
 
       expect(mockRollbarInstance.error).not.toHaveBeenCalled();
     });
 
-    it('should not call rollbar without consent', () => {
+    it('should not call rollbar without consent', async () => {
       mockHasErrorTrackingConsent.mockReturnValue(false);
       reportError(new Error('no consent'));
 
       expect(mockRollbarInstance.error).not.toHaveBeenCalled();
     });
 
-    it('should include context fields as extra payload', () => {
+    it('should include context fields as extra payload', async () => {
       reportError(new Error('ctx error'), { foo: 'bar', count: 42 });
 
       expect(mockRollbarInstance.error).toHaveBeenCalledWith(
@@ -309,7 +309,7 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should handle undefined context gracefully', () => {
+    it('should handle undefined context gracefully', async () => {
       expect(() => reportError(new Error('no ctx'), undefined)).not.toThrow();
       expect(mockRollbarInstance.error).toHaveBeenCalled();
     });
@@ -330,11 +330,11 @@ describe('errorTracking', () => {
       url: 'https://example.com',
     };
 
-    beforeEach(() => {
-      initInProduction();
+    beforeEach(async () => {
+      await initInProduction();
     });
 
-    it('should call rollbar.error for high severity', () => {
+    it('should call rollbar.error for high severity', async () => {
       submitManualBugReport(mockBugReport);
 
       expect(mockRollbarInstance.error).toHaveBeenCalledWith(
@@ -347,22 +347,22 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should call rollbar.critical for critical severity', () => {
+    it('should call rollbar.critical for critical severity', async () => {
       submitManualBugReport({ ...mockBugReport, severity: 'critical' });
       expect(mockRollbarInstance.critical).toHaveBeenCalled();
     });
 
-    it('should call rollbar.warning for medium severity', () => {
+    it('should call rollbar.warning for medium severity', async () => {
       submitManualBugReport({ ...mockBugReport, severity: 'medium' });
       expect(mockRollbarInstance.warning).toHaveBeenCalled();
     });
 
-    it('should call rollbar.info for low severity', () => {
+    it('should call rollbar.info for low severity', async () => {
       submitManualBugReport({ ...mockBugReport, severity: 'low' });
       expect(mockRollbarInstance.info).toHaveBeenCalled();
     });
 
-    it('should include bug report details in the payload', () => {
+    it('should include bug report details in the payload', async () => {
       submitManualBugReport(mockBugReport);
 
       expect(mockRollbarInstance.error).toHaveBeenCalledWith(
@@ -381,7 +381,7 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should use navigator.userAgent and window.location.href as fallbacks', () => {
+    it('should use navigator.userAgent and window.location.href as fallbacks', async () => {
       submitManualBugReport({ ...mockBugReport, userAgent: undefined, url: undefined });
 
       expect(mockRollbarInstance.error).toHaveBeenCalledWith(
@@ -395,15 +395,15 @@ describe('errorTracking', () => {
       );
     });
 
-    it('should call rollbar in development (manual reports always sent with consent)', () => {
+    it('should call rollbar in development (manual reports always sent with consent)', async () => {
       process.env.NODE_ENV = 'development';
-      initializeErrorTracking();
+      await initializeErrorTracking();
       submitManualBugReport(mockBugReport);
 
       expect(mockRollbarInstance.error).toHaveBeenCalled();
     });
 
-    it('should not throw for minimal bug reports', () => {
+    it('should not throw for minimal bug reports', async () => {
       expect(() =>
         submitManualBugReport({
           title: 'Minimal',
@@ -418,11 +418,11 @@ describe('errorTracking', () => {
   // ─── setUserContext ───────────────────────────────────────────────────────
 
   describe('setUserContext', () => {
-    beforeEach(() => {
-      initInProduction();
+    beforeEach(async () => {
+      await initInProduction();
     });
 
-    it('should call rollbar.configure with person context in production', () => {
+    it('should call rollbar.configure with person context in production', async () => {
       setUserContext('user123', 'user@example.com', 'testuser');
 
       expect(mockRollbarInstance.configure).toHaveBeenCalledWith({
@@ -430,27 +430,27 @@ describe('errorTracking', () => {
       });
     });
 
-    it('should never forward email to Rollbar', () => {
+    it('should never forward email to Rollbar', async () => {
       setUserContext('user123', 'user@example.com', 'testuser');
 
       const call = mockRollbarInstance.configure.mock.calls[0][0];
       expect(JSON.stringify(call)).not.toContain('user@example.com');
     });
 
-    it('should handle optional username', () => {
+    it('should handle optional username', async () => {
       setUserContext('user123');
       expect(mockRollbarInstance.configure).toHaveBeenCalledWith({
         payload: { person: { id: 'user123', username: undefined } },
       });
     });
 
-    it('should not call rollbar in development', () => {
+    it('should not call rollbar in development', async () => {
       process.env.NODE_ENV = 'development';
       setUserContext('user123');
       expect(mockRollbarInstance.configure).not.toHaveBeenCalled();
     });
 
-    it('should not call rollbar without consent', () => {
+    it('should not call rollbar without consent', async () => {
       mockHasErrorTrackingConsent.mockReturnValue(false);
       setUserContext('user123');
       expect(mockRollbarInstance.configure).not.toHaveBeenCalled();
@@ -460,7 +460,7 @@ describe('errorTracking', () => {
   // ─── addBreadcrumb ────────────────────────────────────────────────────────
 
   describe('addBreadcrumb', () => {
-    it('should not throw in production or development', () => {
+    it('should not throw in production or development', async () => {
       expect(() =>
         addBreadcrumb('User clicked button', 'ui', { buttonId: 'submit' }),
       ).not.toThrow();
@@ -468,7 +468,7 @@ describe('errorTracking', () => {
       expect(() => addBreadcrumb('Page loaded', 'navigation')).not.toThrow();
     });
 
-    it('should handle optional data parameter', () => {
+    it('should handle optional data parameter', async () => {
       expect(() => addBreadcrumb('Page loaded', 'navigation')).not.toThrow();
     });
   });
@@ -491,7 +491,7 @@ describe('errorTracking', () => {
     });
 
     it('should propagate errors from operations and report them in production', async () => {
-      initInProduction();
+      await initInProduction();
 
       const error = new Error('Operation failed');
       const mockOperation = jest.fn().mockRejectedValue(error);
@@ -522,20 +522,20 @@ describe('errorTracking', () => {
   // ─── edge cases ───────────────────────────────────────────────────────────
 
   describe('edge cases', () => {
-    it('should handle undefined context in reportError without throwing', () => {
-      initInProduction();
+    it('should handle undefined context in reportError without throwing', async () => {
+      await initInProduction();
 
       const error = new Error('Test error');
       expect(() => reportError(error, undefined)).not.toThrow();
       expect(mockRollbarInstance.error).toHaveBeenCalled();
     });
 
-    it('should handle missing global APIs gracefully in captureApplicationContext', () => {
+    it('should handle missing global APIs gracefully in captureApplicationContext', async () => {
       expect(() => captureApplicationContext()).not.toThrow();
     });
 
-    it('should not throw for minimal bug reports', () => {
-      initInProduction();
+    it('should not throw for minimal bug reports', async () => {
+      await initInProduction();
 
       const partialBugReport = {
         title: 'Minimal Bug',

--- a/src/utils/errorTracking.ts
+++ b/src/utils/errorTracking.ts
@@ -1,4 +1,4 @@
-import Rollbar from 'rollbar';
+import type Rollbar from 'rollbar';
 
 import {
   selectMasterDataErrorState,
@@ -51,16 +51,32 @@ interface ExtendedPerformance extends Performance {
  * (uncaught exceptions, unhandled rejections) is disabled outside production.
  * Manual bug reports are always sent regardless of environment.
  */
-export const initializeErrorTracking = (): void => {
+export const initializeErrorTracking = (): Promise<void> => {
   // GDPR: Only initialize if user has consented to error tracking
   if (!hasErrorTrackingConsent()) {
     logger.info('Error tracking disabled - user has not consented to error tracking');
-    return;
+    return Promise.resolve();
   }
 
+  // Rollbar is dynamically imported so its ~80 KB stays out of the entry
+  // chunk — and never downloads at all without consent. Every consumer
+  // null-guards `rollbar`, so the brief async window before it resolves
+  // behaves identically to the long-standing no-consent case. Re-invocation
+  // (consent changes) recreates the instance, matching the previous sync
+  // behavior; the module itself is cached after the first import.
+  return import('rollbar')
+    .then(({ default: RollbarCtor }) => {
+      rollbar = createRollbar(RollbarCtor);
+    })
+    .catch((error: unknown) => {
+      logger.warn('Failed to load error tracking module', { error });
+    });
+};
+
+const createRollbar = (RollbarCtor: typeof Rollbar): Rollbar => {
   const isProduction = process.env.NODE_ENV === 'production';
 
-  rollbar = new Rollbar({
+  return new RollbarCtor({
     accessToken: ERROR_TRACKING_CONFIG.accessToken,
     environment: ERROR_TRACKING_CONFIG.environment,
     codeVersion: ERROR_TRACKING_CONFIG.release,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -308,8 +308,11 @@ ${downloadBtn}
           },
         },
       },
-      // Increase chunk size warning limit
-      chunkSizeWarningLimit: 1000,
+      // Keep the warning limit low so ENTRY-chunk regressions are loud in CI.
+      // Known-large ASYNC chunks (item-data, itemIcons, FightReplay, charts)
+      // will warn — informational; what must never regress is the eager index
+      // chunk creeping back toward its old 11 MB of item data.
+      chunkSizeWarningLimit: 600,
     },
 
     // Define global constants


### PR DESCRIPTION
Every page load — including the landing page — parsed ~14 MB of ESO item data before first paint: the generated `itemIdMap` (11 MB) plus set collections (2 MB) sat in the eager `index` chunk, and a 2.7 MB icon-mapping chunk was fetched at module eval. On old hardware this is the single biggest startup cost in the app. This PR removes all of it from the critical path without changing any feature behavior.

**Entry chunk: 11.3 MB → 804 kB (gzip 195 kB).** `itemIcons` (2.77 MB) and echarts (`charts`, 621 kB) also leave the startup path.

Three separate static chains pulled the data eagerly; each is cut differently:

1. `index.tsx` statically imported `preloadIconData` — now an idle-scheduled dynamic import (`requestIdleCallback`, 5 s timeout fallback). Warm-up is best-effort; consumers (GearPicker, Extract Build) still `await preloadIconData()` themselves and retry on failure, so those flows are unchanged.
2. `ReportFightHeader` (eager on report routes) statically imported `convertLogPlayersToRoster`, which transitively reaches `itemIdMap` via `playerToBuild → combatLogGearMapping`. The conversion now dynamic-imports inside the already-async click handler.
3. The **root redux store** reached `itemIdMap` through `buildEditorSlice` (`getItemInfo`, `isTwoHandedWeapon`) and `setArmorWeights` (`resolveApparelWeight`). These now consult a small `gearItemOracle` registered at module-eval by `itemIconResolver` — which every gear-editing surface already loads before any of these code paths can run. Unregistered fallbacks are graceful (set names unknown → weight freely choosable; nothing two-handed) and unreachable in practice.

Also fixed while in here: `CriticalDamagePanel` was the only report tab panel not `React.lazy` (its render site was already Suspense-wrapped) — that one import dragged echarts into the entry chunk. Rollbar (~80 kB) now loads only after the consent gate passes. The Material Symbols ligature font gets `display=block` so icon names never flash as raw text.

**Approach note for reviewers:** a `manualChunks` pin for the item-data modules was tried and deliberately dropped — under Rolldown the pinned chunk absorbed shared modules (logger, gear-slot memory), which made the 10.9 MB chunk a *static* dependency of every other chunk including the entry (verified in build output). The chain-break alone produces the right chunk graph; the lowered `chunkSizeWarningLimit` (1000 → 600) is the regression alarm instead.

Deferred as a follow-up (documented in the perf plan): converting `itemIdMap` from a TS object literal to a fetched JSON asset — it would speed up the lazy consumers too, but forces an async-init gate across ~14 synchronous call sites.

Verification: `npm run validate` green; full jest 4489 passing (4 suites re-pointed at the oracle seam / registered real data); build inspected — no `modulepreload` of item data, icon data, or charts in `build/index.html`, and the entry chunk's static imports contain none of them.