### PR TITLE
fix(perf): honor detect-gpu result type and pin backgrounds behind content

### DIFF
--- a/src/features/loadout-manager/components/AuroraBackground.tsx
+++ b/src/features/loadout-manager/components/AuroraBackground.tsx
@@ -95,122 +95,133 @@ export const AuroraBackground: React.FC = () => {
         `}
       </style>
 
-      {/* Layer 1: Base gradient wash */}
+      {/* Single fixed, non-interactive stacking context pinned BEHIND all app
+          content (zIndex: -1). Keeping the whole decorative stack here means
+          the inner layers — including the light motes — can never paint above
+          page elements, no matter what stacking context a given element
+          creates. The app's content surfaces are transparent by design, so the
+          background still shows through. */}
       <Box
         sx={{
           position: 'fixed',
           inset: 0,
-          zIndex: 0,
-          background: `
-            radial-gradient(ellipse at 25% 20%, rgba(165, 180, 252, 0.10) 0%, transparent 55%),
-            radial-gradient(ellipse at 75% 75%, rgba(56, 189, 248, 0.08) 0%, transparent 55%),
-            radial-gradient(ellipse at 50% 50%, rgba(236, 172, 190, 0.05) 0%, transparent 60%),
-            linear-gradient(160deg, #f0f4ff 0%, #f8fafc 35%, #fdf2f8 65%, #f0fdfa 100%)
-          `,
-          pointerEvents: 'none',
-        }}
-      />
-
-      {/* Layer 2: Pastel clouds — pre-diffused gradients, no filter:blur */}
-      <Box
-        sx={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 1,
+          zIndex: -1,
           pointerEvents: 'none',
         }}
       >
+        {/* Layer 1: Base gradient wash */}
         <Box
           sx={{
             position: 'absolute',
-            width: '85%',
-            height: '85%',
-            top: '0%',
-            left: '-5%',
-            background: 'radial-gradient(ellipse, rgba(165, 180, 252, 0.08) 0%, transparent 50%)',
-            animation: animate ? 'aurCloudDriftA 42s ease-in-out infinite' : 'none',
+            inset: 0,
+            zIndex: 0,
+            background: `
+              radial-gradient(ellipse at 25% 20%, rgba(165, 180, 252, 0.10) 0%, transparent 55%),
+              radial-gradient(ellipse at 75% 75%, rgba(56, 189, 248, 0.08) 0%, transparent 55%),
+              radial-gradient(ellipse at 50% 50%, rgba(236, 172, 190, 0.05) 0%, transparent 60%),
+              linear-gradient(160deg, #f0f4ff 0%, #f8fafc 35%, #fdf2f8 65%, #f0fdfa 100%)
+            `,
           }}
         />
+
+        {/* Layer 2: Pastel clouds — pre-diffused gradients, no filter:blur */}
         <Box
           sx={{
             position: 'absolute',
-            width: '75%',
-            height: '75%',
-            bottom: '0%',
-            right: '-5%',
-            background: 'radial-gradient(ellipse, rgba(56, 189, 248, 0.06) 0%, transparent 50%)',
-            animation: animate ? 'aurCloudDriftB 34s ease-in-out infinite reverse' : 'none',
+            inset: 0,
+            zIndex: 1,
           }}
-        />
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '85%',
+              height: '85%',
+              top: '0%',
+              left: '-5%',
+              background: 'radial-gradient(ellipse, rgba(165, 180, 252, 0.08) 0%, transparent 50%)',
+              animation: animate ? 'aurCloudDriftA 42s ease-in-out infinite' : 'none',
+            }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '75%',
+              height: '75%',
+              bottom: '0%',
+              right: '-5%',
+              background: 'radial-gradient(ellipse, rgba(56, 189, 248, 0.06) 0%, transparent 50%)',
+              animation: animate ? 'aurCloudDriftB 34s ease-in-out infinite reverse' : 'none',
+            }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '65%',
+              height: '65%',
+              top: '20%',
+              right: '10%',
+              background: 'radial-gradient(ellipse, rgba(236, 172, 190, 0.06) 0%, transparent 50%)',
+              animation: animate ? 'aurCloudDriftC 48s ease-in-out infinite' : 'none',
+            }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '60%',
+              height: '60%',
+              bottom: '10%',
+              left: '5%',
+              background: 'radial-gradient(ellipse, rgba(94, 234, 212, 0.05) 0%, transparent 50%)',
+              animation: animate ? 'aurCloudDriftA 52s ease-in-out infinite reverse' : 'none',
+            }}
+          />
+        </Box>
+
+        {/* Layer 3: Light-mote particles */}
+        {particleCount > 0 && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 2,
+            }}
+          >
+            {motes.map((m) => (
+              <Box
+                key={m.id}
+                sx={{
+                  position: 'absolute',
+                  width: m.size,
+                  height: m.size,
+                  background: m.color,
+                  borderRadius: '50%',
+                  left: `${m.left}%`,
+                  top: `${m.top}%`,
+                  animation: `aurMoteFloat ${m.duration}s ease-in-out infinite`,
+                  animationDelay: `${m.delay}s`,
+                  boxShadow: m.hasGlow ? `0 0 ${m.size * 4}px ${m.color}` : 'none',
+                }}
+              />
+            ))}
+          </Box>
+        )}
+
+        {/* Layer 4: Subtle grid overlay */}
         <Box
           sx={{
             position: 'absolute',
-            width: '65%',
-            height: '65%',
-            top: '20%',
-            right: '10%',
-            background: 'radial-gradient(ellipse, rgba(236, 172, 190, 0.06) 0%, transparent 50%)',
-            animation: animate ? 'aurCloudDriftC 48s ease-in-out infinite' : 'none',
-          }}
-        />
-        <Box
-          sx={{
-            position: 'absolute',
-            width: '60%',
-            height: '60%',
-            bottom: '10%',
-            left: '5%',
-            background: 'radial-gradient(ellipse, rgba(94, 234, 212, 0.05) 0%, transparent 50%)',
-            animation: animate ? 'aurCloudDriftA 52s ease-in-out infinite reverse' : 'none',
+            inset: 0,
+            zIndex: 3,
+            backgroundImage: `
+              linear-gradient(transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px),
+              linear-gradient(90deg, transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px)
+            `,
+            backgroundSize: '50px 50px',
+            opacity: 0.35,
           }}
         />
       </Box>
-
-      {/* Layer 3: Light-mote particles */}
-      {particleCount > 0 && (
-        <Box
-          sx={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 2,
-            pointerEvents: 'none',
-          }}
-        >
-          {motes.map((m) => (
-            <Box
-              key={m.id}
-              sx={{
-                position: 'absolute',
-                width: m.size,
-                height: m.size,
-                background: m.color,
-                borderRadius: '50%',
-                left: `${m.left}%`,
-                top: `${m.top}%`,
-                animation: `aurMoteFloat ${m.duration}s ease-in-out infinite`,
-                animationDelay: `${m.delay}s`,
-                boxShadow: m.hasGlow ? `0 0 ${m.size * 4}px ${m.color}` : 'none',
-              }}
-            />
-          ))}
-        </Box>
-      )}
-
-      {/* Layer 4: Subtle grid overlay */}
-      <Box
-        sx={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 3,
-          backgroundImage: `
-            linear-gradient(transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px),
-            linear-gradient(90deg, transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px)
-          `,
-          backgroundSize: '50px 50px',
-          opacity: 0.35,
-          pointerEvents: 'none',
-        }}
-      />
     </>
   );
 };

--- a/src/features/loadout-manager/components/NebulaBackground.tsx
+++ b/src/features/loadout-manager/components/NebulaBackground.tsx
@@ -76,112 +76,124 @@ export const NebulaBackground: React.FC = () => {
         `}
       </style>
 
-      {/* Layer 1: Base nebula background */}
+      {/* Single fixed, non-interactive stacking context pinned BEHIND all app
+          content (zIndex: -1). Keeping the whole decorative stack here means
+          the inner layers — including the star particles — can never paint
+          above page elements, no matter what stacking context a given element
+          creates. The app's content surfaces are transparent by design, so the
+          background still shows through. */}
       <Box
         sx={{
           position: 'fixed',
           inset: 0,
-          zIndex: 0,
-          background: `
-            radial-gradient(ellipse at 20% 30%, rgba(100, 50, 255, 0.15) 0%, transparent 50%),
-            radial-gradient(ellipse at 80% 70%, rgba(0, 217, 255, 0.12) 0%, transparent 50%),
-            radial-gradient(ellipse at 50% 50%, rgba(50, 0, 100, 0.1) 0%, transparent 60%),
-            linear-gradient(135deg, #050810 0%, #0a0f1e 50%, #050810 100%)
-          `,
-        }}
-      />
-
-      {/* Layer 2: Nebula clouds — pre-diffused gradients, no filter:blur */}
-      <Box
-        sx={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 1,
+          zIndex: -1,
           pointerEvents: 'none',
         }}
       >
+        {/* Layer 1: Base nebula background */}
         <Box
           sx={{
             position: 'absolute',
-            width: '90%',
-            height: '90%',
-            top: '5%',
-            left: '-5%',
-            background: 'radial-gradient(ellipse, rgba(120, 60, 230, 0.12) 0%, transparent 55%)',
-            animation: animate ? 'nebulaDriftSlow 40s ease-in-out infinite' : 'none',
+            inset: 0,
+            zIndex: 0,
+            background: `
+              radial-gradient(ellipse at 20% 30%, rgba(100, 50, 255, 0.15) 0%, transparent 50%),
+              radial-gradient(ellipse at 80% 70%, rgba(0, 217, 255, 0.12) 0%, transparent 50%),
+              radial-gradient(ellipse at 50% 50%, rgba(50, 0, 100, 0.1) 0%, transparent 60%),
+              linear-gradient(135deg, #050810 0%, #0a0f1e 50%, #050810 100%)
+            `,
           }}
         />
+
+        {/* Layer 2: Nebula clouds — pre-diffused gradients, no filter:blur */}
         <Box
           sx={{
             position: 'absolute',
-            width: '75%',
-            height: '75%',
-            bottom: '5%',
-            right: '-5%',
-            background: 'radial-gradient(ellipse, rgba(0, 217, 255, 0.09) 0%, transparent 55%)',
-            animation: animate ? 'nebulaDriftMedium 30s ease-in-out infinite reverse' : 'none',
+            inset: 0,
+            zIndex: 1,
           }}
-        />
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '90%',
+              height: '90%',
+              top: '5%',
+              left: '-5%',
+              background: 'radial-gradient(ellipse, rgba(120, 60, 230, 0.12) 0%, transparent 55%)',
+              animation: animate ? 'nebulaDriftSlow 40s ease-in-out infinite' : 'none',
+            }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '75%',
+              height: '75%',
+              bottom: '5%',
+              right: '-5%',
+              background: 'radial-gradient(ellipse, rgba(0, 217, 255, 0.09) 0%, transparent 55%)',
+              animation: animate ? 'nebulaDriftMedium 30s ease-in-out infinite reverse' : 'none',
+            }}
+          />
+          <Box
+            sx={{
+              position: 'absolute',
+              width: '65%',
+              height: '65%',
+              top: '25%',
+              right: '15%',
+              background: 'radial-gradient(ellipse, rgba(180, 60, 200, 0.07) 0%, transparent 55%)',
+              animation: animate ? 'nebulaDriftSlow 50s ease-in-out infinite' : 'none',
+            }}
+          />
+        </Box>
+
+        {/* Layer 3: Star particles */}
+        {particleCount > 0 && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 2,
+            }}
+          >
+            {particles.map((p) => (
+              <Box
+                key={p.id}
+                sx={{
+                  position: 'absolute',
+                  width: p.size,
+                  height: p.size,
+                  background: `rgba(255, 255, 255, ${p.opacity})`,
+                  borderRadius: '50%',
+                  left: `${p.left}%`,
+                  top: `${p.top}%`,
+                  animation: `nebulaFloat ${p.duration}s ease-in-out infinite`,
+                  animationDelay: `${p.delay}s`,
+                  boxShadow: p.hasGlow
+                    ? `0 0 ${p.size * 3}px rgba(255, 255, 255, ${p.opacity * 0.6})`
+                    : 'none',
+                }}
+              />
+            ))}
+          </Box>
+        )}
+
+        {/* Layer 4: Subtle grid overlay */}
         <Box
           sx={{
             position: 'absolute',
-            width: '65%',
-            height: '65%',
-            top: '25%',
-            right: '15%',
-            background: 'radial-gradient(ellipse, rgba(180, 60, 200, 0.07) 0%, transparent 55%)',
-            animation: animate ? 'nebulaDriftSlow 50s ease-in-out infinite' : 'none',
+            inset: 0,
+            zIndex: 3,
+            backgroundImage: `
+              linear-gradient(transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px),
+              linear-gradient(90deg, transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px)
+            `,
+            backgroundSize: '50px 50px',
+            opacity: 0.4,
           }}
         />
       </Box>
-
-      {/* Layer 3: Star particles */}
-      {particleCount > 0 && (
-        <Box
-          sx={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 2,
-            pointerEvents: 'none',
-          }}
-        >
-          {particles.map((p) => (
-            <Box
-              key={p.id}
-              sx={{
-                position: 'absolute',
-                width: p.size,
-                height: p.size,
-                background: `rgba(255, 255, 255, ${p.opacity})`,
-                borderRadius: '50%',
-                left: `${p.left}%`,
-                top: `${p.top}%`,
-                animation: `nebulaFloat ${p.duration}s ease-in-out infinite`,
-                animationDelay: `${p.delay}s`,
-                boxShadow: p.hasGlow
-                  ? `0 0 ${p.size * 3}px rgba(255, 255, 255, ${p.opacity * 0.6})`
-                  : 'none',
-              }}
-            />
-          ))}
-        </Box>
-      )}
-
-      {/* Layer 4: Subtle grid overlay */}
-      <Box
-        sx={{
-          position: 'fixed',
-          inset: 0,
-          zIndex: 3,
-          backgroundImage: `
-            linear-gradient(transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px),
-            linear-gradient(90deg, transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px)
-          `,
-          backgroundSize: '50px 50px',
-          opacity: 0.4,
-          pointerEvents: 'none',
-        }}
-      />
     </>
   );
 };

--- a/src/utils/detectPerfTier.test.ts
+++ b/src/utils/detectPerfTier.test.ts
@@ -179,7 +179,7 @@ describe('detectPerfTier', () => {
     await expect(detectPerfTier()).resolves.toBe('high');
   });
 
-  it("does NOT trust a FALLBACK tier — a capable device defers to the heuristic", async () => {
+  it('does NOT trust a FALLBACK tier — a capable device defers to the heuristic', async () => {
     // detect-gpu resolves with type:'FALLBACK' (tier defaults to 1) when the
     // GPU isn't in its benchmark DB. Trusting that '1' was the root cause of
     // auto misclassifying capable desktops as 'low'. With healthy hardware

--- a/src/utils/detectPerfTier.test.ts
+++ b/src/utils/detectPerfTier.test.ts
@@ -120,7 +120,7 @@ describe('heuristicPerfTier', () => {
 
 describe('detectPerfTier', () => {
   it("returns 'high' when getGPUTier reports tier 3, even with unreported deviceMemory", async () => {
-    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false });
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false, type: 'BENCHMARK' });
     setNavigatorSignals({ deviceMemory: undefined, hardwareConcurrency: 16 });
     await expect(detectPerfTier()).resolves.toBe('high');
   });
@@ -139,24 +139,24 @@ describe('detectPerfTier', () => {
     await expect(detectPerfTier()).resolves.toBe('low');
   });
 
-  it("returns 'low' on GPU tier 0", async () => {
-    getGPUTierMock.mockResolvedValueOnce({ tier: 0, isMobile: false });
+  it("returns 'low' on benchmarked GPU tier 0", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 0, isMobile: false, type: 'BENCHMARK' });
     await expect(detectPerfTier()).resolves.toBe('low');
   });
 
-  it("returns 'low' on GPU tier 1", async () => {
-    getGPUTierMock.mockResolvedValueOnce({ tier: 1, isMobile: true });
+  it("returns 'low' on benchmarked GPU tier 1", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 1, isMobile: true, type: 'BENCHMARK' });
     await expect(detectPerfTier()).resolves.toBe('low');
   });
 
-  it("returns 'low' on mobile GPU tier 2", async () => {
+  it("returns 'low' on benchmarked mobile GPU tier 2", async () => {
     // Boundary case: mobile tier-2 is the 2020 Moto G Power zone.
-    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: true });
+    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: true, type: 'BENCHMARK' });
     await expect(detectPerfTier()).resolves.toBe('low');
   });
 
-  it("returns 'medium' on desktop GPU tier 2", async () => {
-    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: false });
+  it("returns 'medium' on benchmarked desktop GPU tier 2", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: false, type: 'BENCHMARK' });
     await expect(detectPerfTier()).resolves.toBe('medium');
   });
 
@@ -164,7 +164,7 @@ describe('detectPerfTier', () => {
     // A thermally-throttled phone can have a benchmark that was good
     // when cool but has 2GB RAM and 2 cores — the weak-hardware floor
     // wins.
-    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: true });
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: true, type: 'BENCHMARK' });
     setNavigatorSignals({ deviceMemory: 2, hardwareConcurrency: 2 });
     await expect(detectPerfTier()).resolves.toBe('low');
   });
@@ -174,8 +174,38 @@ describe('detectPerfTier', () => {
     // stays on their hardware tier. MotionConfig handles the motion
     // reduction separately.
     setPrefersReducedMotion(true);
-    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false });
+    getGPUTierMock.mockResolvedValueOnce({ tier: 3, isMobile: false, type: 'BENCHMARK' });
     setNavigatorSignals({ deviceMemory: 32, hardwareConcurrency: 16 });
     await expect(detectPerfTier()).resolves.toBe('high');
+  });
+
+  it("does NOT trust a FALLBACK tier — a capable device defers to the heuristic", async () => {
+    // detect-gpu resolves with type:'FALLBACK' (tier defaults to 1) when the
+    // GPU isn't in its benchmark DB. Trusting that '1' was the root cause of
+    // auto misclassifying capable desktops as 'low'. With healthy hardware
+    // signals the heuristic's 'medium' floor should win instead.
+    getGPUTierMock.mockResolvedValueOnce({ tier: 1, isMobile: false, type: 'FALLBACK' });
+    setNavigatorSignals({ deviceMemory: 16, hardwareConcurrency: 12 });
+    await expect(detectPerfTier()).resolves.toBe('medium');
+  });
+
+  it("returns 'low' on a FALLBACK tier only when hardware signals are genuinely weak", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 1, isMobile: false, type: 'FALLBACK' });
+    setNavigatorSignals({ deviceMemory: 2, hardwareConcurrency: 2 });
+    await expect(detectPerfTier()).resolves.toBe('low');
+  });
+
+  it("defers to the heuristic on WEBGL_UNSUPPORTED instead of assuming 'low'", async () => {
+    getGPUTierMock.mockResolvedValueOnce({ tier: 0, isMobile: false, type: 'WEBGL_UNSUPPORTED' });
+    setNavigatorSignals({ deviceMemory: 16, hardwareConcurrency: 12 });
+    await expect(detectPerfTier()).resolves.toBe('medium');
+  });
+
+  it("returns 'low' on a BLOCKLISTED GPU regardless of reported tier or hardware", async () => {
+    // Blocklisted drivers are flagged for known perf/stability problems, so
+    // pin to 'low' even if the fallback tier or hardware signals look capable.
+    getGPUTierMock.mockResolvedValueOnce({ tier: 2, isMobile: false, type: 'BLOCKLISTED' });
+    setNavigatorSignals({ deviceMemory: 16, hardwareConcurrency: 12 });
+    await expect(detectPerfTier()).resolves.toBe('low');
   });
 });

--- a/src/utils/detectPerfTier.ts
+++ b/src/utils/detectPerfTier.ts
@@ -37,7 +37,20 @@ export const detectPerfTier = async (): Promise<PerfTier> => {
 
   try {
     const gpuTier = await getGPUTier();
-    // detect-gpu returns tier 0..3. Tier 0 = blocklisted or <15 fps.
+    // detect-gpu RESOLVES (it does not throw) even when it can't actually
+    // benchmark the GPU — the `type` field says how trustworthy `tier` is:
+    //   BENCHMARK         — matched the GPU in the benchmark DB. Trust `tier`.
+    //   FALLBACK          — GPU wasn't in the DB, so `tier` is a screen-size
+    //                       guess that defaults to 1. Trusting it misclassifies
+    //                       capable desktops as 'low' — the reason auto felt
+    //                       inaccurate — so defer to the heuristic instead.
+    //   WEBGL_UNSUPPORTED — nothing was measured (no WebGL context). Same as a
+    //                       thrown benchmark: defer to the heuristic.
+    //   BLOCKLISTED       — driver on the known-bad list; pin to 'low'.
+    if (gpuTier.type === 'BLOCKLISTED') return 'low';
+    if (gpuTier.type !== 'BENCHMARK') return heuristic;
+
+    // detect-gpu returns tier 0..3. Tier 0 = <15 fps.
     // Mobile tier-3 and desktop tier-3 use the same internal classification,
     // so `isMobile` alone doesn't automatically demote — let the benchmark
     // speak. isMobile is worth a small demotion only when the benchmark is


### PR DESCRIPTION
## Summary

Fixes two reported issues: the **Auto** performance toggle misclassifying capable devices, and the background particles rendering **on top of** page content.

### 1. Auto perf detection was inaccurate

`detectPerfTier` trusted `getGPUTier().tier` unconditionally. But detect-gpu (v6) *resolves* — it does **not** throw — even when it cannot actually benchmark the GPU, and reports how it arrived at `tier` via `TierResult.type`:

- `BENCHMARK` — matched the GPU in the benchmark DB → the tier is real.
- `FALLBACK` — GPU wasn't in the DB, so `tier` is a screen-size guess that **defaults to `1`**. Trusting this was the root cause: capable desktops with an unrecognized GPU got classified `low`.
- `WEBGL_UNSUPPORTED` / `SSR` — nothing was measured.
- `BLOCKLISTED` — driver flagged for known perf/stability problems.

The `catch` fallback almost never fired because these cases resolve rather than reject.

Now only a `BENCHMARK` result drives the GPU-derived tier. `FALLBACK` / `WEBGL_UNSUPPORTED` / `SSR` defer to the existing hardware heuristic (which fails closed at `medium`, or `low` only when RAM/cores are genuinely weak), and `BLOCKLISTED` pins to `low`. The heuristic low-floor and the reduced-motion separation are unchanged.

### 2. Background dots painted above content

`NebulaBackground` (dark) and `AuroraBackground` (light) rendered four `position: fixed` layers with **positive** z-indexes (0–3). The star particles (`zIndex: 2`) and grid overlay (`zIndex: 3`) therefore painted above any page element that didn't happen to sit in a higher stacking context.

Both backgrounds now wrap their entire decorative stack in a single fixed, non-interactive container at `zIndex: -1`, so the whole thing always renders behind content. Inner layers switch from `fixed` to `absolute` within that container and keep their relative order. The app's content surfaces are already transparent by design, so the background still shows through.

### Testing

- Updated `detectPerfTier.test.ts` to use the real `TierResult` shape (`type` field) and added coverage for the `FALLBACK`, `WEBGL_UNSUPPORTED`, and `BLOCKLISTED` branches.
- `detectPerfTier.test.ts`, `SiteBackground.test.tsx`, `PerfLowNotice.test.tsx`, `HeaderBar.test.tsx` all pass; `tsc --noEmit` and `eslint` clean on the changed files.

## Checklist

- [ ] I have read [CLA.md](/CLA.md) and understand contributions require CLA signature.
- [ ] If prompted by the CLA check, I commented exactly:
  `I have read the CLA Document and I hereby sign the CLA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0194XUvDxyuX9BD3yfoGyXwY)_