### PR TITLE
fix(a11y): keep spinners animating under OS reduced motion

### DIFF
--- a/src/ReduxThemeProvider.tsx
+++ b/src/ReduxThemeProvider.tsx
@@ -120,10 +120,26 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
               '*, *::before, *::after': { boxSizing: 'border-box' },
               '@media (prefers-reduced-motion: reduce)': {
                 '*, *::before, *::after': {
-                  animationDuration: '0.01ms !important',
-                  animationIterationCount: '1 !important',
+                  animationDuration: 'var(--perf-anim-duration, 0.01ms) !important',
+                  animationIterationCount: 'var(--perf-anim-iteration, 1) !important',
                   transitionDuration: '0.01ms !important',
                   scrollBehavior: 'auto !important',
+                },
+                // Progress indicators must keep moving — a frozen spinner reads
+                // as a hang. Same escape hatch as the data-perf='low' rule in
+                // index.css; durations match MUI's own timing so indicators
+                // look normal, not sped up.
+                '.MuiCircularProgress-root': {
+                  '--perf-anim-duration': '1.4s',
+                  '--perf-anim-iteration': 'infinite',
+                },
+                '.MuiLinearProgress-root': {
+                  '--perf-anim-duration': '2.1s',
+                  '--perf-anim-iteration': 'infinite',
+                },
+                '.MuiSkeleton-root': {
+                  '--perf-anim-duration': '2s',
+                  '--perf-anim-iteration': 'infinite',
                 },
               },
             },
@@ -899,10 +915,26 @@ export const ReduxThemeProvider: React.FC<{ children: React.ReactNode }> = ({ ch
             '.u-fade-in-up': { animation: 'none !important' },
             '.u-tab-enter': { animation: 'none !important' },
             '*, *::before, *::after': {
-              animationDuration: '0.01ms !important',
-              animationIterationCount: '1 !important',
+              animationDuration: 'var(--perf-anim-duration, 0.01ms) !important',
+              animationIterationCount: 'var(--perf-anim-iteration, 1) !important',
               transitionDuration: '0.01ms !important',
               scrollBehavior: 'auto !important',
+            },
+            // Progress indicators must keep moving — a frozen spinner reads as
+            // a hang. Same escape hatch as the data-perf='low' rule in
+            // index.css; durations match MUI's own timing so indicators look
+            // normal, not sped up.
+            '.MuiCircularProgress-root': {
+              '--perf-anim-duration': '1.4s',
+              '--perf-anim-iteration': 'infinite',
+            },
+            '.MuiLinearProgress-root': {
+              '--perf-anim-duration': '2.1s',
+              '--perf-anim-iteration': 'infinite',
+            },
+            '.MuiSkeleton-root': {
+              '--perf-anim-duration': '2s',
+              '--perf-anim-iteration': 'infinite',
             },
           },
         }}


### PR DESCRIPTION
## Summary

Pre-existing accessibility bug: both OS `prefers-reduced-motion` blocks in `ReduxThemeProvider.tsx` (the `MuiCssBaseline` override and the `GlobalStyles` block) froze **every** animation to `0.01ms × 1` — including progress indicators. OS reduced-motion users saw frozen `CircularProgress` / `LinearProgress` / `Skeleton` indicators that read as hangs.

This ports the `--perf-anim-duration` / `--perf-anim-iteration` custom-property escape hatch already used by the `html[data-perf='low']` rule in `src/index.css` (PR #1394) into both blocks:

- The wildcard freeze now reads `var(--perf-anim-duration, 0.01ms)` / `var(--perf-anim-iteration, 1)` — identical frozen behavior for everything by default.
- The three MUI indicator roots set the custom properties to their normal MUI timings, so they keep moving: `.MuiCircularProgress-root` **1.4s**, `.MuiLinearProgress-root` **2.1s**, `.MuiSkeleton-root` **2s**, all `infinite`.

Transitions and scroll behavior stay frozen for the indicators too — only their keyframe animation is exempted, matching the `index.css` precedent.

## Verification

Playwright with `reducedMotion: 'reduce'` emulation against the dev server:

- Computed cascade: a plain element computes `animation-duration: 1e-05s / 1 iteration` (freeze intact); `MuiCircularProgress-root` → `1.4s / infinite`, `MuiLinearProgress-root` → `2.1s / infinite`, `MuiSkeleton-root` → `2s / infinite`.
- Live: 320 skeletons on `/calculator` (page chunk stalled to hold the Suspense fallback) all report `duration=2000ms iterations=Infinity state=running` via `document.getAnimations()`, with **zero** other running animations.
- `npm run validate` and the full jest suite pass.

The `@media (prefers-reduced-motion)` rule in `view-transitions.css` targets only `::view-transition-*` pseudo-elements and is unaffected.
