### PR TITLE
perf(site): make the low tier truly barebones — animations, background, hub blur

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -98,6 +98,10 @@ jest.mock('./components/UpdateNotification', () => ({
   UpdateNotification: () => null,
 }));
 
+jest.mock('./components/PerfLowNotice', () => ({
+  PerfLowNotice: () => null,
+}));
+
 jest.mock('./components/BugReportDialog', () => ({
   ModernFeedbackFab: () => null,
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { HashRouteRedirect } from './components/HashRouteRedirect';
 import { HeaderBar } from './components/HeaderBar';
 import { KalpaBanner } from './components/KalpaBanner';
 import { LandingPage } from './components/LandingPage';
+import { PerfLowNotice } from './components/PerfLowNotice';
 import { PerfTierProvider } from './components/PerfTierProvider';
 import { ReportFightsSkeleton } from './components/ReportFightsSkeleton';
 import { RosterBuilderSkeleton } from './components/RosterBuilderSkeleton';
@@ -387,6 +388,8 @@ const App: React.FC = () => {
                       <AppRoutes />
                       {/* Update notification for new versions */}
                       {!window.location.search.includes('embed=1') && <UpdateNotification />}
+                      {/* One-time low-tier performance notice */}
+                      {!window.location.search.includes('embed=1') && <PerfLowNotice />}
                       {/* Cookie consent banner — suppressed in embed/iframe mode to prevent double-banner */}
                       {!window.location.search.includes('embed=1') && <CookieConsent />}
                     </SnackbarProvider>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -64,7 +64,10 @@ const showcaseGlobalStyles = (
 
 import { useEsoLogsClientContext } from '../EsoLogsClientContext';
 import { useAuth } from '../features/auth/AuthContext';
+import { usePerfTier } from '../hooks/usePerfTier';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 import { useViewTransitionNavigate } from '../hooks/useViewTransitionNavigate';
+import { shouldShowLandingFx } from '../utils/landingFx';
 
 import { AuthenticatedLandingSection } from './AuthenticatedLandingSection';
 import { Footer } from './Footer';
@@ -2218,6 +2221,8 @@ const ESORune = styled(Box)<{ delay?: number; x?: string; y?: string }>(
 export const LandingPage: React.FC = () => {
   const [showAnimations, setShowAnimations] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const perfTier = usePerfTier();
+  const reducedMotion = usePrefersReducedMotion();
   const { isLoggedIn } = useAuth();
   const { isReady, isLoggedIn: clientIsLoggedIn } = useEsoLogsClientContext();
   const toolsSectionRef = useRef<HTMLDivElement>(null);
@@ -2227,14 +2232,21 @@ export const LandingPage: React.FC = () => {
     document.title = 'ESO Toolkit';
   }, []);
 
-  // Defer complex animations until after initial render
+  // Defer complex animations until after initial render — and keep them OFF
+  // entirely on the low perf tier / under OS reduced motion (this also gates
+  // the mounted particle layer below, which the CSS animation kill can't
+  // reach: frozen fixed-position particles still cost composite work).
   React.useEffect(() => {
+    if (!shouldShowLandingFx(perfTier, reducedMotion)) {
+      setShowAnimations(false);
+      return;
+    }
     const timer = setTimeout(() => {
       setShowAnimations(true);
     }, 100); // Small delay to ensure initial content is rendered first
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [perfTier, reducedMotion]);
 
   // Intersection Observer for smooth scroll animations
   useEffect(() => {
@@ -2263,29 +2275,31 @@ export const LandingPage: React.FC = () => {
     <LandingContainer id="main-content">
       {showcaseGlobalStyles}
       <HeroSection id="home" showAnimations={showAnimations}>
-        <ParticleContainer>
-          {/* Floating particles with magical glow */}
-          <FloatingParticle delay={0} duration={8} x="15%" y="80%" size="6px" color="#60a5fa" />
-          <FloatingParticle delay={2} duration={12} x="25%" y="75%" size="4px" color="#a78bfa" />
-          <FloatingParticle delay={4} duration={10} x="35%" y="85%" size="5px" color="#34d399" />
-          <FloatingParticle delay={1} duration={9} x="50%" y="90%" size="3px" color="#fbbf24" />
-          <FloatingParticle delay={3} duration={11} x="65%" y="80%" size="6px" color="#f472b6" />
-          <FloatingParticle delay={5} duration={13} x="75%" y="75%" size="4px" color="#06b6d4" />
-          <FloatingParticle delay={6} duration={14} x="85%" y="85%" size="5px" color="#8b5cf6" />
+        {showAnimations && (
+          <ParticleContainer>
+            {/* Floating particles with magical glow */}
+            <FloatingParticle delay={0} duration={8} x="15%" y="80%" size="6px" color="#60a5fa" />
+            <FloatingParticle delay={2} duration={12} x="25%" y="75%" size="4px" color="#a78bfa" />
+            <FloatingParticle delay={4} duration={10} x="35%" y="85%" size="5px" color="#34d399" />
+            <FloatingParticle delay={1} duration={9} x="50%" y="90%" size="3px" color="#fbbf24" />
+            <FloatingParticle delay={3} duration={11} x="65%" y="80%" size="6px" color="#f472b6" />
+            <FloatingParticle delay={5} duration={13} x="75%" y="75%" size="4px" color="#06b6d4" />
+            <FloatingParticle delay={6} duration={14} x="85%" y="85%" size="5px" color="#8b5cf6" />
 
-          {/* Second layer of particles */}
-          <FloatingParticle delay={7} duration={15} x="20%" y="70%" size="3px" color="#3b82f6" />
-          <FloatingParticle delay={8} duration={10} x="40%" y="78%" size="4px" color="#10b981" />
-          <FloatingParticle delay={9} duration={12} x="60%" y="88%" size="5px" color="#f59e0b" />
-          <FloatingParticle delay={10} duration={11} x="80%" y="70%" size="3px" color="#ec4899" />
+            {/* Second layer of particles */}
+            <FloatingParticle delay={7} duration={15} x="20%" y="70%" size="3px" color="#3b82f6" />
+            <FloatingParticle delay={8} duration={10} x="40%" y="78%" size="4px" color="#10b981" />
+            <FloatingParticle delay={9} duration={12} x="60%" y="88%" size="5px" color="#f59e0b" />
+            <FloatingParticle delay={10} duration={11} x="80%" y="70%" size="3px" color="#ec4899" />
 
-          {/* ESO runes for magical atmosphere */}
-          <ESORune delay={0} x="18%" y="25%" />
-          <ESORune delay={3} x="82%" y="30%" />
-          <ESORune delay={6} x="50%" y="15%" />
-          <ESORune delay={9} x="25%" y="50%" />
-          <ESORune delay={12} x="75%" y="55%" />
-        </ParticleContainer>
+            {/* ESO runes for magical atmosphere */}
+            <ESORune delay={0} x="18%" y="25%" />
+            <ESORune delay={3} x="82%" y="30%" />
+            <ESORune delay={6} x="50%" y="15%" />
+            <ESORune delay={9} x="25%" y="50%" />
+            <ESORune delay={12} x="75%" y="55%" />
+          </ParticleContainer>
+        )}
 
         <HeroContent className="u-fade-in-up">
           <HeroTitle variant="h1" showAnimations={showAnimations}>

--- a/src/components/PerfLowNotice.test.tsx
+++ b/src/components/PerfLowNotice.test.tsx
@@ -1,0 +1,67 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import uiReducer, {
+  setPerfTier,
+  setPerfTierOverride,
+  setPerfLowNoticeSeen,
+} from '../store/ui/uiSlice';
+
+import { PerfLowNotice } from './PerfLowNotice';
+
+const mockEnqueueSnackbar = jest.fn();
+jest.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+}));
+
+const makeStore = () => configureStore({ reducer: { ui: uiReducer } });
+
+const renderNotice = (store: ReturnType<typeof makeStore>) =>
+  render(
+    <Provider store={store}>
+      <PerfLowNotice />
+    </Provider>,
+  );
+
+describe('PerfLowNotice', () => {
+  beforeEach(() => {
+    mockEnqueueSnackbar.mockClear();
+  });
+
+  it('fires once for an auto-detected low tier and persists as seen', () => {
+    const store = makeStore();
+    store.dispatch(setPerfTier('low'));
+    renderNotice(store);
+
+    expect(mockEnqueueSnackbar).toHaveBeenCalledTimes(1);
+    expect(store.getState().ui.perfLowNoticeSeen).toBe(true);
+  });
+
+  it('does not fire again once seen', () => {
+    const store = makeStore();
+    store.dispatch(setPerfTier('low'));
+    store.dispatch(setPerfLowNoticeSeen(true));
+    renderNotice(store);
+
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it('does not fire on medium/high tiers', () => {
+    const store = makeStore();
+    store.dispatch(setPerfTier('medium'));
+    renderNotice(store);
+
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for a user-pinned low override (they chose it)', () => {
+    const store = makeStore();
+    store.dispatch(setPerfTier('medium'));
+    store.dispatch(setPerfTierOverride('low'));
+    renderNotice(store);
+
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PerfLowNotice.tsx
+++ b/src/components/PerfLowNotice.tsx
@@ -1,0 +1,36 @@
+import { useSnackbar } from 'notistack';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import { usePerfTier } from '../hooks/usePerfTier';
+import { selectPerfLowNoticeSeen, selectPerfTierOverride } from '../store/ui/uiSelectors';
+import { setPerfLowNoticeSeen } from '../store/ui/uiSlice';
+import { useAppDispatch } from '../store/useAppDispatch';
+
+/**
+ * One-time notice when auto-detection lands a device on the low perf tier:
+ * visuals were quietly reduced (blur, animations, background) and the user
+ * should know where to change that. Never fires for a pinned override (the
+ * user chose it) and persists as seen so it can't nag on every visit.
+ *
+ * Renders nothing. Must mount inside SnackbarProvider — PerfTierProvider
+ * itself sits above it in the tree, so the notice can't live there.
+ */
+export const PerfLowNotice: React.FC = () => {
+  const tier = usePerfTier();
+  const override = useSelector(selectPerfTierOverride);
+  const seen = useSelector(selectPerfLowNoticeSeen);
+  const dispatch = useAppDispatch();
+  const { enqueueSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    if (tier !== 'low' || override !== 'auto' || seen) return;
+    enqueueSnackbar(
+      'Performance mode is on for a smoother experience — change it under Performance in the profile menu.',
+      { variant: 'info', autoHideDuration: 8000 },
+    );
+    dispatch(setPerfLowNoticeSeen(true));
+  }, [tier, override, seen, enqueueSnackbar, dispatch]);
+
+  return null;
+};

--- a/src/components/PerfTierToggle.tsx
+++ b/src/components/PerfTierToggle.tsx
@@ -26,7 +26,8 @@ const OPTIONS: ReadonlyArray<{ value: OptionValue; label: string }> = [
   { value: 'auto', label: 'Auto' },
   { value: 'high', label: 'High' },
   { value: 'medium', label: 'Medium' },
-  { value: 'low', label: 'Low' },
+  // Menu label only — TIER_LABEL keeps the compact pill caption short ("Low").
+  { value: 'low', label: 'Low — minimal effects' },
 ];
 
 const TIER_LABEL: Record<PerfTier, string> = {

--- a/src/components/shared/SiteBackground.test.tsx
+++ b/src/components/shared/SiteBackground.test.tsx
@@ -1,0 +1,35 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { SiteBackground } from './SiteBackground';
+
+// Tier is the unit under test — mock the hook so no store is needed.
+jest.mock('../../hooks/usePerfTier', () => ({
+  usePerfTier: jest.fn(),
+}));
+
+import { usePerfTier } from '../../hooks/usePerfTier';
+const mockUsePerfTier = usePerfTier as jest.MockedFunction<typeof usePerfTier>;
+
+const renderWithMode = (mode: 'light' | 'dark') =>
+  render(
+    <ThemeProvider theme={createTheme({ palette: { mode } })}>
+      <SiteBackground />
+    </ThemeProvider>,
+  );
+
+describe('SiteBackground', () => {
+  it('renders nothing on the low perf tier (both themes)', () => {
+    mockUsePerfTier.mockReturnValue('low');
+    expect(renderWithMode('dark').container.firstChild).toBeNull();
+    expect(renderWithMode('light').container.firstChild).toBeNull();
+  });
+
+  it('renders a background layer on medium and high tiers', () => {
+    mockUsePerfTier.mockReturnValue('medium');
+    expect(renderWithMode('dark').container.firstChild).not.toBeNull();
+    mockUsePerfTier.mockReturnValue('high');
+    expect(renderWithMode('light').container.firstChild).not.toBeNull();
+  });
+});

--- a/src/components/shared/SiteBackground.tsx
+++ b/src/components/shared/SiteBackground.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { AuroraBackground } from '../../features/loadout-manager/components/AuroraBackground';
 import { NebulaBackground } from '../../features/loadout-manager/components/NebulaBackground';
+import { usePerfTier } from '../../hooks/usePerfTier';
 
 /**
  * SiteBackground - Global atmospheric background for the entire site
@@ -19,6 +20,13 @@ import { NebulaBackground } from '../../features/loadout-manager/components/Nebu
  */
 export const SiteBackground: React.FC = () => {
   const theme = useTheme();
+  const perfTier = usePerfTier();
+  // Low tier: skip the whole layer stack (4 fixed composited gradient planes
+  // even with animation off). CssBaseline's body background is a near-match
+  // flat fallback, and the backgrounds are decorative with no layout role.
+  if (perfTier === 'low') {
+    return null;
+  }
   if (theme.palette.mode === 'light') {
     return <AuroraBackground />;
   }

--- a/src/features/build-hub/components/BuildCard.tsx
+++ b/src/features/build-hub/components/BuildCard.tsx
@@ -279,7 +279,6 @@ export const BuildCard: React.FC<BuildCardProps> = React.memo(
                         borderRadius: '6px',
                         fontSize: '0.72rem',
                         fontWeight: 700,
-                        backdropFilter: 'blur(8px)',
                         background: isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)',
                         border: isDark
                           ? '1px solid rgba(255,255,255,0.12)'
@@ -307,7 +306,6 @@ export const BuildCard: React.FC<BuildCardProps> = React.memo(
                 mt: 0.5,
                 borderRadius: '8px',
                 background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.025)',
-                backdropFilter: 'blur(6px)',
                 border: isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.05)',
                 overflow: 'hidden',
               }}

--- a/src/features/pack-hub/components/PackCard.tsx
+++ b/src/features/pack-hub/components/PackCard.tsx
@@ -292,8 +292,6 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
                         borderRadius: '6px',
                         fontSize: '0.72rem',
                         fontWeight: 700,
-                        backdropFilter: 'blur(8px)',
-                        WebkitBackdropFilter: 'blur(8px)',
                         background: isDark ? `${tagColor}25` : `${tagColor}18`,
                         border: `1px solid ${tagColor}50`,
                         color: tagColor,
@@ -405,8 +403,6 @@ export const PackCard: React.FC<PackCardProps> = React.memo(
                 mt: 0.5,
                 borderRadius: '8px',
                 background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.025)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
                 border: isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.05)',
                 overflow: 'hidden',
               }}

--- a/src/features/roster-hub/components/RosterCard.tsx
+++ b/src/features/roster-hub/components/RosterCard.tsx
@@ -459,8 +459,6 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
                         fontSize: '0.72rem',
                         fontWeight: 700,
                         letterSpacing: '0.02em',
-                        backdropFilter: 'blur(8px)',
-                        WebkitBackdropFilter: 'blur(8px)',
                         background: isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)',
                         border: isDark
                           ? '1px solid rgba(255,255,255,0.12)'
@@ -488,8 +486,6 @@ export const RosterCard: React.FC<RosterCardProps> = React.memo(
                 mt: 0.5,
                 borderRadius: '8px',
                 background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.025)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
                 border: isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid rgba(0,0,0,0.05)',
                 overflow: 'hidden',
               }}

--- a/src/hooks/useSelectedTab.test.new.tsx
+++ b/src/hooks/useSelectedTab.test.new.tsx
@@ -43,6 +43,7 @@ const createMockStore = (
       myReportsPage: 1,
       perfTier: 'medium',
       perfTierOverride: 'auto',
+      perfLowNoticeSeen: false,
       chartIntensity: 'subtle',
       ...(initialState.ui || {}),
     },

--- a/src/index.css
+++ b/src/index.css
@@ -139,6 +139,43 @@ html[data-perf='low'] * {
   -webkit-backdrop-filter: none !important;
 }
 
+/* Animation kill for low tier — the animation-side sibling of the blur rule
+   above, and a tier-driven mirror of the OS reduced-motion block in
+   ReduxThemeProvider's GlobalStyles. Entrance animations (fill forwards/both)
+   complete instantly at their final state; infinite loops (landing orbs,
+   marquee, shimmers, electric borders, legendary chips) freeze at base
+   styles; MUI transitions are timeout-driven, so they snap without sticking.
+
+   The custom properties are the escape hatch: any subtree that must keep
+   animating for FEEDBACK (progress indicators) re-declares them — custom
+   properties inherit, so setting them on an indicator root covers its
+   internals (e.g. the CircularProgress SVG dash animation). New functional
+   animations (replay transport pulses, recording dots, …) must opt out the
+   same way or they will freeze on low tier. */
+html[data-perf='low'] *,
+html[data-perf='low'] *::before,
+html[data-perf='low'] *::after {
+  animation-duration: var(--perf-anim-duration, 0.01ms) !important;
+  animation-iteration-count: var(--perf-anim-iteration, 1) !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+/* Progress indicators must keep moving — a frozen spinner reads as a hang.
+   Durations match MUI's own timing so indicators look normal, not sped up. */
+html[data-perf='low'] .MuiCircularProgress-root {
+  --perf-anim-duration: 1.4s;
+  --perf-anim-iteration: infinite;
+}
+html[data-perf='low'] .MuiLinearProgress-root {
+  --perf-anim-duration: 2.1s;
+  --perf-anim-iteration: infinite;
+}
+html[data-perf='low'] .MuiSkeleton-root {
+  --perf-anim-duration: 2s;
+  --perf-anim-iteration: infinite;
+}
+
 /* Opaque fallback for dark-mode glass dialog papers when backdrop-filter is
    stripped (data-perf='low'). Without blur the 12%-alpha gradient becomes
    effectively transparent. data-color-scheme is synced by ReduxThemeProvider.

--- a/src/pages/RaidDashboardPage.tsx
+++ b/src/pages/RaidDashboardPage.tsx
@@ -176,6 +176,10 @@ export const RaidDashboardPage: React.FC = () => {
                   borderRadius: '50%',
                   animation: autoRefreshEnabled ? 'spin 1.2s linear infinite' : 'none',
                   '@keyframes spin': { '100%': { transform: 'rotate(360deg)' } },
+                  // Activity indicator, not decoration — keep spinning on the
+                  // low perf tier (opts out of the index.css animation kill).
+                  '--perf-anim-duration': '1.2s',
+                  '--perf-anim-iteration': 'infinite',
                   flexShrink: 0,
                 }}
               />

--- a/src/store/storeWithHistory.test.ts
+++ b/src/store/storeWithHistory.test.ts
@@ -213,3 +213,35 @@ describe('storeWithHistory - Redux Persist Transform', () => {
     });
   });
 });
+
+// The block above tests a re-created COPY of the transform. This one imports
+// the REAL transform so a persisted field missing from either of its two
+// spots (inbound allowlist / rehydrate defaults) fails here, not in the field.
+describe('storeWithHistory - real uiTransform', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { uiTransform: realTransform } = jest.requireActual('./storeWithHistory');
+
+  it('round-trips perfLowNoticeSeen through persist and rehydrate', () => {
+    const state = {
+      darkMode: true,
+      selectedPlayerId: null,
+      selectedTabId: null,
+      selectedTargetIds: [],
+      selectedFriendlyPlayerId: null,
+      showExperimentalTabs: false,
+      sidebarOpen: false,
+      myReportsPage: 1,
+      perfTier: 'low',
+      perfTierOverride: 'auto',
+      perfLowNoticeSeen: true,
+      chartIntensity: 'subtle',
+    } as UIState;
+
+    const persisted = realTransform.in(state, 'ui', { ui: state });
+    expect(persisted.perfLowNoticeSeen).toBe(true);
+
+    const rehydrated = realTransform.out(persisted, 'ui', { ui: persisted });
+    expect(rehydrated.perfLowNoticeSeen).toBe(true);
+    expect(rehydrated.perfTier).toBe('low');
+  });
+});

--- a/src/store/storeWithHistory.ts
+++ b/src/store/storeWithHistory.ts
@@ -56,7 +56,9 @@ const rootReducer = combineReducers({
 
 // Transform to exclude report/fight-specific UI state from persistence
 // Only persist user preferences, not report-specific selections
-const uiTransform = createTransform<UIState, Partial<UIState>>(
+// (exported for tests — new persisted fields must appear in BOTH the inbound
+// allowlist and the rehydrate defaults, or they silently don't persist)
+export const uiTransform = createTransform<UIState, Partial<UIState>>(
   // Transform state on its way to being serialized and persisted
   (inboundState) => {
     const {
@@ -66,6 +68,7 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       myReportsPage,
       perfTier,
       perfTierOverride,
+      perfLowNoticeSeen,
       chartIntensity,
     } = inboundState;
     return {
@@ -75,6 +78,9 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       myReportsPage,
       perfTier,
       perfTierOverride,
+      // Must appear BOTH here and in the rehydrate defaults below, or the
+      // one-time low-tier notice re-fires on every reload.
+      perfLowNoticeSeen,
       // chartIntensity is a user preference, not report-specific state — without
       // this it was reset to 'subtle' on every reload.
       chartIntensity,
@@ -94,6 +100,7 @@ const uiTransform = createTransform<UIState, Partial<UIState>>(
       myReportsPage: 1,
       perfTier: 'medium',
       perfTierOverride: 'auto',
+      perfLowNoticeSeen: false,
       chartIntensity: 'subtle',
     };
 

--- a/src/store/ui/uiSelectors.ts
+++ b/src/store/ui/uiSelectors.ts
@@ -37,6 +37,8 @@ export const selectChartIntensity = (state: RootState): RootState['ui']['chartIn
   state.ui.chartIntensity ?? 'subtle';
 export const selectPerfTierOverride = (state: RootState): RootState['ui']['perfTierOverride'] =>
   state.ui.perfTierOverride;
+export const selectPerfLowNoticeSeen = (state: RootState): boolean =>
+  state.ui.perfLowNoticeSeen ?? false;
 // Tier the app should actually apply — override wins when set to anything
 // other than 'auto'. This is what feature gates should consume.
 export const selectEffectivePerfTier = createSelector(

--- a/src/store/ui/uiSlice.test.ts
+++ b/src/store/ui/uiSlice.test.ts
@@ -5,6 +5,7 @@ import uiReducer, {
   setDarkMode,
   toggleDarkMode,
   syncWithSystemTheme,
+  setPerfLowNoticeSeen,
   setSelectedPlayerId,
   setSelectedTabId,
   setSelectedTargetIds,
@@ -39,6 +40,7 @@ describe('uiSlice', () => {
         myReportsPage: 1,
         perfTier: 'medium',
         perfTierOverride: 'auto',
+        perfLowNoticeSeen: false,
       });
     });
   });
@@ -238,6 +240,19 @@ describe('uiSlice', () => {
     });
   });
 
+  describe('setPerfLowNoticeSeen', () => {
+    it('should mark the low-tier notice as seen', () => {
+      store.dispatch(setPerfLowNoticeSeen(true));
+      const state = store.getState() as { ui: UIState };
+      expect(state.ui.perfLowNoticeSeen).toBe(true);
+    });
+
+    it('should default to unseen', () => {
+      const state = store.getState() as { ui: UIState };
+      expect(state.ui.perfLowNoticeSeen).toBe(false);
+    });
+  });
+
   describe('setSidebarOpen', () => {
     it('should set sidebar open to true', () => {
       store.dispatch(setSidebarOpen(true));
@@ -301,6 +316,7 @@ describe('uiSlice', () => {
         myReportsPage: 1,
         perfTier: 'medium',
         perfTierOverride: 'auto',
+        perfLowNoticeSeen: false,
       });
     });
 

--- a/src/store/ui/uiSlice.ts
+++ b/src/store/ui/uiSlice.ts
@@ -15,6 +15,8 @@ export interface UIState {
   myReportsPage: number; // Persisted page number for my-reports
   perfTier: PerfTier;
   perfTierOverride: PerfTierOverride;
+  /** One-time "performance mode is on" notice shown to auto-detected-low users. */
+  perfLowNoticeSeen: boolean;
   chartIntensity: ChartIntensity;
 }
 
@@ -32,6 +34,7 @@ const initialState: UIState = {
   // empty persisted store.
   perfTier: 'medium',
   perfTierOverride: 'auto',
+  perfLowNoticeSeen: false,
   chartIntensity: 'subtle',
 };
 
@@ -83,6 +86,9 @@ const uiSlice = createSlice({
     setPerfTierOverride: (state, action: PayloadAction<PerfTierOverride>) => {
       state.perfTierOverride = action.payload;
     },
+    setPerfLowNoticeSeen: (state, action: PayloadAction<boolean>) => {
+      state.perfLowNoticeSeen = action.payload;
+    },
     setChartIntensity: (state, action: PayloadAction<ChartIntensity>) => {
       state.chartIntensity = action.payload;
     },
@@ -103,6 +109,7 @@ export const {
   setMyReportsPage,
   setPerfTier,
   setPerfTierOverride,
+  setPerfLowNoticeSeen,
   setChartIntensity,
 } = uiSlice.actions;
 export default uiSlice.reducer;

--- a/src/test/utils/createMockStore.ts
+++ b/src/test/utils/createMockStore.ts
@@ -77,6 +77,7 @@ export function createMockStore(options: MockStoreOptions = {}): EnhancedStore {
         myReportsPage: 1,
         perfTier: 'medium' as const,
         perfTierOverride: 'auto' as const,
+        perfLowNoticeSeen: false,
         chartIntensity: 'subtle' as const,
         ...(initialState.ui || {}),
       },
@@ -99,5 +100,6 @@ export const defaultMockUIState: UIState = {
   myReportsPage: 1,
   perfTier: 'medium',
   perfTierOverride: 'auto',
+  perfLowNoticeSeen: false,
   chartIntensity: 'subtle',
 };

--- a/src/utils/landingFx.test.ts
+++ b/src/utils/landingFx.test.ts
@@ -1,0 +1,18 @@
+import { shouldShowLandingFx } from './landingFx';
+
+describe('shouldShowLandingFx', () => {
+  it('shows effects on high and medium tiers without reduced motion', () => {
+    expect(shouldShowLandingFx('high', false)).toBe(true);
+    expect(shouldShowLandingFx('medium', false)).toBe(true);
+  });
+
+  it('hides effects on the low tier regardless of motion preference', () => {
+    expect(shouldShowLandingFx('low', false)).toBe(false);
+    expect(shouldShowLandingFx('low', true)).toBe(false);
+  });
+
+  it('hides effects under OS reduced motion regardless of tier', () => {
+    expect(shouldShowLandingFx('high', true)).toBe(false);
+    expect(shouldShowLandingFx('medium', true)).toBe(false);
+  });
+});

--- a/src/utils/landingFx.ts
+++ b/src/utils/landingFx.ts
@@ -1,0 +1,14 @@
+import type { PerfTier } from '../store/ui/uiSlice';
+
+/**
+ * Whether the landing page should run its decorative effects (hero glow +
+ * shimmer, and the mounted particle/rune layer).
+ *
+ * Low perf tier: the CSS animation kill in index.css already freezes the
+ * styled-in loops, but frozen fixed-position particles would still cost
+ * layout/composite work every scroll — so the caller unmounts them entirely.
+ * Reduced motion: the OS preference wins regardless of hardware tier.
+ */
+export function shouldShowLandingFx(tier: PerfTier, reducedMotion: boolean): boolean {
+  return tier !== 'low' && !reducedMotion;
+}


### PR DESCRIPTION
The low performance tier stripped backdrop-filter (the #1013 rule) but left every CSS keyframe animation running — the landing page alone runs ~20 infinite loops (orbs, marquee, shimmers, particles, runes), plus electric top-DPS card borders and legendary chips, all day, on exactly the hardware that can least afford it. Only the OS reduced-motion flag ever stopped them. This PR closes that gap and finishes the low tier as a real barebones mode, per the approved perf plan.

What low tier now means (all verified live against the dev build by flipping the tier at runtime):

- **Running animations on landing: 66 → 4** (the survivors are scroll-driven reveals, idle unless scrolling). One new `index.css` rule mirrors the OS reduced-motion block behind `html[data-perf='low']`, with durations flowing through `--perf-anim-duration`/`--perf-anim-iteration` custom properties as an opt-out seam.
- **Spinners keep spinning.** MUI Circular/Linear/Skeleton indicators re-declare the custom properties at MUI's own timings — a frozen indeterminate spinner reads as a hang. Verified via computed-style probes: an element under `.MuiCircularProgress-root` resolves `1.4s/infinite` while a plain sibling is killed to `0.01ms/1`. (The existing OS reduced-motion block freezes spinners today — pre-existing bug, noted follow-up to port these exemptions.) The RaidDashboard auto-refresh indicator opts out the same way.
- **SiteBackground renders null** (previously: zero particles but still 3-4 full-viewport fixed gradient layers composited on every page). CssBaseline's body background is a near-match flat fallback.
- **Landing hero effects + the 15-node particle/rune layer unmount** — `showAnimations` was a 100 ms setTimeout that always resolved true; it now derives from tier + live reduced-motion preference.
- **Backdrop-filter layers on landing: 27 → 0** (existing rule, re-verified).

One change benefits all tiers: Build/Roster/Pack hub cards stacked blur on the root card PLUS every tag chip PLUS the footer — a 12-card grid with tags composited ~60 backdrop-filter layers. The inner layers sit on the root card's flat gradient (blurring it is a visual no-op) and are deleted outright; medium/high now composite one layer per card.

Discoverability: detection is silent, so auto-detected-low users now get a one-time snackbar pointing at the Performance menu (never shown for a pinned override; persisted via a new `perfLowNoticeSeen` ui field present in both `uiTransform` spots, with a real-transform round-trip test guarding that trap). The toggle's Low option is relabeled "Low — minimal effects".

Reviewer note: the animation kill intentionally freezes the electric top-DPS border and legendary chip glow to their static `@property`-fallback appearance on low — that's the sanctioned degraded state those effects already define.

Verification: `npm run validate` green, full jest 4489 passing; live runtime checks above performed in both directions (low ⇄ high fully reversible, toast fires once and latches).