### PR TITLE
perf(replay): lossless CPU/GPU wins — idle waste, allocations, declutter throttle, preserveDrawingBuffer

### DIFF
--- a/src/features/fight_replay/components/Arena3D.tsx
+++ b/src/features/fight_replay/components/Arena3D.tsx
@@ -784,8 +784,17 @@ const Arena3DComponent: React.FC<Arena3DProps> = ({
             far: 1000,
           }}
           gl={{
-            // Prevent context loss during Strict Mode remounts
-            preserveDrawingBuffer: true,
+            // false (the WebGL default): with `true`, drivers must copy/resolve
+            // the full drawing buffer on every presented frame (and ANGLE loses
+            // its buffer-swap fast path) — pure GPU-bandwidth waste at fullscreen
+            // DPR. Nothing needs the preserved buffer: no readback path exists
+            // (no toDataURL/toBlob/readPixels on this canvas anywhere in src),
+            // the render gate repaints full frames, and a paused canvas keeps
+            // showing its last PRESENTED frame from the compositor regardless.
+            // The old `true` claimed to prevent Strict Mode context loss — it
+            // never did (Strict Mode is disabled app-wide; the real mitigations
+            // are the webglcontextlost/restored listeners below).
+            preserveDrawingBuffer: false,
             powerPreference: 'high-performance',
             antialias: true,
             // Fail if context cannot be created

--- a/src/features/fight_replay/components/Arena3DScene.tsx
+++ b/src/features/fight_replay/components/Arena3DScene.tsx
@@ -879,14 +879,18 @@ export const Arena3DScene: React.FC<Arena3DSceneProps> = ({
 
   return (
     <>
-      {/* Performance Monitor hooks - only active in development mode */}
-      {/* Only the monitoring hooks run inside Canvas, overlay is rendered outside */}
-      <PerformanceMonitorCanvas
-        fpsUpdateInterval={500}
-        memoryUpdateInterval={1000}
-        slowFrameThreshold={33}
-        maxSlowFrameLogsPerMinute={10}
-      />
+      {/* Performance Monitor hooks - only active in development mode.
+          Gate the MOUNT, not just the hook bodies: its three hooks each
+          register a useFrame whose prod path is a no-op early-return —
+          mounting them in prod still pays three subscriber calls per rAF. */}
+      {process.env.NODE_ENV === 'development' && (
+        <PerformanceMonitorCanvas
+          fpsUpdateInterval={500}
+          memoryUpdateInterval={1000}
+          slowFrameThreshold={33}
+          maxSlowFrameLogsPerMinute={10}
+        />
+      )}
       {/* Bloom post-processing (dropped at quality tier 1+ / performance mode). Publishes its render
           handle to composerRef; RenderLoop routes the gated render through it so celestials glow. */}
       {qualityFlags.bloom && <BloomComposer composerRef={composerRef} samples={bloomSamples} />}

--- a/src/features/fight_replay/components/BatchedActorNames3D.tsx
+++ b/src/features/fight_replay/components/BatchedActorNames3D.tsx
@@ -58,6 +58,9 @@ const DEAD_FILL_OPACITY = 0.62;
 // Faded overlappers keep a faint ghost rather than vanishing — enough to hint presence without
 // rejoining the blob. Outline fades proportionally so the dark halo doesn't outlive the fill.
 const FADED_OPACITY = 0.1;
+// Overlap-declutter cadence while the camera/playhead moves. 10Hz cuts the O(N) projections +
+// O(N²) box pass ~10× at trash-pull actor counts; label tracking stays per-frame regardless.
+const DECLUTTER_INTERVAL_MS = 100;
 // Rough on-screen label box, in world units before distance-scale, used only to size the
 // collision rectangle for the overlap pass. troika's true bounds aren't known until an async sync,
 // so we approximate width from glyph count; the declutter only needs the boxes to be in the right
@@ -176,6 +179,19 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
   // is "the followed name is always legible", so the gate must react to selection directly.
   const lastSelected = useRef<number | null | undefined>(undefined);
 
+  // Declutter cadence: the O(N) screen projections + O(N²) overlap resolve run
+  // at most every DECLUTTER_INTERVAL_MS while the playhead/camera moves (label
+  // TRACKING — position/orientation/scale/text — stays per-frame smooth).
+  // Troika applies fillOpacity as a raw uniform with no transition, so between
+  // ticks every label simply holds its last opacity: no flicker is possible,
+  // the only observable change is ≤100ms latency on a newly-overlapping fade.
+  // Selection changes and resizes force a tick (the "followed name is always
+  // legible" contract); actor appear/disappear flips are only discoverable
+  // mid-loop, so they arm forceDeclutter for the NEXT frame (≤1 rAF late — a
+  // fresh label may show at its default opacity for one frame, same as today).
+  const lastDeclutterAt = useRef(-Infinity);
+  const forceDeclutter = useRef(false);
+
   // Scratch objects reused every frame (no per-frame allocation in the hot loop).
   const scratchWorld = useRef(new THREE.Vector3());
   const scratchProjected = useRef(new THREE.Vector3());
@@ -207,6 +223,14 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
     lastSize.current.h = size.height;
     lastSelected.current = selectedActorId;
 
+    const nowMs = performance.now();
+    const declutterDue =
+      forceDeclutter.current ||
+      sizeChanged ||
+      selectionChanged ||
+      nowMs - lastDeclutterAt.current >= DECLUTTER_INTERVAL_MS;
+    forceDeclutter.current = false;
+
     // --- Pass 1: position / orient / scale / text every name; collect on-screen rectangles ----
     const items = screenItems.current;
     items.length = 0;
@@ -225,12 +249,16 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
         if (wasVisible !== false) {
           group.visible = false;
           lastVisible.current.set(actorId, false);
+          // A disappearance frees declutter space — resolve on the next frame.
+          if (!declutterDue) forceDeclutter.current = true;
         }
         return;
       }
       if (wasVisible === false || wasVisible === undefined) {
         group.visible = true;
         lastVisible.current.set(actorId, true);
+        // A fresh label must be resolved promptly (it mounts at full opacity).
+        if (!declutterDue) forceDeclutter.current = true;
       }
 
       // World-anchored position above the actor.
@@ -257,6 +285,10 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
         (text as unknown as { color: string }).color = color;
         lastData.current.set(actorId, { name: actor.name, color, alive });
       }
+
+      // Projection + collision box feed only the declutter pass — skip on
+      // non-tick frames (tracking above already ran; opacities hold).
+      if (!declutterDue) return;
 
       // Project the anchor to screen pixels and size an approximate collision box.
       scratchProjected.current.copy(scratchWorld.current).project(camera);
@@ -293,6 +325,8 @@ export const BatchedActorNames3D: React.FC<BatchedActorNames3DProps> = ({
     });
 
     // --- Pass 2: resolve overlap once, then write opacity through the refs --------------------
+    if (!declutterDue) return;
+    lastDeclutterAt.current = nowMs;
     const visibility = resolveNameVisibility(items, { fadedOpacity: FADED_OPACITY });
 
     handles.forEach((handle, actorId) => {

--- a/src/features/fight_replay/components/BossHealthPanel.test.tsx
+++ b/src/features/fight_replay/components/BossHealthPanel.test.tsx
@@ -57,4 +57,29 @@ describe('BossHealthPanel', () => {
     expect(await screen.findByText('Flame-Herald Bahsei')).toBeInTheDocument();
     expect(await screen.findByText('Add')).toBeInTheDocument();
   });
+
+  it('renders bars only for bosses in a mixed player/boss lookup', async () => {
+    // Guards the for-in boss scan over the by-id record: players and healthless
+    // actors interleaved with bosses must not produce bars.
+    const player = (id: number, name: string): ActorPosition => ({
+      id,
+      name,
+      type: 'player',
+      position: [0, 0, 0],
+      rotation: 0,
+      isDead: false,
+      health: { current: 20000, max: 20000, percentage: 100 },
+    });
+    const lookup = makeLookup([
+      player(1, 'Necrofeell'),
+      boss(2, 'Taleria', 62.5),
+      player(3, 'Spikejo'),
+      { ...boss(4, 'Healthless Add', 0), health: undefined },
+    ]);
+    render(<BossHealthPanel lookup={lookup} timeRef={{ current: 0 }} />);
+    expect(await screen.findByText('Taleria')).toBeInTheDocument();
+    expect(screen.queryByText('Necrofeell')).not.toBeInTheDocument();
+    expect(screen.queryByText('Spikejo')).not.toBeInTheDocument();
+    expect(screen.queryByText('Healthless Add')).not.toBeInTheDocument();
+  });
 });

--- a/src/features/fight_replay/components/BossHealthPanel.tsx
+++ b/src/features/fight_replay/components/BossHealthPanel.tsx
@@ -23,7 +23,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActorPosition,
   TimestampPositionLookup,
-  getAllActorPositionsAtTimestamp,
+  getActorPositionsByIdAtClosestTimestamp,
 } from '../../../workers/calculations/CalculateActorPositions';
 
 interface BossHealthPanelProps {
@@ -110,6 +110,8 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
     // Per-bar last-written values, so a moving playhead still only touches the DOM for bars whose
     // displayed value actually changed (e.g. a boss already at a steady % between samples).
     const lastWritten = new Map<number, { width: string; color: string; text: string }>();
+    // Reused across ticks (length-reset per tick) so the boss scan allocates nothing per frame.
+    const bossScratch: ActorPosition[] = [];
 
     const tick = (): void => {
       const currentTime = timeRef.current;
@@ -118,11 +120,17 @@ export const BossHealthPanel: React.FC<BossHealthPanelProps> = ({
         return;
       }
       lastTickTime = currentTime;
-      const allActors = getAllActorPositionsAtTimestamp(lookup, currentTime);
+      // By-reference record lookup + for-in, NOT getAllActorPositionsAtTimestamp:
+      // that helper Object.values-allocates a fresh array every moving rAF — a
+      // steady GC drip in the playback hot path. Integer-like keys enumerate in
+      // ascending order, so the same MAX_BOSSES bosses are chosen either way.
+      const positionsById = getActorPositionsByIdAtClosestTimestamp(lookup, currentTime);
 
       // Filter to bosses with health (same rule as the old HUD).
-      const bossActors: ActorPosition[] = [];
-      for (const actor of allActors) {
+      bossScratch.length = 0;
+      const bossActors = bossScratch;
+      for (const key in positionsById) {
+        const actor = positionsById[key as unknown as number];
         if (actor.type === 'boss' && actor.health) {
           bossActors.push(actor);
           if (bossActors.length >= MAX_BOSSES) break;

--- a/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
+++ b/src/features/fight_replay/components/InstancedReplayFigures3D.tsx
@@ -918,11 +918,17 @@ export const InstancedReplayFigures3D: React.FC<InstancedReplayFigures3DProps> =
     mesh.setMatrixAt(index, obj.matrix);
   }, []);
 
+  // Memoized: building the signature allocated an array + string EVERY rAF,
+  // before the frame-cache early-return — the hottest allocation site in the
+  // actor loop. The HMR contract survives memoization: Fast Refresh re-runs
+  // useMemo on any edit to this file, so a paused boss-tune edit still
+  // produces a new signature and forces one recompose.
+  const bossSignature = useMemo(() => bossTuneSignature(performanceMode), [performanceMode]);
+
   useFrame((_state, delta) => {
     const currentTime = timeRef ? timeRef.current : 0;
     const selectedActorId = selectedActorRef.current;
     const prevFrame = frameCacheRef.current;
-    const bossSignature = bossTuneSignature(performanceMode);
 
     if (
       prevFrame &&

--- a/src/features/fight_replay/components/PlayerPathTrail3D.tsx
+++ b/src/features/fight_replay/components/PlayerPathTrail3D.tsx
@@ -13,7 +13,7 @@ import { TimestampPositionLookup } from '../../../workers/calculations/Calculate
 import { RenderPriority } from '../constants/renderPriorities';
 import {
   PlayerPath,
-  getPathPointsUpToTime,
+  getPathPointCountUpToTime,
   createPathGeometry,
   updatePathGeometry,
   calculateTrailOpacity,
@@ -73,10 +73,20 @@ const TrailInstance: React.FC<TrailInstanceProps> = ({ path, timeRef, fadeTime, 
   // Create the Line object
   const line = useMemo(() => new THREE.Line(geometry, material), [geometry, material]);
 
+  // Frame cache: skip all per-frame work while the playhead is idle, and skip
+  // geometry writes/uploads unless the visible point COUNT changed (points
+  // sample every ~100ms, so during playback uploads drop from rAF-rate to
+  // ~10Hz). NaN/-1 seeded so a fresh geometry always gets one full write.
+  const lastTimeRef = useRef(Number.NaN);
+  const lastCountRef = useRef(-1);
+
   // Store refs
   useEffect(() => {
     geometryRef.current = geometry;
     materialRef.current = material;
+    // New geometry identity (points/color/width changed) → force a rewrite.
+    lastTimeRef.current = Number.NaN;
+    lastCountRef.current = -1;
 
     return () => {
       geometry.dispose();
@@ -97,26 +107,35 @@ const TrailInstance: React.FC<TrailInstanceProps> = ({ path, timeRef, fadeTime, 
 
     const currentTime = timeRef ? timeRef.current : 0;
 
-    // Get points up to current time
-    const visiblePoints = getPathPointsUpToTime(path, currentTime);
+    // Idle guard: everything below derives from the playhead alone. Without
+    // this, a paused scene (or paused orbit) rebuilt + re-uploaded the whole
+    // line geometry every rAF for every selected trail.
+    if (currentTime === lastTimeRef.current) return;
+    lastTimeRef.current = currentTime;
+
+    // Count-only lookup — no per-frame array allocation.
+    const count = getPathPointCountUpToTime(path, currentTime);
 
     // Update visibility
-    const shouldBeVisible = path.visible && visiblePoints.length > 1;
+    const shouldBeVisible = path.visible && count > 1;
     if (lineRef.current.visible !== shouldBeVisible) {
       lineRef.current.visible = shouldBeVisible;
     }
 
     if (!shouldBeVisible) return;
 
-    // Update geometry with current points
-    updatePathGeometry(geometryRef.current, visiblePoints);
-
-    // Update material opacity based on trail age
-    if (visiblePoints.length > 0) {
-      const newestPointTime = visiblePoints[visiblePoints.length - 1]?.timestamp || 0;
-      const opacity = calculateTrailOpacity(newestPointTime, currentTime, fadeTime);
-      materialRef.current.opacity = Math.max(0.3, opacity * 0.8); // Min 30% opacity
+    // Rewrite + re-upload the geometry only when the visible point count
+    // changed — identical content re-uploads were pure GPU-bandwidth waste.
+    if (count !== lastCountRef.current) {
+      updatePathGeometry(geometryRef.current, path.points, count);
+      lastCountRef.current = count;
     }
+
+    // Update material opacity based on trail age (cheap; every moving frame —
+    // calculateTrailOpacity is continuous in currentTime).
+    const newestPointTime = path.points[count - 1]?.timestamp || 0;
+    const opacity = calculateTrailOpacity(newestPointTime, currentTime, fadeTime);
+    materialRef.current.opacity = Math.max(0.3, opacity * 0.8); // Min 30% opacity
   }, RenderPriority.EFFECTS); // Medium priority after actors but before HUD
 
   // Don't render if path is empty or invisible

--- a/src/features/fight_replay/utils/pathUtils.test.ts
+++ b/src/features/fight_replay/utils/pathUtils.test.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 import {
   ActorPosition,
   TimestampPositionLookup,
@@ -10,10 +12,12 @@ import {
   PlayerPath,
   calculateTrailOpacity,
   extractPlayerPaths,
+  getPathPointCountUpToTime,
   getPathPointsUpToTime,
   getPlayerInfo,
   getVisiblePlayerIds,
   smoothPath,
+  updatePathGeometry,
 } from './pathUtils';
 
 function makeActor(
@@ -258,6 +262,64 @@ describe('getPathPointsUpToTime', () => {
     const path = makePath([0, 100, 200, 300, 400]);
     expect(getPathPointsUpToTime(path, 250).map((p) => p.timestamp)).toEqual([0, 100, 200]);
     expect(getPathPointsUpToTime(path, 200).map((p) => p.timestamp)).toEqual([0, 100, 200]);
+  });
+
+  it('getPathPointCountUpToTime agrees with getPathPointsUpToTime everywhere', () => {
+    // Parity across empty / before-first / exact-timestamp / mid-gap / after-last —
+    // the count variant is the allocation-free hot-path sibling and must never drift.
+    const paths = [makePath([]), makePath([100]), makePath([0, 100, 200, 300, 400])];
+    const times = [-1, 0, 50, 100, 150, 200, 250, 300, 399, 400, 401, 9999];
+    for (const path of paths) {
+      for (const t of times) {
+        expect(getPathPointCountUpToTime(path, t)).toBe(getPathPointsUpToTime(path, t).length);
+      }
+    }
+  });
+});
+
+describe('updatePathGeometry partial count', () => {
+  function makePath(timestamps: number[]): PlayerPath {
+    return {
+      actorId: 1,
+      name: 'P1',
+      points: timestamps.map((t, i) => ({
+        position: [i, 0, i] as [number, number, number],
+        timestamp: t,
+        actorId: 1,
+      })),
+      color: '#fff',
+      visible: true,
+    };
+  }
+
+  it('writes and draws only the first `count` points', () => {
+    const path = makePath([0, 100, 200, 300]);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(4 * 3), 3));
+    geometry.setAttribute('timestamp', new THREE.BufferAttribute(new Float32Array(4), 1));
+
+    updatePathGeometry(geometry, path.points, 2);
+
+    const pos = geometry.getAttribute('position') as THREE.BufferAttribute;
+    const ts = geometry.getAttribute('timestamp') as THREE.BufferAttribute;
+    expect(geometry.drawRange.count).toBe(2);
+    expect(pos.getX(1)).toBe(1);
+    expect(ts.getX(1)).toBe(100);
+    // Index 2 was never written — stays at the Float32Array default.
+    expect(pos.getX(2)).toBe(0);
+    expect(ts.getX(2)).toBe(0);
+  });
+
+  it('defaults to writing every point when count is omitted', () => {
+    const path = makePath([0, 100, 200]);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(3 * 3), 3));
+    geometry.setAttribute('timestamp', new THREE.BufferAttribute(new Float32Array(3), 1));
+
+    updatePathGeometry(geometry, path.points);
+
+    expect(geometry.drawRange.count).toBe(3);
+    expect((geometry.getAttribute('timestamp') as THREE.BufferAttribute).getX(2)).toBe(200);
   });
 });
 

--- a/src/features/fight_replay/utils/pathUtils.ts
+++ b/src/features/fight_replay/utils/pathUtils.ts
@@ -244,6 +244,30 @@ export function getPathPointsUpToTime(path: PlayerPath, currentTime: number): Pa
 }
 
 /**
+ * Count of path points with timestamp <= currentTime — the allocation-free
+ * sibling of getPathPointsUpToTime for per-frame callers: same binary search,
+ * returns the count instead of slicing a fresh array every rAF.
+ */
+export function getPathPointCountUpToTime(path: PlayerPath, currentTime: number): number {
+  const { points } = path;
+  if (points.length === 0 || points[0].timestamp > currentTime) return 0;
+  if (points[points.length - 1].timestamp <= currentTime) return points.length;
+
+  let lo = 0;
+  let hi = points.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (points[mid].timestamp <= currentTime) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return lo + 1;
+}
+
+/**
  * Create THREE.js geometry for path trail
  */
 export function createPathGeometry(points: PathPoint[]): THREE.BufferGeometry {
@@ -272,14 +296,21 @@ export function createPathGeometry(points: PathPoint[]): THREE.BufferGeometry {
 }
 
 /**
- * Update existing geometry with new path points (for performance)
+ * Update existing geometry with new path points (for performance).
+ * `count` limits the write/draw to the first N points so per-frame callers can
+ * pass the full time-sorted array + a count instead of slicing (no alloc).
  */
-export function updatePathGeometry(geometry: THREE.BufferGeometry, points: PathPoint[]): void {
+export function updatePathGeometry(
+  geometry: THREE.BufferGeometry,
+  points: PathPoint[],
+  count: number = points.length,
+): void {
+  const used = Math.min(count, points.length);
   const positionAttribute = geometry.getAttribute('position') as THREE.BufferAttribute;
   const timestampAttribute = geometry.getAttribute('timestamp') as THREE.BufferAttribute;
 
   // Ensure arrays are large enough
-  if (!positionAttribute || positionAttribute.count < points.length) {
+  if (!positionAttribute || positionAttribute.count < used) {
     // Recreate geometry if not large enough
     const newGeometry = createPathGeometry(points);
     geometry.copy(newGeometry);
@@ -288,14 +319,14 @@ export function updatePathGeometry(geometry: THREE.BufferGeometry, points: PathP
   }
 
   // Update existing attributes
-  for (let i = 0; i < points.length; i++) {
+  for (let i = 0; i < used; i++) {
     const point = points[i];
     positionAttribute.setXYZ(i, point.position[0], point.position[1], point.position[2]);
     timestampAttribute.setX(i, point.timestamp);
   }
 
   // Set draw range to only render valid points
-  geometry.setDrawRange(0, points.length);
+  geometry.setDrawRange(0, used);
 
   positionAttribute.needsUpdate = true;
   timestampAttribute.needsUpdate = true;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,9 +52,9 @@ root.render(
   // to help find bugs. However, this causes the WebGL context in the 3D replay
   // viewer to be destroyed and rapidly recreated, which leads to context loss.
   //
-  // The WebGL context loss handlers and preserveDrawingBuffer setting in Arena3D.tsx
-  // help with real context loss scenarios (GPU issues, tab backgrounding, etc.) but
-  // cannot prevent the context destruction caused by Strict Mode's remounting behavior.
+  // The WebGL context loss handlers in Arena3D.tsx help with real context loss
+  // scenarios (GPU issues, tab backgrounding, etc.) but cannot prevent the
+  // context destruction caused by Strict Mode's remounting behavior.
   //
   // Note: Production builds don't use Strict Mode, so this only affects development.
   <App />,


### PR DESCRIPTION
Five lossless performance fixes for the fight-replay viewer — visual behavior preserved exactly, benefiting every user at every quality level. These are the remaining per-frame costs identified by the perf-plan audit after the adaptive-DPR / quality-governor / DOM-playhead work already merged.

1. **Idle micro-waste**: `bossTuneSignature` allocated an array + string every animation frame *before* the actor loop's early-return (memoized on `performanceMode`; the HMR recompose contract survives — Fast Refresh re-runs useMemo). `PerformanceMonitorCanvas` no longer mounts in production, where its three useFrame subscribers were no-op early-returns invoked every frame.
2. **Boss health scan**: the rAF tick allocated a fresh actor array per moving frame via `Object.values`; now a `for-in` over the by-reference record into a reused buffer. Integer-key enumeration order preserves boss selection. New mixed player/boss lookup test.
3. **Trails** (biggest CPU win when enabled): each selected trail rebuilt + re-uploaded its full line geometry every rAF, paused included, though points sample every ~100 ms. Now: time-idle early-return, allocation-free `getPathPointCountUpToTime`, and geometry writes only when the visible point count changes (~10 Hz during playback). Parity + partial-count tests.
4. **Name-tag declutter throttle**: the O(N) projections + O(N²) overlap resolve ran every moving frame (quadratic in trash-pull actor counts). Label tracking stays per-frame; the declutter now runs at 10 Hz, force-ticked on selection change, resize, and actor appear/disappear (≤1 frame late). Troika applies fillOpacity as a raw uniform with no transition — held opacities cannot flicker.
5. **`preserveDrawingBuffer: false`** (isolated last commit, one-line revert): the `true` forced drivers to copy/resolve the full buffer every presented frame and blocked ANGLE's swap fast path. Its justifying comment was wrong twice (Strict Mode is disabled app-wide; the flag never prevented context loss — the contextlost/restored listeners do, and they stay), and no readback consumer exists anywhere in src.

**Live verification** (dev build, Dreadsail Reef Reef-Guardian pull, 12 players): context attributes confirm `preserveDrawingBuffer: false`; paused canvas persists through 3 s idle, a DOM overlay opened/closed above it, and a 4 s tab-away/return — no black flash or blank canvas; playback ~106 fps with a trail enabled; backward seek truncates cleanly. Caveat: verified on one desktop GPU — if any driver misbehaves with the buffer flag, revert commit 5 alone.

`npm run validate` green; full jest 4481 passing (all 51 replay suites).