### PR TITLE
perf(runtime): visibility-gated pollers, isolated countdown, deferred Monte-Carlo, composited AttributeBar

### DIFF
--- a/src/features/build-editor/components/primitives/AttributeBar.tsx
+++ b/src/features/build-editor/components/primitives/AttributeBar.tsx
@@ -146,9 +146,16 @@ export const AttributeBar: React.FC<AttributeBarProps> = ({
           minWidth: 48,
         }}
       >
+        {/* Full-width fill revealed via animated clip-path instead of width:
+            width is a LAYOUT property, so the spring forced a reflow on every
+            animation frame; clip-path composites. Negative insets on the three
+            static sides keep the outer glow un-clipped (clip-path clips the
+            element's own box-shadow); `round 4px` preserves the rounded cap
+            at the moving edge. */}
         <motion.div
           style={{
             height: '100%',
+            width: '100%',
             borderRadius: 4,
             background: `linear-gradient(90deg, ${color} 0%, ${alpha(color, 0.55)} 100%)`,
             boxShadow:
@@ -157,7 +164,7 @@ export const AttributeBar: React.FC<AttributeBarProps> = ({
                 : 'none',
           }}
           initial={false}
-          animate={{ width: `${fillPercent}%` }}
+          animate={{ clipPath: `inset(-12px ${100 - fillPercent}% -12px -12px round 4px)` }}
           transition={
             prefersReduced ? { duration: 0 } : { type: 'spring', stiffness: 300, damping: 30 }
           }

--- a/src/features/live_logging/LiveLog.tsx
+++ b/src/features/live_logging/LiveLog.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch } from '@/store/useAppDispatch';
 
 import { useEsoLogsClientInstance } from '../../EsoLogsClientContext';
 import { GetReportByCodeDocument } from '../../graphql/gql/graphql';
+import { useVisibilityGatedInterval } from '../../hooks/useVisibilityGatedInterval';
 import { ReportFightContext } from '../../ReportFightContext';
 import { reportError } from '../../utils/errorTracking';
 import { TabId } from '../../utils/getSkeletonForTab';
@@ -89,15 +90,11 @@ export const LiveLog: React.FC<React.PropsWithChildren> = (props) => {
     dispatch(setReportCacheMetadata({ lastFetchedReportId: reportId }));
   }, [reportId, client, latestFightId, dispatch]);
 
-  React.useEffect(() => {
-    void fetchLatestFightId();
-
-    const interval = setInterval(() => {
-      void fetchLatestFightId();
-    }, REFETCH_INTERVAL);
-
-    return () => clearInterval(interval);
-  }, [fetchLatestFightId]);
+  // Visibility-gated: the live-log poll pauses while the tab is hidden and
+  // catches up immediately on return (a full hidden interval → instant fetch).
+  useVisibilityGatedInterval(() => void fetchLatestFightId(), REFETCH_INTERVAL, {
+    leading: true,
+  });
 
   const reportFightCtxValue = React.useMemo(
     () => ({

--- a/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
+++ b/src/features/ultimate-simulator/presentation/components/UltimateSimulator.tsx
@@ -171,8 +171,18 @@ export const UltimateSimulator: React.FC<UltimateSimulatorProps> = ({ className 
             </Stack>
           </Paper>
 
-          {/* Results */}
-          <Paper variant="outlined" sx={{ p: 3, flex: 1, minWidth: 0 }}>
+          {/* Results — dimmed while the deferred re-simulation lags the inputs
+              (slider drags stay responsive; numbers catch up on settle) */}
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 3,
+              flex: 1,
+              minWidth: 0,
+              opacity: sim.isStale ? 0.55 : 1,
+              transition: 'opacity 0.15s ease',
+            }}
+          >
             <Typography variant="h6" gutterBottom>
               Results
             </Typography>

--- a/src/features/ultimate-simulator/presentation/useUltimateSimulator.ts
+++ b/src/features/ultimate-simulator/presentation/useUltimateSimulator.ts
@@ -7,7 +7,7 @@
  * needed in this first pass (a worker can be added later if source counts grow).
  */
 
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useDeferredValue } from 'react';
 
 import { runMonteCarlo } from '../core/monteCarlo';
 import {
@@ -43,6 +43,8 @@ export interface UseUltimateSimulator {
   state: UltimateSimulatorState;
   sources: readonly UltimateSource[];
   result: MonteCarloResult;
+  /** True while `result` lags the latest inputs (deferred re-simulation pending). */
+  isStale: boolean;
   setFightDuration: (seconds: number) => void;
   setRuns: (runs: number) => void;
   setDecisiveEnabled: (enabled: boolean) => void;
@@ -55,35 +57,43 @@ export interface UseUltimateSimulator {
 export function useUltimateSimulator(): UseUltimateSimulator {
   const [state, setState] = useState<UltimateSimulatorState>(INITIAL_STATE);
 
+  // The Monte-Carlo run (default 10k iterations, capped 100k) is synchronous.
+  // Deriving it from a DEFERRED copy of the inputs lets React commit the
+  // urgent render (the slider thumb tracking the pointer) first and re-run the
+  // simulation at deferred priority — dragging an uptime slider no longer
+  // re-simulates on every pointer tick. `isStale` flags the lag for the view.
+  const deferredState = useDeferredValue(state);
+  const isStale = deferredState !== state;
+
   // Apply per-source uptime overrides on top of the preset.
   const sources = useMemo<readonly UltimateSource[]>(
     () =>
       RAID_CONTEXT_SOURCES.map((source) => {
-        const override = state.uptimeOverrides[source.id];
+        const override = deferredState.uptimeOverrides[source.id];
         return override === undefined ? source : { ...source, uptime: override };
       }),
-    [state.uptimeOverrides],
+    [deferredState.uptimeOverrides],
   );
 
   const result = useMemo<MonteCarloResult>(() => {
-    const decisive = state.decisiveEnabled
-      ? makeDecisiveConfig(state.decisiveQuality, state.decisiveTwoHanded)
+    const decisive = deferredState.decisiveEnabled
+      ? makeDecisiveConfig(deferredState.decisiveQuality, deferredState.decisiveTwoHanded)
       : null;
     return runMonteCarlo(
       {
-        fightDurationSeconds: state.fightDurationSeconds,
+        fightDurationSeconds: deferredState.fightDurationSeconds,
         sources,
         decisive,
       },
-      { runs: state.runs, baseSeed: DEFAULT_BASE_SEED },
+      { runs: deferredState.runs, baseSeed: DEFAULT_BASE_SEED },
     );
   }, [
     sources,
-    state.fightDurationSeconds,
-    state.runs,
-    state.decisiveEnabled,
-    state.decisiveQuality,
-    state.decisiveTwoHanded,
+    deferredState.fightDurationSeconds,
+    deferredState.runs,
+    deferredState.decisiveEnabled,
+    deferredState.decisiveQuality,
+    deferredState.decisiveTwoHanded,
   ]);
 
   const setFightDuration = useCallback(
@@ -125,6 +135,7 @@ export function useUltimateSimulator(): UseUltimateSimulator {
     state,
     sources,
     result,
+    isStale,
     setFightDuration,
     setRuns,
     setDecisiveEnabled,

--- a/src/hooks/useVisibilityGatedInterval.test.ts
+++ b/src/hooks/useVisibilityGatedInterval.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+
+import { useVisibilityGatedInterval } from './useVisibilityGatedInterval';
+
+// jsdom exposes document.hidden as a getter — redefine per test.
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('useVisibilityGatedInterval', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires on the cadence while visible', () => {
+    const cb = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(cb, 1000));
+    expect(cb).not.toHaveBeenCalled();
+    act(() => void jest.advanceTimersByTime(3100));
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it('fires immediately on start with leading: true', () => {
+    const cb = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(cb, 1000, { leading: true }));
+    expect(cb).toHaveBeenCalledTimes(1);
+    act(() => void jest.advanceTimersByTime(1000));
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('pauses entirely while hidden', () => {
+    const cb = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(cb, 1000));
+    act(() => setHidden(true));
+    act(() => void jest.advanceTimersByTime(10_000));
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('catches up immediately on return when a full interval elapsed hidden', () => {
+    const cb = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(cb, 1000));
+    act(() => void jest.advanceTimersByTime(1000)); // 1 fire
+    act(() => setHidden(true));
+    act(() => void jest.advanceTimersByTime(5000)); // hidden — nothing
+    expect(cb).toHaveBeenCalledTimes(1);
+    act(() => setHidden(false)); // >= interval elapsed → immediate catch-up
+    expect(cb).toHaveBeenCalledTimes(2);
+    act(() => void jest.advanceTimersByTime(1000));
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not double-fire when returning before an interval elapsed', () => {
+    const cb = jest.fn();
+    renderHook(() => useVisibilityGatedInterval(cb, 1000));
+    act(() => void jest.advanceTimersByTime(1000)); // 1 fire
+    act(() => setHidden(true));
+    act(() => void jest.advanceTimersByTime(300));
+    act(() => setHidden(false)); // only 300ms since last fire → no catch-up
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down when disabled', () => {
+    const cb = jest.fn();
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useVisibilityGatedInterval(cb, 1000, { enabled }),
+      { initialProps: { enabled: true } },
+    );
+    act(() => void jest.advanceTimersByTime(1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+    rerender({ enabled: false });
+    act(() => void jest.advanceTimersByTime(5000));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest callback without resetting the cadence', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) => useVisibilityGatedInterval(cb, 1000),
+      {
+        initialProps: { cb: first },
+      },
+    );
+    act(() => void jest.advanceTimersByTime(500));
+    rerender({ cb: second });
+    act(() => void jest.advanceTimersByTime(500));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useVisibilityGatedInterval.ts
+++ b/src/hooks/useVisibilityGatedInterval.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+
+interface VisibilityGatedIntervalOptions {
+  /** Master switch — false tears the interval down entirely. Default true. */
+  enabled?: boolean;
+  /** Fire once immediately on (re)start instead of waiting a full interval. Default false. */
+  leading?: boolean;
+}
+
+/**
+ * setInterval that pauses entirely while the tab is hidden and catches up on
+ * return: if at least one full interval elapsed while hidden, the callback
+ * fires immediately on visibility, then the cadence restarts fresh.
+ *
+ * Use for pollers/refreshers — a hidden tab should not burn network and CPU
+ * re-fetching data nobody is looking at (and re-rendering the tree per tick).
+ * Mirrors the visibility pattern established in useCacheInvalidation.
+ *
+ * The callback is kept in a ref, so an unstable callback identity neither
+ * resets the cadence nor goes stale.
+ */
+export function useVisibilityGatedInterval(
+  callback: () => void,
+  intervalMs: number,
+  options: VisibilityGatedIntervalOptions = {},
+): void {
+  const { enabled = true, leading = false } = options;
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!enabled || intervalMs <= 0) return;
+
+    let intervalId: number | null = null;
+    // Seeded so the first start only fires immediately when `leading` asks for
+    // it; afterwards it tracks real fire times for the catch-up check.
+    let lastFiredAt = leading ? Number.NEGATIVE_INFINITY : Date.now();
+
+    const fire = (): void => {
+      lastFiredAt = Date.now();
+      callbackRef.current();
+    };
+    const start = (): void => {
+      if (intervalId !== null) return;
+      if (Date.now() - lastFiredAt >= intervalMs) fire();
+      intervalId = window.setInterval(fire, intervalMs);
+    };
+    const stop = (): void => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+    const onVisibilityChange = (): void => {
+      if (document.hidden) stop();
+      else start();
+    };
+
+    if (!document.hidden) start();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [enabled, intervalMs, leading]);
+}

--- a/src/pages/ParseAnalysisPage.tsx
+++ b/src/pages/ParseAnalysisPage.tsx
@@ -109,6 +109,7 @@ import { useFriendlyBuffEvents } from '../hooks/events/useFriendlyBuffEvents';
 import { useReportData } from '../hooks/useReportData';
 import { useReportMasterData } from '../hooks/useReportMasterData';
 import { useRoleColors } from '../hooks/useRoleColors';
+import { useVisibilityGatedInterval } from '../hooks/useVisibilityGatedInterval';
 import { useSelectedReportAndFight } from '../ReportFightContext';
 import { setParseReport, clearParseReport } from '../store/parse_analysis/parseAnalysisSlice';
 import { setReportData } from '../store/report/reportSlice';
@@ -226,6 +227,20 @@ const extractReportInfo = (url: string): { reportId: string; fightId: string | n
 
 /** How often to poll for new fights added to the report while the page is open */
 const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * Isolated 1-second countdown to the next poll. Owning the tick here keeps the
+ * per-second setState re-render confined to this leaf — previously the tick
+ * lived in the page and re-rendered the entire ~2,900-line component every
+ * second the page was open. Visibility-gated like the poll itself.
+ */
+const PollCountdown: React.FC<{ nextPollAt: number | null }> = ({ nextPollAt }) => {
+  const [now, setNow] = useState(() => Date.now());
+  useVisibilityGatedInterval(() => setNow(Date.now()), 1000, { enabled: nextPollAt !== null });
+  if (nextPollAt === null) return null;
+  const seconds = Math.max(0, Math.ceil((nextPollAt - now) / 1000));
+  return <>— next check in {seconds}s</>;
+};
 
 /**
  * Public demo log users can explore the parse analysis tool without their own log.
@@ -1049,39 +1064,34 @@ const ParseAnalysisPageContent: React.FC = () => {
     }
   }, [logUrl, analyzeReport, navigate]);
 
-  /** Seconds until the next poll fires — shown in the navigation strip */
-  const [pollCountdown, setPollCountdown] = useState(POLL_INTERVAL_MS / 1000);
+  /** Wall-clock deadline of the next poll — drives the isolated PollCountdown leaf. */
+  const [nextPollAt, setNextPollAt] = useState<number | null>(null);
 
-  // Mirror loading into a ref so the poll interval can read it without listing
-  // state.loading as a dependency (which tore down + recreated the timers and
-  // reset the visible countdown on every analyze).
+  // Mirror loading into a ref so the poll can read it without resetting the
+  // cadence (listing state.loading as a dependency tore the timer down and
+  // restarted the visible countdown on every analyze).
   const loadingRef = useRef(state.loading);
   useEffect(() => {
     loadingRef.current = state.loading;
   }, [state.loading]);
 
-  // Poll for new fights added to the report while the page is open.
-  // Restarts when the report changes; uses closure-captured values so the
-  // interval always reflects the latest fight count.
+  const pollEnabled = Boolean(state.reportCode && client && isReady && isLoggedIn);
+
+  // Arm/refresh the visible deadline when polling starts or stops.
   useEffect(() => {
-    if (!state.reportCode || !client || !isReady || !isLoggedIn) return;
+    setNextPollAt(pollEnabled ? Date.now() + POLL_INTERVAL_MS : null);
+  }, [pollEnabled, state.reportCode]);
 
-    const reportCode = state.reportCode;
-    const currentFightCount = availableFights.length;
-    const intervalSec = POLL_INTERVAL_MS / 1000;
-
-    setPollCountdown(intervalSec);
-
-    // 1-second countdown tick
-    const countdownId = setInterval(() => {
-      setPollCountdown((prev) => (prev <= 1 ? intervalSec : prev - 1));
-    }, 1000);
-
-    const timerId = setInterval(() => {
-      if (loadingRef.current) {
-        setPollCountdown(intervalSec); // reset visual while loading
-        return;
-      }
+  // Poll for new fights added to the report while the page is open.
+  // Visibility-gated: pauses while the tab is hidden, catches up on return.
+  // The hook reads the latest render values through its callback ref, so the
+  // fight count and report code are always current without cadence resets.
+  useVisibilityGatedInterval(
+    () => {
+      setNextPollAt(Date.now() + POLL_INTERVAL_MS);
+      if (loadingRef.current || !state.reportCode || !client) return;
+      const reportCode = state.reportCode;
+      const currentFightCount = availableFights.length;
       void (async () => {
         try {
           const response = await client.query<GetReportByCodeQuery>({
@@ -1112,20 +1122,10 @@ const ParseAnalysisPageContent: React.FC = () => {
           logger.debug('Fight poll error (ignored)', { error: err });
         }
       })();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      clearInterval(countdownId);
-      clearInterval(timerId);
-    };
-  }, [
-    state.reportCode,
-    availableFights.length,
-    client,
-    isReady,
-    isLoggedIn,
-    handleAnalyzeFromParams,
-  ]);
+    },
+    POLL_INTERVAL_MS,
+    { enabled: pollEnabled },
+  );
 
   const handleSelectFight = useCallback(
     (fightId: number): void => {
@@ -2240,7 +2240,7 @@ const ParseAnalysisPageContent: React.FC = () => {
                 {availableFights.length === 1 ? 'Latest Fight' : 'Available Fights'}
               </Typography>
               <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                — next check in {pollCountdown}s
+                <PollCountdown nextPollAt={nextPollAt} />
               </Typography>
             </Stack>
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/src/pages/RaidDashboardPage.tsx
+++ b/src/pages/RaidDashboardPage.tsx
@@ -19,6 +19,7 @@ import { WorkInProgressDisclaimer } from '../components/WorkInProgressDisclaimer
 import { useEsoLogsClientInstance } from '../EsoLogsClientContext';
 import { FightFragment } from '../graphql/gql/graphql';
 import { useReportData } from '../hooks';
+import { useVisibilityGatedInterval } from '../hooks/useVisibilityGatedInterval';
 import {
   addWidget,
   removeWidget,
@@ -49,16 +50,13 @@ export const RaidDashboardPage: React.FC = () => {
     }
   }, [reportId, client, dispatch]);
 
-  React.useEffect(() => {
-    if (!autoRefreshEnabled) return;
-
-    fetchLatestReport();
-    const interval = setInterval(() => {
-      fetchLatestReport();
-    }, REFETCH_INTERVAL);
-
-    return () => clearInterval(interval);
-  }, [fetchLatestReport, autoRefreshEnabled]);
+  // Visibility-gated: a backgrounded dashboard must not re-fetch the whole
+  // report every 5s (and re-render the widget tree) for nobody. On return, a
+  // catch-up fetch fires immediately if a full interval elapsed hidden.
+  useVisibilityGatedInterval(fetchLatestReport, REFETCH_INTERVAL, {
+    enabled: autoRefreshEnabled,
+    leading: true,
+  });
 
   const sortedFights = useMemo(() => {
     if (!reportData?.fights) return [];


### PR DESCRIPTION
Four site-wide runtime CPU fixes from the perf plan — each one stops work that was running for nobody or on the wrong thread priority.

1. **New `useVisibilityGatedInterval` hook** (7 unit tests): setInterval that pauses entirely while the tab is hidden and fires an immediate catch-up on return when a full interval elapsed — the visibilitychange pattern already proven in `useCacheInvalidation`, extracted for reuse.
2. **Pollers gated**: the raid dashboard re-fetched the entire report every 5 s and the live log every 30 s in backgrounded tabs (no `document.hidden` check anywhere). Foreground behavior unchanged (leading fires preserved); hidden tabs now go fully quiet.
3. **ParseAnalysis countdown isolated**: a 1-second `setState` re-rendered the whole ~2,900-line page every second it was open, feeding one caption. It's now a leaf component driven by a `nextPollAt` deadline — the page re-renders once per 15 s cycle — and the fight poll itself is visibility-gated. The hook's callback-ref semantics also remove the old cadence resets whenever the fight count changed.
4. **Ultimate Simulator**: `runMonteCarlo` (10k runs default, 100k cap) ran synchronously in a useMemo on every input change — every pointer tick of a slider drag re-simulated. The memos now derive from `useDeferredValue(state)`: the thumb tracks at urgent priority, the simulation re-runs deferred, and a new `isStale` flag dims the results panel until the numbers catch up.
5. **AttributeBar**: the framer spring animated `width` (layout → per-frame reflow); now an animated `clip-path` inset on a full-width fill, which composites. Negative insets keep the outer glow un-clipped; `round 4px` keeps the moving cap. One knowing delta, called out in the commit: the gradient is revealed rather than compressed — imperceptible on an 8 px bar.

**Heads-up for in-flight local work**: `ParseAnalysisPage.tsx` carries uncommitted local modifications in the primary checkout — that work will need a small rebase over commit 3 when it lands.

`npm run validate` green; full jest 4484 passing, including the 13 suites touching these areas.