### PR TITLE
perf(insights): offload the Players-tab analysis burst to the worker pool

### DIFF
--- a/src/features/report_details/insights/PlayersPanel.tsx
+++ b/src/features/report_details/insights/PlayersPanel.tsx
@@ -24,10 +24,19 @@ import {
 } from '@/store/companion';
 import { useAppDispatch } from '@/store/useAppDispatch';
 import {
+  executePlayerPanelAnalysisTask,
   executeScribingDetectionsTask,
+  selectPlayerPanelAnalysisResult,
   selectScribingDetectionsResult,
   selectScribingDetectionsTask,
 } from '@/store/worker_results';
+import {
+  computePlayerPanelAnalysis,
+  PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD,
+  type PlayerMaxResources,
+  type PlayerPanelAnalysisInput,
+  type PlayerPanelAnalysisResult,
+} from '@/utils/playerPanelAnalysis';
 
 import type { GrimoireData } from '../../../components/ScribingSkillsDisplay';
 import { PlayerAvatarsProvider } from '../../../contexts/PlayerAvatarsContext';
@@ -75,13 +84,8 @@ import {
 } from '../../../types/abilities';
 import { CombatantAura, CombatantInfoEvent } from '../../../types/combatlogEvents';
 import { PlayerGear } from '../../../types/playerDetails';
-import { BuffLookupData } from '../../../utils/BuffLookupUtils';
-import {
-  createSkillLineAbilityMapping,
-  analyzePlayerClassFromEvents,
-  type ClassAnalysisResult,
-} from '../../../utils/classDetectionUtils';
-import { detectBuildIssues, BuildIssue } from '../../../utils/detectBuildIssues';
+import { type ClassAnalysisResult } from '../../../utils/classDetectionUtils';
+import { type BuildIssue } from '../../../utils/detectBuildIssues';
 import {
   ARENA_SET_NAMES,
   isDoubleSetCount,
@@ -106,12 +110,17 @@ import {
   classifyPotionEventsFromBuffStream,
   type PotionStreamResult,
 } from '../../../utils/potionDetectionUtils';
-import {
-  analyzeBarSwaps,
-  type BarSwapAnalysisResult,
-} from '../../parse_analysis/utils/parseAnalysisUtils';
+import { type BarSwapAnalysisResult } from '../../parse_analysis/utils/parseAnalysisUtils';
 
 import { PlayersPanelView } from './PlayersPanelView';
+
+// Stable empty fallbacks for the combined analysis maps while the worker task
+// is in flight (or aborted on a fight switch) — fresh {} literals would churn
+// every downstream memo per render.
+const EMPTY_BAR_SWAP_RESULTS: Record<string, BarSwapAnalysisResult> = {};
+const EMPTY_CLASS_ANALYSIS_RESULTS: Record<string, ClassAnalysisResult> = {};
+const EMPTY_MAX_RESOURCES: Record<string, PlayerMaxResources> = {};
+const EMPTY_BUILD_ISSUES: Record<string, BuildIssue[]> = {};
 
 // Recipe lookup stubs — full recipe resolution pending unified detection service
 const findScribingRecipe = async (_skillId: unknown, _skillName?: string): Promise<null> => null;
@@ -718,60 +727,93 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   }, [fight, healingEvents]);
 
   // Compute bar swap analysis (including bar setup pattern) per player
-  const barSwapByPlayer = React.useMemo(() => {
-    const result: Record<string, BarSwapAnalysisResult> = {};
-    if (!fight || !castEvents || !hasPlayerEntries(playersById)) return result;
-    const { startTime, endTime } = fight;
-    for (const player of Object.values(playersById)) {
-      if (!player?.id) continue;
-      result[String(player.id)] = analyzeBarSwaps(
-        castEvents,
-        Number(player.id),
-        startTime,
-        endTime,
-      );
-    }
-    return result;
-  }, [fight, castEvents, playersById]);
-
   const { abilitiesById } = reportMasterData;
 
-  const publicClassAnalysisByPlayer = React.useMemo(() => {
-    const result: Record<string, ClassAnalysisResult> = {};
-
-    if (!abilitiesById || !hasPlayerEntries(playersById)) {
-      return result;
-    }
-
-    const classMapping = createSkillLineAbilityMapping(abilitiesById);
-
-    Object.values(playersById).forEach((player) => {
-      if (!player?.id) return;
-
-      const playerId = String(player.id);
-      result[playerId] = analyzePlayerClassFromEvents(
-        playerId,
-        abilitiesById,
-        combatantInfoEvents,
-        castEvents,
-        damageEvents,
-        friendlyBuffEvents,
-        debuffEvents,
-        player.combatantInfo?.talents,
-        classMapping,
-      );
-    });
-
-    return result;
+  // ── Combined per-player analysis (worker-offloaded) ────────────────────────
+  // Public class detection, bar swaps, max resources and build issues were the
+  // panel's dominant main-thread burst on fight open/switch — each one is
+  // O(players × events) or a full event-array pass. They now run as ONE worker
+  // task (a single structured-clone of the shared event arrays; the pool clones
+  // task.data per execute, so one combined task beats four), or inline for
+  // small fights where the clone would cost more than the compute itself.
+  const panelAnalysisInput = React.useMemo((): PlayerPanelAnalysisInput | null => {
+    if (!fight || !hasPlayerEntries(playersById) || !castEvents || !damageEvents) return null;
+    const players = Object.values(playersById)
+      .filter((p): p is NonNullable<typeof p> => Boolean(p?.id))
+      .map((p) => ({
+        id: Number(p.id),
+        role: p.role,
+        talents: p.combatantInfo?.talents,
+        gear: (p.combatantInfo?.gear ?? []).filter((g) => g.id !== 0),
+      }));
+    if (players.length === 0) return null;
+    return {
+      fightStartTime: fight.startTime,
+      fightEndTime: fight.endTime,
+      players,
+      castEvents,
+      damageEvents,
+      healingEvents: healingEvents ?? [],
+      resourceEvents: resourceEvents ?? [],
+      combatantInfoEvents: combatantInfoEvents ?? [],
+      friendlyBuffEvents: friendlyBuffEvents ?? [],
+      debuffEvents: debuffEvents ?? [],
+      abilitiesById,
+      friendlyBuffLookup: friendlyBuffLookup ?? { buffIntervals: {} },
+    };
   }, [
-    abilitiesById,
+    fight,
     playersById,
-    combatantInfoEvents,
     castEvents,
     damageEvents,
+    healingEvents,
+    resourceEvents,
+    combatantInfoEvents,
     friendlyBuffEvents,
     debuffEvents,
+    abilitiesById,
+    friendlyBuffLookup,
   ]);
+
+  // Small fights compute inline — identical output shape via the shared pure fn.
+  const panelAnalysisSync = React.useMemo(() => {
+    if (!panelAnalysisInput) return null;
+    const totalEvents =
+      panelAnalysisInput.castEvents.length +
+      panelAnalysisInput.damageEvents.length +
+      panelAnalysisInput.healingEvents.length +
+      panelAnalysisInput.resourceEvents.length;
+    if (totalEvents >= PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD) return null;
+    return computePlayerPanelAnalysis(panelAnalysisInput);
+  }, [panelAnalysisInput]);
+
+  React.useEffect(() => {
+    if (!panelAnalysisInput || panelAnalysisSync) return;
+    const promise = dispatch(executePlayerPanelAnalysisTask(panelAnalysisInput));
+    return () => {
+      promise.abort();
+    };
+  }, [dispatch, panelAnalysisInput, panelAnalysisSync]);
+
+  const panelAnalysisWorker = useSelector(
+    selectPlayerPanelAnalysisResult,
+  ) as PlayerPanelAnalysisResult | null;
+
+  // Fight-window guard: player ids overlap across fights in a report, so a
+  // stale result from the previous fight must never be consumed while the next
+  // fight's task is still in flight — cards render their loading/empty state
+  // instead (classAnalysis/barSwap are optional PlayerCard props already).
+  const panelAnalysis = React.useMemo(() => {
+    const candidate = panelAnalysisSync ?? panelAnalysisWorker;
+    if (!candidate || !fight) return null;
+    return candidate.fightStartTime === fight.startTime && candidate.fightEndTime === fight.endTime
+      ? candidate
+      : null;
+  }, [panelAnalysisSync, panelAnalysisWorker, fight]);
+
+  const barSwapByPlayer = panelAnalysis?.barSwapByPlayer ?? EMPTY_BAR_SWAP_RESULTS;
+  const publicClassAnalysisByPlayer =
+    panelAnalysis?.publicClassAnalysisByPlayer ?? EMPTY_CLASS_ANALYSIS_RESULTS;
 
   // Fetch critical damage data for the inline crit summary on DPS player cards
   const { criticalDamageData } = useCriticalDamageTask({ context: resolvedContext });
@@ -1260,110 +1302,11 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   }, [playersById]);
 
   // Calculate max resources (health, stamina, magicka) per player using all resource events throughout the fight
-  const maxResourcesByPlayer = React.useMemo(() => {
-    const result: Record<string, { health: number; stamina: number; magicka: number }> = {};
-
-    if (!hasPlayerEntries(playersById) || !fight) return result;
-
-    // Initialize with 0 for each player
-    Object.values(playersById).forEach((player) => {
-      if (player?.id) {
-        result[String(player.id)] = { health: 0, stamina: 0, magicka: 0 };
-      }
-    });
-
-    const updatePlayerResources = (
-      playerId: string,
-      resources: { maxHitPoints?: number; maxStamina?: number; maxMagicka?: number },
-    ): void => {
-      if (result[playerId] !== undefined && resources) {
-        if (resources.maxHitPoints) {
-          result[playerId].health = Math.max(result[playerId].health, resources.maxHitPoints);
-        }
-        if (resources.maxStamina) {
-          result[playerId].stamina = Math.max(result[playerId].stamina, resources.maxStamina);
-        }
-        if (resources.maxMagicka) {
-          result[playerId].magicka = Math.max(result[playerId].magicka, resources.maxMagicka);
-        }
-      }
-    };
-
-    // Look for max resources across all resource events within the fight timeframe
-    if (resourceEvents) {
-      resourceEvents.forEach((event) => {
-        if (event.type === 'resourcechange') {
-          // Only consider events within the current fight timeframe
-          const isInFightTimeframe =
-            event.timestamp >= fight.startTime && event.timestamp <= fight.endTime;
-
-          if (isInFightTimeframe) {
-            // Check source resources
-            if (event.sourceID && event.sourceResources) {
-              const playerId = String(event.sourceID);
-              updatePlayerResources(playerId, event.sourceResources);
-            }
-
-            // Check target resources
-            if (event.targetID && event.targetResources) {
-              const playerId = String(event.targetID);
-              updatePlayerResources(playerId, event.targetResources);
-            }
-          }
-        }
-      });
-    }
-
-    // Also check damage and healing events for additional resource data
-    if (damageEvents) {
-      damageEvents.forEach((event) => {
-        if (event.type === 'damage') {
-          const isInFightTimeframe =
-            event.timestamp >= fight.startTime && event.timestamp <= fight.endTime;
-
-          if (isInFightTimeframe) {
-            // Check source resources in damage events
-            if (event.sourceID && event.sourceResources) {
-              const playerId = String(event.sourceID);
-              updatePlayerResources(playerId, event.sourceResources);
-            }
-
-            // Check target resources in damage events
-            if (event.targetID && event.targetResources) {
-              const playerId = String(event.targetID);
-              updatePlayerResources(playerId, event.targetResources);
-            }
-          }
-        }
-      });
-    }
-
-    // Also check healing events for additional resource data
-    if (healingEvents) {
-      healingEvents.forEach((event) => {
-        if (event.type === 'heal') {
-          const isInFightTimeframe =
-            event.timestamp >= fight.startTime && event.timestamp <= fight.endTime;
-
-          if (isInFightTimeframe) {
-            // Check source resources in healing events
-            if (event.sourceID && event.sourceResources) {
-              const playerId = String(event.sourceID);
-              updatePlayerResources(playerId, event.sourceResources);
-            }
-
-            // Check target resources in healing events
-            if (event.targetID && event.targetResources) {
-              const playerId = String(event.targetID);
-              updatePlayerResources(playerId, event.targetResources);
-            }
-          }
-        }
-      });
-    }
-
-    return result;
-  }, [playersById, resourceEvents, damageEvents, healingEvents, fight]);
+  // Offloaded to the combined worker task (see panelAnalysis above).
+  const maxResourcesByPlayer = React.useMemo(
+    () => panelAnalysis?.maxResourcesByPlayer ?? EMPTY_MAX_RESOURCES,
+    [panelAnalysis],
+  );
 
   // Extract individual max resources for backward compatibility
   const maxHealthByPlayer = React.useMemo(() => {
@@ -1391,66 +1334,8 @@ export const PlayersPanel: React.FC<PlayersPanelProps> = ({ context: contextOver
   }, [maxResourcesByPlayer]);
 
   // Calculate build issues per player
-  const buildIssuesByPlayer = React.useMemo(() => {
-    const result: Record<string, BuildIssue[]> = {};
-
-    if (
-      !hasPlayerEntries(playersById) ||
-      !friendlyBuffLookup ||
-      !fight?.startTime ||
-      !fight?.endTime
-    ) {
-      return result;
-    }
-
-    Object.values(playersById).forEach((player) => {
-      if (!player?.id) return;
-
-      const playerId = String(player.id);
-      const gear = (player?.combatantInfo?.gear ?? []).filter((g) => g.id !== 0);
-      const resourceSnapshot = maxResourcesByPlayer[playerId];
-      const playerResourceProfile = resourceSnapshot
-        ? { stamina: resourceSnapshot.stamina, magicka: resourceSnapshot.magicka }
-        : undefined;
-
-      // Extract auras for this player from combatant info events
-      const playerAuras: CombatantAura[] = [];
-      if (combatantInfoEvents) {
-        const playerCombatantInfo = combatantInfoEvents.find(
-          (event) => event.sourceID === player.id,
-        );
-        if (playerCombatantInfo?.auras) {
-          playerAuras.push(...playerCombatantInfo.auras);
-        }
-      }
-
-      const emptyBuffLookup: BuffLookupData = { buffIntervals: {} };
-
-      const buildIssues = detectBuildIssues(
-        gear,
-        friendlyBuffLookup || emptyBuffLookup,
-        fight.startTime,
-        fight.endTime,
-        playerAuras,
-        player.role,
-        damageEvents,
-        player.id,
-        playerResourceProfile,
-      );
-
-      result[playerId] = buildIssues;
-    });
-
-    return result;
-  }, [
-    playersById,
-    friendlyBuffLookup,
-    fight?.startTime,
-    fight?.endTime,
-    damageEvents,
-    combatantInfoEvents,
-    maxResourcesByPlayer,
-  ]);
+  // Offloaded to the combined worker task (see panelAnalysis above).
+  const buildIssuesByPlayer = panelAnalysis?.buildIssuesByPlayer ?? EMPTY_BUILD_ISSUES;
 
   // Build scribing skills per player from the worker detection results
   const scribingSkillsByPlayer = React.useMemo(() => {

--- a/src/store/worker_results/actionCreators.ts
+++ b/src/store/worker_results/actionCreators.ts
@@ -28,6 +28,8 @@ import {
   executeElementalWeaknessStacksTask,
   playerTravelDistancesActions,
   executePlayerTravelDistancesTask,
+  playerPanelAnalysisActions,
+  executePlayerPanelAnalysisTask,
   scribingDetectionsActions,
   executeScribingDetectionsTask,
 } from './workerResultsSlice';
@@ -47,6 +49,7 @@ const taskActionsMap = {
   calculateStaggerStacks: staggerStacksActions,
   calculateElementalWeaknessStacks: elementalWeaknessStacksActions,
   calculatePlayerTravelDistances: playerTravelDistancesActions,
+  calculatePlayerPanelAnalysis: playerPanelAnalysisActions,
   calculateScribingDetections: scribingDetectionsActions,
 } as const;
 
@@ -68,6 +71,7 @@ const taskThunkMap: Record<
   calculateStaggerStacks: executeStaggerStacksTask,
   calculateElementalWeaknessStacks: executeElementalWeaknessStacksTask,
   calculatePlayerTravelDistances: executePlayerTravelDistancesTask,
+  calculatePlayerPanelAnalysis: executePlayerPanelAnalysisTask,
   calculateScribingDetections: executeScribingDetectionsTask,
 } as const;
 

--- a/src/store/worker_results/playerPanelAnalysisSlice.ts
+++ b/src/store/worker_results/playerPanelAnalysisSlice.ts
@@ -1,0 +1,58 @@
+import memoizeOne from 'memoize-one';
+
+import type { PlayerPanelAnalysisInput } from '@/workers/calculations/CalculatePlayerPanelAnalysis';
+
+import { createWorkerTaskSlice } from './workerTaskSliceFactory';
+
+/** djb2-variant string hash (same scheme as the scribing task slice). */
+function simpleHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+// Cheap identity for a task input: fight window + who's in it + stream sizes.
+// Event arrays are immutable per fight load, so counts + the fight window are
+// a sufficient discriminator without hashing tens of thousands of events.
+const computePlayerPanelAnalysisHash = memoizeOne(
+  (
+    fightStartTime: number,
+    fightEndTime: number,
+    playerIds: string,
+    castCount: number,
+    damageCount: number,
+    healCount: number,
+    resourceCount: number,
+  ) =>
+    simpleHash(
+      JSON.stringify({
+        fightStartTime,
+        fightEndTime,
+        playerIds,
+        castCount,
+        damageCount,
+        healCount,
+        resourceCount,
+      }),
+    ),
+);
+
+export const playerPanelAnalysisSlice = createWorkerTaskSlice(
+  'calculatePlayerPanelAnalysis',
+  (input: PlayerPanelAnalysisInput) =>
+    computePlayerPanelAnalysisHash(
+      input.fightStartTime,
+      input.fightEndTime,
+      input.players.map((p) => p.id).join(','),
+      input.castEvents.length,
+      input.damageEvents.length,
+      input.healingEvents.length,
+      input.resourceEvents.length,
+    ),
+);
+
+export const playerPanelAnalysisActions = playerPanelAnalysisSlice.actions;
+export const executePlayerPanelAnalysisTask = playerPanelAnalysisSlice.executeTask;
+export const playerPanelAnalysisReducer = playerPanelAnalysisSlice.reducer;

--- a/src/store/worker_results/selectors.ts
+++ b/src/store/worker_results/selectors.ts
@@ -162,6 +162,9 @@ export const selectDamageReductionResult = selectWorkerTaskResult('calculateDama
 export const selectDebuffLookupResult = selectWorkerTaskResult('calculateDebuffLookup');
 export const selectHostileBuffLookupResult = selectWorkerTaskResult('calculateHostileBuffLookup');
 export const selectScribingDetectionsResult = selectWorkerTaskResult('calculateScribingDetections');
+export const selectPlayerPanelAnalysisResult = selectWorkerTaskResult(
+  'calculatePlayerPanelAnalysis',
+);
 
 // Aggregate selectors
 export const selectAnyWorkerTaskLoading = createSelector([selectWorkerResults], (workerResults) =>

--- a/src/store/worker_results/taskSlices.ts
+++ b/src/store/worker_results/taskSlices.ts
@@ -91,6 +91,13 @@ export {
 } from './playerTravelDistancesSlice';
 
 export {
+  playerPanelAnalysisSlice,
+  playerPanelAnalysisActions,
+  executePlayerPanelAnalysisTask,
+  playerPanelAnalysisReducer,
+} from './playerPanelAnalysisSlice';
+
+export {
   scribingDetectionsSlice,
   scribingDetectionsActions,
   executeScribingDetectionsTask,

--- a/src/store/worker_results/workerResultsSlice.ts
+++ b/src/store/worker_results/workerResultsSlice.ts
@@ -14,6 +14,7 @@ import {
   staggerStacksReducer,
   elementalWeaknessStacksReducer,
   playerTravelDistancesReducer,
+  playerPanelAnalysisReducer,
   scribingDetectionsReducer,
 } from './taskSlices';
 
@@ -32,6 +33,7 @@ const workerResultsReducer = combineReducers({
   calculateDebuffLookup: debuffLookupReducer,
   calculateHostileBuffLookup: hostileBuffLookupReducer,
   calculatePlayerTravelDistances: playerTravelDistancesReducer,
+  calculatePlayerPanelAnalysis: playerPanelAnalysisReducer,
   calculateScribingDetections: scribingDetectionsReducer,
 });
 
@@ -49,6 +51,7 @@ export {
   staggerStacksActions,
   elementalWeaknessStacksActions,
   playerTravelDistancesActions,
+  playerPanelAnalysisActions,
   damageReductionActions,
   debuffLookupActions,
   hostileBuffLookupActions,
@@ -68,6 +71,7 @@ export {
   executeDebuffLookupTask,
   executeHostileBuffLookupTask,
   executeScribingDetectionsTask,
+  executePlayerPanelAnalysisTask,
 } from './taskSlices';
 
 // Export the factory function and types for potential reuse

--- a/src/utils/playerPanelAnalysis.test.ts
+++ b/src/utils/playerPanelAnalysis.test.ts
@@ -1,0 +1,150 @@
+import {
+  computePlayerPanelAnalysis,
+  PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD,
+  type PlayerPanelAnalysisInput,
+} from './playerPanelAnalysis';
+
+/**
+ * Tests the COMBINER: per-player keying, the max-resource scan (window filter,
+ * source/target maxima), aura wiring, and the fight-window echo. The wrapped
+ * analyses (analyzeBarSwaps, analyzePlayerClassFromEvents, detectBuildIssues)
+ * each carry their own behavioral suites.
+ */
+
+const FIGHT_START = 1000;
+const FIGHT_END = 9000;
+
+function makeInput(overrides: Partial<PlayerPanelAnalysisInput> = {}): PlayerPanelAnalysisInput {
+  return {
+    fightStartTime: FIGHT_START,
+    fightEndTime: FIGHT_END,
+    players: [
+      { id: 1, role: 'dps', gear: [] },
+      { id: 2, role: 'healer', gear: [] },
+    ],
+    castEvents: [],
+    damageEvents: [],
+    healingEvents: [],
+    resourceEvents: [],
+    combatantInfoEvents: [],
+    friendlyBuffEvents: [],
+    debuffEvents: [],
+    abilitiesById: {},
+    friendlyBuffLookup: { buffIntervals: {} },
+    ...overrides,
+  };
+}
+
+describe('computePlayerPanelAnalysis', () => {
+  it('echoes the fight window and keys every map by player id', () => {
+    const result = computePlayerPanelAnalysis(makeInput());
+
+    expect(result.fightStartTime).toBe(FIGHT_START);
+    expect(result.fightEndTime).toBe(FIGHT_END);
+    for (const map of [
+      result.publicClassAnalysisByPlayer,
+      result.barSwapByPlayer,
+      result.maxResourcesByPlayer,
+      result.buildIssuesByPlayer,
+    ]) {
+      expect(Object.keys(map).sort()).toEqual(['1', '2']);
+    }
+  });
+
+  it('tracks per-player resource maxima from source AND target snapshots', () => {
+    const result = computePlayerPanelAnalysis(
+      makeInput({
+        resourceEvents: [
+          {
+            type: 'resourcechange',
+            timestamp: 2000,
+            sourceID: 1,
+            sourceResources: { maxHitPoints: 20000, maxStamina: 30000, maxMagicka: 12000 },
+          },
+          {
+            type: 'resourcechange',
+            timestamp: 3000,
+            targetID: 1,
+            targetResources: { maxHitPoints: 22000, maxStamina: 29000 },
+          },
+        ],
+        damageEvents: [
+          {
+            type: 'damage',
+            timestamp: 4000,
+            sourceID: 2,
+            sourceResources: { maxHitPoints: 25000, maxMagicka: 40000 },
+          },
+        ],
+      }),
+    );
+
+    expect(result.maxResourcesByPlayer['1']).toEqual({
+      health: 22000,
+      stamina: 30000,
+      magicka: 12000,
+    });
+    expect(result.maxResourcesByPlayer['2']).toEqual({
+      health: 25000,
+      stamina: 0,
+      magicka: 40000,
+    });
+  });
+
+  it('ignores resource snapshots outside the fight window', () => {
+    const result = computePlayerPanelAnalysis(
+      makeInput({
+        resourceEvents: [
+          {
+            type: 'resourcechange',
+            timestamp: FIGHT_START - 1,
+            sourceID: 1,
+            sourceResources: { maxHitPoints: 99999 },
+          },
+          {
+            type: 'resourcechange',
+            timestamp: FIGHT_END + 1,
+            sourceID: 1,
+            sourceResources: { maxHitPoints: 88888 },
+          },
+        ],
+      }),
+    );
+
+    expect(result.maxResourcesByPlayer['1'].health).toBe(0);
+  });
+
+  it('ignores snapshots for actors that are not tracked players', () => {
+    const result = computePlayerPanelAnalysis(
+      makeInput({
+        resourceEvents: [
+          {
+            type: 'resourcechange',
+            timestamp: 2000,
+            sourceID: 999,
+            sourceResources: { maxHitPoints: 12345 },
+          },
+        ],
+      }),
+    );
+
+    expect(result.maxResourcesByPlayer['999']).toBeUndefined();
+  });
+
+  it('skips class analysis when abilities data is absent, keeping other maps', () => {
+    const result = computePlayerPanelAnalysis(
+      makeInput({
+        abilitiesById: undefined as unknown as PlayerPanelAnalysisInput['abilitiesById'],
+      }),
+    );
+
+    expect(result.publicClassAnalysisByPlayer).toEqual({});
+    expect(Object.keys(result.barSwapByPlayer)).toHaveLength(2);
+    expect(Object.keys(result.buildIssuesByPlayer)).toHaveLength(2);
+  });
+
+  it('sync threshold is a sane positive bound', () => {
+    expect(PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD).toBeGreaterThan(1000);
+    expect(PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD).toBeLessThan(1_000_000);
+  });
+});

--- a/src/utils/playerPanelAnalysis.ts
+++ b/src/utils/playerPanelAnalysis.ts
@@ -1,0 +1,212 @@
+/**
+ * Combined per-player analysis for the report Players tab — the pure core of
+ * the `calculatePlayerPanelAnalysis` worker task.
+ *
+ * These four computations (public class detection, bar-swap analysis,
+ * max-resource scan, build-issue detection) were ~the entire main-thread burst
+ * when opening or switching a fight: each is O(players × events) or does full
+ * event-array passes, and they previously ran inside PlayersPanel useMemos,
+ * blocking paint. They are combined into ONE task because the worker pool
+ * structured-clones `task.data` per execute() across interchangeable workers —
+ * one task means the (large) event arrays are cloned once, not four times.
+ *
+ * Pure and synchronous by design: the panel calls it directly on the main
+ * thread for small fights (clone overhead would exceed the compute), and the
+ * worker calls the same function for large ones — identical output shape.
+ */
+
+import {
+  analyzeBarSwaps,
+  type BarSwapAnalysisResult,
+} from '../features/parse_analysis/utils/parseAnalysisUtils';
+import type { CombatantAura, CombatantInfoEvent } from '../types/combatlogEvents';
+import type { PlayerGear, PlayerTalent } from '../types/playerDetails';
+
+import type { BuffLookupData } from './BuffLookupUtils';
+import {
+  analyzePlayerClassFromEvents,
+  createSkillLineAbilityMapping,
+  type ClassAnalysisResult,
+} from './classDetectionUtils';
+import { detectBuildIssues, type BuildIssue } from './detectBuildIssues';
+
+// The bar-swap analyzer lives with the parse-analysis feature; its cast-event
+// walk is pure and worker-safe.
+
+/** Minimal structural shape of any event carrying unit resource snapshots. */
+interface ResourceBearingEvent {
+  type: string;
+  timestamp: number;
+  sourceID?: number;
+  targetID?: number;
+  sourceResources?: { maxHitPoints?: number; maxStamina?: number; maxMagicka?: number };
+  targetResources?: { maxHitPoints?: number; maxStamina?: number; maxMagicka?: number };
+}
+
+export interface PlayerPanelAnalysisPlayer {
+  id: number;
+  role: 'dps' | 'tank' | 'healer';
+  talents?: PlayerTalent[];
+  /** Gear pre-filtered to real items (id !== 0), as the panel already does. */
+  gear: PlayerGear[];
+}
+
+export interface PlayerPanelAnalysisInput {
+  fightStartTime: number;
+  fightEndTime: number;
+  players: PlayerPanelAnalysisPlayer[];
+  /* eslint-disable @typescript-eslint/no-explicit-any -- the analysis functions
+     define their own event parameter types; this module forwards the arrays
+     verbatim and must not force every caller through re-casts. */
+  castEvents: any[];
+  damageEvents: any[];
+  healingEvents: any[];
+  resourceEvents: any[];
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  combatantInfoEvents: CombatantInfoEvent[];
+  friendlyBuffEvents: Parameters<typeof analyzePlayerClassFromEvents>[5];
+  debuffEvents: Parameters<typeof analyzePlayerClassFromEvents>[6];
+  abilitiesById: Parameters<typeof analyzePlayerClassFromEvents>[1];
+  friendlyBuffLookup: BuffLookupData;
+}
+
+export interface PlayerMaxResources {
+  health: number;
+  stamina: number;
+  magicka: number;
+}
+
+export interface PlayerPanelAnalysisResult {
+  /** Echo of the analyzed fight window — consumers MUST match it against the
+   *  current fight before using the maps, or a fight switch would briefly show
+   *  the previous fight's analysis (player ids overlap across fights). */
+  fightStartTime: number;
+  fightEndTime: number;
+  publicClassAnalysisByPlayer: Record<string, ClassAnalysisResult>;
+  barSwapByPlayer: Record<string, BarSwapAnalysisResult>;
+  maxResourcesByPlayer: Record<string, PlayerMaxResources>;
+  buildIssuesByPlayer: Record<string, BuildIssue[]>;
+}
+
+/**
+ * Events-total heuristic for the sync-vs-worker decision: below this, the
+ * structured-clone cost of shipping the arrays to a worker exceeds the compute
+ * itself, so the panel computes inline. Roughly a short solo/dummy fight.
+ */
+export const PLAYER_PANEL_ANALYSIS_SYNC_THRESHOLD = 20_000;
+
+export function computePlayerPanelAnalysis(
+  input: PlayerPanelAnalysisInput,
+): PlayerPanelAnalysisResult {
+  const {
+    fightStartTime,
+    fightEndTime,
+    players,
+    castEvents,
+    damageEvents,
+    healingEvents,
+    resourceEvents,
+    combatantInfoEvents,
+    friendlyBuffEvents,
+    debuffEvents,
+    abilitiesById,
+    friendlyBuffLookup,
+  } = input;
+
+  const publicClassAnalysisByPlayer: Record<string, ClassAnalysisResult> = {};
+  const barSwapByPlayer: Record<string, BarSwapAnalysisResult> = {};
+  const maxResourcesByPlayer: Record<string, PlayerMaxResources> = {};
+  const buildIssuesByPlayer: Record<string, BuildIssue[]> = {};
+
+  // ── Max resources: one pass over each resource-bearing stream ─────────────
+  for (const player of players) {
+    maxResourcesByPlayer[String(player.id)] = { health: 0, stamina: 0, magicka: 0 };
+  }
+  const updatePlayerResources = (
+    playerId: string,
+    resources: ResourceBearingEvent['sourceResources'],
+  ): void => {
+    const entry = maxResourcesByPlayer[playerId];
+    if (!entry || !resources) return;
+    if (resources.maxHitPoints) entry.health = Math.max(entry.health, resources.maxHitPoints);
+    if (resources.maxStamina) entry.stamina = Math.max(entry.stamina, resources.maxStamina);
+    if (resources.maxMagicka) entry.magicka = Math.max(entry.magicka, resources.maxMagicka);
+  };
+  const scanResourceStream = (events: ResourceBearingEvent[], type: string): void => {
+    for (const event of events) {
+      if (event.type !== type) continue;
+      if (event.timestamp < fightStartTime || event.timestamp > fightEndTime) continue;
+      if (event.sourceID && event.sourceResources) {
+        updatePlayerResources(String(event.sourceID), event.sourceResources);
+      }
+      if (event.targetID && event.targetResources) {
+        updatePlayerResources(String(event.targetID), event.targetResources);
+      }
+    }
+  };
+  scanResourceStream(resourceEvents ?? [], 'resourcechange');
+  scanResourceStream(damageEvents ?? [], 'damage');
+  scanResourceStream(healingEvents ?? [], 'heal');
+
+  // ── Per-player analyses ──────────────────────────────────────────────────
+  // Shared precompute — previously rebuilt per memo run; here once per task.
+  const classMapping = abilitiesById ? createSkillLineAbilityMapping(abilitiesById) : undefined;
+  const emptyBuffLookup: BuffLookupData = { buffIntervals: {} };
+
+  for (const player of players) {
+    const playerId = String(player.id);
+
+    barSwapByPlayer[playerId] = analyzeBarSwaps(
+      castEvents,
+      player.id,
+      fightStartTime,
+      fightEndTime,
+    );
+
+    if (abilitiesById) {
+      publicClassAnalysisByPlayer[playerId] = analyzePlayerClassFromEvents(
+        playerId,
+        abilitiesById,
+        combatantInfoEvents,
+        castEvents,
+        damageEvents,
+        friendlyBuffEvents,
+        debuffEvents,
+        player.talents,
+        classMapping,
+      );
+    }
+
+    const resourceSnapshot = maxResourcesByPlayer[playerId];
+    const playerResourceProfile = resourceSnapshot
+      ? { stamina: resourceSnapshot.stamina, magicka: resourceSnapshot.magicka }
+      : undefined;
+
+    const playerAuras: CombatantAura[] = [];
+    const playerCombatantInfo = combatantInfoEvents?.find((event) => event.sourceID === player.id);
+    if (playerCombatantInfo?.auras) {
+      playerAuras.push(...playerCombatantInfo.auras);
+    }
+
+    buildIssuesByPlayer[playerId] = detectBuildIssues(
+      player.gear,
+      friendlyBuffLookup || emptyBuffLookup,
+      fightStartTime,
+      fightEndTime,
+      playerAuras,
+      player.role,
+      damageEvents,
+      player.id,
+      playerResourceProfile,
+    );
+  }
+
+  return {
+    fightStartTime,
+    fightEndTime,
+    publicClassAnalysisByPlayer,
+    barSwapByPlayer,
+    maxResourcesByPlayer,
+    buildIssuesByPlayer,
+  };
+}

--- a/src/workers/SharedWorker.ts
+++ b/src/workers/SharedWorker.ts
@@ -11,6 +11,7 @@ import { calculateDamageOverTimeData } from './calculations/CalculateDamageOverT
 import { calculateDamageReductionData } from './calculations/CalculateDamageReduction';
 import { calculateElementalWeaknessStacks } from './calculations/CalculateElementalWeaknessStacks';
 import { calculatePenetrationData } from './calculations/CalculatePenetration';
+import { calculatePlayerPanelAnalysis } from './calculations/CalculatePlayerPanelAnalysis';
 import { calculatePlayerTravelDistances } from './calculations/CalculatePlayerTravelDistances';
 import { calculateScribingDetections } from './calculations/CalculateScribingDetections';
 import { calculateStaggerStacks } from './calculations/CalculateStaggerStacks';
@@ -31,6 +32,7 @@ const SHARED_WORKER = {
   calculateElementalWeaknessStacks,
   calculateActorPositions,
   calculatePlayerTravelDistances,
+  calculatePlayerPanelAnalysis,
   calculateScribingDetections,
 };
 

--- a/src/workers/calculations/CalculatePlayerPanelAnalysis.ts
+++ b/src/workers/calculations/CalculatePlayerPanelAnalysis.ts
@@ -1,0 +1,24 @@
+import {
+  computePlayerPanelAnalysis,
+  type PlayerPanelAnalysisInput,
+  type PlayerPanelAnalysisResult,
+} from '@/utils/playerPanelAnalysis';
+
+import type { OnProgressCallback } from '../Utils';
+
+export type { PlayerPanelAnalysisInput, PlayerPanelAnalysisResult };
+
+/**
+ * Worker entry for the Players-tab per-player analysis (class detection,
+ * bar swaps, max resources, build issues). Thin wrapper — the pure logic in
+ * utils/playerPanelAnalysis is shared with the panel's small-fight sync path.
+ */
+export function calculatePlayerPanelAnalysis(
+  data: PlayerPanelAnalysisInput,
+  onProgress?: OnProgressCallback,
+): PlayerPanelAnalysisResult {
+  onProgress?.(0);
+  const result = computePlayerPanelAnalysis(data);
+  onProgress?.(100);
+  return result;
+}


### PR DESCRIPTION
The report Players tab ran its four heaviest computations — public class detection, bar-swap analysis, the max-resource scan, and build-issue detection — synchronously in useMemos on every fight open/switch. Each is O(players × events) or a full event-array pass; together they were the panel's dominant paint-blocking burst, and the one notable gap in an otherwise well-worker-offloaded app (15 existing pool tasks). This is the last PR of the perf plan.

Design points:

- **One combined task, not four.** The WorkerPool structured-clones `task.data` per `execute()` across interchangeable pooled workers (no resident data), so a single `calculatePlayerPanelAnalysis` task clones the shared event arrays once. The skill-line ability mapping is also built once per task instead of once per memo run.
- **Pure core, sync fallback.** `computePlayerPanelAnalysis` is a pure importable function: fights under ~20k total events compute inline (the clone would cost more than the compute) with an identical output shape; larger fights go to the pool. Registration follows the scribing-detections pattern exactly (calc wrapper → SHARED_WORKER map → `createWorkerTaskSlice` with a cheap fight-window + player-ids + stream-counts hash → selectors/actions).
- **Progressive render + stale-fight guard.** The panel doesn't gate on the task: the maps fall back to stable empty records and `classAnalysis`/`barSwap` are already optional PlayerCard props (the async scribing stream set the pattern). The result echoes its fight window and the panel rejects any result whose window doesn't match the current fight — player ids overlap across fights, so a stale map must never be consumed.
- Cheap single-pass memos (damage stats, HPS, CPM, mundus, CP, auras, gear) stay on the main thread. Net −115 lines in the panel.

**Live verification** (dev, DSR Reef Guardian, 12 players): the task completes in the worker with no error, all four maps carry 12 players, class detection resolves live skill lines ("Soldier of Apocrypha" etc.), and the cards render their skill-line chips from the worker result.

`npm run validate` green; full jest 4483 passing, plus new combiner tests (per-player keying, window-filtered source/target resource maxima, missing-abilities path).