### PR TITLE
docs(design): design-sync bundle for Claude Design + fix stale ui-updates skill

### DIFF
--- a/.agents/skills/ui-updates/SKILL.md
+++ b/.agents/skills/ui-updates/SKILL.md
@@ -11,7 +11,7 @@ You are making UI changes to the ESO Log Aggregator application. Every component
 
 The app uses a **modern glassmorphism** aesthetic — blurred translucent panels, gradient overlays, subtle inset highlights, and smooth transitions. It is **not** fantasy/game-themed. The look is clean, tech-oriented, and polished.
 
-**Stack**: React 19+, MUI v7, Emotion (`styled()` + `sx`), Chart.js via `react-chartjs-2`.
+**Stack**: React 19+, MUI v9, Emotion (`styled()` + `sx`), ECharts 6 (via `src/utils/echartsTheme.ts` + `useEChartsTheme()`).
 
 ---
 
@@ -125,6 +125,33 @@ This is the defining visual style. Apply it to panels, cards, and elevated surfa
 }
 ```
 
+### Shared Recipe Modules (use these, don't re-type inline)
+
+| Recipe | Module | Notes |
+|---|---|---|
+| Accent glass card (bloom + 3px top strip + hover glow) | `src/theme/glassCardSurface.ts` (`glassCardSurfaceSx`, `SUMMARY_ACCENTS`) | The canonical "premium card" |
+| Dropdown/Select menu glass | `src/theme/dropdownMenu.ts` (`dropdownMenuPaperSx`) | Opaque fill must win via `&&` — global `!important` overrides exist |
+| Roster glass panels/chips | `src/components/roster/shared/glassSx.ts` | |
+| Build-editor glass/rarity/attribute tokens | `src/features/build-editor/theme/buildEditorTokens.ts` (`BE_TOKENS`) | |
+| ESO class colors (accent/glow/gradient/accentRgb) | `src/features/build-editor/theme/classColorMap.ts` (`CLASS_COLOR_MAP`) | Injected as `--be-accent*` CSS vars by `BuildEditorThemeProvider` |
+| Glossy chips (shine sweep + gloss dome, 11 variants) | `src/utils/playerCardStyleUtils.ts` (`getGlossyBaseSx`, `buildVariantSx`) | Several report_details files carry stale inline copies — import instead |
+| Filter-bar/field glass | `src/features/latest_reports/latestReportsStyles.ts` | Duplicated in roster-hub/build-hub/pack-hub FilterBars |
+| Accent tables/accordions/badges | `src/features/report_summary/summaryStyles.ts` (`accentTableSx`, …) | |
+| Replay control-deck surfaces | `src/features/fight_replay/constants/replayDesign.ts` | |
+
+### Blur Tier Ladder
+
+`backdrop-filter` blur tracks z-order — stay within the tier for your surface (always pair with `WebkitBackdropFilter`):
+chrome/appbar 8–10px · chips/pills 6–10px · cards/panels 12–16px · dialogs 10–20px · menus/popovers 20–24px · hero/tooltips 22–24px.
+
+### Boundary Idioms
+
+- **Accent top strip**: `::before` `height:3px; linear-gradient(90deg, transparent, rgba(A,0.95) 50%, transparent)` (see `glassCardSurface.ts`)
+- **Layout-safe selected/hover rail**: `boxShadow: 'inset 3px 0 0 <color>'` (not `borderLeft`, which shifts layout — or reserve with `borderLeft: '3px solid transparent'`)
+- **Gradient border ring** (the standard idiom): absolutely-positioned overlay with `padding:1.5px; background:<gradient>; WebkitMask:'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)'; WebkitMaskComposite:'xor'; maskComposite:'exclude'` (see `IconPickerGrid.tsx`). Avoid `borderImage` — the shorthand resets border-color (documented in `GlassPanel.tsx:6-9`)
+- **Accent glow**: append `0 0 <14–60>px rgba(A, 0.12–0.35)` after the depth shadow
+- **Inset top highlight**: `inset 0 1px 0 rgba(255,255,255,α)` — α 0.05–0.06 panels, 0.08–0.12 menus, 0.2–0.3 glossy chips, 0.6–0.9 light mode
+
 ### Gradient Patterns
 
 | Context       | Gradient                                                                                   |
@@ -193,11 +220,27 @@ Available inline via `sx` `@keyframes`:
 | `.u-hover-glow` | Accent glow on hover                                      |
 | `.u-focus-ring`  | 2px solid accent outline on `:focus-visible`              |
 | `.u-fade-in`     | Opacity fade-in animation                                  |
-| `.u-fade-in-up`  | Fade-in with upward slide                                 |
-| `.u-hover-lift`  | Translate-Y lift on hover                                 |
 | `.u-tabular`     | `fontVariantNumeric: 'tabular-nums'` for stat numbers     |
 
+> ⚠️ **Known defect**: `.u-hover-lift` and `.u-fade-in-up` are referenced by ~8 components but are **not defined anywhere** (only `.u-fade-in`, `.u-tab-enter`, `.u-hover-glow`, `.u-focus-ring`, `.u-tabular` exist in `ReduxThemeProvider.tsx:882-912`). Do not rely on them; if you need a lift/slide-up, write it explicitly.
+
 All animations respect `prefers-reduced-motion: reduce`.
+
+### View Transitions
+
+Route navigation uses the **View Transitions API Level 2**: `src/styles/view-transitions.css` defines 8 named types (`forward`, `back`, `hero`, `up`, `down`, `slide-left`, `slide-right`, …) driven by `html:active-view-transition-type(...)`, with easing tokens `--vt-decel`/`--vt-ease-out`/`--vt-snap`. Driver hook: `src/hooks/useViewTransitionNavigate.ts`; shared-element morphs via `data-vt-hero="<name>"`. Note `AnimatedTabContent` deliberately does **not** use view transitions (documented perf regression).
+
+### Performance Tiers
+
+A third theme axis: `<html data-perf="low|medium|high">` (set from `src/utils/detectPerfTier.ts`). At **low** tier, `src/index.css:136-186` strips all `backdrop-filter` and freezes animations (escape hatches: `--perf-anim-duration`, `--perf-anim-iteration`), `.glass-dialog` falls back to opaque `#0f172a`, and `SiteBackground` renders nothing. Any new glass/animated surface must look acceptable opaque and static.
+
+---
+
+## Legacy / Misleading Files (not the design system)
+
+- `src/landingpage.css`, `src/landingpage.html`, `src/landingpage.js` — dead, unimported; the real landing page is `src/components/LandingPage.tsx`
+- The `--site-*` `:root` block in `src/index.css:120-127` (`#121212`, `#7289da`) — legacy vars, not the app palette
+- `src/test/themes/storybookThemes.ts` — wrong palette (red/#121212); Storybook does not render the real theme
 
 ---
 
@@ -336,19 +379,14 @@ import { styled, alpha } from '@mui/material/styles';
 
 ---
 
-## Chart.js Styling
+## Chart Styling (ECharts 6)
 
-```tsx
-import { Chart as ChartJS, CategoryScale, LinearScale, ... } from 'chart.js';
-ChartJS.register(CategoryScale, LinearScale, ...);
-```
+Charts use **ECharts 6** (there is no Chart.js in the tree). The theme lives in `src/utils/echartsTheme.ts` and is consumed via `useEChartsTheme()` (`src/hooks/useEChartsTheme.ts`).
 
 Conventions:
-- **Disable animations**: `animation: { duration: 0 }`
-- **Interaction**: `interaction: { intersect: false, mode: 'index' }`
-- **Container**: `<Box sx={{ width: '100%', height: 300 }}><Line ... /></Box>`
-- Annotation lines: dashed, `#2e7d32` green for targets
-- Extract callbacks to module-level for performance
+- Palettes: 12-color `DARK_PALETTE` / `LIGHT_PALETTE` in `echartsTheme.ts` — never invent chart colors
+- Use `buildBaseOption()` as the option starting point; `glowLineStyle()` and `gradientAreaStyle()` for the signature glow-line/gradient-area look
+- Animation duration/easing switch on `perfTier` and the `intensity: 'subtle' | 'bold'` flag — don't hardcode
 - See `src/utils/chartPhaseAnnotationUtils.ts` for annotation patterns
 
 ---

--- a/design-sync/README.md
+++ b/design-sync/README.md
@@ -1,0 +1,47 @@
+# ESO Helper Design System
+
+Source-of-truth project for Claude Design when generating UI for the ESO log
+aggregator app — a modern glassmorphism analytics dashboard (MUI v9 + Emotion,
+ECharts 6, Inter / Space Grotesk). **Not** fantasy-themed.
+
+**Last verified against app source: 2026-07-26.**
+
+## What's here
+
+- `colors_and_type.css` — every token: core dark/light schemes, role, rarity
+  (two per-surface palettes), class, and chart palettes, blur-tier and
+  inset-highlight scales, radii/spacing/motion, chip variants, type ramp.
+- `SKILL.md` — generation rules: identity, hard rules (blur ladder, inset
+  alphas, perf-tier degradation), exact idiom snippets, the card index, and
+  the known-defects list.
+- `preview/*.html` — self-contained recipe cards, each showing dark and light
+  side by side over the app's real backdrop. Grouped by first-line marker
+  `<!-- @dsCard group="…" -->` into: **Colors, Surfaces, Boundaries,
+  Patterns, Components** (plus existing Brand/Type/Spacing cards).
+
+## How this maps to the repo
+
+This project is authored in the repo at `design-sync/` (eso-log-aggregator)
+and pushed here with the `/design-sync` tool — the repo copy is the reviewable
+history; this project is what Claude Design reads. Files starting with `_` are
+local authoring aids and are not uploaded.
+
+Real values live in TypeScript, not CSS. Primary sources:
+
+- `src/ReduxThemeProvider.tsx` — MUI createTheme: core tokens (lines 37–69),
+  runtime CSS vars (587–610), all component overrides.
+- Recipe modules: `src/theme/glassCardSurface.ts`, `src/theme/dropdownMenu.ts`,
+  `src/utils/playerCardStyleUtils.ts`, `src/features/build-editor/theme/*`
+  (`buildEditorTokens.ts`, `classColorMap.ts`), `src/utils/roleColors.ts`,
+  `src/utils/gearMappings.ts` + `src/components/GearIcon.tsx`,
+  `src/utils/echartsTheme.ts`, `src/styles/view-transitions.css`,
+  `src/index.css` (perf tiers only — its `--site-*` block is legacy).
+
+## Maintenance
+
+Hand-maintained — there is no generated pipeline. When the app's theme or
+recipe modules change, re-check the cited `file:line` values (start with
+`ReduxThemeProvider.tsx` and the recipe modules above), update the affected
+card(s) + `colors_and_type.css`, bump the last-verified date, and re-sync via
+`/design-sync`. The app's current rendered design is canonical: transcribe
+exactly, per surface — never round, unify, or "improve" values.

--- a/design-sync/SKILL.md
+++ b/design-sync/SKILL.md
@@ -1,0 +1,207 @@
+# ESO Helper Design System — generation instructions
+
+Read this before generating any UI in this system. `colors_and_type.css` holds
+every token; the `preview/` cards are living recipe demos (index below).
+Values were verified against the app source on 2026-07-26.
+
+## Identity
+
+A **modern glassmorphism analytics app** for ESO combat-log analysis. It is
+**NOT fantasy/game-themed** — no parchment, no runes, no medieval type. Think
+premium data dashboard: dark cosmic backdrops, frosted glass, cyan accents,
+dense-but-calm stat layouts.
+
+- **Stack:** MUI v9 + Emotion (`sx` / `styled`), ECharts 6, Vite, TypeScript.
+- **Type:** body Inter; headings Space Grotesk 600. Noto Sans exists only as a
+  system glyph fallback in the font stack — never a deliberate choice.
+- **Theming:** `<html data-color-scheme="dark|light">` + runtime CSS vars
+  published on `:root` — `--bg`, `--panel`, `--panel-2`, `--text`, `--muted`,
+  `--accent`, `--accent-2`, `--ok`, `--warn`, `--danger`, `--border`,
+  `--scrollbar-*`. Dark is the primary scheme.
+- **Light-mode accent is `#0f172a` dark slate — intentional.** Light mode reads
+  as "ink on paper"; cyan `#38bdf8` survives only where recipes hard-code it.
+- Radii ramp: 8 controls / 10 base / 12 badges / 14 cards / 24 dialogs /
+  28 glossy chips / 9999 pills.
+
+## The blur-tier ladder (hard rule)
+
+Every glass surface picks its `backdrop-filter: blur()` from its tier:
+
+| Tier | Blur |
+|---|---|
+| Chrome (app bar, bottom bars) | 8–10px |
+| Chips & pills | 6–10px |
+| Cards & panels | 12–16px |
+| Dialogs | 10–20px (standard dialog 20, reduced picker 10) |
+| Menus & dropdowns | 20–24px (often `saturate(1.5)`) |
+| Hero / mobile sheet / max tier | 22–24px |
+
+Tooltips: `blur(16px) saturate(1.4)`. Alerts: `blur(8px)`.
+**Always pair `backdropFilter` with `WebkitBackdropFilter`** — every recipe in
+the app writes both.
+
+## The inset top-highlight alpha scale (hard rule)
+
+Glass surfaces get `inset 0 1px 0 rgba(255,255,255, α)` appended AFTER the
+depth shadow:
+
+- α = **0.05–0.06** panels / large cards (dark)
+- α = **0.08–0.12** menus and dropdowns (dark)
+- α = **0.2–0.3** glossy chips (0.3 on hover)
+- α = **0.6–0.9** light mode panels/menus
+
+Bottom shading (`inset 0 -1px 0 rgba(0,0,0,…)`) appears ONLY in glossy chips.
+Recessed inputs invert to dark inner shadow: `inset 0 2px 4px rgba(0,0,0,0.4)`.
+
+## Key idioms (exact snippets)
+
+**Mask-XOR gradient border** — the repo's standard gradient ring
+(IconPickerGrid.tsx:213-227). An absolutely-positioned overlay whose padding
+equals the ring width:
+
+```css
+position: absolute; inset: 0; border-radius: 14px; padding: 1.5px;
+background: <gradient>;
+-webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+-webkit-mask-composite: xor;
+mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+mask-composite: exclude;
+pointer-events: none;
+```
+
+**Accent top strip** (glass cards, dropdowns, summary cards):
+
+```css
+&::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 3px; /* menus use 2px */
+  background: linear-gradient(90deg, transparent 0%, rgba(ACCENT_RGB, 0.95) 50%, transparent 100%);
+  pointer-events: none; z-index: 1;
+}
+```
+
+Variant: inset "glow slit" — `top: 1px; left: 12%; right: 12%; height: 1px` in
+`rgba(var(--be-accent-rgb), 0.70)` (GlassPanel primary).
+
+**Layout-safe selection rail** — never a real border (avoids layout shift):
+
+```css
+box-shadow: inset 3px 0 0 rgb(56,189,248);  /* menu items, table first cells */
+```
+
+(Alternative border-rail idiom reserves space with `border-left: 3px solid transparent`.)
+
+**Accent glow signature** — hover/active glow appended after the depth shadow:
+
+```css
+box-shadow: <depth shadow>, 0 0 Rpx rgba(ACCENT_RGB, A);  /* R = 16–60, A = 0.12–0.35 */
+/* e.g. card hover: 0 14px 48px rgba(0,0,0,0.5), 0 0 28px rgba(56,189,248,0.14) */
+```
+
+**Electric conic border** (top-DPS card). Requires `@property` registration or
+the angle will not animate, and the host needs `overflow: visible` plus room
+for the halo:
+
+```css
+@property --tdps-angle { syntax: "<angle>"; initial-value: 0deg; inherits: false; }
+@keyframes electricBorderSpin { to { --tdps-angle: 360deg; } }
+/* ring overlay: inset -1px; padding 1.5px; mask-XOR as above; then */
+background: conic-gradient(from var(--tdps-angle), transparent 0deg,
+  rgba(251,191,36,0.15) 40deg, rgba(245,158,11,0.85) 80deg, #fde68a 100deg,
+  rgba(245,158,11,0.85) 120deg, rgba(251,191,36,0.15) 160deg,
+  transparent 200deg, transparent 360deg);
+filter: drop-shadow(0 0 4px rgba(245,158,11,0.55));
+animation: electricBorderSpin 4s linear infinite;
+```
+
+Plus a pulsing outer halo (`inset: -3px`, amber box-shadows, 2.8s ease-in-out).
+
+**Class accent mechanism** — the build editor injects `--be-accent`,
+`--be-accent-rgb`, `--be-glow`, `--be-gradient` on a wrapper div from the
+selected class (classColorMap.ts); recipes consume
+`rgba(var(--be-accent-rgb), α)`. Generalize this pattern for any theming axis.
+
+**Glass surface base** (accent card, glassCardSurface.ts): translucent dual
+gradient (accent bloom over base) + `blur(16px)` + 1px accent border at
+0.18–0.20 alpha + top strip + inset highlight; hover raises border alpha to
+~0.42 and adds the glow signature.
+
+## Perf-tier axis (hard rule)
+
+`<html data-perf="high|medium|low">`. At `data-perf="low"` the app strips ALL
+`backdrop-filter`s and freezes ALL animations (src/index.css:136-177), keeping
+only feedback loops (spinners/progress via `--perf-anim-duration` /
+`--perf-anim-iteration` escape hatch). **Every design must degrade to an
+opaque, static equivalent**: dark glass dialogs fall back to solid `#0f172a`;
+translucent fills must stay legible without blur. Charts drop glow/gradient
+styles and animation at low tier.
+
+## Accessibility (already in the app — preserve it)
+
+- `prefers-reduced-motion: reduce` collapses all animations/transitions to
+  0.01ms, with the same spinner escape hatch; `.u-fade-in` etc. are disabled.
+- View transitions are zeroed under reduced motion.
+- Focus rings: `.u-focus-ring:focus-visible` → `outline: 2px solid var(--accent);
+  outline-offset: 2px; border-radius: inherit`. Build editor scopes the same
+  ring in `var(--be-accent)`. Filter fields use border
+  `rgba(96,165,250,0.55)` + ring `0 0 0 3px rgba(96,165,250,0.12)`.
+- Touch targets: buttons get `min-height: 44px` on coarse pointers; form fields
+  are ≥16px font on mobile (blocks iOS zoom).
+
+## Card index (`preview/`)
+
+| Card | Group | Documents |
+|---|---|---|
+| brand-* | Brand | Logos, class icons, brand marks (assets) |
+| colors-core | Colors | Dark core tokens (`--bg`…`--border`) |
+| colors-light-mode | Colors | Full light token set; the dark-slate accent rule |
+| colors-roles | Colors | Role colors (dark solids / light gradients + solid fallbacks), colored-area termination (hard 1px seam, never a fade), progress-fill gradients |
+| colors-rarity | Colors | BOTH rarity palettes labeled by surface (gear-UI ESO + desaturated; build-editor Material), rarity borders on gear tiles |
+| colors-charts | Colors | 12-swatch ECharts palettes dark/light, glow-line + gradient-area styles |
+| type-* | Type | Type ramp, Inter/Space Grotesk pairing, mono/tabular numerals |
+| spacing-* | Spacing | 8px spacing unit, radii ramp |
+| surface-glass-tiers | Surfaces | The blur ladder with live tooltip/dialog/appbar/alert swatches |
+| surface-glass-cards | Surfaces | Accent card glass (G1) × summary accents info/damage/death |
+| surface-glass-menus | Surfaces | Cyan dropdown glass (G2) + HeaderBar rich dropdown (G8: shimmer strip, noise, mouse spotlight) |
+| surface-be-glass | Surfaces | Build-editor GlassPanel variants (G3) + `--be-accent` class-var mechanism |
+| surface-glossy-chips | Surfaces | Glossy chip shine-sweep + gloss dome (G4) + legendary rainbow borderImage |
+| surface-filter-fields | Surfaces | Filter bar panel/field/segmented glass (G9) + recessed input wells (G12) |
+| surface-corner-glow | Surfaces | Replay control-deck corner glows (G11) + footer radial bloom |
+| surface-card-grid | Surfaces | Card-grid glass (G13) + scribing glass (G10) |
+| boundary-accent-rails | Boundaries | borderLeft rails + layout-safe `inset 3px 0 0` rails (B1/B2) |
+| boundary-top-strips | Boundaries | Four top-strip sub-patterns (B3) |
+| boundary-gradient-borders | Boundaries | Mask-XOR ring idiom + borderImage caveat (B4/B6) |
+| boundary-electric-border | Boundaries | Animated conic electric border (B5) |
+| boundary-tables-seams | Boundaries | Accent table header seam, zebra 0.035, hover rail (B12) |
+| boundary-glows-insets | Boundaries | Glow signature + inset-highlight alpha scale (B10/B11) |
+| boundary-dividers | Boundaries | Tri-color hairline, @property shimmer divider, scanning dot (B14) |
+| boundary-edge-masks | Boundaries | Scroll-edge mask fades, clip-path progress, overflow rules (B15) |
+| boundary-focus-rings | Boundaries | All focus-ring variants (B16) |
+| pattern-background-layers | Patterns | Nebula (dark) / Aurora (light) 4-layer backdrops |
+| pattern-view-transitions | Patterns | 8 transition types + `--vt-*` easings |
+| pattern-perf-tiers | Patterns | data-perf axis; what low tier strips; opaque fallbacks |
+| comp-* (buttons, chips, tabs, navbar, player-card) | Components | MUI component overrides as rendered |
+| comp-metric-pills | Components | MetricPill: 5 intents × solid/outline/mono variants (G14) |
+
+## Known defects — do NOT replicate
+
+These exist in the app and are documented so you don't copy or "fix" them:
+
+1. **`u-hover-lift` / `u-fade-in-up` are undefined.** Eight components apply
+   these classes but no rule defines them (only `.u-fade-in` / `.u-tab-enter`
+   exist). Don't emit the undefined classes; don't invent styles for them.
+2. **Three rarity palettes are intentional per-surface** (gear-UI ESO,
+   gear-details desaturated, build-editor Material). Use the one matching the
+   surface; never unify them or invent a fourth.
+3. **Two `saturate()` dialects:** unitless (`saturate(1.4)`, `saturate(1.5)`)
+   in tooltips/menus vs percentage (`saturate(140%)`–`saturate(180%)`) in
+   editor glass. Match whichever the surface you're imitating uses.
+4. **Two chip intent palettes:** glossy chip variants vs MetricPill intents are
+   divergent copies. Each is canonical for its component only.
+5. **Glossy chip light mode keeps the white border**
+   (`1px solid rgba(255,255,255,0.15)`) — low-contrast, but as-shipped.
+6. **GlassPanel declares a blur token (16) but never applies backdropFilter.**
+   Build-editor panels are translucent-but-unblurred; document, don't add blur.
+7. **borderImage caveat:** the borderImage shorthand can leave `border-color`
+   at `currentColor` in some paint paths (why GlassPanel dropped its gradient
+   borderImage). Prefer the mask-XOR ring; the legendary chip is the one
+   sanctioned borderImage use.

--- a/design-sync/_authoring-guide.md
+++ b/design-sync/_authoring-guide.md
@@ -1,0 +1,111 @@
+# design-sync/ authoring guide (local reference — NOT synced to claude.ai)
+
+This folder is the local source for the claude.ai "ESO Helper Design System" project
+(id df317386-a5c9-431a-a368-ac1fd0464b7a). Every file under `preview/` is a
+self-contained HTML "card" rendered in the Claude Design pane. `colors_and_type.css`,
+`SKILL.md`, `README.md` are project-level files. Files starting with `_` are local
+authoring aids and are not uploaded.
+
+## Hard rules for every preview card
+
+1. **Line 1 must be exactly** (no BOM, nothing before it):
+   `<!-- @dsCard group="Colors|Surfaces|Boundaries|Patterns|Components" -->`
+2. Fully self-contained: all CSS inline in one `<style>` block, no external assets
+   except the Google Fonts link below. No JS unless the card demonstrates a
+   JS-driven effect (spotlight, scanning dot) — then keep it minimal and inline.
+3. File size < 256 KiB (DesignSync cap). Aim well under.
+4. Every recipe demo shows **dark and light side by side** using the app's real
+   mechanism: two wrapper divs `data-color-scheme="dark"` / `data-color-scheme="light"`,
+   with tokens scoped by attribute selector (see token block below).
+5. Values are transcribed **exactly** from the cited source file — never rounded,
+   never "improved". Label each demo with the source `file:line` in a small caption.
+6. Glass demos must sit on the mini-backdrop (below) so `backdrop-filter` is visible.
+7. Use the type stack: body Inter, headings Space Grotesk 600.
+
+## Card shell template
+
+```html
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Card Title</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  /* tokens + shell (copy verbatim from below) */
+  /* card-specific recipes here */
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Card Title</h1>
+  <p class="ds-sub">One-line description. Source: src/theme/glassCardSurface.ts:29-70</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark"><h2>Dark</h2> ...demos... </section>
+    <section class="ds-mode" data-color-scheme="light"><h2>Light</h2> ...demos... </section>
+  </div>
+</div>
+```
+
+## Token + shell CSS (copy verbatim into every card)
+
+Values verified against `src/ReduxThemeProvider.tsx:37-69` on 2026-07-26.
+
+```css
+* { margin:0; box-sizing:border-box; }
+body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+[data-color-scheme="dark"] {
+  --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+  --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+  --border:#1f2937;
+}
+[data-color-scheme="light"] {
+  --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+  --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+  --border:#bcd9ff;
+}
+/* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+   Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+.ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+.ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+.ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+.ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+@media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+.ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+.ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+.ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+```
+
+## Mini-backdrop (required under glass demos)
+
+Simplified from `NebulaBackground.tsx` (dark) / `AuroraBackground.tsx` (light) —
+enough visual noise for backdrop-filter to visibly blur. Place as the first child
+of `.ds-mode`, then wrap demos in `position:relative; z-index:1`.
+
+```css
+.ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+[data-color-scheme="dark"] .ds-backdrop {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+    radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+    radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+    #0b1220;
+}
+[data-color-scheme="light"] .ds-backdrop {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+    radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+    radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+    #f8fafc;
+}
+```
+
+## Labeling demos
+
+Each demo block gets a caption: recipe name + source, e.g.
+`<div class="ds-src">glassCardSurfaceSx(dark, '56,189,248') — src/theme/glassCardSurface.ts:29</div>`
+
+## Groups in use
+
+Colors, Surfaces, Boundaries, Patterns, Components. Keep group names exact —
+the Design pane groups cards by this string.

--- a/design-sync/colors_and_type.css
+++ b/design-sync/colors_and_type.css
@@ -1,0 +1,494 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   ESO Helper Design System — tokens + type
+   ═══════════════════════════════════════════════════════════════════════════
+   SOURCE OF TRUTH: src/ReduxThemeProvider.tsx (MUI createTheme + GlobalStyles).
+   The app publishes these tokens at runtime as CSS custom properties on :root
+   (ReduxThemeProvider.tsx:587-610) and flips <html data-color-scheme="dark|light">
+   (ReduxThemeProvider.tsx:32-34). This file mirrors that mechanism.
+
+   All values verified against source on 2026-07-26. Per-section citations below.
+   Cited files (repo eso-log-aggregator):
+     - src/ReduxThemeProvider.tsx:37-69 (core tokens), :587-610 (CSS vars)
+     - src/utils/roleColors.ts                  (role colors)
+     - src/components/GearIcon.tsx:41-58        (gear-UI rarity, + desaturated)
+     - src/utils/gearMappings.ts:166-174        (gear-UI rarity incl. Trash)
+     - src/features/build-editor/theme/buildEditorTokens.ts   (BE glass + rarity)
+     - src/features/build-editor/theme/classColorMap.ts       (class accents)
+     - src/utils/echartsTheme.ts                (chart palettes)
+     - src/styles/view-transitions.css:17-21    (--vt-* easings)
+     - src/utils/playerCardStyleUtils.ts        (glossy chip variants)
+     - src/components/MetricPill.tsx:27-53      (metric-pill intents)
+   NOTE: class colors live in src/features/build-editor/theme/classColorMap.ts.
+   A previous version of this file cited src/utils/classColors.ts — that file
+   does NOT exist and never did in the current tree.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Fonts ──────────────────────────────────────────────────────────────────
+   Body: Inter (variable). Headings: Space Grotesk 600. Noto Sans appears in
+   the MUI font stack ONLY as a system glyph fallback — never load it as a
+   webfont or use it deliberately. Source: ReduxThemeProvider.tsx:89-99. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   1. CORE TOKENS — dark is the default scheme
+   Source: src/ReduxThemeProvider.tsx:37-69 (verified 2026-07-26)
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root,
+[data-color-scheme='dark'] {
+  --bg: #0b1220;
+  --panel: #0f172a;
+  --panel-2: #0d1430;
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --accent: #38bdf8;   /* brand cyan */
+  --accent-2: #00e1ff;
+  --ok: #22c55e;
+  --warn: #ff9800;
+  --danger: #ef4444;
+  --border: #1f2937;
+
+  /* Scrollbar theme — ReduxThemeProvider.tsx:602-609 */
+  --scrollbar-track: rgba(15, 23, 42, 0.5);
+  --scrollbar-thumb: rgba(56, 189, 248, 0.3);
+  --scrollbar-thumb-hover: rgba(56, 189, 248, 0.5);
+  --scrollbar-thumb-active: rgba(56, 189, 248, 0.7);
+
+  /* Surface rgba / gradient tokens (dark) */
+  --surface-paper: linear-gradient(180deg, rgba(15, 23, 42, 0.66) 0%, rgba(3, 7, 18, 0.66) 100%);   /* MuiPaper + MuiCard, :161-163 / :226-228 */
+  --surface-dialog: linear-gradient(135deg, rgba(15, 23, 42, 0.97) 0%, rgba(13, 20, 48, 0.97) 100%); /* MuiDialog, :388-390 */
+  --surface-menu-solid: #0f172a;                                   /* global MuiMenu/MuiPopover paper, :178 */
+  --surface-menu-glass: rgb(45, 64, 99);                           /* cyan dropdown glass, dropdownMenu.ts:140 */
+  --surface-tooltip-gear: rgba(10, 16, 32, 0.78);                  /* .gear-set-tooltip, :234 */
+  --surface-tooltip-skill: rgba(10, 16, 32, 0.92);                 /* .skill-tooltip, :246 */
+  --surface-be-glass: rgba(15, 23, 42, 0.84);                      /* BE_TOKENS.glass.bg */
+  --surface-be-glass-border: rgba(255, 255, 255, 0.09);            /* BE_TOKENS.glass.border */
+  --surface-chip-default: rgba(2, 6, 23, 0.45);                    /* MuiChip colorDefault, :325 */
+  --surface-input-well: rgba(0, 0, 0, 0.22);                       /* BE_TOKENS.input.dark.bg */
+  --surface-accordion-wash: linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%); /* MuiAccordion, :501-502 (same string both modes) */
+
+  /* Shadow tokens (dark) */
+  --shadow-paper: 0 8px 30px rgba(0, 0, 0, 0.25);                                            /* MuiPaper, :166-167 */
+  --shadow-card-hover: 0 10px 40px rgba(0, 0, 0, 0.3), 0 0 60px rgba(56, 189, 248, 0.08);    /* MuiCard :hover, :266-267 */
+  --shadow-dialog: 0 24px 64px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.03) inset; /* MuiDialog, :397-398 */
+  --shadow-glossy-chip: 0 8px 32px 0 rgba(0, 0, 0, 0.37), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.2); /* playerCardStyleUtils.ts:39-41 */
+  --shadow-be-glass: 0 8px 32px rgba(0, 0, 0, 0.32), 0 1px 0 rgba(255, 255, 255, 0.05) inset;  /* BE_TOKENS.glass.shadow */
+  --shadow-glass-card: 0 10px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06); /* glassCardSurface.ts:47-48 */
+
+  /* Gradient tokens (dark) */
+  --grad-button-primary: linear-gradient(135deg, #38bdf8, #00e1ff);  /* MuiButton containedPrimary, :284 (accent → accent-2) */
+  --grad-chrome: rgba(11, 18, 32, 0.95);                              /* MuiAppBar bg, :150 */
+  --chrome-border: rgba(56, 189, 248, 0.15);                          /* MuiAppBar borderBottom, :152-153 */
+
+  /* Role colors — src/utils/roleColors.ts:5-9 (DARK_ROLE_COLORS, solids) */
+  --role-dps: #ff8b61;
+  --role-healer: #b970ff;
+  --role-tank: #62baff;
+  /* Dark mode has no role gradients — gradient vars alias the solids so
+     interchangeable use is safe. Light mode overrides with real gradients. */
+  --role-dps-gradient: var(--role-dps);
+  --role-healer-gradient: var(--role-healer);
+  --role-tank-gradient: var(--role-tank);
+
+  /* Chart palette — src/utils/echartsTheme.ts:7-20 (DARK_PALETTE) */
+  --chart-1: #38bdf8;  /* sky */
+  --chart-2: #f43f5e;  /* rose */
+  --chart-3: #22c55e;  /* green */
+  --chart-4: #f59e0b;  /* amber */
+  --chart-5: #a855f7;  /* purple */
+  --chart-6: #06b6d4;  /* cyan */
+  --chart-7: #eab308;  /* yellow */
+  --chart-8: #8b5cf6;  /* violet */
+  --chart-9: #10b981;  /* emerald */
+  --chart-10: #ef4444; /* red */
+  --chart-11: #3b82f6; /* blue */
+  --chart-12: #ec4899; /* pink */
+  --chart-grid-line: rgba(255, 255, 255, 0.06);  /* echartsTheme.ts:69 */
+  --chart-tooltip-bg: rgba(15, 23, 42, 0.88);    /* echartsTheme.ts:70-73 (0.95 when intensity=bold) */
+
+  /* Inset top-highlight (dark values) — see §6 for the full alpha scale */
+  --inset-hl-panel: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --inset-hl-menu: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  --inset-hl-glossy: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   2. LIGHT SCHEME — [data-color-scheme='light'] on <html>
+   Source: src/ReduxThemeProvider.tsx:53-68 (verified 2026-07-26)
+
+   ⚠ IMPORTANT: light --accent is DELIBERATELY #0f172a (dark slate), NOT a
+   light blue. Light mode's primary/accent reads as near-black ink; the cyan
+   #38bdf8 survives only where recipes hard-code it. Do not "fix" this.
+   ═══════════════════════════════════════════════════════════════════════════ */
+[data-color-scheme='light'] {
+  --bg: #f8fafc;
+  --panel: #ffffff;
+  --panel-2: #f8fafc;
+  --text: #1e293b;
+  --muted: #64748b;
+  --accent: #0f172a;   /* dark slate — intentional, see note above */
+  --accent-2: #1e293b;
+  --ok: #059669;
+  --warn: #f97316;
+  --danger: #dc2626;
+  --border: #bcd9ff;
+
+  --scrollbar-track: rgba(188, 217, 255, 0.2);
+  --scrollbar-thumb: rgba(15, 23, 42, 0.25);
+  --scrollbar-thumb-hover: rgba(15, 23, 42, 0.4);
+  --scrollbar-thumb-active: rgba(15, 23, 42, 0.55);
+
+  --surface-paper: linear-gradient(180deg, rgb(230 241 248 / 56%) 0%, rgb(255 255 255 / 95%) 100%);
+  --surface-dialog: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.98) 100%);
+  --surface-menu-solid: #ffffff;
+  --surface-menu-glass: rgb(250, 253, 255);
+  --surface-tooltip-gear: rgba(255, 255, 255, 0.82);
+  --surface-tooltip-skill: rgba(255, 255, 255, 0.92);
+  --surface-be-glass: rgba(255, 255, 255, 0.84);
+  --surface-be-glass-border: rgba(15, 23, 42, 0.13);
+  --surface-chip-default: rgba(241, 245, 249, 0.8);
+  --surface-input-well: rgba(0, 0, 0, 0.04);
+
+  --shadow-paper: 0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.03);
+  --shadow-card-hover: 0 6px 20px rgba(15, 23, 42, 0.08), 0 2px 8px rgba(15, 23, 42, 0.04);
+  --shadow-dialog: 0 12px 40px rgba(15, 23, 42, 0.12), 0 4px 12px rgba(15, 23, 42, 0.06);
+  --shadow-glossy-chip: 0 4px 16px 0 rgba(59, 130, 246, 0.15), 0 2px 8px 0 rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  --shadow-be-glass: 0 4px 24px rgba(15, 23, 42, 0.10), 0 1px 0 rgba(255, 255, 255, 0.80) inset;
+  --shadow-glass-card: 0 6px 28px rgba(15, 23, 42, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+
+  --grad-button-primary: linear-gradient(135deg, #0f172a, #1e293b);
+  --grad-chrome: rgba(255, 255, 255, 0.98);
+  --chrome-border: rgba(15, 23, 42, 0.08);
+
+  /* Role colors — light mode ships GRADIENTS (roleColors.ts:12-16); the solid
+     vars fall back to LIGHT_ROLE_COLORS_SOLID (roleColors.ts:19-23) for
+     contexts that can't take a gradient (progress bars, text, borders). */
+  --role-dps: #ff5722;      /* solid fallback */
+  --role-healer: #7c3aed;   /* solid fallback */
+  --role-tank: #0891b2;     /* solid fallback */
+  --role-dps-gradient: linear-gradient(135deg, #ff9246 36% 36%, #ff3400e6 100%);
+  --role-healer-gradient: linear-gradient(135deg, #9333ea 0%, #c084fc 100%);
+  --role-tank-gradient: linear-gradient(135deg, #0ea5e9 0%, #38bdf8 100%);
+
+  /* Chart palette — echartsTheme.ts:22-35 (LIGHT_PALETTE, Tailwind-600 tones) */
+  --chart-1: #0284c7;  /* sky-600 */
+  --chart-2: #e11d48;  /* rose-600 */
+  --chart-3: #16a34a;  /* green-600 */
+  --chart-4: #d97706;  /* amber-600 */
+  --chart-5: #9333ea;  /* purple-600 */
+  --chart-6: #0891b2;  /* cyan-600 */
+  --chart-7: #ca8a04;  /* yellow-600 */
+  --chart-8: #7c3aed;  /* violet-600 */
+  --chart-9: #059669;  /* emerald-600 */
+  --chart-10: #dc2626; /* red-600 */
+  --chart-11: #2563eb; /* blue-600 */
+  --chart-12: #db2777; /* pink-600 */
+  --chart-grid-line: rgba(0, 0, 0, 0.06);
+  --chart-tooltip-bg: rgba(255, 255, 255, 0.88);
+
+  /* Light-mode inset highlights run far hotter (0.6–0.9) — see §6 */
+  --inset-hl-panel: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --inset-hl-menu: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  --inset-hl-glossy: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   3. MODE-INDEPENDENT PALETTES
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root {
+  /* ── Rarity, GEAR-UI SURFACE (ESO in-game palette) ────────────────────────
+     Used for gear icon borders, tooltips, report gear tables.
+     Source: src/components/GearIcon.tsx:41-48; Trash tier only exists in
+     src/utils/gearMappings.ts:166-174 (QUALITY_COLORS; #9d9d9d ≠ #9e9e9e). */
+  --rarity-eso-trash: #9d9d9d;
+  --rarity-eso-normal: #ffffff;
+  --rarity-eso-fine: #62a603;
+  --rarity-eso-superior: #417dc1;
+  --rarity-eso-epic: #c040c0;
+  --rarity-eso-legendary: #ffbf00;
+  --rarity-eso-mythic: #ff6b35;
+
+  /* Desaturated ESO set — gear DETAILS TABLE only. GearIcon.tsx:51-58. */
+  --rarity-eso-normal-desat: #e5e5e5;
+  --rarity-eso-fine-desat: #7cb342;
+  --rarity-eso-superior-desat: #5c9ce6;
+  --rarity-eso-epic-desat: #9978d4;
+  --rarity-eso-legendary-desat: #dec369;
+  --rarity-eso-mythic-desat: #c47a5a;
+
+  /* ── Rarity, BUILD-EDITOR SURFACE (Material palette) ──────────────────────
+     Used for build-editor gear-slot borders ONLY. Deliberately different from
+     the gear-UI set — do NOT unify, do NOT invent a blend of the two.
+     Source: buildEditorTokens.ts:38-45 (BE_TOKENS.rarity). No trash tier. */
+  --rarity-be-normal: #9e9e9e;
+  --rarity-be-fine: #4caf50;
+  --rarity-be-superior: #2196f3;
+  --rarity-be-epic: #9c27b0;
+  --rarity-be-legendary: #ff9800;
+  --rarity-be-mythic: #f44336;
+
+  /* ── Class accents ────────────────────────────────────────────────────────
+     Source: src/features/build-editor/theme/classColorMap.ts (NOT the
+     nonexistent src/utils/classColors.ts). At runtime,
+     BuildEditorThemeProvider.tsx:26-29 injects the selected class as
+     --be-accent / --be-accent-rgb / --be-glow / --be-gradient on the build
+     editor wrapper; build-editor recipes consume var(--be-accent) etc.
+     Glow = rgba(accent, 0.35) (0.30 for any-class);
+     gradient = linear-gradient(135deg, accent 0%, lighter-tint 100%). */
+  --class-any-class: #94a3b8;        --class-any-class-rgb: 148, 163, 184;
+  --class-dragonknight: #e05c00;     --class-dragonknight-rgb: 224, 92, 0;
+  --class-sorcerer: #00acc1;         --class-sorcerer-rgb: 0, 172, 193;
+  --class-nightblade: #e53935;       --class-nightblade-rgb: 229, 57, 53;
+  --class-templar: #ffb300;          --class-templar-rgb: 255, 179, 0;
+  --class-warden: #26a69a;           --class-warden-rgb: 38, 166, 154;
+  --class-necromancer: #7c4dff;      --class-necromancer-rgb: 124, 77, 255;
+  --class-arcanist: #43a047;         --class-arcanist-rgb: 67, 160, 71;
+
+  /* Summary-card accents (RGB triplets) — glassCardSurface.ts:5-12 */
+  --summary-accent-info: 56, 189, 248;    /* brand cyan — header/overview */
+  --summary-accent-damage: 251, 191, 36;  /* amber — damage breakdown */
+  --summary-accent-death: 248, 113, 113;  /* coral — death analysis */
+
+  /* Build-editor attribute colors — buildEditorTokens.ts:48-52 */
+  --attr-magicka: #6c8fff;
+  --attr-health: #e05c5c;
+  --attr-stamina: #4caf82;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   4. VIEW-TRANSITION EASING TOKENS
+   Source: src/styles/view-transitions.css:17-21 (verified 2026-07-26)
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root {
+  --vt-decel: cubic-bezier(0.16, 1, 0.3, 1);
+  --vt-ease-out: cubic-bezier(0.32, 0.72, 0, 1);
+  --vt-snap: cubic-bezier(0.2, 0.9, 0.3, 1);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   5. BLUR-TIER LADDER (emergent rule across all glass recipes)
+   Always pair `backdrop-filter` with `-webkit-backdrop-filter`.
+   All blur is stripped at html[data-perf='low'] (src/index.css:136-140).
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root {
+  --blur-chrome: 10px;        /* app bar / bottom bars: 8–10px (ReduxThemeProvider.tsx:151, SetupTabBar) */
+  --blur-chip: 10px;          /* chips & pills: 6–10px (glossy chips 10, MetricPill 10, card-grid footer 6) */
+  --blur-card: 16px;          /* cards & panels: 12–16px (glassCardSurface 16, card-grid 12, filter panel 16, field 12, segmented 8) */
+  --blur-dialog: 20px;        /* dialogs: 10–20px (MuiDialog 20, PickerDialog reduced 10) */
+  --blur-menu: 20px;          /* menus: 20–24px (cyan dropdown 20 + saturate(1.5), HeaderBar dropdown 24) */
+  --blur-hero: 24px;          /* hero/mobile-sheet/tooltip max tier: 22–24px (HeaderBar sheet 24) */
+  --blur-tooltip: 16px;       /* tooltips: blur(16px) saturate(1.4) (ReduxThemeProvider.tsx:235) */
+  --blur-alert: 8px;          /* alerts (MuiAlert, ReduxThemeProvider.tsx:458) */
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   6. INSET TOP-HIGHLIGHT ALPHA SCALE (emergent rule)
+   Pattern: `inset 0 1px 0 rgba(255,255,255, α)` appended to the depth shadow.
+     α = 0.05–0.06  panels / large glass cards (dark)
+     α = 0.08–0.12  menus & dropdowns (dark; cyan dropdown uses 0.12)
+     α = 0.2–0.3    glossy chips (both modes; 0.3 on hover)
+     α = 0.6–0.9    light mode panels/menus (e.g. 0.8 BE glass, 0.9 dropdowns)
+   Bottom shading inset (`inset 0 -1px 0 rgba(0,0,0,…)`) exists ONLY in the
+   glossy chip recipe (G4). Recessed inputs invert the scheme with dark inner
+   shadows: inset 0 2px 4px rgba(0,0,0,0.4).
+   Ready-made tokens: --inset-hl-panel / --inset-hl-menu / --inset-hl-glossy
+   (defined per scheme in §1/§2).
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   7. RADII / SPACING / MOTION
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root {
+  /* Radii scale — from MUI theme + recipes */
+  --radius-base: 10px;        /* theme.shape.borderRadius (ReduxThemeProvider.tsx:88), list items, dropdown items */
+  --radius-card: 14px;        /* MuiPaper / MuiCard (:165, :230), dropdown paper, electric-border ring */
+  --radius-control: 8px;      /* buttons, inputs, selects (:278, :333) */
+  --radius-badge: 12px;       /* alerts, accordions, tooltips (:457, :504, :243) */
+  --radius-dialog: 24px;      /* MuiDialog (:396) */
+  --radius-chip-glossy: 28px; /* glossy chips (playerCardStyleUtils.ts:35; re-typed at 25px in report_details copies) */
+  --radius-pill: 9999px;      /* fully-rounded pills */
+
+  /* Spacing — MUI 8px unit; sx values are unit multiples (0.5 → 4px) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  /* Motion — durations from BE_TOKENS.duration + common theme transitions */
+  --motion-fast: 0.15s;       /* hovers, menu item transitions */
+  --motion-normal: 0.25s;     /* standard transitions (theme uses 0.2–0.3s freely) */
+  --motion-slow: 0.4s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);           /* input transitions (:334) */
+  --ease-entrance: cubic-bezier(0.26, 0.53, 0.74, 1.48);   /* tooltipEnter / .u-fade-in (:883) */
+
+  /* Focus ring — .u-focus-ring (ReduxThemeProvider.tsx:904-908); build editor
+     uses the same geometry with var(--be-accent). */
+  --focus-ring: 2px solid var(--accent);
+  --focus-ring-offset: 2px;
+  /* Filter-bar field focus — latestReportsStyles.ts:29-30 */
+  --focus-field-border: rgba(96, 165, 250, 0.55);
+  --focus-field-glow: 0 0 0 3px rgba(96, 165, 250, 0.12);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   8. CHIP VARIANT COLORS (glossy gear chips)
+   Source: src/utils/playerCardStyleUtils.ts:95-243 (buildVariantSx).
+   Pattern (dark): 3-stop 135° gradient at alphas 0.25/0.15/0.08 + border at
+   0.3–0.35 + bright label color. Light: alphas 0.12/0.08/0.04 + dark label.
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root,
+[data-color-scheme='dark'] {
+  --chip-green-bg: linear-gradient(135deg, rgba(76, 217, 100, 0.25) 0%, rgba(76, 217, 100, 0.15) 50%, rgba(76, 217, 100, 0.08) 100%);
+  --chip-green-border: rgba(76, 217, 100, 0.3);      --chip-green-text: #5ce572;
+  --chip-blue-bg: linear-gradient(135deg, rgba(0, 122, 255, 0.25) 0%, rgba(0, 122, 255, 0.15) 50%, rgba(0, 122, 255, 0.08) 100%);
+  --chip-blue-border: rgba(0, 122, 255, 0.3);        --chip-blue-text: #4da3ff;
+  --chip-lightblue-bg: linear-gradient(135deg, rgba(94, 234, 255, 0.25) 0%, rgba(94, 234, 255, 0.15) 50%, rgba(94, 234, 255, 0.08) 100%);
+  --chip-lightblue-border: rgba(94, 234, 255, 0.35); --chip-lightblue-text: #7ee8ff;
+  --chip-purple-bg: linear-gradient(135deg, rgba(175, 82, 222, 0.25) 0%, rgba(175, 82, 222, 0.15) 50%, rgba(175, 82, 222, 0.08) 100%);
+  --chip-purple-border: rgba(175, 82, 222, 0.3);     --chip-purple-text: #c57fff;
+  --chip-indigo-bg: linear-gradient(135deg, rgba(88, 86, 214, 0.25) 0%, rgba(88, 86, 214, 0.15) 50%, rgba(88, 86, 214, 0.08) 100%);
+  --chip-indigo-border: rgba(88, 86, 214, 0.3);      --chip-indigo-text: #8583ff;
+  --chip-gold-bg: linear-gradient(135deg, rgba(255, 193, 7, 0.25) 0%, rgba(255, 193, 7, 0.15) 50%, rgba(255, 193, 7, 0.08) 100%);
+  --chip-gold-border: rgba(255, 193, 7, 0.35);       --chip-gold-text: #ffd54f;
+  --chip-silver-bg: linear-gradient(135deg, rgba(236, 240, 241, 0.25) 0%, rgba(236, 240, 241, 0.15) 50%, rgba(236, 240, 241, 0.08) 100%);
+  --chip-silver-border: rgba(236, 240, 241, 0.35);   --chip-silver-text: #ecf0f1;
+  --chip-champion-red-bg: linear-gradient(135deg, rgba(255, 68, 68, 0.25) 0%, rgba(255, 68, 68, 0.15) 50%, rgba(255, 68, 68, 0.08) 100%);
+  --chip-champion-red-border: rgba(255, 68, 68, 0.3);   --chip-champion-red-text: #ff6666;
+  --chip-champion-blue-bg: linear-gradient(135deg, rgba(68, 136, 255, 0.25) 0%, rgba(68, 136, 255, 0.15) 50%, rgba(68, 136, 255, 0.08) 100%);
+  --chip-champion-blue-border: rgba(68, 136, 255, 0.3); --chip-champion-blue-text: #66aaff;
+  --chip-champion-green-bg: linear-gradient(135deg, rgba(68, 255, 136, 0.25) 0%, rgba(68, 255, 136, 0.15) 50%, rgba(68, 255, 136, 0.08) 100%);
+  --chip-champion-green-border: rgba(68, 255, 136, 0.3); --chip-champion-green-text: #66ffaa;
+  /* legendary: rainbow bg + borderImage + 3s legendaryGlow pulse — see SKILL.md */
+  --chip-legendary-bg: linear-gradient(135deg, rgba(255, 0, 150, 0.2) 0%, rgba(255, 150, 0, 0.2) 20%, rgba(255, 255, 0, 0.2) 40%, rgba(0, 255, 0, 0.2) 60%, rgba(0, 150, 255, 0.2) 80%, rgba(150, 0, 255, 0.2) 100%);
+  --chip-legendary-border-image: linear-gradient(135deg, #ff0096, #ff9600, #ffff00, #00ff00, #0096ff, #9600ff) 1;
+  --chip-legendary-text: #ffffff;
+}
+
+[data-color-scheme='light'] {
+  --chip-green-bg: linear-gradient(135deg, rgba(5, 150, 105, 0.12) 0%, rgba(16, 185, 129, 0.08) 50%, rgba(34, 197, 94, 0.04) 100%);
+  --chip-green-border: rgba(5, 150, 105, 0.3);       --chip-green-text: #065f46;
+  --chip-blue-bg: linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(59, 130, 246, 0.08) 50%, rgba(96, 165, 250, 0.04) 100%);
+  --chip-blue-border: rgba(37, 99, 235, 0.3);        --chip-blue-text: #1e3a8a;
+  --chip-lightblue-bg: linear-gradient(135deg, rgba(2, 132, 199, 0.12) 0%, rgba(14, 165, 233, 0.08) 50%, rgba(56, 189, 248, 0.04) 100%);
+  --chip-lightblue-border: rgba(2, 132, 199, 0.3);   --chip-lightblue-text: #0c4a6e;
+  --chip-purple-bg: linear-gradient(135deg, rgba(126, 34, 206, 0.12) 0%, rgba(147, 51, 234, 0.08) 50%, rgba(168, 85, 247, 0.04) 100%);
+  --chip-purple-border: rgba(126, 34, 206, 0.3);     --chip-purple-text: #581c87;
+  --chip-indigo-bg: linear-gradient(135deg, rgba(67, 56, 202, 0.12) 0%, rgba(99, 102, 241, 0.08) 50%, rgba(129, 140, 248, 0.04) 100%);
+  --chip-indigo-border: rgba(67, 56, 202, 0.3);      --chip-indigo-text: #3730a3;
+  --chip-gold-bg: linear-gradient(135deg, rgba(217, 119, 6, 0.12) 0%, rgba(245, 158, 11, 0.08) 50%, rgba(251, 191, 36, 0.04) 100%);
+  --chip-gold-border: rgba(217, 119, 6, 0.3);        --chip-gold-text: #92400e;
+  --chip-silver-bg: linear-gradient(135deg, rgba(100, 116, 139, 0.12) 0%, rgba(148, 163, 184, 0.08) 50%, rgba(203, 213, 225, 0.04) 100%);
+  --chip-silver-border: rgba(100, 116, 139, 0.3);    --chip-silver-text: #334155;
+  --chip-champion-red-bg: linear-gradient(135deg, rgba(220, 38, 38, 0.12) 0%, rgba(239, 68, 68, 0.08) 50%, rgba(248, 113, 113, 0.04) 100%);
+  --chip-champion-red-border: rgba(220, 38, 38, 0.3);   --chip-champion-red-text: #991b1b;
+  --chip-champion-blue-bg: linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(59, 130, 246, 0.08) 50%, rgba(96, 165, 250, 0.04) 100%);
+  --chip-champion-blue-border: rgba(37, 99, 235, 0.3);  --chip-champion-blue-text: #1e3a8a;
+  --chip-champion-green-bg: linear-gradient(135deg, rgba(5, 150, 105, 0.12) 0%, rgba(16, 185, 129, 0.08) 50%, rgba(34, 197, 94, 0.04) 100%);
+  --chip-champion-green-border: rgba(5, 150, 105, 0.3); --chip-champion-green-text: #065f46;
+  --chip-legendary-text: #1f2937;  /* bg + borderImage same as dark */
+}
+
+/* MetricPill intents (comp-metric-pills) — MetricPill.tsx:27-53. A DIVERGENT
+   sibling of the chip palette above (success reuses green, info reuses
+   lightBlue, but warning text is #ff9800 and neutral is slate). Both palettes
+   are canonical for their own component — do not merge them. */
+:root {
+  --pill-success-border: rgba(76, 217, 100, 0.3);   --pill-success-text: #5ce572;
+  --pill-warning-border: rgba(255, 193, 7, 0.35);   --pill-warning-text: #ff9800;
+  --pill-danger-border: rgba(255, 68, 68, 0.3);     --pill-danger-text: #ff6666;
+  --pill-info-border: rgba(94, 234, 255, 0.35);     --pill-info-text: #7ee8ff;
+  --pill-neutral-border: rgba(148, 163, 184, 0.3);  --pill-neutral-text: var(--text);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   9. TYPE SCALE
+   Body Inter; headings Space Grotesk 600 (ReduxThemeProvider.tsx:89-99).
+   Classes used across preview cards; sizes are the design-system ramp.
+   ═══════════════════════════════════════════════════════════════════════════ */
+body,
+.p {
+  font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.6;
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+}
+
+.h-display,
+.h1,
+.h2,
+.h3 {
+  font-family: 'Space Grotesk', Inter, system-ui, sans-serif;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.h-display { font-size: clamp(2.2rem, 4vw, 3.2rem); line-height: 1.1; letter-spacing: -0.02em; }
+.h1 { font-size: 2rem; line-height: 1.2; }
+.h2 { font-size: 1.5rem; line-height: 1.25; }
+.h3 { font-size: 1.17rem; line-height: 1.3; }
+
+.eyebrow {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.subtitle { font-size: 0.9rem; line-height: 1.5; color: var(--muted); }
+.caption { font-size: 0.75rem; line-height: 1.4; color: var(--muted); }
+
+.mono {
+  font-family: 'JetBrains Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums; /* .u-tabular idiom for stat columns */
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   10. BACK-COMPAT ALIASES
+   Keep older card markup working; prefer the canonical names above.
+   ═══════════════════════════════════════════════════════════════════════════ */
+:root {
+  --panel2: var(--panel-2);
+  --text-muted: var(--muted);
+  --color-bg: var(--bg);
+  --color-panel: var(--panel);
+  --color-accent: var(--accent);
+  --color-border: var(--border);
+  --success: var(--ok);
+  --warning: var(--warn);
+  --error: var(--danger);
+
+  /* aliases used by pre-2026-07 preview cards */
+  --font-sans: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu,
+               Cantarell, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+  --font-display: 'Space Grotesk', Inter, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Source Code Pro', Menlo, Monaco, Consolas,
+               'Courier New', monospace;
+  --text-2: #cbd5e1;
+  --text-3: var(--muted);
+  --text-4: #64748b;
+  --fg-1: var(--text);
+  --fg-2: var(--text-2);
+  --fg-3: var(--text-3);
+  --fg-4: var(--text-4);
+  --bg-0: #030712;            /* paper-gradient floor (MuiPaper dark stop 2) */
+  --bg-1: var(--bg);
+  --bg-2: var(--panel);
+  --bg-3: var(--panel-2);
+  --r-xs: 4px;
+  --r-sm: var(--radius-control);
+  --r-md: var(--radius-badge);
+  --r-lg: var(--radius-card);
+  --r-xl: 20px;
+  --r-pill: var(--radius-pill);
+  --grad-accent: var(--grad-button-primary);
+  --grad-hero: linear-gradient(135deg, #ffffff 0%, #38bdf8 50%, #00e1ff 100%);
+}
+
+/* ⚠ LEGACY, NOT the design system: src/index.css:120-127 declares a
+   conflicting `--site-*` palette (#121212 / #7289da / 8px radius) used only
+   by the old Pickr theme. Never source values from it. */

--- a/design-sync/preview/boundary-accent-rails.html
+++ b/design-sync/preview/boundary-accent-rails.html
@@ -1,0 +1,202 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Accent Rails — borderLeft &amp; inset-shadow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:18px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+
+  /* ── B1a: role-colored slot card rail — src/components/roster/DPSSlotCard.tsx:172-189 ── */
+  .slot-card { border-radius:12px; padding:12px 14px; cursor:default;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.2s ease; }
+  [data-color-scheme="dark"] .slot-card {
+    background-color:#ff8b610a;                 /* `${dpsRoleColors.dps}0a` (dark dps #ff8b61) */
+    border:1px solid #ff8b6120;
+    border-left:3px solid #ff8b61;
+  }
+  [data-color-scheme="light"] .slot-card {
+    background-color:#ff572206;                 /* `${dpsRoleColors.dps}06` (light solid dps #ff5722) */
+    border:1px solid #ff572218;
+    border-left:3px solid #ff5722;
+  }
+  [data-color-scheme="dark"] .slot-card:hover, [data-color-scheme="dark"] .slot-card.is-hover {
+    transform:translateY(-1px);
+    border-color:#ff8b6135; border-left-color:#ff8b61;
+    box-shadow:0 4px 16px #ff8b6118, 0 2px 8px rgba(0,0,0,0.1);
+  }
+  [data-color-scheme="light"] .slot-card:hover, [data-color-scheme="light"] .slot-card.is-hover {
+    transform:translateY(-1px);
+    border-color:#ff572235; border-left-color:#ff5722;
+    box-shadow:0 4px 16px #ff572218, 0 2px 8px rgba(0,0,0,0.1);
+  }
+  .slot-card .name { font-weight:600; font-size:.85rem; }
+  .slot-card .sub { font-size:.72rem; color:var(--muted); }
+
+  /* ── B1b: selection rail transparent-reserve — src/components/PerFightBuilds.tsx:805-810 ── */
+  .sel-row { position:relative; border-radius:8px; padding:6px 8px 6px 10px;
+    display:flex; align-items:center; gap:6px; font-size:.8rem;
+    border-left:3px solid transparent; background-color:transparent;
+    transition:background-color 0.15s ease; }
+  .sel-row.is-active { border-left:3px solid #38bdf8; }
+  [data-color-scheme="dark"] .sel-row.is-active { background-color:rgba(56,189,248,0.12); }
+  [data-color-scheme="light"] .sel-row.is-active { background-color:rgba(56,189,248,0.10); }
+
+  /* ── B1c: semantic 3px rail callout — src/features/report_summary/summaryStyles.ts:189-201 (patternCalloutSx) ── */
+  .callout { border-radius:8px; padding:10px 14px; margin-bottom:8px; font-size:.78rem;
+    backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); }
+  [data-color-scheme="dark"] .callout { color:rgb(226, 232, 240); }
+  [data-color-scheme="light"] .callout { color:rgb(30, 41, 59); }
+  /* High severity — coral 248,113,113 (SEVERITY_ACCENTS.High) */
+  [data-color-scheme="dark"] .callout.coral {
+    border:1px solid rgba(248, 113, 113, 0.28); border-left:3px solid rgb(248, 113, 113);
+    background:linear-gradient(135deg, rgba(248, 113, 113, 0.13) 0%, rgba(248, 113, 113, 0.04) 100%); }
+  [data-color-scheme="light"] .callout.coral {
+    border:1px solid rgba(248, 113, 113, 0.24); border-left:3px solid rgb(248, 113, 113);
+    background:linear-gradient(135deg, rgba(248, 113, 113, 0.09) 0%, rgba(248, 113, 113, 0.03) 100%); }
+  /* Medium severity — amber 251,191,36 */
+  [data-color-scheme="dark"] .callout.amber {
+    border:1px solid rgba(251, 191, 36, 0.28); border-left:3px solid rgb(251, 191, 36);
+    background:linear-gradient(135deg, rgba(251, 191, 36, 0.13) 0%, rgba(251, 191, 36, 0.04) 100%); }
+  [data-color-scheme="light"] .callout.amber {
+    border:1px solid rgba(251, 191, 36, 0.24); border-left:3px solid rgb(251, 191, 36);
+    background:linear-gradient(135deg, rgba(251, 191, 36, 0.09) 0%, rgba(251, 191, 36, 0.03) 100%); }
+
+  /* ── B2a: layout-safe inset rail on list rows — summaryStyles.ts:235-243 (listRowHoverSx, info accent) ── */
+  .list-row { padding:8px 12px; font-size:.8rem; border-radius:4px;
+    transition:background-color 0.15s ease, box-shadow 0.15s ease; }
+  [data-color-scheme="dark"] .list-row:hover, [data-color-scheme="dark"] .list-row.is-hover {
+    background-color:rgba(56, 189, 248, 0.07);
+    box-shadow:inset 3px 0 0 rgba(56, 189, 248, 0.8); }
+  [data-color-scheme="light"] .list-row:hover, [data-color-scheme="light"] .list-row.is-hover {
+    background-color:rgba(56, 189, 248, 0.05);
+    box-shadow:inset 3px 0 0 rgba(56, 189, 248, 0.7); }
+
+  /* ── B2b: 2px inset rail + translateX — src/components/HeaderBar.tsx:449-456 (menuItemSx hover) ── */
+  .menu-item { padding:8px 12px; margin:2px 6px; border-radius:10px; font-size:.82rem;
+    display:flex; flex-direction:column; gap:1px;
+    transition:background 0.25s ease, transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s ease; }
+  .menu-item .secondary { font-size:.7rem; opacity:0.45; transition:opacity 0.25s ease; }
+  [data-color-scheme="dark"] .menu-item:hover, [data-color-scheme="dark"] .menu-item.is-hover {
+    background:linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(56,189,248,0.03) 100%);
+    transform:translateX(4px);
+    box-shadow:inset 2px 0 0 #38bdf8, 0 2px 12px rgba(56,189,248,0.1); }
+  [data-color-scheme="light"] .menu-item:hover, [data-color-scheme="light"] .menu-item.is-hover {
+    background:linear-gradient(135deg, rgba(56,189,248,0.10) 0%, rgba(56,189,248,0.02) 100%);
+    transform:translateX(4px);
+    box-shadow:inset 2px 0 0 #38bdf8, 0 2px 8px rgba(56,189,248,0.06); }
+  .menu-item:hover .secondary, .menu-item.is-hover .secondary { opacity:0.75; }
+
+  .rule-note { font-size:.74rem; color:#94a3b8; line-height:1.5; margin-top:14px;
+    border:1px solid #1f2937; border-radius:10px; padding:10px 14px; background:#0f172a; }
+  .rule-note b { color:#e5e7eb; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Accent Rails — borderLeft &amp; inset-shadow</h1>
+  <p class="ds-sub">B1 borderLeft rails (role / selection / semantic) + B2 layout-safe inset-shadow rails. Sources: DPSSlotCard.tsx:172-189, PerFightBuilds.tsx:805-810, summaryStyles.ts:189-201/235-243, HeaderBar.tsx:449-456</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B1 — role-colored slot card rail (hover state on 2nd)</div>
+          <div class="slot-card" style="margin-bottom:8px"><div class="name">@stamplar-one</div><div class="sub">Banner Jail DD</div></div>
+          <div class="slot-card is-hover"><div class="name">@nightblade-two</div><div class="sub">Martial Knowledge Jail DD</div></div>
+          <div class="ds-src">borderLeft: 3px solid #ff8b61 over #ff8b610a fill — src/components/roster/DPSSlotCard.tsx:172-189</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B1 — selection rail, transparent-reserve trick</div>
+          <div class="sel-row is-active">Fight 3 — Hall of Fleshcraft</div>
+          <div class="sel-row">Fight 4 — Overfiend Kazpian</div>
+          <div class="ds-src">active ? '3px solid #38bdf8' : '3px solid transparent' — src/components/PerFightBuilds.tsx:805</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B1 — semantic 3px rail callout</div>
+          <div class="callout coral">High: 6 deaths to Burst Damage in the execute phase.</div>
+          <div class="callout amber">Medium: uptime on Major Slayer dipped below 70%.</div>
+          <div class="ds-src">patternCalloutSx(dark, accentRgb) — src/features/report_summary/summaryStyles.ts:189-201</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B2 — inset-shadow rail on list rows (hover forced)</div>
+          <div class="list-row">Colossus drop coverage</div>
+          <div class="list-row is-hover">Off-balance uptime windows</div>
+          <div class="ds-src">inset 3px 0 0 rgba(56,189,248,0.8) — listRowHoverSx, summaryStyles.ts:235-243</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B2 — 2px inset rail + translateX(4px) (hover forced)</div>
+          <div class="menu-item"><span>Latest Reports</span><span class="secondary">Browse recent trial logs</span></div>
+          <div class="menu-item is-hover"><span>Roster Builder</span><span class="secondary">Plan a 12-player comp</span></div>
+          <div class="ds-src">inset 2px 0 0 accent + translateX(4px) — src/components/HeaderBar.tsx:449-456</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B1 — role-colored slot card rail (hover state on 2nd)</div>
+          <div class="slot-card" style="margin-bottom:8px"><div class="name">@stamplar-one</div><div class="sub">Banner Jail DD</div></div>
+          <div class="slot-card is-hover"><div class="name">@nightblade-two</div><div class="sub">Martial Knowledge Jail DD</div></div>
+          <div class="ds-src">borderLeft: 3px solid #ff5722 over #ff572206 fill — DPSSlotCard.tsx:172-189 (light solid dps)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B1 — selection rail, transparent-reserve trick</div>
+          <div class="sel-row is-active">Fight 3 — Hall of Fleshcraft</div>
+          <div class="sel-row">Fight 4 — Overfiend Kazpian</div>
+          <div class="ds-src">active ? '3px solid #38bdf8' : '3px solid transparent' — PerFightBuilds.tsx:805</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B1 — semantic 3px rail callout</div>
+          <div class="callout coral">High: 6 deaths to Burst Damage in the execute phase.</div>
+          <div class="callout amber">Medium: uptime on Major Slayer dipped below 70%.</div>
+          <div class="ds-src">patternCalloutSx(light, accentRgb) — summaryStyles.ts:189-201</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B2 — inset-shadow rail on list rows (hover forced)</div>
+          <div class="list-row">Colossus drop coverage</div>
+          <div class="list-row is-hover">Off-balance uptime windows</div>
+          <div class="ds-src">inset 3px 0 0 rgba(56,189,248,0.7) — listRowHoverSx, summaryStyles.ts:235-243</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B2 — 2px inset rail + translateX(4px) (hover forced)</div>
+          <div class="menu-item"><span>Latest Reports</span><span class="secondary">Browse recent trial logs</span></div>
+          <div class="menu-item is-hover"><span>Roster Builder</span><span class="secondary">Plan a 12-player comp</span></div>
+          <div class="ds-src">inset 2px 0 0 accent + translateX(4px) — HeaderBar.tsx:449-456</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="rule-note">
+    <b>Border rail vs inset rail.</b> A <b>borderLeft rail</b> (B1) is a layout property — it shifts content 3px, so
+    toggleable rails must reserve the space with <code>3px solid transparent</code> when inactive (the PerFightBuilds trick).
+    An <b>inset-shadow rail</b> (B2, <code>box-shadow: inset 3px 0 0 …</code>) paints inside the box with zero layout shift,
+    so it is the idiom for hover/transient rails (table first-cells, list rows, menu items).
+  </div>
+</div>

--- a/design-sync/preview/boundary-dividers.html
+++ b/design-sync/preview/boundary-dividers.html
@@ -1,0 +1,170 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Dividers — tri-color hairline, shimmer, fading rules (B14)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:20px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:10px; }
+
+  /* ── @property registrations + shimmer keyframes — LandingPage.tsx:17-32 ── */
+  @property --divider-pos {
+    syntax: '<percentage>';
+    inherits: false;
+    initial-value: 50%;
+  }
+  @property --glow-opacity {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 0.3;
+  }
+  @keyframes dividerShimmer {
+    0%   { --divider-pos: 20%; --glow-opacity: 0.3; }
+    50%  { --divider-pos: 80%; --glow-opacity: 0.6; }
+    100% { --divider-pos: 20%; --glow-opacity: 0.3; }
+  }
+
+  /* ── Tri-color hairline + bloom + scanning dot — LandingPage.tsx:1104-1141, keyframes :1220-1224 ── */
+  @keyframes scanDot {
+    0%, 100% { left: 0%; opacity: 0; }
+    5%   { opacity: 1; }
+    50%  { left: 100%; opacity: 1; }
+    55%  { opacity: 0; }
+  }
+  .bridge-rule { position:relative; width:100%; height:1px; margin:18px 0 8px; }
+  [data-color-scheme="dark"] .bridge-rule {
+    background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.3) 20%, rgba(129, 140, 248, 0.4) 50%, rgba(192, 132, 252, 0.3) 80%, transparent 100%); }
+  [data-color-scheme="light"] .bridge-rule {
+    background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.2) 20%, rgba(99, 102, 241, 0.3) 50%, rgba(168, 85, 247, 0.2) 80%, transparent 100%); }
+  .bridge-rule::before { content:""; position:absolute; top:-8px; left:10%; right:10%; height:16px; filter:blur(6px); }
+  [data-color-scheme="dark"] .bridge-rule::before {
+    background:linear-gradient(90deg, transparent, rgba(56, 189, 248, 0.08) 30%, rgba(129, 140, 248, 0.12) 50%, rgba(192, 132, 252, 0.08) 70%, transparent); }
+  [data-color-scheme="light"] .bridge-rule::before {
+    background:linear-gradient(90deg, transparent, rgba(56, 189, 248, 0.05) 30%, rgba(99, 102, 241, 0.08) 50%, transparent); }
+  .bridge-rule::after { content:""; position:absolute; top:-3px; left:0; width:7px; height:7px; border-radius:50%;
+    animation:scanDot 4s ease-in-out infinite; }
+  [data-color-scheme="dark"] .bridge-rule::after {
+    background:#38bdf8; box-shadow:0 0 12px 3px rgba(56, 189, 248, 0.4); }
+  [data-color-scheme="light"] .bridge-rule::after {
+    background:#0ea5e9; box-shadow:0 0 10px 2px rgba(14, 165, 233, 0.3); }
+
+  /* ── @property shimmer dividers — violet consumer LandingPage.tsx:1545-1557, amber :1797-1810 ── */
+  .shimmer-strip { position:relative; height:34px; border-radius:8px; background:var(--panel-2);
+    border:1px solid var(--border); overflow:hidden; }
+  .shimmer-strip::before { content:""; position:absolute; top:0; left:0; right:0; height:2px;
+    animation:dividerShimmer 6s ease-in-out infinite; }
+  [data-color-scheme="dark"] .shimmer-strip.violet::before {
+    background:linear-gradient(90deg, transparent, rgba(139, 92, 246, var(--glow-opacity)) var(--divider-pos), transparent); }
+  [data-color-scheme="light"] .shimmer-strip.violet::before {
+    background:linear-gradient(90deg, transparent, rgba(139, 92, 246, calc(var(--glow-opacity) * 0.7)) var(--divider-pos), transparent); }
+  [data-color-scheme="dark"] .shimmer-strip.amber::before {
+    background:linear-gradient(90deg, transparent, rgba(245, 158, 11, var(--glow-opacity)) var(--divider-pos), transparent);
+    animation-delay:-3s; }
+  [data-color-scheme="light"] .shimmer-strip.amber::before {
+    background:linear-gradient(90deg, transparent, rgba(180, 120, 20, calc(var(--glow-opacity) * 0.7)) var(--divider-pos), transparent);
+    animation-delay:-3s; }
+  .shimmer-strip .lbl { position:absolute; inset:0; display:flex; align-items:center; padding:0 12px;
+    font-size:.72rem; color:var(--muted); }
+
+  /* ── Mirrored fading caption rules — LandingPage.tsx:1192-1218 (.bridge-caption) ── */
+  .bridge-caption { display:flex; align-items:center; justify-content:center; gap:0.75rem;
+    font-size:0.78rem; font-weight:500; letter-spacing:0.08em; text-transform:uppercase; }
+  [data-color-scheme="dark"] .bridge-caption { color:rgba(255, 255, 255, 0.25); }
+  [data-color-scheme="light"] .bridge-caption { color:rgba(0, 0, 0, 0.25); }
+  .bridge-caption::before, .bridge-caption::after { content:""; width:2.5rem; height:1px; flex-shrink:0; }
+  [data-color-scheme="dark"] .bridge-caption::before { background:linear-gradient(90deg, transparent, rgba(255,255,255,0.12)); }
+  [data-color-scheme="light"] .bridge-caption::before { background:linear-gradient(90deg, transparent, rgba(0,0,0,0.08)); }
+  [data-color-scheme="dark"] .bridge-caption::after { background:linear-gradient(90deg, rgba(255,255,255,0.12), transparent); }
+  [data-color-scheme="light"] .bridge-caption::after { background:linear-gradient(90deg, rgba(0,0,0,0.08), transparent); }
+
+  /* ── Header fade rule — HeaderBar.tsx:404-409 (section-header ::after) ── */
+  .header-fade { display:flex; align-items:center; gap:10px; }
+  .header-fade .txt { font-size:0.7rem; letter-spacing:0.08em; text-transform:uppercase; font-weight:700;
+    background:linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+    -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text; }
+  .header-fade::after { content:""; flex:1; height:1px;
+    background:linear-gradient(90deg, rgba(56, 189, 248, 0.25), transparent); }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Dividers — tri-color hairline, shimmer, fading rules (B14)</h1>
+  <p class="ds-sub">All animated. Sources: LandingPage.tsx:17-32 (@property), :1104-1141 (bridge-rule), :1192-1218 (caption), :1220-1224 (scanDot), :1545-1557 &amp; :1797-1810 (shimmer consumers), HeaderBar.tsx:404-409</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Tri-color hairline + blur bloom + scanning dot</div>
+          <div class="bridge-rule"></div>
+          <div class="ds-src">cyan .3 / indigo .4 / violet .3 gradient; ::before 16px bloom blur(6px); ::after 7px dot, scanDot 4s — LandingPage.tsx:1104-1141</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">@property shimmer dividers — violet + amber (delay -3s)</div>
+          <div class="shimmer-strip violet" style="margin-bottom:8px"><span class="lbl">Kalpa section — rgba(139,92,246, var(--glow-opacity)) at var(--divider-pos)</span></div>
+          <div class="shimmer-strip amber"><span class="lbl">Amber section — animationDelay: -3s desynchronises the pair</span></div>
+          <div class="ds-src">@property --divider-pos / --glow-opacity + dividerShimmer 6s — LandingPage.tsx:17-32; consumers :1545-1557, :1797-1810</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Mirrored fading caption rules</div>
+          <div class="bridge-caption">Live tools</div>
+          <div class="ds-src">::before fades in →, ::after fades out → (2.5rem × 1px) — LandingPage.tsx:1204-1217</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Header fade rule (menu section header)</div>
+          <div class="header-fade"><span class="txt">Reports</span></div>
+          <div class="ds-src">::after flex:1, linear-gradient(90deg, alpha(accent, 0.25), transparent) — HeaderBar.tsx:404-409</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Tri-color hairline + blur bloom + scanning dot</div>
+          <div class="bridge-rule"></div>
+          <div class="ds-src">light: alphas drop to .2/.3/.2, dot #0ea5e9, bloom loses the violet stop — LandingPage.tsx:1110, 1123, 1136-1139</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">@property shimmer dividers — violet + amber (delay -3s)</div>
+          <div class="shimmer-strip violet" style="margin-bottom:8px"><span class="lbl">Light: alpha scaled by calc(var(--glow-opacity) * 0.7)</span></div>
+          <div class="shimmer-strip amber"><span class="lbl">Amber goes earthier: rgba(180,120,20, …)</span></div>
+          <div class="ds-src">LandingPage.tsx:1555, :1807</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Mirrored fading caption rules</div>
+          <div class="bridge-caption">Live tools</div>
+          <div class="ds-src">light: rgba(0,0,0,0.08) rules, rgba(0,0,0,0.25) text — LandingPage.tsx:1202-1217</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Header fade rule (menu section header)</div>
+          <div class="header-fade"><span class="txt">Reports</span></div>
+          <div class="ds-src">HeaderBar.tsx:404-409 (accent alpha 0.25 both modes)</div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/design-sync/preview/boundary-edge-masks.html
+++ b/design-sync/preview/boundary-edge-masks.html
@@ -1,0 +1,148 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Edge Masks &amp; Clips — fades, clipPath, overflow rules (B15)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:16px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+
+  /* ── B15a: scroll-edge mask fades, 24px per edge — MetricsScrollRow.tsx:27-40 (demo'd static) ── */
+  .pill-row { display:flex; gap:8px; overflow:hidden; padding:2px 0; }
+  .pill-row .pill { flex-shrink:0; font-size:.7rem; padding:5px 12px; border-radius:999px;
+    background:var(--panel-2); border:1px solid var(--border); color:var(--text); white-space:nowrap; }
+  .fade-right { mask-image:linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
+    -webkit-mask-image:linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%); }
+  .fade-left { mask-image:linear-gradient(to right, transparent 0, #000 24px, #000 100%);
+    -webkit-mask-image:linear-gradient(to right, transparent 0, #000 24px, #000 100%); }
+  .fade-both { mask-image:linear-gradient(to right, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%);
+    -webkit-mask-image:linear-gradient(to right, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%); }
+
+  /* ── B15b: marquee fade — LandingPage.tsx:878-879 ── */
+  .marquee { overflow:hidden; padding:10px 0; white-space:nowrap; font-size:.72rem; color:var(--muted);
+    mask-image:linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%);
+    -webkit-mask-image:linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%); }
+  [data-color-scheme="dark"] .marquee { border-top:1px solid rgba(255,255,255,0.04); border-bottom:1px solid rgba(255,255,255,0.04);
+    background:rgba(255, 255, 255, 0.01); }
+  [data-color-scheme="light"] .marquee { border-top:1px solid rgba(0,0,0,0.04); border-bottom:1px solid rgba(0,0,0,0.04);
+    background:rgba(0, 0, 0, 0.01); }
+  @keyframes marqueeScroll { from { transform:translateX(0); } to { transform:translateX(-50%); } }
+  .marquee .track { display:inline-block; animation:marqueeScroll 14s linear infinite; }
+
+  /* ── B15c: chip-rail fade — RosterViewPage.tsx:1449 ── */
+  .chip-rail { display:flex; gap:4px; overflow:hidden; padding:6px 0;
+    backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px);
+    mask-image:linear-gradient(90deg, #000 92%, transparent);
+    -webkit-mask-image:linear-gradient(90deg, #000 92%, transparent); }
+  .chip-rail .chip { flex-shrink:0; font-size:.68rem; padding:4px 10px; border-radius:999px;
+    background:var(--panel-2); border:1px solid var(--border); white-space:nowrap; }
+
+  /* ── B15d: clipPath progress with negative insets — AttributeBar.tsx:155-171 ── */
+  .attr-track { position:relative; height:14px; border-radius:4px; margin:6px 0 2px; }
+  [data-color-scheme="dark"] .attr-track { background:rgba(255,255,255,0.06); }
+  [data-color-scheme="light"] .attr-track { background:rgba(15,23,42,0.08); }
+  .attr-fill { height:100%; width:100%; border-radius:4px;
+    background:linear-gradient(90deg, #38bdf8 0%, rgba(56, 189, 248, 0.55) 100%);
+    box-shadow:0 0 10px rgba(56, 189, 248, 0.45), inset 0 1px 0 rgba(255,255,255,0.18);
+    clip-path:inset(-12px 36% -12px -12px round 4px); }
+
+  .note { font-size:.74rem; color:#94a3b8; line-height:1.55; margin-top:14px;
+    border:1px solid #1f2937; border-radius:10px; padding:10px 14px; background:#0f172a; }
+  .note b { color:#e5e7eb; }
+  .note code { font-size:.68rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Edge Masks &amp; Clips (B15)</h1>
+  <p class="ds-sub">Scroll-edge mask fades, marquee/chip-rail fades, clipPath progress with negative insets, and the overflow visible-vs-hidden negotiation. Sources: MetricsScrollRow.tsx:27-40, LandingPage.tsx:878-879, RosterViewPage.tsx:1449, AttributeBar.tsx:155-171</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Scroll-edge mask fades — 24px per scrollable edge (static variants)</div>
+          <div class="pill-row fade-right" style="margin-bottom:6px"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="pill-row fade-left" style="margin-bottom:6px"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="pill-row fade-both"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="ds-src">FADE_PX = 24; per-edge dynamic (right = "more this way →") — MetricsScrollRow.tsx:27-40, applied :99-104</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Marquee fade — 10% / 90% stops</div>
+          <div class="marquee"><span class="track">LOG AGGREGATOR · ROSTER BUILDER · BUILD EDITOR · FIGHT REPLAY · PARSE ANALYSIS · ULTIMATE CALCULATOR · LOG AGGREGATOR · ROSTER BUILDER · BUILD EDITOR · FIGHT REPLAY · PARSE ANALYSIS · ULTIMATE CALCULATOR · </span></div>
+          <div class="ds-src">maskImage: linear-gradient(90deg, transparent 0%, black 10%, black 90%, transparent 100%) — LandingPage.tsx:878-879</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Chip-rail fade — right edge only, 92% stop</div>
+          <div class="chip-rail"><span class="chip">AA</span><span class="chip">SO</span><span class="chip">HRC</span><span class="chip">MoL</span><span class="chip">HoF</span><span class="chip">AS</span><span class="chip">CR</span><span class="chip">SS</span><span class="chip">KA</span><span class="chip">RG</span><span class="chip">DSR</span><span class="chip">SE</span><span class="chip">LC</span><span class="chip">OC</span></div>
+          <div class="ds-src">maskImage: linear-gradient(90deg, #000 92%, transparent) — RosterViewPage.tsx:1449</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">clipPath progress — negative insets keep the glow un-clipped (64% fill)</div>
+          <div class="attr-track"><div class="attr-fill"></div></div>
+          <div class="ds-src">clipPath: inset(-12px 36% -12px -12px round 4px); fill 90deg color → alpha(color, 0.55); glow 0 0 10px alpha(color, 0.45) — AttributeBar.tsx:155-171</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Scroll-edge mask fades — 24px per scrollable edge (static variants)</div>
+          <div class="pill-row fade-right" style="margin-bottom:6px"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="pill-row fade-left" style="margin-bottom:6px"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="pill-row fade-both"><span class="pill">DPS 131.2k</span><span class="pill">Uptime 98%</span><span class="pill">Deaths 0</span><span class="pill">Res 2</span><span class="pill">Interrupts 4</span><span class="pill">Bash 12</span><span class="pill">Dodges 9</span><span class="pill">Blocks 31</span></div>
+          <div class="ds-src">CSS mask blends with any translucent card bg in any theme — MetricsScrollRow.tsx:52-59</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Marquee fade — 10% / 90% stops</div>
+          <div class="marquee"><span class="track">LOG AGGREGATOR · ROSTER BUILDER · BUILD EDITOR · FIGHT REPLAY · PARSE ANALYSIS · ULTIMATE CALCULATOR · LOG AGGREGATOR · ROSTER BUILDER · BUILD EDITOR · FIGHT REPLAY · PARSE ANALYSIS · ULTIMATE CALCULATOR · </span></div>
+          <div class="ds-src">LandingPage.tsx:878-879</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Chip-rail fade — right edge only, 92% stop</div>
+          <div class="chip-rail"><span class="chip">AA</span><span class="chip">SO</span><span class="chip">HRC</span><span class="chip">MoL</span><span class="chip">HoF</span><span class="chip">AS</span><span class="chip">CR</span><span class="chip">SS</span><span class="chip">KA</span><span class="chip">RG</span><span class="chip">DSR</span><span class="chip">SE</span><span class="chip">LC</span><span class="chip">OC</span></div>
+          <div class="ds-src">RosterViewPage.tsx:1449</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">clipPath progress — negative insets keep the glow un-clipped (64% fill)</div>
+          <div class="attr-track"><div class="attr-fill"></div></div>
+          <div class="ds-src">AttributeBar.tsx:155-171 (fill gradient is mode-independent)</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="note">
+    <b>Why clip-path, not width:</b> width is a layout property, so the spring animation forced a reflow every frame; clip-path
+    composites. Negative insets on the three static sides (<code>-12px</code>) keep the fill's outer glow un-clipped — clip-path
+    clips the element's <b>own</b> box-shadow — and <code>round 4px</code> preserves the rounded cap at the moving edge
+    (AttributeBar.tsx:149-154).<br>
+    <b>Overflow negotiation rule:</b> a surface keeps <code>overflow: hidden</code> when it paints decorations that must stay
+    inside its rounded corners (GlassPanel / glassCardSurface top strips, the expanded replay deck's corner glow), but must switch
+    to <code>overflow: visible</code> when children render beyond its edge — the compact replay overlay's scrub-preview bubble
+    (replayDesign.ts:135-139) and the top-DPS card's negative-inset electric ring + halo (PlayerCard.tsx:601-605).
+  </div>
+</div>

--- a/design-sync/preview/boundary-electric-border.html
+++ b/design-sync/preview/boundary-electric-border.html
@@ -1,0 +1,147 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Electric Border — animated conic top-DPS ring (B5)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+
+  /* ── @property + keyframes — src/ReduxThemeProvider.tsx:866-881 ── */
+  @property --tdps-angle {
+    syntax: "<angle>";
+    initial-value: 0deg;
+    inherits: false;
+  }
+  /* Sweep the gradient's start angle, NOT the element's transform — that keeps the
+     rectangular ring in place and moves only the bright "current" travelling around its edge. */
+  @keyframes electricBorderSpin { to { --tdps-angle: 360deg; } }
+  /* Gentle glow pulse on the outer halo */
+  @keyframes electricBorderPulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+
+  /* ── Host card — PlayerCard.tsx:588-611 (cardStyles, isTopDps branch) ── */
+  .tdps-card { position:relative; margin:12px 6px 8px; border-radius:12px;
+    overflow:visible; /* let ring + halo (negative insets) render beyond the card edge — PlayerCard.tsx:601-605 */
+    background:linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%); }
+  [data-color-scheme="dark"] .tdps-card {
+    border:1px solid rgba(245,158,11,0.55);
+    box-shadow:0 0 16px rgba(245,158,11,0.18), 0 0 40px rgba(245,158,11,0.06), inset 0 1px 0 rgba(251,191,36,0.12); }
+  [data-color-scheme="light"] .tdps-card {
+    border:1px solid rgba(180,83,9,0.5);
+    box-shadow:0 0 16px rgba(180,83,9,0.12), 0 0 40px rgba(245,158,11,0.08), inset 0 1px 0 rgba(251,191,36,0.18); }
+
+  /* ── Ring: rotating conic "current" — PlayerCard.tsx:1210-1233 ── */
+  .tdps-ring { position:absolute; inset:-1px; border-radius:14px; padding:1.5px; z-index:2; pointer-events:none;
+    background:conic-gradient(from var(--tdps-angle), transparent 0deg, rgba(251,191,36,0.15) 40deg, rgba(245,158,11,0.85) 80deg, #fde68a 100deg, rgba(245,158,11,0.85) 120deg, rgba(251,191,36,0.15) 160deg, transparent 200deg, transparent 360deg);
+    -webkit-mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite:xor;
+    mask-composite:exclude;
+    animation:electricBorderSpin 4s linear infinite;
+    filter:drop-shadow(0 0 4px rgba(245,158,11,0.55)); }
+
+  /* ── Halo: soft pulsing outer glow — PlayerCard.tsx:1236-1250 ── */
+  .tdps-halo { position:absolute; inset:-3px; border-radius:16px; z-index:0; pointer-events:none;
+    animation:electricBorderPulse 2.8s ease-in-out infinite; }
+  [data-color-scheme="dark"] .tdps-halo {
+    box-shadow:0 0 14px 1px rgba(245,158,11,0.35), 0 0 34px 4px rgba(245,158,11,0.12); }
+  [data-color-scheme="light"] .tdps-halo {
+    box-shadow:0 0 14px 1px rgba(180,83,9,0.28), 0 0 34px 4px rgba(245,158,11,0.14); }
+
+  /* mock card content */
+  .tdps-content { position:relative; z-index:1; padding:16px; }
+  .tdps-head { display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+  .tdps-avatar { width:36px; height:36px; border-radius:10px; background:linear-gradient(135deg,#f59e0b,#fde68a); }
+  .tdps-name { font-weight:700; font-size:.92rem; }
+  .tdps-class { font-size:.7rem; color:var(--muted); }
+  .tdps-badge { margin-left:auto; font-size:.64rem; font-weight:800; letter-spacing:.08em; text-transform:uppercase;
+    color:#f59e0b; border:1px solid rgba(245,158,11,0.45); background:rgba(245,158,11,0.12);
+    padding:3px 8px; border-radius:999px; }
+  .tdps-stats { display:flex; gap:16px; font-variant-numeric:tabular-nums; }
+  .tdps-stat b { display:block; font-size:1.05rem; font-family:'Space Grotesk',Inter,sans-serif; }
+  .tdps-stat span { font-size:.64rem; color:var(--muted); text-transform:uppercase; letter-spacing:.06em; }
+
+  .note { font-size:.74rem; color:#94a3b8; line-height:1.5; margin-top:14px;
+    border:1px solid #1f2937; border-radius:10px; padding:10px 14px; background:#0f172a; }
+  .note b { color:#e5e7eb; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Electric Border — animated conic top-DPS ring (B5)</h1>
+  <p class="ds-sub">@property --tdps-angle + electricBorderSpin/Pulse (ReduxThemeProvider.tsx:866-881); ring + halo + host geometry (PlayerCard.tsx:588-611, 1210-1250)</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="tdps-card">
+          <div class="tdps-ring" aria-hidden="true"></div>
+          <div class="tdps-halo" aria-hidden="true"></div>
+          <div class="tdps-content">
+            <div class="tdps-head">
+              <div class="tdps-avatar"></div>
+              <div><div class="tdps-name">@arcanist-prime</div><div class="tdps-class">Arcanist — DPS</div></div>
+              <div class="tdps-badge">Top DPS</div>
+            </div>
+            <div class="tdps-stats">
+              <div class="tdps-stat"><b>131.2k</b><span>DPS</span></div>
+              <div class="tdps-stat"><b>24.1%</b><span>of group</span></div>
+              <div class="tdps-stat"><b>0</b><span>deaths</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="ds-src">ring: inset -1px, radius 14px, padding 1.5px, conic from var(--tdps-angle), mask XOR, spin 4s linear — PlayerCard.tsx:1210-1233 · halo: inset -3px, radius 16px, pulse 2.8s — :1236-1250</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="tdps-card">
+          <div class="tdps-ring" aria-hidden="true"></div>
+          <div class="tdps-halo" aria-hidden="true"></div>
+          <div class="tdps-content">
+            <div class="tdps-head">
+              <div class="tdps-avatar"></div>
+              <div><div class="tdps-name">@arcanist-prime</div><div class="tdps-class">Arcanist — DPS</div></div>
+              <div class="tdps-badge">Top DPS</div>
+            </div>
+            <div class="tdps-stats">
+              <div class="tdps-stat"><b>131.2k</b><span>DPS</span></div>
+              <div class="tdps-stat"><b>24.1%</b><span>of group</span></div>
+              <div class="tdps-stat"><b>0</b><span>deaths</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="ds-src">light halo: 0 0 14px 1px rgba(180,83,9,0.28), 0 0 34px 4px rgba(245,158,11,0.14); host border rgba(180,83,9,0.5) — PlayerCard.tsx:594-609, 1244-1247</div>
+      </div>
+    </section>
+  </div>
+  <div class="note">
+    <b>Mechanics.</b> <code>@property --tdps-angle</code> (syntax <code>&lt;angle&gt;</code>, initial 0deg, inherits false) lets the
+    conic-gradient's start angle interpolate; without it the ring is a graceful static fallback. The host card must set
+    <code>overflow: visible</code> (PlayerCard.tsx:605) plus the amber 1px border, or MUI Card's default clipping cuts off the
+    negative-inset ring and halo. The conic gradient is mode-independent; only host border/shadow and halo change per mode.
+    Both layers animate via CSS keyframes so the global <code>prefers-reduced-motion</code> rule neutralises them automatically.
+  </div>
+</div>

--- a/design-sync/preview/boundary-focus-rings.html
+++ b/design-sync/preview/boundary-focus-rings.html
@@ -1,0 +1,158 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Focus Rings — all variants (B16)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:16px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:8px; }
+  .row { display:flex; flex-wrap:wrap; gap:14px; align-items:center; }
+
+  .btn { font-family:inherit; font-size:.78rem; font-weight:600; padding:8px 16px;
+    border-radius:8px; background:var(--panel-2); color:var(--text);
+    border:1px solid var(--border); cursor:pointer; }
+
+  /* ── .u-focus-ring — ReduxThemeProvider.tsx:904-908 (ring forced via .force-ring) ── */
+  .u-focus-ring:focus-visible, .u-focus-ring.force-ring {
+    outline:2px solid var(--accent);
+    outline-offset:2px;
+    border-radius:inherit; }
+
+  /* ── .u-hover-glow — ReduxThemeProvider.tsx:898-903 (forced via .force-glow) ── */
+  .u-hover-glow { transition:box-shadow .2s ease; }
+  .u-hover-glow:hover, .u-hover-glow.force-glow {
+    box-shadow:0 0 0 3px rgba(56, 189, 248, 0.25); }
+
+  /* ── be-accent variant — BuildEditorThemeProvider.tsx:35-43 ── */
+  .be-focus:focus-visible, .be-focus.force-ring {
+    outline:2px solid var(--be-accent, #38bdf8);
+    outline-offset:2px; }
+
+  /* ── FOCUS_BORDER outline — latestReportsStyles.ts:29, :143 ── */
+  .lr-focus:focus-visible, .lr-focus.force-ring {
+    outline:2px solid rgba(96,165,250,0.55);
+    outline-offset:2px; }
+
+  /* ── Input shadow rings ── */
+  .field { font-family:inherit; font-size:.78rem; padding:9px 12px; border-radius:8px;
+    color:var(--text); width:100%; max-width:280px; display:block; }
+  /* MUI filled input focus — ReduxThemeProvider.tsx:339-344: 0 0 0 2px `${tokens.accent}40` */
+  [data-color-scheme="dark"] .field.mui-input { background:var(--bg); border:1px solid rgba(56, 189, 248, 0.3); }
+  [data-color-scheme="light"] .field.mui-input { background:rgba(255, 255, 255, 1); border:1px solid rgba(144, 202, 249, 0.5); }
+  [data-color-scheme="dark"] .field.mui-input:focus, [data-color-scheme="dark"] .field.mui-input.force-ring {
+    box-shadow:0 0 0 2px #38bdf840; outline:none; }
+  [data-color-scheme="light"] .field.mui-input:focus, [data-color-scheme="light"] .field.mui-input.force-ring {
+    box-shadow:0 0 0 2px #0f172a40; outline:none; }
+  /* Latest-reports glass field focus — latestReportsStyles.ts:29-30, 66-69 */
+  [data-color-scheme="dark"] .field.lr-input { background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.10); }
+  [data-color-scheme="light"] .field.lr-input { background:rgba(255,255,255,0.7); border:1px solid rgba(0,0,0,0.08); }
+  .field.lr-input:focus, .field.lr-input.force-ring {
+    border-color:rgba(96,165,250,0.55); border-width:1px;
+    box-shadow:0 0 0 3px rgba(96,165,250,0.12); outline:none; }
+
+  /* ── MetricPill double ring — MetricPill.tsx:119-121 ── */
+  .metric-pill-demo { display:inline-flex; flex-direction:column; align-items:center; justify-content:center;
+    min-width:70px; padding:4px 12px; border-radius:4px; cursor:pointer;
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.22) 0%, rgba(56, 189, 248, 0.08) 100%);
+    border:1px solid rgba(56, 189, 248, 0.4); outline:none; }
+  .metric-pill-demo .lbl { font-size:.6rem; color:var(--muted); text-transform:uppercase; letter-spacing:0.05em; }
+  .metric-pill-demo .val { font-size:.82rem; font-weight:700; font-variant-numeric:tabular-nums; }
+  .metric-pill-demo:focus-visible, .metric-pill-demo.force-ring {
+    box-shadow:0 0 0 2px var(--panel), 0 0 0 4px var(--accent); }
+
+  .defect-note { font-size:.74rem; color:#94a3b8; line-height:1.5; margin-top:14px;
+    border:1px solid #1f2937; border-left:3px solid #ef4444; border-radius:10px;
+    padding:10px 14px; background:#0f172a; }
+  .defect-note b { color:#e5e7eb; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Focus Rings — all variants (B16)</h1>
+  <p class="ds-sub">Rings forced visible via classes. Sources: ReduxThemeProvider.tsx:898-908, :339-344 · BuildEditorThemeProvider.tsx:35-43 · latestReportsStyles.ts:29-30, :66-69, :143 · MetricPill.tsx:119-121</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Outline rings (2px, offset 2)</div>
+          <div class="row">
+            <button class="btn u-focus-ring force-ring">.u-focus-ring</button>
+            <button class="btn be-focus force-ring">be-accent ring</button>
+            <button class="btn lr-focus force-ring">FOCUS_BORDER ring</button>
+            <button class="btn u-hover-glow force-glow">.u-hover-glow</button>
+          </div>
+          <div class="ds-src">outline 2px var(--accent) offset 2 — ReduxThemeProvider.tsx:904-908 · var(--be-accent, #38bdf8) — BuildEditorThemeProvider.tsx:35-43 · rgba(96,165,250,0.55) — latestReportsStyles.ts:143 · hover glow 0 0 0 3px rgba(56,189,248,0.25) — :898-903</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Input shadow rings (focus forced)</div>
+          <input class="field mui-input force-ring" value="MUI filled input — 0 0 0 2px accent40" readonly style="margin-bottom:8px">
+          <input class="field lr-input force-ring" value="Glass field — 0 0 0 3px rgba(96,165,250,0.12)" readonly>
+          <div class="ds-src">boxShadow 0 0 0 2px `${tokens.accent}40` — ReduxThemeProvider.tsx:341-343 · FOCUS_BORDER + FOCUS_GLOW — latestReportsStyles.ts:29-30, 66-69</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">MetricPill double ring — paper gap + primary ring</div>
+          <span class="metric-pill-demo force-ring" tabindex="0"><span class="lbl">DPS</span><span class="val">131.2k</span></span>
+          <div class="ds-src">0 0 0 2px background.paper, 0 0 0 4px primary.main — MetricPill.tsx:119-121</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">Outline rings (2px, offset 2)</div>
+          <div class="row">
+            <button class="btn u-focus-ring force-ring">.u-focus-ring</button>
+            <button class="btn be-focus force-ring">be-accent ring</button>
+            <button class="btn lr-focus force-ring">FOCUS_BORDER ring</button>
+            <button class="btn u-hover-glow force-glow">.u-hover-glow</button>
+          </div>
+          <div class="ds-src">light var(--accent) = #0f172a (slate ring); be-accent + FOCUS_BORDER stay blue; hover glow stays cyan</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">Input shadow rings (focus forced)</div>
+          <input class="field mui-input force-ring" value="MUI filled input — 0 0 0 2px accent40" readonly style="margin-bottom:8px">
+          <input class="field lr-input force-ring" value="Glass field — 0 0 0 3px rgba(96,165,250,0.12)" readonly>
+          <div class="ds-src">ReduxThemeProvider.tsx:341-343 (same `${tokens.accent}40` expression both modes) · latestReportsStyles.ts:29-30 (mode-independent)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">MetricPill double ring — paper gap + primary ring</div>
+          <span class="metric-pill-demo force-ring" tabindex="0"><span class="lbl">DPS</span><span class="val">131.2k</span></span>
+          <div class="ds-src">MetricPill.tsx:119-121 (paper = #fff in light)</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="defect-note">
+    <b>Known defect — do not replicate:</b> <code>u-hover-lift</code> and <code>u-fade-in-up</code> are referenced as classNames in
+    8 components (e.g. PlayerCard.tsx:1198) but are <b>defined nowhere</b> — no global style registers them, so they silently do
+    nothing (the reduced-motion block at ReduxThemeProvider.tsx:915 even tries to disable the nonexistent
+    <code>u-fade-in-up</code>). Use <code>.u-focus-ring</code>, <code>.u-hover-glow</code>, <code>.u-fade-in</code>,
+    <code>.u-tab-enter</code> — the ones that exist.
+  </div>
+</div>

--- a/design-sync/preview/boundary-glows-insets.html
+++ b/design-sync/preview/boundary-glows-insets.html
@@ -1,0 +1,181 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Accent Glows (B10) &amp; Inset Highlight Scale (B11)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:16px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+
+  /* ── B10: accent outer-glow signature — glow appended AFTER the depth shadow ── */
+  /* glassCardSurface hover — glassCardSurface.ts:63-68 */
+  .glow-card { border-radius:20px; padding:12px 14px; font-size:.78rem; }
+  [data-color-scheme="dark"] .glow-card {
+    border:1px solid rgba(56, 189, 248, 0.42);
+    background:linear-gradient(160deg, rgba(20, 32, 54, 0.82) 0%, rgba(7, 12, 26, 0.8) 100%);
+    box-shadow:0 14px 48px rgba(0, 0, 0, 0.5), 0 0 28px rgba(56, 189, 248, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.08); }
+  [data-color-scheme="light"] .glow-card {
+    border:1px solid rgba(56, 189, 248, 0.34);
+    background:linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 248, 255, 0.85) 100%);
+    box-shadow:0 10px 36px rgba(15, 23, 42, 0.16), 0 0 24px rgba(56, 189, 248, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9); }
+
+  /* stat tile hover glow — summaryStyles.ts:71-77 (damage accent) */
+  .glow-tile { border-radius:8px; padding:10px 12px; font-size:.78rem; transform:translateY(-2px); }
+  [data-color-scheme="dark"] .glow-tile {
+    border:1px solid rgba(251, 191, 36, 0.48);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.14) 0%, rgba(251, 191, 36, 0.03) 100%);
+    box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 26px rgba(0, 0, 0, 0.4), 0 0 20px rgba(251, 191, 36, 0.2); }
+  [data-color-scheme="light"] .glow-tile {
+    border:1px solid rgba(251, 191, 36, 0.4);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.1) 0%, rgba(251, 191, 36, 0.02) 100%);
+    box-shadow:0 8px 20px rgba(15, 23, 42, 0.1), 0 0 16px rgba(251, 191, 36, 0.14); }
+
+  /* icon badge + pill — summaryStyles.ts:103-118, 134-147 (info accent) */
+  .badge-row { display:flex; align-items:center; gap:10px; }
+  .icon-badge { display:inline-flex; align-items:center; justify-content:center;
+    width:38px; height:38px; border-radius:8px; flex-shrink:0;
+    color:rgb(56, 189, 248); background:rgba(56, 189, 248, 0.13);
+    border:1px solid rgba(56, 189, 248, 0.3);
+    box-shadow:0 0 18px rgba(56, 189, 248, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.08); }
+  .icon-badge svg { filter:drop-shadow(0 0 5px rgba(56, 189, 248, 0.45)); }
+  .metric-pill { display:inline-block; padding:4px 12px; border-radius:999px; font-weight:700;
+    font-family:'Space Grotesk',Inter,system-ui,sans-serif; letter-spacing:0.01em; font-size:.76rem;
+    color:rgb(56, 189, 248); }
+  [data-color-scheme="dark"] .metric-pill {
+    border:1px solid rgba(56, 189, 248, 0.4);
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.22) 0%, rgba(56, 189, 248, 0.08) 100%);
+    box-shadow:0 0 14px rgba(56, 189, 248, 0.15); }
+  [data-color-scheme="light"] .metric-pill {
+    border:1px solid rgba(56, 189, 248, 0.34);
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.16) 0%, rgba(56, 189, 248, 0.05) 100%);
+    box-shadow:none; }
+
+  /* global Card hover — ReduxThemeProvider.tsx:264-270 */
+  .global-card { border-radius:12px; padding:12px 14px; font-size:.78rem; background:var(--panel);
+    transform:translateY(-3px); }
+  [data-color-scheme="dark"] .global-card {
+    border:1px solid rgba(56, 189, 248, 0.3);
+    box-shadow:0 10px 40px rgba(0, 0, 0, 0.3), 0 0 60px rgba(56, 189, 248, 0.08); }
+  [data-color-scheme="light"] .global-card {
+    border:1px solid rgba(15, 23, 42, 0.15);
+    box-shadow:0 6px 20px rgba(15, 23, 42, 0.08), 0 2px 8px rgba(15, 23, 42, 0.04); }
+
+  /* KalpaAppWindow 0-blur spread ring — LandingPage.tsx:1701-1704 */
+  .kalpa-window { border-radius:14px; padding:12px 14px; font-size:.78rem; }
+  [data-color-scheme="dark"] .kalpa-window { background:rgba(15, 15, 25, 0.95);
+    box-shadow:0 25px 80px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(139, 92, 246, 0.1), 0 0 60px rgba(139, 92, 246, 0.06); }
+  [data-color-scheme="light"] .kalpa-window { background:rgba(250, 250, 252, 0.98);
+    box-shadow:0 25px 80px rgba(15, 23, 42, 0.12), 0 0 0 1px rgba(139, 92, 246, 0.08), 0 0 60px rgba(139, 92, 246, 0.03); }
+
+  /* ── B11: inset top-highlight alpha tiers ── */
+  .tier-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+  .tier { border-radius:10px; padding:10px 12px; font-size:.7rem; background:var(--panel-2);
+    border:1px solid var(--border); }
+  .tier b { display:block; font-size:.72rem; margin-bottom:2px; }
+  .tier .val { font-family:'JetBrains Mono',Consolas,monospace; font-size:.62rem; color:var(--muted); }
+  .tier.t-panel  { box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.06); }
+  .tier.t-menu   { box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.12); }
+  .tier.t-glossy { box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.2); }
+  .tier.t-light  { box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.9); background:#ffffff; color:#1e293b; }
+  .tier.t-light .val { color:#64748b; }
+  .tier.t-input  { box-shadow:inset 0 2px 4px rgba(0,0,0,0.4); }
+  [data-color-scheme="light"] .tier.t-input { box-shadow:inset 0 2px 4px rgba(0,0,0,0.06); }
+
+  .rule-note { font-size:.74rem; color:#94a3b8; line-height:1.55; margin-top:14px;
+    border:1px solid #1f2937; border-radius:10px; padding:10px 14px; background:#0f172a; }
+  .rule-note b { color:#e5e7eb; }
+  .rule-note code { font-size:.68rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Accent Glows (B10) &amp; Inset Highlight Scale (B11)</h1>
+  <p class="ds-sub">The signature: 0 0 &lt;R&gt;px rgba(accent, 0.12–0.35) appended AFTER the depth shadow. Sources: glassCardSurface.ts:66, summaryStyles.ts:75/:115/:144, ReduxThemeProvider.tsx:267, LandingPage.tsx:1701-1704, playerCardStyleUtils.ts:41, TextEditor.tsx:281-284</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B10 — glow signature (hover states forced)</div>
+          <div class="glow-card" style="margin-bottom:8px">Glass card hover — … , <b>0 0 28px rgba(A, 0.14)</b>, inset …</div>
+          <div class="glow-tile" style="margin-bottom:8px">Stat tile hover — … , <b>0 0 20px rgba(A, 0.2)</b></div>
+          <div class="badge-row" style="margin-bottom:8px">
+            <span class="icon-badge"><svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg></span>
+            <span class="metric-pill">98.2% uptime</span>
+          </div>
+          <div class="global-card" style="margin-bottom:8px">Global MuiCard hover — 0 10px 40px rgba(0,0,0,0.3), <b>0 0 60px rgba(56,189,248,0.08)</b></div>
+          <div class="kalpa-window">Kalpa app window — <b>0 0 0 1px rgba(139,92,246,0.1)</b> zero-blur spread ring as a second border + 0 0 60px bloom</div>
+          <div class="ds-src">glassCardSurface.ts:66 · summaryStyles.ts:75 (tile), :115 (badge 0 0 18px + drop-shadow 0 0 5px), :144 (pill 0 0 14px) · ReduxThemeProvider.tsx:267 · LandingPage.tsx:1701-1704</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B11 — inset 0 1px 0 rgba(255,255,255,α) tiers</div>
+          <div class="tier-grid">
+            <div class="tier t-panel"><b>Panels α 0.05–0.06</b><span class="val">glassCardSurface.ts:48 (.06) · buildEditorTokens.ts:15 (.05) · replayDesign.ts:133 (.05)</span></div>
+            <div class="tier t-menu"><b>Menus α 0.08–0.12</b><span class="val">dropdownMenu.ts:135 (.12) · glassCardSurface hover (.08)</span></div>
+            <div class="tier t-glossy"><b>Glossy α 0.2–0.3 + bottom shade</b><span class="val">playerCardStyleUtils.ts:41 — only recipe with inset 0 -1px 0 rgba(0,0,0,0.2)</span></div>
+            <div class="tier t-light"><b>Light mode α 0.6–0.9</b><span class="val">glassCardSurface.ts:49 (.9) · buildEditorTokens.ts:16 (.80)</span></div>
+            <div class="tier t-input" style="grid-column:1 / -1"><b>Recessed input — inversion</b><span class="val">inset 0 2px 4px rgba(0,0,0,0.4) — TextEditor.tsx:283 ("sunken input")</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B10 — glow signature (hover states forced)</div>
+          <div class="glow-card" style="margin-bottom:8px">Glass card hover — … , <b>0 0 24px rgba(A, 0.12)</b>, inset …</div>
+          <div class="glow-tile" style="margin-bottom:8px">Stat tile hover — … , <b>0 0 16px rgba(A, 0.14)</b></div>
+          <div class="badge-row" style="margin-bottom:8px">
+            <span class="icon-badge"><svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg></span>
+            <span class="metric-pill">98.2% uptime</span>
+          </div>
+          <div class="global-card" style="margin-bottom:8px">Global MuiCard hover — light drops the accent glow entirely (depth only)</div>
+          <div class="kalpa-window">Kalpa app window — <b>0 0 0 1px rgba(139,92,246,0.08)</b> spread ring + 0 0 60px rgba(139,92,246,0.03)</div>
+          <div class="ds-src">light: glassCardSurface.ts:67 · summaryStyles.ts:76 · pill glow 'none' :144 · ReduxThemeProvider.tsx:268 · LandingPage.tsx:1704</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B11 — tiers (light keeps its own 0.6–0.9 highlight; recessed inverts at 0.06)</div>
+          <div class="tier-grid">
+            <div class="tier t-light"><b>Light glass α 0.9</b><span class="val">inset 0 1px 0 rgba(255,255,255,0.9) — glassCardSurface.ts:49</span></div>
+            <div class="tier t-light" style="box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.80)"><b>Light BE panel α 0.80</b><span class="val">buildEditorTokens.ts:16</span></div>
+            <div class="tier t-glossy" style="background:#ffffff; color:#1e293b; box-shadow:inset 0 1px 0 rgba(255,255,255,0.2), inset 0 -1px 0 rgba(0,0,0,0.1)"><b>Glossy light: bottom shade 0.1</b><span class="val" style="color:#64748b">playerCardStyleUtils.ts:42</span></div>
+            <div class="tier t-input"><b>Recessed input α 0.06</b><span class="val">inset 0 2px 4px rgba(0,0,0,0.06) — TextEditor.tsx:284</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="rule-note">
+    <b>Rule (B10):</b> accent glow is always <code>0 0 &lt;R&gt;px rgba(accent, 0.12–0.35)</code> appended <b>after</b> the black depth
+    shadow, never alone — R grows with surface size (14px pills → 18–28px cards → 60px page-level hover). Light mode either
+    shrinks alpha or drops the glow.<br>
+    <b>Rule (B11):</b> the top inner highlight <code>inset 0 1px 0 rgba(255,255,255,α)</code> follows a strict alpha scale —
+    <b>0.05–0.06</b> panels/cards · <b>0.08–0.12</b> menus/hover · <b>0.2–0.3</b> glossy chips (the only tier that also adds
+    bottom shading <code>inset 0 -1px 0 rgba(0,0,0,0.1–0.2)</code>) · <b>0.6–0.9</b> light mode. Recessed inputs invert the
+    scheme entirely: <code>inset 0 2px 4px rgba(0,0,0,0.4)</code> dark / <code>0.06</code> light.
+  </div>
+</div>

--- a/design-sync/preview/boundary-gradient-borders.html
+++ b/design-sync/preview/boundary-gradient-borders.html
@@ -1,0 +1,183 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Gradient Borders — mask-XOR idiom &amp; borderImage rainbow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:18px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+
+  /* keyframes for the legendary chip glow — playerCardStyleUtils.ts:17-28 */
+  @keyframes legendaryGlow {
+    0%, 100% { box-shadow: 0 8px 32px 0 rgba(255, 0, 150, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.3); }
+    50%      { box-shadow: 0 8px 32px 0 rgba(0, 150, 255, 0.3),  inset 0 1px 0 rgba(255, 255, 255, 0.3); }
+  }
+
+  /* ── B4: mask-XOR gradient ring, selected tile — IconPickerGrid.tsx:147-153, 212-228 ── */
+  .tile-row { display:flex; gap:12px; }
+  .tile { position:relative; width:104px; }
+  .tile-btn { width:104px; height:84px; border-radius:14px; display:flex; flex-direction:column;
+    align-items:center; justify-content:center; gap:6px; }
+  [data-color-scheme="dark"] .tile-btn { background:rgba(255,255,255,0.03); border:1px solid rgba(255,255,255,0.08); }
+  [data-color-scheme="light"] .tile-btn { background:rgba(15,23,42,0.03); border:1px solid rgba(15,23,42,0.10); }
+  [data-color-scheme="dark"] .tile.selected .tile-btn { background:rgba(var(--be-accent-rgb, 56, 189, 248), 0.14); border-color:transparent;
+    box-shadow:0 0 16px rgba(var(--be-accent-rgb, 56, 189, 248), 0.3), 0 4px 12px rgba(var(--be-accent-rgb, 56, 189, 248), 0.15); }
+  [data-color-scheme="light"] .tile.selected .tile-btn { background:rgba(var(--be-accent-rgb, 56, 189, 248), 0.08); border-color:transparent;
+    box-shadow:0 0 16px rgba(var(--be-accent-rgb, 56, 189, 248), 0.3), 0 4px 12px rgba(var(--be-accent-rgb, 56, 189, 248), 0.15); }
+  .tile-glyph { width:28px; height:28px; border-radius:8px; background:linear-gradient(135deg, #38bdf8, #818cf8); }
+  .tile-label { font-size:11px; line-height:1.2; font-weight:500; color:var(--muted);
+    font-family:'Space Grotesk',Inter,system-ui; text-align:center; transition:color 0.15s; }
+  .tile.selected .tile-label { font-weight:700; color:var(--be-accent, #38bdf8); }
+  /* The mask-XOR ring overlay itself — transcribed exactly */
+  .tile-ring { position:absolute; inset:0; border-radius:14px; padding:1.5px;
+    background:linear-gradient(135deg, rgba(var(--be-accent-rgb, 56, 189, 248), 0.7) 0%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.15) 50%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.4) 100%);
+    -webkit-mask:linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite:xor;
+    mask:linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite:exclude;
+    pointer-events:none; }
+
+  /* ── B4 static variant — src/components/BuildEditorSkeleton.tsx:67-83 (primary card ring, 1px) ── */
+  .skel-card { position:relative; border-radius:12px; padding:14px 16px; overflow:hidden; }
+  [data-color-scheme="dark"] .skel-card { background:rgba(15, 23, 42, 0.84);
+    box-shadow:0 8px 32px rgba(0, 0, 0, 0.32), 0 1px 0 rgba(255, 255, 255, 0.05) inset; }
+  [data-color-scheme="light"] .skel-card { background:rgba(255, 255, 255, 0.84);
+    box-shadow:0 4px 24px rgba(15, 23, 42, 0.10), 0 1px 0 rgba(255, 255, 255, 0.80) inset; }
+  .skel-card::before { content:""; position:absolute; inset:0; border-radius:inherit; padding:1px;
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.25) 0%, rgba(56, 189, 248, 0.05) 50%, rgba(56, 189, 248, 0.12) 100%);
+    -webkit-mask:linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite:xor;
+    mask:linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite:exclude;
+    pointer-events:none; }
+  .skel-line { height:10px; border-radius:5px; margin:6px 0; }
+  [data-color-scheme="dark"] .skel-line { background:rgba(255,255,255,0.06); }
+  [data-color-scheme="light"] .skel-line { background:rgba(15,23,42,0.06); }
+
+  /* ── B6: borderImage rainbow legendary chip — playerCardStyleUtils.ts:156-164 ── */
+  .legendary-chip { display:inline-block; padding:6px 16px; border-radius:28px; font-size:.78rem; font-weight:500;
+    background:linear-gradient(135deg, rgba(255,0,150,0.2) 0%, rgba(255,150,0,0.2) 20%, rgba(255,255,0,0.2) 40%, rgba(0,255,0,0.2) 60%, rgba(0,150,255,0.2) 80%, rgba(150,0,255,0.2) 100%);
+    border-image:linear-gradient(135deg, #ff0096, #ff9600, #ffff00, #00ff00, #0096ff, #9600ff) 1;
+    border:1px solid transparent;
+    color:#ffffff;
+    animation:legendaryGlow 3s ease-in-out infinite; }
+
+  .code-box { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; line-height:1.55;
+    color:#a5d8ff; background:#0a1020; border:1px solid #1f2937; border-radius:10px;
+    padding:12px 14px; overflow-x:auto; white-space:pre; margin-top:6px; }
+  .caveat { font-size:.74rem; color:#94a3b8; line-height:1.5; margin-top:14px;
+    border:1px solid #1f2937; border-left:3px solid #ff9800; border-radius:10px;
+    padding:10px 14px; background:#0f172a; }
+  .caveat b { color:#e5e7eb; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Gradient Borders — mask-XOR idiom (B4) &amp; borderImage rainbow (B6)</h1>
+  <p class="ds-sub">The repo's standard gradient ring: double background + mask XOR. Sources: IconPickerGrid.tsx:147-153, 212-228 · BuildEditorSkeleton.tsx:67-83 · playerCardStyleUtils.ts:17-28, 156-164 · GlassPanel.tsx:6-9</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B4 — selected tile: 1.5px gradient ring + paired glow</div>
+          <div class="tile-row">
+            <div class="tile selected">
+              <div class="tile-btn"><div class="tile-glyph"></div><div class="tile-label">Mundus</div></div>
+              <div class="tile-ring"></div>
+            </div>
+            <div class="tile">
+              <div class="tile-btn"><div class="tile-glyph" style="opacity:.5"></div><div class="tile-label">Race</div></div>
+            </div>
+          </div>
+          <div class="ds-src">IconPickerGrid.tsx:212-228 (ring) + :147-153 (gradient stops, glowShadow)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B4 — static 1px variant (skeleton primary card)</div>
+          <div class="skel-card"><div class="skel-line" style="width:40%"></div><div class="skel-line" style="width:85%"></div><div class="skel-line" style="width:70%"></div></div>
+          <div class="ds-src">src/components/BuildEditorSkeleton.tsx:67-83</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B6 — borderImage rainbow + legendaryGlow cross-fade</div>
+          <div class="legendary-chip">Perfected Ansuul's Torment ×5</div>
+          <div class="ds-src">playerCardStyleUtils.ts:156-164 + legendaryGlow keyframes :17-28</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">B4 — selected tile: 1.5px gradient ring + paired glow</div>
+          <div class="tile-row">
+            <div class="tile selected">
+              <div class="tile-btn"><div class="tile-glyph"></div><div class="tile-label">Mundus</div></div>
+              <div class="tile-ring"></div>
+            </div>
+            <div class="tile">
+              <div class="tile-btn"><div class="tile-glyph" style="opacity:.5"></div><div class="tile-label">Race</div></div>
+            </div>
+          </div>
+          <div class="ds-src">IconPickerGrid.tsx:212-228 — selected fill drops to alpha 0.08 in light (:145)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B4 — static 1px variant (skeleton primary card)</div>
+          <div class="skel-card"><div class="skel-line" style="width:40%"></div><div class="skel-line" style="width:85%"></div><div class="skel-line" style="width:70%"></div></div>
+          <div class="ds-src">BuildEditorSkeleton.tsx:67-83 (ring gradient is mode-independent)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">B6 — borderImage rainbow + legendaryGlow cross-fade</div>
+          <div class="legendary-chip">Perfected Ansuul's Torment ×5</div>
+          <div class="ds-src">playerCardStyleUtils.ts:156-164 — dark-variant recipe; unchanged by mode</div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <div class="demo-label" style="color:#e5e7eb; margin-top:16px;">The exact mask-XOR snippet (transcribe as-is)</div>
+  <div class="code-box">/* IconPickerGrid.tsx:212-228 — overlay Box on the selected tile */
+position: 'absolute',
+inset: 0,
+borderRadius: '14px',
+padding: '1.5px',
+background: 'linear-gradient(135deg, rgba(var(--be-accent-rgb, 56, 189, 248), 0.7) 0%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.15) 50%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.4) 100%)',
+WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+WebkitMaskComposite: 'xor',
+mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+maskComposite: 'exclude',
+pointerEvents: 'none',
+
+/* paired glow on the tile itself — IconPickerGrid.tsx:151-153 */
+boxShadow: '0 0 16px rgba(var(--be-accent-rgb, 56, 189, 248), 0.3), 0 4px 12px rgba(var(--be-accent-rgb, 56, 189, 248), 0.15)'</div>
+
+  <div class="caveat">
+    <b>borderImage caveat — documented in GlassPanel.tsx:6-9:</b> "Previously used a gradient borderImage; removed because
+    the accent color bleed read as a debug outline." The implementation note (GlassPanel.tsx:45-48): the gradient
+    <code>borderImage</code> shorthand left <code>border-color</code> falling back to <code>currentColor</code> in some composite
+    paths, producing a visible "debug" outline around every primary panel. Prefer the mask-XOR ring (B4) for gradient borders;
+    <code>borderImage</code> survives only in the legendary rainbow chip (and ignores border-radius by nature).
+  </div>
+</div>

--- a/design-sync/preview/boundary-tables-seams.html
+++ b/design-sync/preview/boundary-tables-seams.html
@@ -1,0 +1,152 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Table Seams — accentTableSx (B12)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+
+  /* ── B12: accentTableSx — summaryStyles.ts:17-46 (info accent 56,189,248) ── */
+  /* color set explicitly: quirks-mode viewers don't inherit color into <table> */
+  .accent-table { width:100%; border-collapse:collapse; font-size:.78rem; color:var(--text); }
+  .accent-table th, .accent-table td {
+    padding:8px 12px; text-align:left; font-variant-numeric:tabular-nums;
+    border-bottom:1px solid; }
+  [data-color-scheme="dark"] .accent-table th, [data-color-scheme="dark"] .accent-table td {
+    border-bottom-color:rgba(148, 163, 184, 0.12); }
+  [data-color-scheme="light"] .accent-table th, [data-color-scheme="light"] .accent-table td {
+    border-bottom-color:rgba(15, 23, 42, 0.08); }
+  /* thead: 2px accent seam + diagonal wash */
+  .accent-table thead th {
+    text-transform:uppercase; letter-spacing:0.5px; font-size:11px; font-weight:700;
+    color:var(--muted); }
+  [data-color-scheme="dark"] .accent-table thead th {
+    border-bottom:2px solid rgba(56, 189, 248, 0.4);
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(56, 189, 248, 0.03) 100%); }
+  [data-color-scheme="light"] .accent-table thead th {
+    border-bottom:2px solid rgba(56, 189, 248, 0.32);
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.09) 0%, rgba(56, 189, 248, 0.02) 100%); }
+  /* zebra 0.035 / 0.015 */
+  .accent-table tbody tr { transition:background-color 0.15s ease; }
+  [data-color-scheme="dark"] .accent-table tbody tr:nth-of-type(odd) td {
+    background-color:rgba(148, 163, 184, 0.035); }
+  [data-color-scheme="light"] .accent-table tbody tr:nth-of-type(odd) td {
+    background-color:rgba(15, 23, 42, 0.015); }
+  /* hover tint + first-cell inset rail (also forced via .is-hover for the static demo) */
+  [data-color-scheme="dark"] .accent-table tbody tr:hover td,
+  [data-color-scheme="dark"] .accent-table tbody tr.is-hover td {
+    background-color:rgba(56, 189, 248, 0.1); }
+  [data-color-scheme="light"] .accent-table tbody tr:hover td,
+  [data-color-scheme="light"] .accent-table tbody tr.is-hover td {
+    background-color:rgba(56, 189, 248, 0.07); }
+  [data-color-scheme="dark"] .accent-table tbody tr:hover td:first-of-type,
+  [data-color-scheme="dark"] .accent-table tbody tr.is-hover td:first-of-type {
+    box-shadow:inset 3px 0 0 rgba(56, 189, 248, 0.95); }
+  [data-color-scheme="light"] .accent-table tbody tr:hover td:first-of-type,
+  [data-color-scheme="light"] .accent-table tbody tr.is-hover td:first-of-type {
+    box-shadow:inset 3px 0 0 rgba(56, 189, 248, 0.85); }
+  /* last-row border removal */
+  .accent-table tbody tr:last-of-type td { border-bottom:none; }
+
+  /* ── B12: fightAccordionSx — summaryStyles.ts:205-217 ── */
+  .fight-accordion { margin-bottom:8px; border-radius:8px; overflow:hidden;
+    box-shadow:none; }
+  [data-color-scheme="dark"] .fight-accordion {
+    background-color:rgba(255, 255, 255, 0.025);
+    border:1px solid rgba(255, 255, 255, 0.07); }
+  [data-color-scheme="light"] .fight-accordion {
+    background-color:rgba(15, 23, 42, 0.02);
+    border:1px solid rgba(15, 23, 42, 0.07); }
+  /* MUI Accordion's default top divider (::before) is killed: '&::before': { display: 'none' } */
+  .fight-accordion::before { display:none; }
+  .fight-accordion .acc-head { display:flex; justify-content:space-between; align-items:center;
+    padding:10px 14px; font-size:.8rem; font-weight:600; cursor:pointer; }
+  .fight-accordion .acc-head .chev { color:var(--muted); font-size:.7rem; }
+  .fight-accordion .acc-body { padding:0 14px 12px; font-size:.74rem; color:var(--muted); }
+
+  .note { font-size:.74rem; color:#94a3b8; line-height:1.5; margin-top:14px;
+    border:1px solid #1f2937; border-radius:10px; padding:10px 14px; background:#0f172a; }
+  .note b { color:#e5e7eb; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Table Seams — accentTableSx (B12)</h1>
+  <p class="ds-sub">2px accent header seam + diagonal wash, zebra 0.035, hover tint with first-cell inset rail, last-row border removal. Source: src/features/report_summary/summaryStyles.ts:17-46 (accentTableSx), :205-217 (fightAccordionSx)</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-label">accentTableSx(dark, '56, 189, 248') — 3rd row hover forced</div>
+        <table class="accent-table">
+          <thead><tr><th>Player</th><th>DPS</th><th>Uptime</th><th>Deaths</th></tr></thead>
+          <tbody>
+            <tr><td>@arcanist-prime</td><td>131,240</td><td>98.2%</td><td>0</td></tr>
+            <tr><td>@stamplar-one</td><td>124,905</td><td>96.7%</td><td>1</td></tr>
+            <tr class="is-hover"><td>@nightblade-two</td><td>119,344</td><td>95.1%</td><td>0</td></tr>
+            <tr><td>@sorc-supreme</td><td>112,872</td><td>93.8%</td><td>2</td></tr>
+          </tbody>
+        </table>
+        <div class="ds-src">accentTableSx — summaryStyles.ts:17-46 (hover rail :41-43 inset 3px 0 0 rgba(A,0.95))</div>
+        <div class="demo-label" style="margin-top:14px">fightAccordionSx — ::before kill + overflow hidden</div>
+        <div class="fight-accordion">
+          <div class="acc-head"><span>Fight 3 — Hall of Fleshcraft (kill)</span><span class="chev">▾</span></div>
+          <div class="acc-body">Subtle-glass frame: bg rgba(255,255,255,0.025), border rgba(255,255,255,0.07). MUI's default ::before divider is display:none'd; overflow:hidden clips inner tables to the radius.</div>
+        </div>
+        <div class="ds-src">fightAccordionSx — summaryStyles.ts:205-217</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-label">accentTableSx(light, '56, 189, 248') — 3rd row hover forced</div>
+        <table class="accent-table">
+          <thead><tr><th>Player</th><th>DPS</th><th>Uptime</th><th>Deaths</th></tr></thead>
+          <tbody>
+            <tr><td>@arcanist-prime</td><td>131,240</td><td>98.2%</td><td>0</td></tr>
+            <tr><td>@stamplar-one</td><td>124,905</td><td>96.7%</td><td>1</td></tr>
+            <tr class="is-hover"><td>@nightblade-two</td><td>119,344</td><td>95.1%</td><td>0</td></tr>
+            <tr><td>@sorc-supreme</td><td>112,872</td><td>93.8%</td><td>2</td></tr>
+          </tbody>
+        </table>
+        <div class="ds-src">seam rgba(A,0.32), wash 0.09→0.02, zebra 0.015, hover 0.07, rail 0.85 — summaryStyles.ts:17-46</div>
+        <div class="demo-label" style="margin-top:14px">fightAccordionSx — ::before kill + overflow hidden</div>
+        <div class="fight-accordion">
+          <div class="acc-head"><span>Fight 3 — Hall of Fleshcraft (kill)</span><span class="chev">▾</span></div>
+          <div class="acc-body">Light frame: bg rgba(15,23,42,0.02), border rgba(15,23,42,0.07).</div>
+        </div>
+        <div class="ds-src">fightAccordionSx — summaryStyles.ts:205-217</div>
+      </div>
+    </section>
+  </div>
+  <div class="note">
+    <b>Seam anatomy.</b> Cell borders stay near-invisible (rgba(148,163,184,0.12) dark / rgba(15,23,42,0.08) light) with
+    <code>tabular-nums</code> everywhere; the <b>only</b> strong horizontal line is the 2px accent seam under the header, backed
+    by a 135° accent wash (0.12→0.03 dark). Zebra rows sit at alpha 0.035 (dark) — deliberately faint. Row hover adds an accent
+    tint plus an <code>inset 3px 0 0</code> rail on the first cell only, and the final row drops its border so the table ends at
+    the card edge, not at a line. The same accents come from SUMMARY_ACCENTS (info/damage/death).
+  </div>
+</div>

--- a/design-sync/preview/boundary-top-strips.html
+++ b/design-sync/preview/boundary-top-strips.html
@@ -1,0 +1,217 @@
+<!-- @dsCard group="Boundaries" -->
+<meta charset="utf-8">
+<title>Top Strips — four sub-patterns</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+
+  .ds-z { position:relative; z-index:1; }
+  .demo-block { margin-bottom:16px; }
+  .demo-label { font-size:.7rem; font-weight:600; color:var(--text); margin-bottom:6px; }
+  .body-txt { font-size:.76rem; color:var(--muted); }
+  .panel-title { font-size:.85rem; font-weight:600; margin-bottom:2px; }
+
+  /* ── (a) Full-bleed fading bar, 3px — src/theme/glassCardSurface.ts:29-70 (info accent 56,189,248) ── */
+  .glass-card { position:relative; overflow:hidden; border-radius:20px; padding:14px 16px;
+    backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px);
+    transition:box-shadow 0.28s ease, border-color 0.28s ease; }
+  [data-color-scheme="dark"] .glass-card {
+    border:1px solid rgba(56, 189, 248, 0.20);
+    background:linear-gradient(180deg, rgba(56, 189, 248, 0.1) 0%, rgba(56, 189, 248, 0) 150px),
+               linear-gradient(160deg, rgba(20, 32, 54, 0.82) 0%, rgba(7, 12, 26, 0.8) 100%);
+    box-shadow:0 10px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06); }
+  [data-color-scheme="light"] .glass-card {
+    border:1px solid rgba(56, 189, 248, 0.18);
+    background:linear-gradient(180deg, rgba(56, 189, 248, 0.08) 0%, rgba(56, 189, 248, 0) 150px),
+               linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 248, 255, 0.85) 100%);
+    box-shadow:0 6px 28px rgba(15, 23, 42, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9); }
+  .glass-card::before { content:""; position:absolute; top:0; left:0; right:0; height:3px;
+    pointer-events:none; z-index:1; }
+  [data-color-scheme="dark"] .glass-card::before {
+    background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.95) 50%, transparent 100%); }
+  [data-color-scheme="light"] .glass-card::before {
+    background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.85) 50%, transparent 100%); }
+
+  /* 2px variant on a stat tile — summaryStyles.ts:49-79 (statTileSx, damage accent 251,191,36) */
+  .stat-tile { position:relative; overflow:hidden; border-radius:8px; padding:12px 14px;
+    transition:transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+  [data-color-scheme="dark"] .stat-tile {
+    border:1px solid rgba(251, 191, 36, 0.24);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.14) 0%, rgba(251, 191, 36, 0.03) 100%);
+    box-shadow:inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 6px 16px rgba(0, 0, 0, 0.3); }
+  [data-color-scheme="light"] .stat-tile {
+    border:1px solid rgba(251, 191, 36, 0.2);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.1) 0%, rgba(251, 191, 36, 0.02) 100%);
+    box-shadow:0 2px 8px rgba(15, 23, 42, 0.05); }
+  .stat-tile::before { content:""; position:absolute; top:0; left:0; right:0; height:2px; }
+  [data-color-scheme="dark"] .stat-tile::before {
+    background:linear-gradient(90deg, transparent, rgba(251, 191, 36, 0.9), transparent); }
+  [data-color-scheme="light"] .stat-tile::before {
+    background:linear-gradient(90deg, transparent, rgba(251, 191, 36, 0.8), transparent); }
+
+  /* ── (b) Inset slit — build-editor GlassPanel primary, primitives/GlassPanel.tsx:95-108 ── */
+  .be-panel { position:relative; border-radius:12px; padding:14px 16px;
+    transition:box-shadow 0.3s ease, border-color 0.25s ease; }
+  [data-color-scheme="dark"] .be-panel {
+    background:rgba(15, 23, 42, 0.84); border:1px solid rgba(255, 255, 255, 0.09);
+    box-shadow:0 8px 40px rgba(0, 0, 0, 0.42), 0 1px 0 rgba(255, 255, 255, 0.06) inset; }
+  [data-color-scheme="light"] .be-panel {
+    background:rgba(255, 255, 255, 0.84); border:1px solid rgba(15, 23, 42, 0.13);
+    box-shadow:0 4px 28px rgba(15, 23, 42, 0.14), 0 1px 0 rgba(255, 255, 255, 0.90) inset; }
+  .be-panel::after { content:""; position:absolute; top:1px; left:12%; right:12%; height:1px;
+    background:linear-gradient(90deg, transparent 0%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.70) 50%, transparent 100%);
+    pointer-events:none; z-index:2; }
+
+  /* Replay deck slit at 6% — src/features/fight_replay/constants/replayDesign.ts:142-152 */
+  .replay-deck { position:relative; border-radius:12px; padding:14px 16px; overflow:hidden; }
+  [data-color-scheme="dark"] .replay-deck { background:var(--panel);
+    box-shadow:0 14px 40px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05); }
+  [data-color-scheme="light"] .replay-deck { background:var(--panel); border:1px solid var(--border);
+    box-shadow:0 10px 28px rgba(15,23,42,0.12), inset 0 1px 0 rgba(255,255,255,0.7); }
+  .replay-deck::before { content:""; position:absolute; top:0; left:6%; right:6%; height:1px;
+    background:linear-gradient(90deg, transparent, var(--accent-2), transparent);
+    pointer-events:none; }
+  [data-color-scheme="dark"] .replay-deck::before { opacity:0.7; }
+  [data-color-scheme="light"] .replay-deck::before { opacity:0.4; }
+
+  /* ── (c) Solid semantic strip — parse_analysis/components/BuildIssuesPanel.tsx:38-41 ── */
+  .issue-row { display:flex; align-items:flex-start; gap:12px; padding:10px 12px; border-radius:6px;
+    border-top:2px solid var(--warn); font-size:.76rem; font-weight:500;
+    transition:all 0.15s ease-out; }
+  [data-color-scheme="dark"] .issue-row { background-color:rgba(255, 152, 0, 0.08); }
+  [data-color-scheme="light"] .issue-row { background-color:rgba(255, 152, 0, 0.06); }
+
+  /* ParseAnalysisPage.tsx:1170-1181 — success / error over matching tint */
+  .food-card { border-radius:8px; padding:10px 14px; font-size:.78rem; font-weight:600; }
+  .food-card.ok { border:1px solid #81c784; border-top:3px solid #66bb6a; }
+  [data-color-scheme="dark"] .food-card.ok { background-color:rgba(46, 125, 50, 0.10); }
+  [data-color-scheme="light"] .food-card.ok { border-color:#4caf50; border-top-color:#2e7d32; background-color:rgba(46, 125, 50, 0.05); }
+  .food-card.err { border:1px solid #e57373; border-top:3px solid #f44336; }
+  [data-color-scheme="dark"] .food-card.err { background-color:rgba(211, 47, 47, 0.10); }
+  [data-color-scheme="light"] .food-card.err { border-color:#ef5350; border-top-color:#d32f2f; background-color:rgba(211, 47, 47, 0.05); }
+
+  /* ── (d) Class-gradient shell strip + 180px ambient bloom — BuildEditorShell.tsx:30-70 (class=dragonknight) ── */
+  .be-shell { position:relative; border-radius:12px; overflow:clip; min-height:150px; padding:16px; }
+  [data-color-scheme="dark"] .be-shell {
+    border:1px solid rgba(255, 255, 255, 0.08); background-color:rgb(8, 14, 26);
+    background-image:
+      radial-gradient(ellipse at 50% 0%, rgba(224, 92, 0, 0.12) 0%, transparent 45%),
+      radial-gradient(ellipse at 88% 12%, rgba(224, 92, 0, 0.06) 0%, transparent 35%),
+      radial-gradient(ellipse at 12% 18%, rgba(224, 92, 0, 0.04) 0%, transparent 30%); }
+  [data-color-scheme="light"] .be-shell {
+    border:1px solid rgba(15, 23, 42, 0.10); background-color:rgb(245, 248, 252);
+    background-image:
+      radial-gradient(ellipse at 50% 0%, rgba(224, 92, 0, 0.08) 0%, transparent 45%),
+      radial-gradient(ellipse at 85% 10%, rgba(224, 92, 0, 0.04) 0%, transparent 35%); }
+  .be-shell::before { content:""; position:absolute; top:0; left:0; right:0; height:3px;
+    background:linear-gradient(135deg, #e05c00 0%, #ff8a3d 100%); opacity:0.9;
+    pointer-events:none; z-index:2; }
+  .be-shell::after { content:""; position:absolute; top:0; left:0; right:0; height:180px;
+    background:linear-gradient(to bottom, rgba(224, 92, 0, 0.08) 0%, rgba(224, 92, 0, 0.02) 60%, transparent 100%);
+    pointer-events:none; z-index:0; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Top Strips — four sub-patterns (B3)</h1>
+  <p class="ds-sub">(a) full-bleed fading bar · (b) inset slit · (c) solid semantic strip · (d) class-gradient shell strip + 180px bloom. Sources: glassCardSurface.ts:52-62, summaryStyles.ts:62-70, GlassPanel.tsx:95-108, replayDesign.ts:142-152, BuildIssuesPanel.tsx:38-41, ParseAnalysisPage.tsx:1177-1181, BuildEditorShell.tsx:46-70</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">(a) Full-bleed fading bar — 3px card / 2px tile</div>
+          <div class="glass-card" style="margin-bottom:8px"><div class="panel-title">Report Overview</div><div class="body-txt">3px accent bar fades to transparent at both ends.</div></div>
+          <div class="stat-tile"><div class="panel-title">128.4k DPS</div><div class="body-txt">2px sheen bar on a raised metric tile.</div></div>
+          <div class="ds-src">src/theme/glassCardSurface.ts:52-62 (3px) · summaryStyles.ts:62-70 (2px)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(b) Inset slit — top:1px, inset 12% / top:0, inset 6%</div>
+          <div class="be-panel" style="margin-bottom:8px"><div class="panel-title">Equipment</div><div class="body-txt">1px slit at top:1px, left/right 12%, rgba(--be-accent-rgb, 0.70).</div></div>
+          <div class="replay-deck"><div class="panel-title">Replay transport</div><div class="body-txt">1px seam at 6% insets, opacity 0.7 dark / 0.4 light.</div></div>
+          <div class="ds-src">GlassPanel.tsx:95-108 (12%) · replayDesign.ts:142-152 (6%, theme secondary)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(c) Solid semantic strip</div>
+          <div class="issue-row" style="margin-bottom:8px">⚠ Missing a 5-piece body set bonus on the back bar.</div>
+          <div class="food-card ok" style="margin-bottom:8px">Food buff active — Bewitched Sugar Skulls</div>
+          <div class="food-card err">No food buff detected for this parse</div>
+          <div class="ds-src">borderTop 2px warning over rgba(255,152,0,0.08) — BuildIssuesPanel.tsx:38-41 · borderTop 3px success/error — ParseAnalysisPage.tsx:1177-1181</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(d) Class-gradient shell strip + 180px ambient bloom</div>
+          <div class="be-shell"><div class="panel-title">Build Editor — Dragonknight</div><div class="body-txt">3px class gradient at opacity 0.9, then a 180px bloom fading 0.08 → 0.02 → 0.</div></div>
+          <div class="ds-src">BuildEditorShell.tsx:46-70 (classTheme.gradient = linear-gradient(135deg, #e05c00, #ff8a3d))</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="ds-z">
+        <div class="demo-block">
+          <div class="demo-label">(a) Full-bleed fading bar — 3px card / 2px tile</div>
+          <div class="glass-card" style="margin-bottom:8px"><div class="panel-title">Report Overview</div><div class="body-txt">3px accent bar fades to transparent at both ends.</div></div>
+          <div class="stat-tile"><div class="panel-title">128.4k DPS</div><div class="body-txt">2px sheen bar on a raised metric tile.</div></div>
+          <div class="ds-src">glassCardSurface.ts:52-62 (0.85 peak) · summaryStyles.ts:62-70 (0.8 peak)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(b) Inset slit — top:1px, inset 12% / top:0, inset 6%</div>
+          <div class="be-panel" style="margin-bottom:8px"><div class="panel-title">Equipment</div><div class="body-txt">1px slit at top:1px, left/right 12%, rgba(--be-accent-rgb, 0.70).</div></div>
+          <div class="replay-deck"><div class="panel-title">Replay transport</div><div class="body-txt">1px seam at 6% insets, opacity 0.7 dark / 0.4 light.</div></div>
+          <div class="ds-src">GlassPanel.tsx:95-108 · replayDesign.ts:142-152</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(c) Solid semantic strip</div>
+          <div class="issue-row" style="margin-bottom:8px">⚠ Missing a 5-piece body set bonus on the back bar.</div>
+          <div class="food-card ok" style="margin-bottom:8px">Food buff active — Bewitched Sugar Skulls</div>
+          <div class="food-card err">No food buff detected for this parse</div>
+          <div class="ds-src">BuildIssuesPanel.tsx:38-41 (0.06 tint) · ParseAnalysisPage.tsx:1177-1181 (0.05 tint)</div>
+        </div>
+        <div class="demo-block">
+          <div class="demo-label">(d) Class-gradient shell strip + 180px ambient bloom</div>
+          <div class="be-shell"><div class="panel-title">Build Editor — Dragonknight</div><div class="body-txt">3px class gradient at opacity 0.9, then a 180px bloom fading 0.08 → 0.02 → 0.</div></div>
+          <div class="ds-src">BuildEditorShell.tsx:46-70 (light mesh drops the third radial)</div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/design-sync/preview/brand-bg-atmosphere.html
+++ b/design-sync/preview/brand-bg-atmosphere.html
@@ -1,0 +1,61 @@
+<!-- @dsCard group="Brand" -->
+<meta charset="utf-8"><title>Background Atmosphere</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;color:var(--text);font-family:Inter,system-ui,sans-serif;padding:0;box-sizing:border-box}
+body{background:var(--bg);padding:16px}
+.pair{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+@media (max-width:640px){.pair{grid-template-columns:1fr}}
+.pane{position:relative;min-height:240px;border-radius:12px;overflow:hidden;border:1px solid var(--border)}
+
+/* dark: NebulaBackground layer 1 base + layer 4 grid */
+.nebula{background:
+  radial-gradient(ellipse at 20% 30%, rgba(100,50,255,.15) 0%, transparent 50%),
+  radial-gradient(ellipse at 80% 70%, rgba(0,217,255,.12) 0%, transparent 50%),
+  radial-gradient(ellipse at 50% 50%, rgba(50,0,100,.1) 0%, transparent 60%),
+  linear-gradient(135deg,#050810 0%,#0a0f1e 50%,#050810 100%)}
+.nebula .grid{position:absolute;inset:0;opacity:.4;background-image:
+  linear-gradient(transparent 24px, rgba(0,217,255,.025) 24px, rgba(0,217,255,.025) 25px, transparent 25px),
+  linear-gradient(90deg, transparent 24px, rgba(0,217,255,.025) 24px, rgba(0,217,255,.025) 25px, transparent 25px);
+  background-size:50px 50px}
+.star{position:absolute;border-radius:50%;background:rgba(255,255,255,.6)}
+.star.g{box-shadow:0 0 9px rgba(255,255,255,.4)}
+
+/* light: AuroraBackground layer 1 base + layer 4 grid */
+.aurora{background:
+  radial-gradient(ellipse at 25% 20%, rgba(165,180,252,.10) 0%, transparent 55%),
+  radial-gradient(ellipse at 75% 75%, rgba(56,189,248,.08) 0%, transparent 55%),
+  radial-gradient(ellipse at 50% 50%, rgba(236,172,190,.05) 0%, transparent 60%),
+  linear-gradient(160deg,#f0f4ff 0%,#f8fafc 35%,#fdf2f8 65%,#f0fdfa 100%)}
+.aurora .grid{position:absolute;inset:0;opacity:.35;background-image:
+  linear-gradient(transparent 24px, rgba(165,180,252,.03) 24px, rgba(165,180,252,.03) 25px, transparent 25px),
+  linear-gradient(90deg, transparent 24px, rgba(165,180,252,.03) 24px, rgba(165,180,252,.03) 25px, transparent 25px);
+  background-size:50px 50px}
+.mote{position:absolute;border-radius:50%}
+
+.lbl{position:absolute;left:12px;bottom:10px;font-family:Consolas,Menlo,monospace;font-size:10px;color:rgba(148,163,184,.9);z-index:2}
+.aurora .lbl{color:#64748b}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="pair">
+  <div class="pane nebula">
+    <div class="grid"></div>
+    <span class="star g" style="width:3px;height:3px;left:22%;top:30%"></span>
+    <span class="star" style="width:2px;height:2px;left:64%;top:18%"></span>
+    <span class="star" style="width:2px;height:2px;left:80%;top:52%"></span>
+    <span class="star g" style="width:4px;height:4px;left:40%;top:66%"></span>
+    <span class="star" style="width:2px;height:2px;left:12%;top:74%"></span>
+    <div class="lbl">// dark — NebulaBackground</div>
+  </div>
+  <div class="pane aurora">
+    <div class="grid"></div>
+    <span class="mote" style="width:3px;height:3px;left:26%;top:28%;background:rgba(147,130,220,.45)"></span>
+    <span class="mote" style="width:3px;height:3px;left:60%;top:60%;background:rgba(56,189,248,.4)"></span>
+    <span class="mote" style="width:2px;height:2px;left:78%;top:24%;background:rgba(94,234,212,.35)"></span>
+    <span class="mote" style="width:3px;height:3px;left:14%;top:70%;background:rgba(236,172,190,.35)"></span>
+    <div class="lbl">// light — AuroraBackground</div>
+  </div>
+</div>
+<div class="src">dark: base 135° #050810→#0a0f1e→#050810 + violet/cyan/deep-purple radial ellipses; 50px grid rgba(0,217,255,.025) at .4; white star motes with glow —
+NebulaBackground.tsx:99-104, 160-177, 188-194. Fixed, zIndex −1, animated cloud drift 30–50s at perf tiers &gt; low.<br>
+light: base 160° #f0f4ff→#f8fafc→#fdf2f8→#f0fdfa + periwinkle/sky/rose radials; 50px grid rgba(165,180,252,.03) at .35; pastel motes —
+AuroraBackground.tsx:17-23, 118-123, 216-222. (The old dot-grid + rotating-orb treatment was the legacy static landing page.)</div>

--- a/design-sync/preview/brand-logo.html
+++ b/design-sync/preview/brand-logo.html
@@ -1,0 +1,24 @@
+<!-- @dsCard group="Brand" -->
+<meta charset="utf-8"><title>Logo & Wordmark</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:24px;box-sizing:border-box}
+.logo-row{display:flex;gap:40px;align-items:center;flex-wrap:wrap}
+.mark{display:flex;align-items:center;gap:8px}
+.mark img{width:30px;height:30px;object-fit:contain}
+.mark .wm{font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-size:20px;font-weight:800;letter-spacing:-.02em;background:linear-gradient(135deg,#ffffff 0%,#f8fafc 50%,#e2e8f0 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.mark.big img{width:96px;height:96px}
+.mark.big .wm{font-size:32px}
+.light-chip{background:#f8fafc;border-radius:10px;padding:10px 16px}
+.light-chip .wm{background:linear-gradient(135deg,#0f172a 0%,#1e293b 50%,#334155 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.lockup{display:flex;flex-direction:column;align-items:flex-start;gap:2px}
+.lockup .tag{font-family:Consolas,Menlo,monospace;font-size:10px;color:var(--muted);letter-spacing:.15em;text-transform:uppercase}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:16px;line-height:1.6}
+</style>
+<div class="logo-row">
+  <div class="mark"><img src="../assets/eso-helper-logo.png"><div class="wm">ESO Toolkit</div></div>
+  <div class="mark light-chip"><img src="../assets/eso-helper-logo.png"><div class="wm">ESO Toolkit</div></div>
+  <div class="mark big"><img src="../assets/eso-helper-logo.png"><div class="lockup"><div class="wm">ESO Toolkit</div><div class="tag">Combat analysis · esotk.com</div></div></div>
+</div>
+<div class="src">header lockup — HeaderBar.tsx:836-858: icon 30px (src/assets/ESOHelpers-logo-icon.svg) + "ESO Toolkit" in Space Grotesk 800, ls −.02em.<br>
+wordmark gradient (135°): dark #ffffff → #f8fafc 50% → #e2e8f0 · light #0f172a → #1e293b 50% → #334155 — NOT the cyan accent gradient.<br>
+Uppercase transform applies on the home route only (:846-847). No glow/drop-shadow on the mark in source.</div>

--- a/design-sync/preview/colors-charts.html
+++ b/design-sync/preview/colors-charts.html
@@ -1,0 +1,170 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8">
+<title>Chart Palettes — ECharts Dark/Light + Glow Line & Gradient Area</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* card-specific */
+  .sec { margin-bottom:18px; position:relative; z-index:1; }
+  .sec h3 { font-size:.7rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin-bottom:8px; }
+  .pal { display:grid; grid-template-columns:1fr 1fr; gap:4px 10px; }
+  .pal .p { display:flex; align-items:center; gap:7px; font-size:.66rem; }
+  .pal .n { font-family:'JetBrains Mono',Consolas,monospace; color:var(--muted); width:16px; text-align:right; }
+  .pal .c { width:26px; height:16px; border-radius:4px; border:1px solid var(--border); flex:none; }
+  .pal .hex { font-family:'JetBrains Mono',Consolas,monospace; color:var(--text); }
+  .pal .nm { color:var(--muted); }
+  .chart-demo { border:1px solid var(--border); border-radius:10px; background:var(--panel); padding:8px 10px 4px; }
+  .chart-demo svg { display:block; width:100%; height:auto; }
+  .demo-cap { font-size:.62rem; color:var(--muted); margin-top:2px; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Chart Palettes — ECharts Dark/Light + Glow Line &amp; Gradient Area</h1>
+  <p class="ds-sub">12-series palettes and the signature glow/gradient series styles. Source: src/utils/echartsTheme.ts (palettes :7-35, glowLineStyle :84-96, gradientAreaStyle :98-116)</p>
+  <div class="ds-modes">
+
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+
+      <div class="sec">
+        <h3>DARK_PALETTE (Tailwind 400/500 tier)</h3>
+        <div class="pal">
+          <div class="p"><span class="n">1</span><span class="c" style="background:#38bdf8"></span><span class="hex">#38bdf8</span><span class="nm">sky</span></div>
+          <div class="p"><span class="n">2</span><span class="c" style="background:#f43f5e"></span><span class="hex">#f43f5e</span><span class="nm">rose</span></div>
+          <div class="p"><span class="n">3</span><span class="c" style="background:#22c55e"></span><span class="hex">#22c55e</span><span class="nm">green</span></div>
+          <div class="p"><span class="n">4</span><span class="c" style="background:#f59e0b"></span><span class="hex">#f59e0b</span><span class="nm">amber</span></div>
+          <div class="p"><span class="n">5</span><span class="c" style="background:#a855f7"></span><span class="hex">#a855f7</span><span class="nm">purple</span></div>
+          <div class="p"><span class="n">6</span><span class="c" style="background:#06b6d4"></span><span class="hex">#06b6d4</span><span class="nm">cyan</span></div>
+          <div class="p"><span class="n">7</span><span class="c" style="background:#eab308"></span><span class="hex">#eab308</span><span class="nm">yellow</span></div>
+          <div class="p"><span class="n">8</span><span class="c" style="background:#8b5cf6"></span><span class="hex">#8b5cf6</span><span class="nm">violet</span></div>
+          <div class="p"><span class="n">9</span><span class="c" style="background:#10b981"></span><span class="hex">#10b981</span><span class="nm">emerald</span></div>
+          <div class="p"><span class="n">10</span><span class="c" style="background:#ef4444"></span><span class="hex">#ef4444</span><span class="nm">red</span></div>
+          <div class="p"><span class="n">11</span><span class="c" style="background:#3b82f6"></span><span class="hex">#3b82f6</span><span class="nm">blue</span></div>
+          <div class="p"><span class="n">12</span><span class="c" style="background:#ec4899"></span><span class="hex">#ec4899</span><span class="nm">pink</span></div>
+        </div>
+        <div class="ds-src">src/utils/echartsTheme.ts:7-20</div>
+      </div>
+
+      <div class="sec">
+        <h3>glowLineStyle + gradientAreaStyle — bold</h3>
+        <div class="chart-demo">
+          <svg viewBox="0 0 300 84" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="areaDarkBold" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0" stop-color="#38bdf866"/>
+                <stop offset="1" stop-color="#38bdf800"/>
+              </linearGradient>
+            </defs>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18 L300,84 L0,84 Z" fill="url(#areaDarkBold)"/>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18" fill="none" stroke="#38bdf8" stroke-width="2" style="filter:drop-shadow(0 2px 12px #38bdf8)"/>
+          </svg>
+          <div class="demo-cap">bold: shadowBlur 12, shadowColor = series color, shadowOffsetY 2; area top alpha 0.4 → '66' suffix</div>
+        </div>
+        <div class="ds-src">glowLineStyle('#38bdf8','bold') → { shadowBlur:12, shadowColor:'#38bdf8', shadowOffsetY:2 } — echartsTheme.ts:84-96; gradientAreaStyle → vertical '#38bdf866' → '#38bdf800' — :98-116</div>
+      </div>
+
+      <div class="sec">
+        <h3>glowLineStyle + gradientAreaStyle — subtle</h3>
+        <div class="chart-demo">
+          <svg viewBox="0 0 300 84" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="areaDarkSubtle" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0" stop-color="#38bdf826"/>
+                <stop offset="1" stop-color="#38bdf800"/>
+              </linearGradient>
+            </defs>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18 L300,84 L0,84 Z" fill="url(#areaDarkSubtle)"/>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18" fill="none" stroke="#38bdf8" stroke-width="2" style="filter:drop-shadow(0 0 4px #38bdf880)"/>
+          </svg>
+          <div class="demo-cap">subtle: shadowBlur 4, shadowColor = color + '80', shadowOffsetY 0; area top alpha 0.15 → '26' suffix</div>
+        </div>
+        <div class="ds-src">perfTier 'low' returns {} for BOTH — no glow, no area fill — echartsTheme.ts:89,103</div>
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+
+      <div class="sec">
+        <h3>LIGHT_PALETTE (same hues, -600 tier)</h3>
+        <div class="pal">
+          <div class="p"><span class="n">1</span><span class="c" style="background:#0284c7"></span><span class="hex">#0284c7</span><span class="nm">sky-600</span></div>
+          <div class="p"><span class="n">2</span><span class="c" style="background:#e11d48"></span><span class="hex">#e11d48</span><span class="nm">rose-600</span></div>
+          <div class="p"><span class="n">3</span><span class="c" style="background:#16a34a"></span><span class="hex">#16a34a</span><span class="nm">green-600</span></div>
+          <div class="p"><span class="n">4</span><span class="c" style="background:#d97706"></span><span class="hex">#d97706</span><span class="nm">amber-600</span></div>
+          <div class="p"><span class="n">5</span><span class="c" style="background:#9333ea"></span><span class="hex">#9333ea</span><span class="nm">purple-600</span></div>
+          <div class="p"><span class="n">6</span><span class="c" style="background:#0891b2"></span><span class="hex">#0891b2</span><span class="nm">cyan-600</span></div>
+          <div class="p"><span class="n">7</span><span class="c" style="background:#ca8a04"></span><span class="hex">#ca8a04</span><span class="nm">yellow-600</span></div>
+          <div class="p"><span class="n">8</span><span class="c" style="background:#7c3aed"></span><span class="hex">#7c3aed</span><span class="nm">violet-600</span></div>
+          <div class="p"><span class="n">9</span><span class="c" style="background:#059669"></span><span class="hex">#059669</span><span class="nm">emerald-600</span></div>
+          <div class="p"><span class="n">10</span><span class="c" style="background:#dc2626"></span><span class="hex">#dc2626</span><span class="nm">red-600</span></div>
+          <div class="p"><span class="n">11</span><span class="c" style="background:#2563eb"></span><span class="hex">#2563eb</span><span class="nm">blue-600</span></div>
+          <div class="p"><span class="n">12</span><span class="c" style="background:#db2777"></span><span class="hex">#db2777</span><span class="nm">pink-600</span></div>
+        </div>
+        <div class="ds-src">src/utils/echartsTheme.ts:22-35</div>
+      </div>
+
+      <div class="sec">
+        <h3>glowLineStyle + gradientAreaStyle — bold</h3>
+        <div class="chart-demo">
+          <svg viewBox="0 0 300 84" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="areaLightBold" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0" stop-color="#0284c766"/>
+                <stop offset="1" stop-color="#0284c700"/>
+              </linearGradient>
+            </defs>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18 L300,84 L0,84 Z" fill="url(#areaLightBold)"/>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18" fill="none" stroke="#0284c7" stroke-width="2" style="filter:drop-shadow(0 2px 12px #0284c7)"/>
+          </svg>
+          <div class="demo-cap">bold: shadowBlur 12, shadowColor = series color, shadowOffsetY 2; area top alpha 0.4 → '66' suffix</div>
+        </div>
+        <div class="ds-src">glowLineStyle('#0284c7','bold') → { shadowBlur:12, shadowColor:'#0284c7', shadowOffsetY:2 } — echartsTheme.ts:84-96; gradientAreaStyle → vertical '#0284c766' → '#0284c700' — :98-116</div>
+      </div>
+
+      <div class="sec">
+        <h3>glowLineStyle + gradientAreaStyle — subtle</h3>
+        <div class="chart-demo">
+          <svg viewBox="0 0 300 84" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <defs>
+              <linearGradient id="areaLightSubtle" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0" stop-color="#0284c726"/>
+                <stop offset="1" stop-color="#0284c700"/>
+              </linearGradient>
+            </defs>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18 L300,84 L0,84 Z" fill="url(#areaLightSubtle)"/>
+            <path d="M0,64 L40,42 L80,52 L120,24 L160,38 L200,14 L240,30 L280,10 L300,18" fill="none" stroke="#0284c7" stroke-width="2" style="filter:drop-shadow(0 0 4px #0284c780)"/>
+          </svg>
+          <div class="demo-cap">subtle: shadowBlur 4, shadowColor = color + '80', shadowOffsetY 0; area top alpha 0.15 → '26' suffix</div>
+        </div>
+        <div class="ds-src">alpha suffixes are computed 8-digit hex: Math.round(opacity*255).toString(16) — echartsTheme.ts:109-111; perfTier 'low' → {} (no glow, no area)</div>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/design-sync/preview/colors-classes.html
+++ b/design-sync/preview/colors-classes.html
@@ -1,0 +1,62 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8">
+<title>ESO Class Colors</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; color:#e5e7eb; padding:20px; }
+  h1 { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:1.2rem; margin-bottom:2px; }
+  .sub { font-size:.75rem; color:#94a3b8; margin-bottom:16px; font-family:'JetBrains Mono',Consolas,monospace; }
+  .row { display:flex; gap:14px; flex-wrap:wrap; }
+  .cls { display:flex; flex-direction:column; align-items:center; gap:6px; width:104px;
+         padding:12px 8px; border-radius:12px; background:#0f172a; border:1px solid #1f2937; }
+  .cls img { width:52px; height:52px; object-fit:contain; filter:drop-shadow(0 0 8px var(--glow)); }
+  .cls .grad { width:100%; height:6px; border-radius:3px; background:var(--gradient); }
+  .cls .name { font-size:10px; color:#94a3b8; letter-spacing:.05em; text-transform:uppercase; text-align:center; font-weight:600; }
+  .cls .hex { font-size:9px; color:#64748b; font-family:'JetBrains Mono',Consolas,monospace; }
+  .note { margin-top:16px; font-size:.72rem; color:#94a3b8; max-width:720px; line-height:1.5; }
+  .note code { font-family:'JetBrains Mono',Consolas,monospace; color:#7ee8ff; font-size:.68rem; }
+</style>
+<h1>ESO Class Colors</h1>
+<div class="sub">CLASS_COLOR_MAP — src/features/build-editor/theme/classColorMap.ts (accent / glow 0.35 / 135° gradient)</div>
+<div class="row">
+  <div class="cls" style="--glow:rgba(224,92,0,.35); --gradient:linear-gradient(135deg,#e05c00 0%,#ff8a3d 100%)">
+    <img src="../assets/classes/dragonknight.png" alt=""><div class="grad"></div>
+    <div class="name">Dragonknight</div><div class="hex">#e05c00</div>
+  </div>
+  <div class="cls" style="--glow:rgba(0,172,193,.35); --gradient:linear-gradient(135deg,#00acc1 0%,#4dd0e1 100%)">
+    <img src="../assets/classes/sorcerer.png" alt=""><div class="grad"></div>
+    <div class="name">Sorcerer</div><div class="hex">#00acc1</div>
+  </div>
+  <div class="cls" style="--glow:rgba(229,57,53,.35); --gradient:linear-gradient(135deg,#e53935 0%,#ef9a9a 100%)">
+    <img src="../assets/classes/nightblade.png" alt=""><div class="grad"></div>
+    <div class="name">Nightblade</div><div class="hex">#e53935</div>
+  </div>
+  <div class="cls" style="--glow:rgba(255,179,0,.35); --gradient:linear-gradient(135deg,#ffb300 0%,#ffe082 100%)">
+    <img src="../assets/classes/templar.png" alt=""><div class="grad"></div>
+    <div class="name">Templar</div><div class="hex">#ffb300</div>
+  </div>
+  <div class="cls" style="--glow:rgba(38,166,154,.35); --gradient:linear-gradient(135deg,#26a69a 0%,#4dd0c8 100%)">
+    <img src="../assets/classes/warden.png" alt=""><div class="grad"></div>
+    <div class="name">Warden</div><div class="hex">#26a69a</div>
+  </div>
+  <div class="cls" style="--glow:rgba(124,77,255,.35); --gradient:linear-gradient(135deg,#7c4dff 0%,#b388ff 100%)">
+    <img src="../assets/classes/necromancer.png" alt=""><div class="grad"></div>
+    <div class="name">Necromancer</div><div class="hex">#7c4dff</div>
+  </div>
+  <div class="cls" style="--glow:rgba(67,160,71,.35); --gradient:linear-gradient(135deg,#43a047 0%,#81c784 100%)">
+    <img src="../assets/classes/arcanist.png" alt=""><div class="grad"></div>
+    <div class="name">Arcanist</div><div class="hex">#43a047</div>
+  </div>
+  <div class="cls" style="--glow:rgba(148,163,184,.30); --gradient:linear-gradient(135deg,#64748b 0%,#94a3b8 100%)">
+    <img src="../assets/classes/mundus-stone.png" alt=""><div class="grad"></div>
+    <div class="name">Any class</div><div class="hex">#94a3b8</div>
+  </div>
+</div>
+<div class="note">
+  Injected at runtime as CSS custom properties on the build-editor wrapper:
+  <code>--be-accent</code>, <code>--be-accent-rgb</code>, <code>--be-glow</code>, <code>--be-gradient</code>
+  (BuildEditorThemeProvider.tsx). Consume as <code>rgba(var(--be-accent-rgb, 56, 189, 248), α)</code>.
+  Same hexes are mirrored in esoStaticData.ts and UltimateCalculator.tsx — this map is canonical.
+</div>

--- a/design-sync/preview/colors-light-mode.html
+++ b/design-sync/preview/colors-light-mode.html
@@ -1,0 +1,90 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8">
+<title>Core Tokens — Light Mode (with Dark Comparison)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* card-specific */
+  .sw-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(108px,1fr)); gap:10px; position:relative; z-index:1; }
+  .sw { border:1px solid var(--border); border-radius:10px; overflow:hidden; background:var(--panel); }
+  .sw .chip { height:44px; border-bottom:1px solid var(--border); }
+  .sw .meta { padding:6px 8px; }
+  .sw .name { font-size:.6rem; color:var(--muted); letter-spacing:.04em; font-family:'JetBrains Mono',Consolas,monospace; }
+  .sw .hex { font-family:'JetBrains Mono',Consolas,monospace; font-size:.68rem; color:var(--text); }
+  .sw.is-callout { outline:2px solid var(--danger); outline-offset:1px; }
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid var(--border); background:var(--panel); font-size:.72rem; line-height:1.5; color:var(--text); position:relative; z-index:1; }
+  .callout strong { color:var(--danger); }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.68rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Core Tokens — Light Mode (with Dark Comparison)</h1>
+  <p class="ds-sub">The full light token set beside the dark set. Every value transcribed exactly. Source: src/ReduxThemeProvider.tsx:37-69</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark — for comparison</h2>
+      <div class="sw-grid">
+        <div class="sw"><div class="chip" style="background:#0b1220"></div><div class="meta"><div class="name">--bg</div><div class="hex">#0b1220</div></div></div>
+        <div class="sw"><div class="chip" style="background:#0f172a"></div><div class="meta"><div class="name">--panel</div><div class="hex">#0f172a</div></div></div>
+        <div class="sw"><div class="chip" style="background:#0d1430"></div><div class="meta"><div class="name">--panel-2</div><div class="hex">#0d1430</div></div></div>
+        <div class="sw"><div class="chip" style="background:#e5e7eb"></div><div class="meta"><div class="name">--text</div><div class="hex">#e5e7eb</div></div></div>
+        <div class="sw"><div class="chip" style="background:#94a3b8"></div><div class="meta"><div class="name">--muted</div><div class="hex">#94a3b8</div></div></div>
+        <div class="sw"><div class="chip" style="background:#38bdf8"></div><div class="meta"><div class="name">--accent</div><div class="hex">#38bdf8</div></div></div>
+        <div class="sw"><div class="chip" style="background:#00e1ff"></div><div class="meta"><div class="name">--accent-2</div><div class="hex">#00e1ff</div></div></div>
+        <div class="sw"><div class="chip" style="background:#22c55e"></div><div class="meta"><div class="name">--ok</div><div class="hex">#22c55e</div></div></div>
+        <div class="sw"><div class="chip" style="background:#ff9800"></div><div class="meta"><div class="name">--warn</div><div class="hex">#ff9800</div></div></div>
+        <div class="sw"><div class="chip" style="background:#ef4444"></div><div class="meta"><div class="name">--danger</div><div class="hex">#ef4444</div></div></div>
+        <div class="sw"><div class="chip" style="background:#1f2937"></div><div class="meta"><div class="name">--border</div><div class="hex">#1f2937</div></div></div>
+      </div>
+      <div class="ds-src">dark tokens — src/ReduxThemeProvider.tsx:40-52</div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light — the subject of this card</h2>
+      <div class="sw-grid">
+        <div class="sw"><div class="chip" style="background:#f8fafc"></div><div class="meta"><div class="name">--bg</div><div class="hex">#f8fafc</div></div></div>
+        <div class="sw"><div class="chip" style="background:#ffffff"></div><div class="meta"><div class="name">--panel</div><div class="hex">#ffffff</div></div></div>
+        <div class="sw"><div class="chip" style="background:#f8fafc"></div><div class="meta"><div class="name">--panel-2</div><div class="hex">#f8fafc</div></div></div>
+        <div class="sw"><div class="chip" style="background:#1e293b"></div><div class="meta"><div class="name">--text</div><div class="hex">#1e293b</div></div></div>
+        <div class="sw"><div class="chip" style="background:#64748b"></div><div class="meta"><div class="name">--muted</div><div class="hex">#64748b</div></div></div>
+        <div class="sw is-callout"><div class="chip" style="background:#0f172a"></div><div class="meta"><div class="name">--accent</div><div class="hex">#0f172a</div></div></div>
+        <div class="sw"><div class="chip" style="background:#1e293b"></div><div class="meta"><div class="name">--accent-2</div><div class="hex">#1e293b</div></div></div>
+        <div class="sw"><div class="chip" style="background:#059669"></div><div class="meta"><div class="name">--ok</div><div class="hex">#059669</div></div></div>
+        <div class="sw"><div class="chip" style="background:#f97316"></div><div class="meta"><div class="name">--warn</div><div class="hex">#f97316</div></div></div>
+        <div class="sw"><div class="chip" style="background:#dc2626"></div><div class="meta"><div class="name">--danger</div><div class="hex">#dc2626</div></div></div>
+        <div class="sw"><div class="chip" style="background:#bcd9ff"></div><div class="meta"><div class="name">--border</div><div class="hex">#bcd9ff</div></div></div>
+      </div>
+      <div class="ds-src">light tokens — src/ReduxThemeProvider.tsx:55-67</div>
+      <div class="callout">
+        <strong>Deliberate:</strong> light-mode <code>--accent</code> is <code>#0f172a</code> — a <em>dark slate</em>, not a light blue.
+        <code>--accent-2</code> follows at <code>#1e293b</code>. Do not "fix" this to cyan: light-mode accents are slate,
+        while cyan <code>#38bdf8</code> remains hard-coded inside many dark-leaning recipes even when they render in light mode.
+        Also note light <code>--panel-2</code> equals light <code>--bg</code> (<code>#f8fafc</code>) — the tinted second panel exists only in dark mode.
+      </div>
+    </section>
+  </div>
+</div>

--- a/design-sync/preview/colors-neutrals.html
+++ b/design-sync/preview/colors-neutrals.html
@@ -1,0 +1,22 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8"><title>Neutrals</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.grid{display:grid;grid-template-columns:repeat(5,1fr);gap:10px}
+.sw{aspect-ratio:2/1;border-radius:8px;border:1px solid var(--border);padding:8px;display:flex;flex-direction:column;justify-content:flex-end;font-family:Consolas,Menlo,monospace;font-size:10px;color:#fff;text-shadow:0 1px 2px #0008}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="grid">
+<div class="sw" style="background:#030712;color:#94a3b8">#030712 paper-gradient floor</div>
+<div class="sw" style="background:#0b1220;color:#94a3b8">#0b1220 --bg</div>
+<div class="sw" style="background:#0f172a">#0f172a --panel</div>
+<div class="sw" style="background:#0d1430">#0d1430 --panel-2</div>
+<div class="sw" style="background:#1f2937">#1f2937 --border</div>
+<div class="sw" style="background:#1e293b">#1e293b menu-item hover</div>
+<div class="sw" style="background:#94a3b8;color:#0b1220">#94a3b8 --muted</div>
+<div class="sw" style="background:#e5e7eb;color:#0b1220">#e5e7eb --text</div>
+<div class="sw" style="background:#f8fafc;color:#0b1220">#f8fafc light --bg</div>
+<div class="sw" style="background:#ffffff;color:#0b1220">#ffffff light --panel</div>
+</div>
+<div class="src">Dark neutrals — src/ReduxThemeProvider.tsx:41-51 (tokens), :162 (paper gradient floor rgba(3,7,18,.66)), :186 (menu hover #1e293b); light :56-66.<br>
+Body text is #e5e7eb, not white — white-alpha "fg" ramps are not part of the current system.</div>

--- a/design-sync/preview/colors-primary.html
+++ b/design-sync/preview/colors-primary.html
@@ -1,0 +1,26 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8"><title>Primary / Accent</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+  html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;}
+  body{padding:20px;box-sizing:border-box;}
+  .row{display:flex;gap:12px;flex-wrap:wrap;align-items:center;}
+  .swatch{width:80px;height:80px;border-radius:var(--radius-base);border:1px solid var(--border);display:flex;align-items:flex-end;padding:6px;font-size:10px;color:var(--text);text-shadow:0 1px 2px rgba(0,0,0,.6);font-family:Consolas,Menlo,monospace;}
+  .stack{display:flex;flex-direction:column;gap:4px;}
+  .label{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;letter-spacing:.05em;}
+  .val{font-size:11px;color:var(--muted);font-family:Consolas,Menlo,monospace;}
+  .src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:14px;}
+</style>
+<div class="row">
+  <div class="swatch" style="background:#38bdf8">#38bdf8</div>
+  <div class="swatch" style="background:#00e1ff">#00e1ff</div>
+  <div class="swatch" style="background:var(--grad-button-primary)">gradient</div>
+  <div class="stack">
+    <div class="label">PRIMARY / ACCENT (DARK)</div>
+    <div class="val">--accent&nbsp;&nbsp;#38bdf8 · sky-400</div>
+    <div class="val">--accent-2 #00e1ff · bright cyan</div>
+    <div class="val">--grad-button-primary 135° (accent → accent-2)</div>
+    <div class="val">⚠ light-mode --accent is #0f172a (dark slate), NOT a light blue</div>
+  </div>
+</div>
+<div class="src">src/ReduxThemeProvider.tsx:46-47 (tokens), :61-62 (light), :284 (contained-primary gradient)</div>

--- a/design-sync/preview/colors-rarity.html
+++ b/design-sync/preview/colors-rarity.html
@@ -1,0 +1,155 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8">
+<title>Rarity Palettes — Gear UI (ESO) vs Build Editor (Material)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* card-specific */
+  .sec { margin-bottom:18px; position:relative; z-index:1; }
+  .sec h3 { font-size:.7rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin-bottom:8px; }
+  .tile-row { display:grid; grid-template-columns:repeat(auto-fill,minmax(64px,1fr)); gap:8px; }
+  .gear { text-align:center; }
+  /* mock gear tile — real treatment from GearIcon.tsx:102-112:
+     border: quality !== 'normal' ? `2px solid ${colors[quality]}` : 'none'; borderRadius rounded ? 4 : 0 */
+  .gear .tile { width:44px; height:44px; margin:0 auto; border-radius:4px;
+    background:radial-gradient(circle at 35% 30%, rgba(255,255,255,0.18), rgba(255,255,255,0.02) 60%), #1a2333; }
+  [data-color-scheme="light"] .gear .tile {
+    background:radial-gradient(circle at 35% 30%, rgba(255,255,255,0.5), rgba(0,0,0,0.06) 60%), #cbd5e1; }
+  .gear .lab { font-size:.58rem; color:var(--muted); margin-top:4px; }
+  .gear .hex { font-family:'JetBrains Mono',Consolas,monospace; font-size:.58rem; color:var(--text); }
+  .note { padding:10px 12px; border-radius:10px; border:1px solid var(--border); background:var(--panel); font-size:.72rem; line-height:1.5; color:var(--text); position:relative; z-index:1; }
+  .note strong { color:var(--warn); }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Rarity Palettes — Gear UI (ESO) vs Build Editor (Material)</h1>
+  <p class="ds-sub">Two DIFFERENT rarity systems live in the app, on different surfaces. Sources: src/components/GearIcon.tsx:41-58, src/utils/gearMappings.ts:166-174, src/features/build-editor/theme/buildEditorTokens.ts:38-45</p>
+  <div class="ds-modes">
+
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+
+      <div class="sec">
+        <h3>(a) Gear-UI ESO palette — qualityColors</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:none"></div><div class="lab">normal (no border)</div><div class="hex">#ffffff</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #62a603"></div><div class="lab">fine</div><div class="hex">#62a603</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #417dc1"></div><div class="lab">superior</div><div class="hex">#417dc1</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #c040c0"></div><div class="lab">epic</div><div class="hex">#c040c0</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ffbf00"></div><div class="lab">legendary</div><div class="hex">#ffbf00</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ff6b35"></div><div class="lab">mythic</div><div class="hex">#ff6b35</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9d9d9d"></div><div class="lab">trash*</div><div class="hex">#9d9d9d</div></div>
+        </div>
+        <div class="ds-src">GearIcon.tsx:41-48 (border treatment :107 — 2px solid, radius 4, normal renders borderless). *trash (#9d9d9d, quality 0) exists only in QUALITY_COLORS — gearMappings.ts:166-174; GearIcon's quality prop has no trash tier.</div>
+      </div>
+
+      <div class="sec">
+        <h3>(a) Gear-UI desaturated set — gear details table</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:none"></div><div class="lab">normal (no border)</div><div class="hex">#e5e5e5</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #7cb342"></div><div class="lab">fine</div><div class="hex">#7cb342</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #5c9ce6"></div><div class="lab">superior</div><div class="hex">#5c9ce6</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9978d4"></div><div class="lab">epic</div><div class="hex">#9978d4</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #dec369"></div><div class="lab">legendary</div><div class="hex">#dec369</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #c47a5a"></div><div class="lab">mythic</div><div class="hex">#c47a5a</div></div>
+        </div>
+        <div class="ds-src">desaturatedQualityColors — GearIcon.tsx:51-58 (useDesaturatedColors, gear details table only)</div>
+      </div>
+
+      <div class="sec">
+        <h3>(b) Build-editor Material palette — BE_TOKENS.rarity</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:2px solid #9e9e9e"></div><div class="lab">normal</div><div class="hex">#9e9e9e</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #4caf50"></div><div class="lab">fine</div><div class="hex">#4caf50</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #2196f3"></div><div class="lab">superior</div><div class="hex">#2196f3</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9c27b0"></div><div class="lab">epic</div><div class="hex">#9c27b0</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ff9800"></div><div class="lab">legendary</div><div class="hex">#ff9800</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #f44336"></div><div class="lab">mythic</div><div class="hex">#f44336</div></div>
+        </div>
+        <div class="ds-src">buildEditorTokens.ts:38-45 — gear-slot borders inside the build editor only</div>
+      </div>
+
+      <div class="note">
+        <strong>Do not merge these palettes.</strong> (a) is the ESO in-game rarity palette, used on gear icons in
+        report/player views (GearIcon + gearMappings). (b) is a Material-Design palette scoped to the build editor's
+        gear slots (BE_TOKENS). Same tier names, different hexes, different surfaces — pick by surface, never unify.
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+
+      <div class="sec">
+        <h3>(a) Gear-UI ESO palette — qualityColors</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:none"></div><div class="lab">normal (no border)</div><div class="hex">#ffffff</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #62a603"></div><div class="lab">fine</div><div class="hex">#62a603</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #417dc1"></div><div class="lab">superior</div><div class="hex">#417dc1</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #c040c0"></div><div class="lab">epic</div><div class="hex">#c040c0</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ffbf00"></div><div class="lab">legendary</div><div class="hex">#ffbf00</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ff6b35"></div><div class="lab">mythic</div><div class="hex">#ff6b35</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9d9d9d"></div><div class="lab">trash*</div><div class="hex">#9d9d9d</div></div>
+        </div>
+        <div class="ds-src">Rarity hexes are NOT theme-aware — identical in both modes. GearIcon.tsx:41-48; gearMappings.ts:166-174 (*trash)</div>
+      </div>
+
+      <div class="sec">
+        <h3>(a) Gear-UI desaturated set — gear details table</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:none"></div><div class="lab">normal (no border)</div><div class="hex">#e5e5e5</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #7cb342"></div><div class="lab">fine</div><div class="hex">#7cb342</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #5c9ce6"></div><div class="lab">superior</div><div class="hex">#5c9ce6</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9978d4"></div><div class="lab">epic</div><div class="hex">#9978d4</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #dec369"></div><div class="lab">legendary</div><div class="hex">#dec369</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #c47a5a"></div><div class="lab">mythic</div><div class="hex">#c47a5a</div></div>
+        </div>
+        <div class="ds-src">desaturatedQualityColors — GearIcon.tsx:51-58</div>
+      </div>
+
+      <div class="sec">
+        <h3>(b) Build-editor Material palette — BE_TOKENS.rarity</h3>
+        <div class="tile-row">
+          <div class="gear"><div class="tile" style="border:2px solid #9e9e9e"></div><div class="lab">normal</div><div class="hex">#9e9e9e</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #4caf50"></div><div class="lab">fine</div><div class="hex">#4caf50</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #2196f3"></div><div class="lab">superior</div><div class="hex">#2196f3</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #9c27b0"></div><div class="lab">epic</div><div class="hex">#9c27b0</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #ff9800"></div><div class="lab">legendary</div><div class="hex">#ff9800</div></div>
+          <div class="gear"><div class="tile" style="border:2px solid #f44336"></div><div class="lab">mythic</div><div class="hex">#f44336</div></div>
+        </div>
+        <div class="ds-src">buildEditorTokens.ts:38-45 — also mode-independent</div>
+      </div>
+
+      <div class="note">
+        <strong>Do not merge these palettes.</strong> (a) ESO palette on gear icons in report/player views;
+        (b) Material palette on build-editor gear slots. Same tier names, different hexes, different surfaces —
+        pick by surface, never unify.
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/design-sync/preview/colors-roles.html
+++ b/design-sync/preview/colors-roles.html
@@ -1,0 +1,236 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8">
+<title>Role Colors — Solids, Gradients, Washes, Progress Fills</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* card-specific */
+  .sec { margin-bottom:18px; position:relative; z-index:1; }
+  .sec h3 { font-size:.7rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin-bottom:8px; }
+  .role-row { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
+  .role-sw { border:1px solid var(--border); border-radius:10px; overflow:hidden; background:var(--panel); }
+  .role-sw .chip { height:38px; }
+  .role-sw .meta { padding:5px 8px; }
+  .role-sw .name { font-size:.6rem; color:var(--muted); }
+  .role-sw .hex { font-family:'JetBrains Mono',Consolas,monospace; font-size:.62rem; color:var(--text); word-break:break-all; }
+
+  /* mini table */
+  .mini-table { border:1px solid var(--border); border-radius:10px; overflow:hidden; font-size:.72rem; }
+  [data-color-scheme="dark"] .mini-table {
+    background:linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%);
+  }
+  [data-color-scheme="light"] .mini-table {
+    background:linear-gradient(135deg, rgb(110 214 240 / 25%) 0%, rgb(131 208 227 / 15%) 50%, rgb(35 122 144 / 8%) 100%);
+  }
+  .mini-table .tr { display:grid; grid-template-columns:1fr 64px 56px; padding:6px 10px; border-bottom:1px solid var(--border); align-items:center; }
+  .mini-table .tr:last-child { border-bottom:none; }
+  .mini-table .th { font-size:.62rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); }
+  .mono { font-family:'JetBrains Mono',Consolas,monospace; }
+  .role-dot { display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:6px; vertical-align:-1px; }
+
+  /* accordion header */
+  .mini-accordion { border-radius:10px; padding:9px 12px; font-size:.74rem; font-weight:600; display:flex; justify-content:space-between; align-items:center;
+    background:linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(213 201 255 / 15%) 50%, rgb(255 255 255 / 8%) 100%); }
+  [data-color-scheme="dark"] .mini-accordion { border:1px solid rgba(66, 45, 45, 0.1); box-shadow:0 2px 8px 0 rgba(0, 0, 0, 0.2);
+    text-shadow:0 2px 4px rgba(0,0,0,0.8), 0 4px 8px rgba(0,0,0,0.4), 0 8px 16px rgba(0,0,0,0.2); }
+  [data-color-scheme="light"] .mini-accordion { border:1px solid rgba(15, 23, 42, 0.12); box-shadow:0 2px 4px 0 rgba(15, 23, 42, 0.06);
+    text-shadow:0 1px 2px rgba(15, 23, 42, 0.15), 0 2px 4px rgba(15, 23, 42, 0.08); }
+  .mini-accordion-bg { border-radius:10px; padding:9px 12px; font-size:.74rem; margin-top:8px; border:1px solid var(--border); }
+  [data-color-scheme="dark"] .mini-accordion-bg {
+    background:linear-gradient(135deg, rgb(110 214 240 / 25%) 0%, rgb(131 208 227 / 15%) 50%, rgb(35 122 144 / 8%) 100%); }
+  [data-color-scheme="light"] .mini-accordion-bg {
+    background:linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.95) 50%, rgba(241, 245, 249, 0.98) 100%); }
+
+  /* progress bars — track per useRoleColors.ts:78-91 */
+  .pb-track { height:8px; border-radius:4px; overflow:hidden; margin-bottom:4px; }
+  [data-color-scheme="dark"] .pb-track { background:rgba(117, 117, 117, 0.3); border:none; box-shadow:inset 0 1px 2px rgba(0, 0, 0, 0.4); }
+  [data-color-scheme="light"] .pb-track { background:rgba(203, 213, 225, 0.4); border:1px solid rgba(15, 23, 42, 0.08); box-shadow:inset 0 1px 2px rgba(15, 23, 42, 0.1); }
+  .pb-bar { height:100%; border-radius:4px; }
+  [data-color-scheme="dark"] .pb-bar { box-shadow:0 1px 3px rgba(0, 0, 0, 0.3); }
+  [data-color-scheme="light"] .pb-bar { box-shadow:0 1px 2px rgba(0, 0, 0, 0.15); }
+
+  /* buff uptime bar — BuffUptimeProgressBar.tsx:286-294 (radius 2 in source; glow-on-fill) */
+  .buff-track { height:12px; border-radius:2px; background:transparent; overflow:visible; margin-bottom:4px; }
+  .buff-bar { height:100%; border-radius:2px; }
+  [data-color-scheme="dark"] .buff-bar { background:linear-gradient(90deg, #3b82f6 0%, #8b5cf6 100%);
+    box-shadow:0 2px 8px rgba(59, 130, 246, 0.3), 0 0 20px rgba(139, 92, 246, 0.2); }
+  [data-color-scheme="light"] .buff-bar { background:linear-gradient(90deg, #67e8f9 0%, #93c5fd 25%, #c4b5fd 75%, #f9a8d4 100%);
+    box-shadow:0 1px 3px rgba(103, 232, 249, 0.3), 0 0 8px rgba(147, 197, 253, 0.2); }
+
+  /* termination demo */
+  .term { border:1px solid var(--border); border-radius:10px; overflow:hidden; font-size:.7rem; }
+  .term .band { padding:8px 12px; font-weight:600; color:#fff; }
+  .term .band.seam { border-bottom:1px solid var(--border); }
+  .term .body { padding:8px 12px; background:var(--panel); color:var(--muted); }
+  .term-label { font-size:.62rem; margin-top:4px; }
+  .term-label.ok { color:var(--ok); }
+  .term-label.bad { color:var(--danger); }
+  .term-pair { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Role Colors — Solids, Gradients, Washes, Progress Fills</h1>
+  <p class="ds-sub">DPS / Healer / Tank identity colors and everywhere they touch chrome. Sources: src/utils/roleColors.ts, src/hooks/useRoleColors.ts:45-91, src/features/report_details/insights/BuffUptimeProgressBar.tsx:286-294</p>
+  <div class="ds-modes">
+
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+
+      <div class="sec">
+        <h3>Role solids (DARK_ROLE_COLORS)</h3>
+        <div class="role-row">
+          <div class="role-sw"><div class="chip" style="background:#ff8b61"></div><div class="meta"><div class="name">dps</div><div class="hex">#ff8b61</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:#b970ff"></div><div class="meta"><div class="name">healer</div><div class="hex">#b970ff</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:#62baff"></div><div class="meta"><div class="name">tank</div><div class="hex">#62baff</div></div></div>
+        </div>
+        <div class="ds-src">src/utils/roleColors.ts:5-9 — dark mode uses solids only, for text AND fills</div>
+      </div>
+
+      <div class="sec">
+        <h3>Table wash (getTableBackground)</h3>
+        <div class="mini-table">
+          <div class="tr"><span class="th">Player</span><span class="th">DPS</span><span class="th">%</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#ff8b61"></span>Stamblade</span><span class="mono">112.4k</span><span class="mono">31.2</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#b970ff"></span>Wardenheal</span><span class="mono">8.1k</span><span class="mono">2.2</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#62baff"></span>DKTank</span><span class="mono">14.9k</span><span class="mono">4.1</span></div>
+        </div>
+        <div class="ds-src">linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(152 131 227 / 15%) 50%, rgb(173 192 255 / 8%) 100%) — src/hooks/useRoleColors.ts:45-49</div>
+      </div>
+
+      <div class="sec">
+        <h3>Accordion (getAccordionStyles + getAccordionBackground)</h3>
+        <div class="mini-accordion"><span>Damage Done</span><span>▾</span></div>
+        <div class="ds-src">getAccordionStyles — bg linear-gradient(135deg, rgb(110 170 240 / 25%) 0%, rgb(213 201 255 / 15%) 50%, rgb(255 255 255 / 8%) 100%) (mode-independent); border 1px solid rgba(66, 45, 45, 0.1); shadow 0 2px 8px 0 rgba(0, 0, 0, 0.2) — src/hooks/useRoleColors.ts:57-64</div>
+        <div class="mini-accordion-bg">getAccordionBackground (dark branch)</div>
+        <div class="ds-src">linear-gradient(135deg, rgb(110 214 240 / 25%) 0%, rgb(131 208 227 / 15%) 50%, rgb(35 122 144 / 8%) 100%) — src/hooks/useRoleColors.ts:51-55</div>
+      </div>
+
+      <div class="sec">
+        <h3>Progress fills</h3>
+        <div class="buff-track"><div class="buff-bar" style="width:78%"></div></div>
+        <div class="ds-src">buff uptime, dark 2-stop + glow-on-fill: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 100%); box-shadow 0 2px 8px rgba(59, 130, 246, 0.3), 0 0 20px rgba(139, 92, 246, 0.2) — BuffUptimeProgressBar.tsx:286-294</div>
+        <div class="pb-track" style="margin-top:10px"><div class="pb-bar" style="width:62%; background:linear-gradient(90deg, rgba(255, 139, 97, 0.7) 0%, rgba(255, 139, 97, 0.5) 100%)"></div></div>
+        <div class="ds-src">MUTED_ORANGE_PROGRESS_DARK — bar linear-gradient(90deg, rgba(255, 139, 97, 0.7) 0%, rgba(255, 139, 97, 0.5) 100%) on bg rgba(255, 139, 97, 0.12) — src/utils/roleColors.ts:26-29; track: rgba(117, 117, 117, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4) — useRoleColors.ts:78-91</div>
+      </div>
+
+      <div class="sec">
+        <h3>How role-colored areas terminate</h3>
+        <div class="term-pair">
+          <div>
+            <div class="term">
+              <div class="band seam" style="background:#62baff; color:#0b1220">Tank section</div>
+              <div class="body">content below the seam</div>
+            </div>
+            <div class="term-label ok">DO — hard 1px border seam</div>
+          </div>
+          <div>
+            <div class="term">
+              <div class="band" style="background:linear-gradient(180deg, #62baff 0%, transparent 100%); color:#0b1220">Tank section</div>
+              <div class="body">content</div>
+            </div>
+            <div class="term-label bad">DON'T — never fade out</div>
+          </div>
+        </div>
+        <div class="ds-src">B9 rule: role-colored regions end at a hard 1px var(--border) seam, never a gradient fade</div>
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+
+      <div class="sec">
+        <h3>Role gradients (LIGHT_ROLE_COLORS)</h3>
+        <div class="role-row">
+          <div class="role-sw"><div class="chip" style="background:linear-gradient(135deg, #ff9246 36% 36%, #ff3400e6 100%)"></div><div class="meta"><div class="name">dps</div><div class="hex">135deg, #ff9246 36% 36%, #ff3400e6 100%</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:linear-gradient(135deg, #9333ea 0%, #c084fc 100%)"></div><div class="meta"><div class="name">healer</div><div class="hex">135deg, #9333ea 0%, #c084fc 100%</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:linear-gradient(135deg, #0ea5e9 0%, #38bdf8 100%)"></div><div class="meta"><div class="name">tank</div><div class="hex">135deg, #0ea5e9 0%, #38bdf8 100%</div></div></div>
+        </div>
+        <div class="ds-src">src/utils/roleColors.ts:12-16 — note dps uses a double stop "36% 36%" and 8-digit hex #ff3400e6, exactly as in source</div>
+      </div>
+
+      <div class="sec">
+        <h3>Solid fallbacks (LIGHT_ROLE_COLORS_SOLID)</h3>
+        <div class="role-row">
+          <div class="role-sw"><div class="chip" style="background:#ff5722"></div><div class="meta"><div class="name">dps</div><div class="hex">#ff5722</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:#7c3aed"></div><div class="meta"><div class="name">healer</div><div class="hex">#7c3aed</div></div></div>
+          <div class="role-sw"><div class="chip" style="background:#0891b2"></div><div class="meta"><div class="name">tank</div><div class="hex">#0891b2</div></div></div>
+        </div>
+        <div class="ds-src">src/utils/roleColors.ts:19-23 — used where gradients can't render (progress bars, dots) via getRoleColorSolid / getPlayerColor</div>
+      </div>
+
+      <div class="sec">
+        <h3>Table wash (getTableBackground)</h3>
+        <div class="mini-table">
+          <div class="tr"><span class="th">Player</span><span class="th">DPS</span><span class="th">%</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#ff5722"></span>Stamblade</span><span class="mono">112.4k</span><span class="mono">31.2</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#7c3aed"></span>Wardenheal</span><span class="mono">8.1k</span><span class="mono">2.2</span></div>
+          <div class="tr"><span><span class="role-dot" style="background:#0891b2"></span>DKTank</span><span class="mono">14.9k</span><span class="mono">4.1</span></div>
+        </div>
+        <div class="ds-src">linear-gradient(135deg, rgb(110 214 240 / 25%) 0%, rgb(131 208 227 / 15%) 50%, rgb(35 122 144 / 8%) 100%) — src/hooks/useRoleColors.ts:45-49 (light branch)</div>
+      </div>
+
+      <div class="sec">
+        <h3>Accordion (getAccordionStyles + getAccordionBackground)</h3>
+        <div class="mini-accordion"><span>Damage Done</span><span>▾</span></div>
+        <div class="ds-src">getAccordionStyles — same mode-independent gradient; border 1px solid rgba(15, 23, 42, 0.12); shadow 0 2px 4px 0 rgba(15, 23, 42, 0.06) — src/hooks/useRoleColors.ts:57-64</div>
+        <div class="mini-accordion-bg">getAccordionBackground (light branch)</div>
+        <div class="ds-src">linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.95) 50%, rgba(241, 245, 249, 0.98) 100%) — src/hooks/useRoleColors.ts:51-55</div>
+      </div>
+
+      <div class="sec">
+        <h3>Progress fills</h3>
+        <div class="buff-track"><div class="buff-bar" style="width:78%"></div></div>
+        <div class="ds-src">buff uptime, light 4-stop pastel + softer glow: linear-gradient(90deg, #67e8f9 0%, #93c5fd 25%, #c4b5fd 75%, #f9a8d4 100%); box-shadow 0 1px 3px rgba(103, 232, 249, 0.3), 0 0 8px rgba(147, 197, 253, 0.2) — BuffUptimeProgressBar.tsx:286-294</div>
+        <div class="pb-track" style="margin-top:10px"><div class="pb-bar" style="width:62%; background:linear-gradient(90deg, rgba(255, 139, 97, 0.6) 0%, rgba(255, 139, 97, 0.4) 100%)"></div></div>
+        <div class="ds-src">MUTED_ORANGE_PROGRESS_LIGHT — bar linear-gradient(90deg, rgba(255, 139, 97, 0.6) 0%, rgba(255, 139, 97, 0.4) 100%) on bg rgba(255, 139, 97, 0.08) — src/utils/roleColors.ts:31-34; track: rgba(203, 213, 225, 0.4), border 1px solid rgba(15, 23, 42, 0.08), inset 0 1px 2px rgba(15, 23, 42, 0.1) — useRoleColors.ts:78-91</div>
+      </div>
+
+      <div class="sec">
+        <h3>How role-colored areas terminate</h3>
+        <div class="term-pair">
+          <div>
+            <div class="term">
+              <div class="band seam" style="background:linear-gradient(135deg, #0ea5e9 0%, #38bdf8 100%)">Tank section</div>
+              <div class="body">content below the seam</div>
+            </div>
+            <div class="term-label ok">DO — hard 1px border seam</div>
+          </div>
+          <div>
+            <div class="term">
+              <div class="band" style="background:linear-gradient(180deg, #0ea5e9 0%, transparent 100%)">Tank section</div>
+              <div class="body">content</div>
+            </div>
+            <div class="term-label bad">DON'T — never fade out</div>
+          </div>
+        </div>
+        <div class="ds-src">B9 rule: role-colored regions end at a hard 1px var(--border) seam, never a gradient fade</div>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/design-sync/preview/colors-semantic.html
+++ b/design-sync/preview/colors-semantic.html
@@ -1,0 +1,21 @@
+<!-- @dsCard group="Colors" -->
+<meta charset="utf-8"><title>Chip Label Palette</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+.sw{aspect-ratio:2/1;border-radius:8px;padding:8px;display:flex;flex-direction:column;justify-content:flex-end;font-family:Consolas,Menlo,monospace;font-size:10px;color:#0b1220;font-weight:600}
+.dark{color:#fff;text-shadow:0 1px 2px #0008}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="grid">
+<div class="sw" style="background:#5ce572">#5ce572 green · 5pc set</div>
+<div class="sw" style="background:#4da3ff">#4da3ff blue · arena</div>
+<div class="sw" style="background:#7ee8ff">#7ee8ff lightBlue · 1pc monster</div>
+<div class="sw" style="background:#c57fff">#c57fff purple · 2pc monster</div>
+<div class="sw" style="background:#ffd54f">#ffd54f gold · mythic</div>
+<div class="sw dark" style="background:#ff6666">#ff6666 championRed</div>
+<div class="sw" style="background:#66aaff">#66aaff championBlue</div>
+<div class="sw" style="background:#66ffaa">#66ffaa championGreen</div>
+</div>
+<div class="src">Glossy-chip label colors (dark) — src/utils/playerCardStyleUtils.ts:95-165; mapping getGearChipProps :252-296.<br>
+Theme semantic tokens are separate: --ok #22c55e · --warn #ff9800 · --danger #ef4444 (ReduxThemeProvider.tsx:48-50).</div>

--- a/design-sync/preview/comp-buttons.html
+++ b/design-sync/preview/comp-buttons.html
@@ -1,0 +1,18 @@
+<!-- @dsCard group="Components" -->
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg-0);color:var(--fg-1);font-family:var(--font-sans);padding:24px;box-sizing:border-box}
+.row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.btn-primary{padding:.9rem 2rem;background:linear-gradient(135deg,#38bdf8,#00e1ff);color:#0b1220;font-weight:600;border-radius:8px;border:none;box-shadow:0 4px 15px rgba(56,189,248,.25);font-size:15px;cursor:pointer;font-family:inherit}
+.btn-primary:hover{box-shadow:0 6px 25px rgba(56,189,248,.35)}
+.btn-secondary{padding:.9rem 2rem;background:transparent;color:#38bdf8;font-weight:600;border-radius:8px;border:2px solid rgba(56,189,248,.5);font-size:15px;cursor:pointer;font-family:inherit}
+.btn-ghost{padding:.8rem 1.5rem;background:linear-gradient(135deg,rgba(56,189,248,.15),rgba(56,189,248,.05));color:#e9fbff;border-radius:8px;border:1px solid rgba(56,189,248,.3);font-size:14px;font-weight:600;cursor:pointer;font-family:inherit}
+.src{font-family:var(--font-mono);font-size:10px;color:var(--fg-3);margin-top:14px}
+</style></head><body>
+<div class="row">
+<button class="btn-primary">Explore Tools</button>
+<button class="btn-secondary">Join Discord</button>
+<button class="btn-ghost">Launch Editor</button>
+</div>
+<div class="src">MuiButton overrides — src/ReduxThemeProvider.tsx (containedPrimary gradient 135° #38bdf8→#00e1ff, radius 8, glow 0 4px 15px rgba(56,189,248,.25) → hover 0 6px 25px .35)</div>
+</body></html>

--- a/design-sync/preview/comp-chips.html
+++ b/design-sync/preview/comp-chips.html
@@ -1,0 +1,135 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Glossy Gear Chips</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>
+html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:28px;box-sizing:border-box}
+.group{display:flex;flex-direction:column;gap:12px;margin-bottom:30px}
+.group .lbl{font:700 10px Consolas,Menlo,monospace;letter-spacing:.18em;color:var(--muted);text-transform:uppercase}
+.row{display:flex;gap:10px;flex-wrap:wrap;align-items:center;padding:18px 20px;background:#0b1220;border:1px solid var(--border);border-radius:12px}
+.caption{font:500 11px Consolas,Menlo,monospace;color:var(--muted);margin-top:2px}
+
+/* glossyBaseSx — exact port of src/utils/playerCardStyleUtils.ts:30-84 */
+.chip{
+  /* MUI Chip size="small" defaults */
+  display:inline-flex;align-items:center;
+  height:24px;
+  font-size:.8125rem;
+  line-height:18px;
+
+  position:relative;
+  overflow:hidden;
+  cursor:pointer;
+  transition:all .3s ease;
+  border-radius:28px;
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+  border:1px solid rgba(255,255,255,.15);
+  box-shadow:
+    0 8px 32px 0 rgba(0,0,0,.37),
+    inset 0 1px 0 rgba(255,255,255,.2),
+    inset 0 -1px 0 rgba(0,0,0,.2);
+}
+/* label (dark): #fff + text-shadow, weight 500 — :43-50 */
+.chip .MuiChip-label{
+  display:block;
+  padding-left:12px;padding-right:12px;
+  white-space:nowrap;
+  color:#ffffff;
+  text-shadow:0 1px 3px rgba(0,0,0,.5);
+  font-weight:500;
+  font-size:.8125rem;
+  position:relative;z-index:1;
+}
+/* shine sweep — :51-62 (rgba .15, skewX(-15deg), left -100% → 100% on hover) */
+.chip::before{
+  content:"";
+  position:absolute;top:0;left:-100%;
+  width:100%;height:100%;
+  background:linear-gradient(90deg, transparent, rgba(255,255,255,.15), transparent);
+  transform:skewX(-15deg);
+  transform-origin:center center;
+  transition:left .5s ease;
+}
+/* top arched glass highlight — :63-73 (static; no hover morph in source) */
+.chip::after{
+  content:"";
+  position:absolute;
+  top:0;left:0;right:0;
+  height:50%;
+  background:linear-gradient(180deg, rgba(255,255,255,.15) 0%, transparent 100%);
+  border-radius:28px 28px 100px 100px / 28px 28px 50px 50px;
+  pointer-events:none;
+}
+/* hover — :74-83 */
+.chip:hover{
+  transform:translateY(-2px);
+  box-shadow:
+    0 12px 40px 0 rgba(0,0,0,.5),
+    inset 0 1px 0 rgba(255,255,255,.3),
+    inset 0 -1px 0 rgba(0,0,0,.3);
+}
+.chip:hover::before{left:100%}
+
+/* variant tints (dark) — :95-165. Merge overrides ONLY background + borderColor
+   + color. NOTE: green/blue/lightBlue/purple/gold/silver set root `color`
+   (label stays white); indigo + champion* override the LABEL color instead. */
+.v-green      {background:linear-gradient(135deg, rgba(76,217,100,.25) 0%, rgba(76,217,100,.15) 50%, rgba(76,217,100,.08) 100%);  border-color:rgba(76,217,100,.3);  color:#5ce572}
+.v-blue       {background:linear-gradient(135deg, rgba(0,122,255,.25)  0%, rgba(0,122,255,.15)  50%, rgba(0,122,255,.08)  100%);  border-color:rgba(0,122,255,.3);  color:#4da3ff}
+.v-lightblue  {background:linear-gradient(135deg, rgba(94,234,255,.25) 0%, rgba(94,234,255,.15) 50%, rgba(94,234,255,.08) 100%);  border-color:rgba(94,234,255,.35);color:#7ee8ff}
+.v-purple     {background:linear-gradient(135deg, rgba(175,82,222,.25) 0%, rgba(175,82,222,.15) 50%, rgba(175,82,222,.08) 100%);  border-color:rgba(175,82,222,.3); color:#c57fff}
+.v-gold       {background:linear-gradient(135deg, rgba(255,193,7,.25)  0%, rgba(255,193,7,.15)  50%, rgba(255,193,7,.08)  100%);  border-color:rgba(255,193,7,.35); color:#ffd54f}
+.v-silver     {background:linear-gradient(135deg, rgba(236,240,241,.25) 0%, rgba(236,240,241,.15) 50%, rgba(236,240,241,.08) 100%);border-color:rgba(236,240,241,.35);color:#ecf0f1}
+.v-indigo     {background:linear-gradient(135deg, rgba(88,86,214,.25)  0%, rgba(88,86,214,.15)  50%, rgba(88,86,214,.08)  100%);  border-color:rgba(88,86,214,.3)}
+.v-indigo .MuiChip-label{color:#8583ff}
+.v-cpred      {background:linear-gradient(135deg, rgba(255,68,68,.25)  0%, rgba(255,68,68,.15)  50%, rgba(255,68,68,.08)  100%);  border-color:rgba(255,68,68,.3)}
+.v-cpred .MuiChip-label{color:#ff6666}
+.v-cpblue     {background:linear-gradient(135deg, rgba(68,136,255,.25) 0%, rgba(68,136,255,.15) 50%, rgba(68,136,255,.08) 100%);  border-color:rgba(68,136,255,.3)}
+.v-cpblue .MuiChip-label{color:#66aaff}
+.v-cpgreen    {background:linear-gradient(135deg, rgba(68,255,136,.25) 0%, rgba(68,255,136,.15) 50%, rgba(68,255,136,.08) 100%);  border-color:rgba(68,255,136,.3)}
+.v-cpgreen .MuiChip-label{color:#66ffaa}
+
+@keyframes legendaryGlow{
+  0%,100%{box-shadow:0 8px 32px 0 rgba(255,0,150,.3), inset 0 1px 0 rgba(255,255,255,.3)}
+  50%    {box-shadow:0 8px 32px 0 rgba(0,150,255,.3), inset 0 1px 0 rgba(255,255,255,.3)}
+}
+.v-legendary{
+  background:linear-gradient(135deg, rgba(255,0,150,.2) 0%, rgba(255,150,0,.2) 20%, rgba(255,255,0,.2) 40%, rgba(0,255,0,.2) 60%, rgba(0,150,255,.2) 80%, rgba(150,0,255,.2) 100%);
+  border:1px solid transparent;
+  border-image:linear-gradient(135deg, #ff0096, #ff9600, #ffff00, #00ff00, #0096ff, #9600ff) 1;
+  animation:legendaryGlow 3s ease-in-out infinite;
+}
+.v-legendary .MuiChip-label{color:#ffffff}
+</style>
+
+<div class="group">
+  <div class="lbl">gear sets — all variant classes from the source</div>
+  <div class="row">
+    <span class="chip v-gold"><span class="MuiChip-label">1 Oakensoul Ring</span></span>
+    <span class="chip v-blue"><span class="MuiChip-label">2 Maelstrom</span></span>
+    <span class="chip v-green"><span class="MuiChip-label">5 Perfected Saxhleel Champion</span></span>
+    <span class="chip v-green"><span class="MuiChip-label">7 War Machine</span></span>
+    <span class="chip v-lightblue"><span class="MuiChip-label">1 Slimecraw</span></span>
+    <span class="chip v-purple"><span class="MuiChip-label">2 Nazaray</span></span>
+    <span class="chip v-silver"><span class="MuiChip-label">3 Random</span></span>
+  </div>
+  <div class="caption">variant mapping: gold=mythic · blue=arena · green=5pc (and 4pc Highland Sentinel) · purple=2pc monster · lightBlue=1pc monster · silver=default — getGearChipProps, playerCardStyleUtils.ts:252-296</div>
+</div>
+
+<div class="group">
+  <div class="lbl">champion points (label color set per-variant)</div>
+  <div class="row">
+    <span class="chip v-cpred"><span class="MuiChip-label" style="font-size:.58rem">Fighting Finesse</span></span>
+    <span class="chip v-cpblue"><span class="MuiChip-label" style="font-size:.58rem">Reaving Blows</span></span>
+    <span class="chip v-cpgreen"><span class="MuiChip-label" style="font-size:.58rem">Steed's Blessing</span></span>
+    <span class="chip v-indigo"><span class="MuiChip-label" style="font-size:.58rem">Rejuvenation</span></span>
+  </div>
+  <div class="caption">call-site override: <code>'&amp; .MuiChip-label': { fontSize: '0.58rem' }</code> — PlayerCard.tsx:2178</div>
+</div>
+
+<div class="group">
+  <div class="lbl">legendary (animated, 3s glow pulse)</div>
+  <div class="row">
+    <span class="chip v-legendary"><span class="MuiChip-label">Perfect Roe</span></span>
+  </div>
+  <div class="caption">source: src/utils/playerCardStyleUtils.ts — glossyBaseSx :30-84 · dark variants :95-165 (values verified 2026-07-26)</div>
+</div>

--- a/design-sync/preview/comp-log-input.html
+++ b/design-sync/preview/comp-log-input.html
@@ -1,0 +1,24 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Log Input Hero Field</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:18px;box-sizing:border-box}
+.field{display:flex;align-items:stretch;gap:0;border:1px solid rgba(56,189,248,.2);border-radius:16px;max-width:600px;box-shadow:0 20px 60px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.1);overflow:hidden;position:relative;transition:all .4s cubic-bezier(.4,0,.2,1)}
+.field::before{content:"";position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent,rgba(56,189,248,.6),transparent)}
+.field:hover{transform:translateY(-4px);box-shadow:0 25px 80px rgba(0,0,0,.5),0 0 40px rgba(56,189,248,.15),inset 0 1px 0 rgba(255,255,255,.2);border-color:rgba(56,189,248,.4)}
+.linkic{align-self:center;margin-left:20px;color:#38bdf8;font-size:18px}
+input{flex:1;height:64px;padding:0 20px 0 8px;background:transparent;border:none;color:#e5e7eb;font-size:16px;font-family:inherit;outline:none}
+input::placeholder{color:#94a3b8}
+button{min-width:200px;height:64px;padding:0 28px;background:linear-gradient(135deg,#38bdf8 0%,#00e1ff 50%,#0ea5e9 100%);color:#ffffff;font-weight:700;border:none;font-size:1.1rem;letter-spacing:1px;text-transform:uppercase;cursor:pointer;border-radius:0 16px 16px 0}
+button:hover{background:linear-gradient(135deg,#0ea5e9 0%,#38bdf8 50%,#00e1ff 100%)}
+.lbl{font-family:Consolas,Menlo,monospace;font-size:11px;color:var(--muted);margin-bottom:8px}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="lbl">// LogInputContainer — hero field with top sweep highlight + Analyze CTA</div>
+<div class="field">
+<span class="linkic">🔗</span>
+<input placeholder="ESOLogs.com Log URL">
+<button>Analyze Log</button>
+</div>
+<div class="src">container: border rgba(56,189,248,.2), radius 16px, shadow 0 20px 60px rgba(0,0,0,.4) + inset hl .1, top sweep rgba(56,189,248,.6), hover lift −4px — LandingPage.tsx:566-630.<br>
+input: transparent bg, 64px tall, text #e5e7eb, MUI floating label "ESOLogs.com Log URL" + cyan LinkIcon adornment — UnauthenticatedLandingSection.tsx:89-155.<br>
+button: 200×64, gradient 135° #38bdf8 → #00e1ff 50% → #0ea5e9, WHITE uppercase 700 text, radius 0 16 16 0 — UnauthenticatedLandingSection.tsx:156-221.</div>

--- a/design-sync/preview/comp-metric-pills.html
+++ b/design-sync/preview/comp-metric-pills.html
@@ -1,0 +1,246 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8">
+<title>Metric Pills — 5 Intents &times; 3 Variants</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* Mini-backdrop (simplified Nebula/Aurora) so backdrop-filter: blur(10px) is visible */
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+
+  /* ═══ MetricPill — src/components/MetricPill.tsx ═══ */
+
+  /* Intent palette — MetricPill.tsx:27-53 (exact 3-stop 135deg gradients) */
+  .i-success {
+    --mp-bg:linear-gradient(135deg, rgba(76, 217, 100, 0.25) 0%, rgba(76, 217, 100, 0.15) 50%, rgba(76, 217, 100, 0.08) 100%);
+    --mp-border:rgba(76, 217, 100, 0.3); --mp-text:#5ce572;
+  }
+  .i-warning {
+    --mp-bg:linear-gradient(135deg, rgba(255, 193, 7, 0.25) 0%, rgba(255, 193, 7, 0.15) 50%, rgba(255, 193, 7, 0.08) 100%);
+    --mp-border:rgba(255, 193, 7, 0.35); --mp-text:#ff9800;
+  }
+  .i-danger {
+    --mp-bg:linear-gradient(135deg, rgba(255, 68, 68, 0.25) 0%, rgba(255, 68, 68, 0.15) 50%, rgba(255, 68, 68, 0.08) 100%);
+    --mp-border:rgba(255, 68, 68, 0.3); --mp-text:#ff6666;
+  }
+  .i-info {
+    --mp-bg:linear-gradient(135deg, rgba(94, 234, 255, 0.25) 0%, rgba(94, 234, 255, 0.15) 50%, rgba(94, 234, 255, 0.08) 100%);
+    --mp-border:rgba(94, 234, 255, 0.35); --mp-text:#7ee8ff;
+  }
+  /* neutral text = theme.palette.text.primary in dark (#e5e7eb) */
+  .i-neutral {
+    --mp-bg:linear-gradient(135deg, rgba(148, 163, 184, 0.25) 0%, rgba(148, 163, 184, 0.15) 50%, rgba(148, 163, 184, 0.08) 100%);
+    --mp-border:rgba(148, 163, 184, 0.3); --mp-text:#e5e7eb;
+  }
+
+  /* Container — MetricPill.tsx:100-122. md size: minWidth {xs:50, sm:60}(→60),
+     px:1.5→12px, py:0.5→4px, borderRadius:1→10px (theme shape.borderRadius=10) */
+  .mp {
+    display:flex; flex-direction:column; align-items:center; justify-content:center;
+    min-width:60px; padding:4px 12px; border-radius:10px;
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+    outline:none; box-shadow:none;
+    transition:transform 120ms ease, box-shadow 120ms ease;
+    color:var(--mp-text);
+  }
+  .mp:hover { transform:translateY(-1px); }
+  /* Light mode: value/label text forced #000000; container gains a lift shadow */
+  [data-color-scheme="light"] .mp { color:#000000; }
+  [data-color-scheme="light"] .mp {
+    box-shadow:rgba(0, 0, 0, 0.16) 0px 10px 36px 0px, rgba(0, 0, 0, 0.06) 0px 0px 0px 1px;
+  }
+
+  /* Variants — MetricPill.tsx:57-81 */
+  .v-solid   { background:var(--mp-bg); border:1px solid var(--mp-border); }
+  .v-outline { background:transparent;  border:1px solid var(--mp-border); }
+  .v-mono    { background:transparent;  border:2px solid var(--mp-text); }
+
+  /* Double focus ring — MetricPill.tsx:119-121:
+     0 0 0 2px background.paper, 0 0 0 4px primary.main
+     dark: paper #0f172a, primary #38bdf8 · light: paper #ffffff, primary #0f172a
+     (ReduxThemeProvider.tsx:76-81) */
+  [data-color-scheme="dark"] .mp.is-focus { box-shadow:0 0 0 2px #0f172a, 0 0 0 4px #38bdf8; }
+  [data-color-scheme="light"] .mp.is-focus { box-shadow:0 0 0 2px #ffffff, 0 0 0 4px #0f172a; }
+
+  /* Label — MetricPill.tsx:124-140 (md: .65rem at sm breakpoint; mb:0.25→2px) */
+  .mp .lbl {
+    color:var(--muted); font-size:.65rem; font-weight:500; text-transform:uppercase;
+    letter-spacing:.05em; margin-bottom:2px;
+  }
+  [data-color-scheme="dark"] .mp .lbl { text-shadow:0 1px 2px rgba(0,0,0,0.5); }
+  [data-color-scheme="light"] .mp .lbl { text-shadow:0 1px 1px rgba(15, 23, 42, 0.1); }
+  /* Value — MetricPill.tsx:141-154 (md: .7rem at sm breakpoint) */
+  .mp .val { font-weight:600; font-size:.7rem; }
+  [data-color-scheme="dark"] .mp .val { text-shadow:0 1px 3px rgba(0,0,0,0.6); }
+  [data-color-scheme="light"] .mp .val { text-shadow:0 1px 2px rgba(15, 23, 42, 0.15); }
+  /* sm size — MetricPill.tsx:105,128,145: minWidth 70, label .65rem, value .8rem */
+  .mp.sz-sm { min-width:70px; }
+  .mp.sz-sm .val { font-size:.8rem; }
+
+  .row { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:6px; }
+  .row-name { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; font-weight:600; color:var(--muted); margin:12px 0 6px; }
+
+  /* Divergent chip palette (comparison only) — playerCardStyleUtils.ts:95-155 */
+  .chip-cmp { display:inline-flex; align-items:center; padding:4px 12px; border-radius:28px;
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); font-size:.7rem; font-weight:500;
+    border:1px solid; }
+  .chip-gold { background:linear-gradient(135deg, rgba(255, 193, 7, 0.25) 0%, rgba(255, 193, 7, 0.15) 50%, rgba(255, 193, 7, 0.08) 100%);
+    border-color:rgba(255, 193, 7, 0.35); color:#ffd54f; }
+  .chip-silver { background:linear-gradient(135deg, rgba(236, 240, 241, 0.25) 0%, rgba(236, 240, 241, 0.15) 50%, rgba(236, 240, 241, 0.08) 100%);
+    border-color:rgba(236, 240, 241, 0.35); color:#ecf0f1; }
+  .cmp-vs { font-size:.66rem; color:var(--muted); align-self:center; }
+
+  .doc-panel { border-radius:16px; padding:18px; background:#0f172a; border:1px solid #1f2937; margin-top:16px; }
+  .doc-panel h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#94a3b8; margin-bottom:10px; }
+  .note { font-size:.72rem; color:#94a3b8; line-height:1.55; margin-top:8px; }
+  .note b { color:#e5e7eb; font-weight:600; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Metric Pills — 5 Intents &times; 3 Variants</h1>
+  <p class="ds-sub">Glass stat pill (G14): 3-stop 135deg intent gradient, blur(10px), label-over-value stack, double focus ring. Source: src/components/MetricPill.tsx</p>
+
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2 class="demo-z">Dark</h2>
+      <div class="demo-z">
+        <div class="row-name">variant="solid" (default)</div>
+        <div class="row">
+          <div class="mp v-solid i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-solid i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-solid i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-solid i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-solid i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">bg 3-stop gradient + 1px border + blur(10) — MetricPill.tsx:75-81, palette :27-53</div>
+
+        <div class="row-name">variant="outline"</div>
+        <div class="row">
+          <div class="mp v-outline i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-outline i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-outline i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-outline i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-outline i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">transparent bg, 1px intent border, blur(10) — MetricPill.tsx:57-63</div>
+
+        <div class="row-name">variant="mono"</div>
+        <div class="row">
+          <div class="mp v-mono i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-mono i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-mono i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-mono i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-mono i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">transparent bg, 2px solid intent-text border, blur(10) — MetricPill.tsx:66-73</div>
+
+        <div class="row-name">focus-visible + size="sm"</div>
+        <div class="row">
+          <div class="mp v-solid i-info is-focus"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-solid i-success sz-sm"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+        </div>
+        <div class="ds-src">focus: 0 0 0 2px #0f172a, 0 0 0 4px #38bdf8 (paper, primary) — :119-121 &middot; sm: minWidth 70, value .8rem — :105,145</div>
+
+        <div class="row-name">divergence vs glossy chip palette (dark values, as-is)</div>
+        <div class="row">
+          <div class="mp v-solid i-warning"><span class="lbl">warning</span><span class="val">#ff9800</span></div>
+          <span class="cmp-vs">vs</span>
+          <span class="chip-cmp chip-gold">gold chip #ffd54f</span>
+          <div class="mp v-solid i-neutral"><span class="lbl">neutral</span><span class="val">slate</span></div>
+          <span class="cmp-vs">vs</span>
+          <span class="chip-cmp chip-silver">silver chip</span>
+        </div>
+        <div class="ds-src">MetricPill.tsx:33-36,48-52 vs playerCardStyleUtils.ts:126-137 — different surfaces, both canonical</div>
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2 class="demo-z">Light</h2>
+      <div class="demo-z">
+        <div class="row-name">variant="solid" (default)</div>
+        <div class="row">
+          <div class="mp v-solid i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-solid i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-solid i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-solid i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-solid i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">same gradients; text forced #000000; lift shadow rgba(0,0,0,.16) 0 10px 36px + rgba(0,0,0,.06) ring — :61,111-114</div>
+
+        <div class="row-name">variant="outline"</div>
+        <div class="row">
+          <div class="mp v-outline i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-outline i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-outline i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-outline i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-outline i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">intent border stays; light text #000000 — MetricPill.tsx:57-63</div>
+
+        <div class="row-name">variant="mono"</div>
+        <div class="row">
+          <div class="mp v-mono i-success"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+          <div class="mp v-mono i-warning"><span class="lbl">Deaths</span><span class="val">3</span></div>
+          <div class="mp v-mono i-danger"><span class="lbl">Wipes</span><span class="val">2</span></div>
+          <div class="mp v-mono i-info"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-mono i-neutral"><span class="lbl">Pulls</span><span class="val">14</span></div>
+        </div>
+        <div class="ds-src">2px border keeps the DARK intent text color even in light mode (p.text) — MetricPill.tsx:66-73</div>
+
+        <div class="row-name">focus-visible + size="sm"</div>
+        <div class="row">
+          <div class="mp v-solid i-info is-focus"><span class="lbl">DPS</span><span class="val">112.4k</span></div>
+          <div class="mp v-solid i-success sz-sm"><span class="lbl">Uptime</span><span class="val">98.2%</span></div>
+        </div>
+        <div class="ds-src">focus: 0 0 0 2px #ffffff, 0 0 0 4px #0f172a (paper, primary) — :119-121</div>
+      </div>
+    </section>
+  </div>
+
+  <div class="doc-panel">
+    <h2>Palette divergence — document both, do not unify</h2>
+    <p class="note">MetricPill's intent palette (MetricPill.tsx:27-53) is a <b>divergent copy</b> of the glossy-chip variant palette (src/utils/playerCardStyleUtils.ts:95-155). Identical: <b>success</b> &equiv; chip <code>green</code>, <b>info</b> &equiv; chip <code>lightBlue</code>, <b>danger</b> gradient/border &equiv; chip <code>championRed</code> (both text #ff6666). Diverged: <b>warning</b> shares the gold gradient/border but uses text <code>#ff9800</code> where the chip <code>gold</code> uses <code>#ffd54f</code>; <b>neutral</b> is slate <code>rgba(148,163,184,&hellip;)</code> where the chip <code>silver</code> is <code>rgba(236,240,241,&hellip;)</code> with text <code>#ecf0f1</code>; light-mode text is forced <code>#000000</code> here vs <code>#1f2937</code> on chips (playerCardStyleUtils.ts:44). Pills are also flat (radius 10, no gloss); chips are the G4 glossy recipe (radius 28, shine sweep, gloss dome). Different surfaces — transcribe each as-is.</p>
+    <p class="note"><b>Other exact values:</b> hover <code>translateY(-1px)</code> with <code>transition: transform 120ms ease, box-shadow 120ms ease</code> (:115-118); dark container shadow <code>none</code> (:111-114); label textShadow dark <code>0 1px 2px rgba(0,0,0,0.5)</code> / light <code>0 1px 1px rgba(15,23,42,0.1)</code> (:133-136); value textShadow dark <code>0 1px 3px rgba(0,0,0,0.6)</code> / light <code>0 1px 2px rgba(15,23,42,0.15)</code> (:146-149).</p>
+  </div>
+</div>

--- a/design-sync/preview/comp-navbar.html
+++ b/design-sync/preview/comp-navbar.html
@@ -1,0 +1,25 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Header / Navbar</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.nav{background:rgba(11,18,32,.95);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);border-bottom:1px solid rgba(56,189,248,.15);padding:10px 24px;display:flex;align-items:center;justify-content:space-between;border-radius:8px;min-height:64px;box-sizing:border-box}
+.logo{display:flex;align-items:center;gap:8px;font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-size:18px;font-weight:800;letter-spacing:-.02em;background:linear-gradient(135deg,#ffffff 0%,#f8fafc 50%,#e2e8f0 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.logo img{width:30px;height:30px}
+.links{display:flex;gap:12px;list-style:none;margin:0;padding:0;align-items:center}
+.links a{display:inline-block;color:var(--text);text-decoration:none;font-size:14px;font-weight:500;padding:8px 16px;border-radius:20px;border:1px solid transparent;transition:all .3s cubic-bezier(.4,0,.2,1)}
+.links a:hover{background:rgba(56,189,248,.08);border-color:rgba(56,189,248,.2);transform:translateY(-1px);box-shadow:0 4px 20px rgba(56,189,248,.15),0 2px 8px rgba(0,0,0,.1)}
+.signin{font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-weight:700;font-size:.85rem;color:#fff;padding:6px 20px;border-radius:10px;background:linear-gradient(135deg,#3b82f6 0%,#2563eb 100%);box-shadow:0 4px 16px rgba(59,130,246,.3),inset 0 1px 0 rgba(255,255,255,.15);text-decoration:none}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<nav class="nav">
+<div class="logo"><img src="../assets/eso-helper-icon.svg" onerror="this.style.display='none'">ESO Toolkit</div>
+<ul class="links">
+<li><a>👥 Roster Hub</a></li><li><a>🏗️ Build Hub</a></li><li><a>🧩 Pack Hub</a></li>
+<li><a>Reports ▾</a></li><li><a>Tools ▾</a></li>
+<li><a class="signin">Sign in</a></li>
+</ul>
+</nav>
+<div class="src">bar: rgba(11,18,32,.95) + blur(10px) + border-bottom rgba(56,189,248,.15) — MuiAppBar override, ReduxThemeProvider.tsx:150-154.<br>
+wordmark: Space Grotesk 800, ls -.02em, gradient #ffffff→#f8fafc→#e2e8f0 (dark) — HeaderBar.tsx:843-855; logo icon 30px.<br>
+nav buttons: pill (radius 20px), weight 500, hover rgba(56,189,248,.08) bg + .2 border + lift — navButtonSx, HeaderBar.tsx:258-299. No active underline in source.<br>
+Sign in: gradient #3b82f6→#2563eb, radius 10px — HeaderBar.tsx:1047-1056.</div>

--- a/design-sync/preview/comp-player-card.html
+++ b/design-sync/preview/comp-player-card.html
@@ -1,0 +1,30 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Player Card</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.card{background:linear-gradient(135deg,rgb(110 170 240 / 25%) 0%,rgb(152 131 227 / 15%) 50%,rgb(173 192 255 / 8%) 100%);border:1px solid rgba(255,255,255,.1);border-radius:14px;padding:16px;max-width:420px}
+.head{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.ava{width:40px;height:40px;border-radius:50%;background:linear-gradient(135deg,#38bdf8,#00e1ff);display:flex;align-items:center;justify-content:center;overflow:hidden}
+.ava img{width:26px;height:26px;filter:brightness(0) invert(1)}
+.name{font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-size:1.15rem;font-weight:400;line-height:1.2}
+.sub{display:flex;align-items:center;gap:4px;font-size:11px;color:var(--muted)}
+.armor{display:inline-flex;align-items:center;gap:3px;font-size:11px;margin-left:auto}
+.armor .h{color:#ff7a7a}.armor .m{color:#93f093}.armor .l{color:#3c9bff}
+.talents{display:flex;gap:10px;margin-bottom:10px}
+.slot{width:32px;height:32px;border-radius:4px;background:linear-gradient(135deg,#1e293b,#0f172a);border:1px solid #b5b8bd59;display:flex;align-items:center;justify-content:center;font-size:12px;color:#38bdf8}
+.ult{width:34px;height:34px;border:1.5px solid #b3b3b3f2;box-shadow:inset 0 2px 4px rgb(0 0 0 / 100%),0 0 0 1px rgb(255 255 255 / 18%),0 0 10px rgb(255 255 255 / 25%),0 2px 6px rgb(0 0 0 / 60%)}
+.metrics{display:flex;gap:10px;font-size:10px;color:var(--muted);padding-top:10px;border-top:1px solid var(--border)}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="card">
+<div class="head">
+<div class="ava"><img src="../assets/classes/arcanist.png"></div>
+<div><div class="name">@bigknifeboi</div><div class="sub">Herald · Soldier · Curative</div></div>
+<div class="armor"><span class="h">0</span>•<span class="m">2</span>•<span class="l">5</span></div>
+</div>
+<div class="talents"><div class="slot">⚡</div><div class="slot">🌀</div><div class="slot">💥</div><div class="slot">🛡</div><div class="slot">⚔</div><div class="slot ult">🔥</div></div>
+<div class="metrics">🍲 <b style="color:#c57fff">TRI</b> · 💀 0 · ❤ 2 · 🐭 42.1</div>
+</div>
+<div class="src">src/features/report_details/insights/PlayerCard.tsx — bg gradient (blue-violet, both modes) :592-593 · border rgba(255,255,255,.1) :599 ·
+radius 14 via MuiCard override (ReduxThemeProvider.tsx:230) · skill slots 32px / ultimate 34px, 1px #b5b8bd59 / 1.5px #b3b3b3f2 + inset glow :1621-1631 ·
+armor counts #ff7a7a / #93f093 / #3c9bff :1333,1351,1367 · avatar 40px (PlayerIcon.tsx:26) · name Space Grotesk 1.15rem (declared fontWeight:100) :1300-1309</div>

--- a/design-sync/preview/comp-status-badges.html
+++ b/design-sync/preview/comp-status-badges.html
@@ -1,0 +1,27 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Status Badges</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.row{display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-bottom:16px}
+
+/* MarketingBadge — cyan glass pill with float animation */
+.marketing{display:inline-flex;align-items:center;gap:.5rem;background:linear-gradient(135deg,rgba(56,189,248,.1),rgba(0,225,255,.05));border:1px solid rgba(56,189,248,.2);border-radius:50px;padding:.5rem 1.2rem;font-size:.9rem;font-weight:600;color:#38bdf8;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);box-shadow:0 4px 20px rgba(56,189,248,.1);animation:float 3s ease-in-out infinite}
+@keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}
+
+/* Addon eyebrow + COMING SOON pill (dark values) */
+.eyebrow{display:inline-flex;align-items:center;gap:10px;padding:5px 10px;border-radius:6px;background:rgba(245,158,11,.08);border:1px solid rgba(245,158,11,.15)}
+.eyebrow .t{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.12em;color:#f59e0b}
+.coming{padding:2px 6px;border-radius:4px;background:rgba(245,158,11,.18);font-size:.65rem;font-weight:700;color:#fbbf24;letter-spacing:.08em;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.7}}
+
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:8px;line-height:1.6}
+</style>
+<div class="row">
+<span class="marketing">✨ Combat analysis for ESO</span>
+</div>
+<div class="row">
+<span class="eyebrow"><span class="t">In-Game Addon</span><span class="coming">COMING SOON</span></span>
+</div>
+<div class="src">MarketingBadge — src/components/MarketingBadge.tsx:4-22 (cyan glass pill, radius 50px, float 3s).<br>
+"COMING SOON" pill — src/components/LandingPage.tsx:2874-2924 (amber rgba(245,158,11,.18) bg, #fbbf24 text, radius 4px, pulse 2s opacity 1→0.7; eyebrow #f59e0b).<br>
+The gold-gradient badge + Live/Beta pills of the older card came from the legacy static src/landingpage.css and are not in the live app.</div>

--- a/design-sync/preview/comp-tabs.html
+++ b/design-sync/preview/comp-tabs.html
@@ -1,0 +1,24 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Report Tabs</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.tabs{display:flex;gap:8px;align-items:center;overflow-x:auto}
+.tab{display:inline-flex;align-items:center;justify-content:center;min-width:48px;min-height:48px;padding:6px 12px;border-radius:100px;font-size:20px;color:#94a3b8;cursor:pointer;flex-shrink:0;transition:background .2s ease}
+.tab:hover{background:rgba(56,189,248,.08)}
+.tab.active{color:#38bdf8}
+.content{padding:16px;font-size:13px;color:var(--muted);font-family:Consolas,Menlo,monospace;animation:tabFadeIn 150ms ease-out}
+@keyframes tabFadeIn{from{opacity:0}to{opacity:1}}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:10px;line-height:1.6}
+</style>
+<div class="tabs">
+<div class="tab active" title="Insights">✨</div>
+<div class="tab" title="Players">👥</div>
+<div class="tab" title="Damage Done">⚔️</div>
+<div class="tab" title="Healing Done">💚</div>
+<div class="tab" title="Deaths">💀</div>
+<div class="tab" title="Maps">🗺️</div>
+</div>
+<div class="content">// icon-only pill tabs with tooltips — the indicator is hidden</div>
+<div class="src">MUI Tabs, scrollable — FightDetailsView.tsx:400-453: indicator display:none, flexContainer gap 8px, tab min 48×48, padding 6px 12px, radius 100px.
+Selected = theme primary #38bdf8; unselected = text.secondary #94a3b8. No MuiTab(s) theme overrides exist in ReduxThemeProvider.tsx.
+Tab content enters with a 150ms tabFadeIn (AnimatedTabContent.tsx:25-33).</div>

--- a/design-sync/preview/comp-tool-card.html
+++ b/design-sync/preview/comp-tool-card.html
@@ -1,0 +1,27 @@
+<!-- @dsCard group="Components" -->
+<meta charset="utf-8"><title>Landing Tool Card</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.card{background:rgba(15,23,42,.6);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border:1px solid rgba(56,189,248,.1);border-radius:16px;padding:2rem;max-width:340px;box-shadow:0 8px 32px rgba(0,0,0,.3),inset 0 1px 0 rgba(255,255,255,.05);position:relative;overflow:hidden}
+.card::before{content:"";position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent,rgba(56,189,248,.6),transparent);opacity:0;transition:opacity .4s ease}
+.card:hover{border-color:rgba(56,189,248,.3);box-shadow:0 20px 60px rgba(0,0,0,.4),0 0 60px rgba(56,189,248,.15),inset 0 1px 0 rgba(255,255,255,.1)}
+.card:hover::before{opacity:1}
+.ic{width:64px;height:64px;background:linear-gradient(135deg,rgba(56,189,248,.15),rgba(0,225,255,.1));border:1px solid rgba(56,189,248,.2);border-radius:16px;display:flex;align-items:center;justify-content:center;font-size:2rem;margin-bottom:1.5rem;color:#38bdf8;box-shadow:0 4px 20px rgba(0,0,0,.2),inset 0 1px 0 rgba(255,255,255,.1)}
+h3{margin:0 0 16px;font-size:1.5rem;font-weight:700;font-family:'Space Grotesk',Inter,system-ui,sans-serif}
+p{margin:0 0 16px;color:var(--muted);font-size:14px;font-weight:200;line-height:1.6}
+ul{list-style:none;margin:0 0 24px;padding:0;color:var(--muted);font-size:13px}
+ul li{padding:.5rem 0 .5rem 1.5rem;position:relative;font-weight:500}
+ul li::before{content:"✓";position:absolute;left:0;color:#38bdf8;font-weight:bold}
+.cta{display:block;text-align:center;padding:.875rem 1.5rem;background:linear-gradient(135deg,#38bdf8 0%,#0ea5e9 100%);color:#ffffff;border-radius:12px;border:none;font-weight:600;font-size:.95rem;letter-spacing:.5px;text-decoration:none;box-shadow:0 4px 20px rgba(0,0,0,.2),inset 0 1px 0 rgba(255,255,255,.2)}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="card">
+<div class="ic">🧮</div>
+<h3>Build Calculator</h3>
+<p>Optimize your character's stats. Track penetration, crit, and armor to hit crucial caps.</p>
+<ul><li>Penetration optimizer (18,200 cap)</li><li>Critical damage calculator (125% cap)</li><li>Armor resistance planner</li></ul>
+<a class="cta" href="#">Launch Calculator</a>
+</div>
+<div class="src">src/components/LandingPage.tsx — ToolCard :1281-1361 (rgba(15,23,42,.6) + blur(12px), border rgba(56,189,248,.1), radius 16, shadow 0 8px 32px + inset .05, hover hairline) ·
+ToolIcon :1363-1420 (64px, radius 16, cyan glass) · ToolFeatures :1422-1441 (✓ #38bdf8) · ToolAction :1443-1498 (solid #38bdf8→#0ea5e9, white, radius 12).
+The old translucent-cyan CTA / 14px-radius card came from the legacy static src/landingpage.css.</div>

--- a/design-sync/preview/pattern-background-layers.html
+++ b/design-sync/preview/pattern-background-layers.html
@@ -1,0 +1,326 @@
+<!-- @dsCard group="Patterns" -->
+<meta charset="utf-8">
+<title>Background Layers — Nebula / Aurora</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  h3.sect { font-size:.8rem; color:var(--text); margin:16px 0 8px; }
+  .note { font-size:.72rem; color:var(--muted); line-height:1.5; margin-top:8px; }
+  pre.code { background:#0d1430; border:1px solid #1f2937; border-radius:10px; padding:12px;
+    font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; line-height:1.55;
+    color:#94a3b8; overflow-x:auto; margin-top:8px; white-space:pre; }
+  pre.code b { color:#e5e7eb; font-weight:500; }
+
+  /* ── Real keyframes, transcribed exactly ─────────────────────────────── */
+  /* NebulaBackground.tsx:44-61 */
+  @keyframes nebulaFloat {
+    0%, 100% { transform: translateY(0) translateX(0) scale(1); opacity: 0.3; }
+    25%      { transform: translateY(-15px) translateX(8px) scale(1.05); opacity: 0.7; }
+    50%      { transform: translateY(-25px) translateX(-5px) scale(0.95); opacity: 0.5; }
+    75%      { transform: translateY(-12px) translateX(12px) scale(1.02); opacity: 0.8; }
+  }
+  /* NebulaBackground.tsx:62-65 */
+  @keyframes nebulaDriftSlow {
+    0%, 100% { transform: scale(1) translate(0, 0) rotate(0deg); }
+    50% { transform: scale(1.15) translate(-30px, 15px) rotate(2deg); }
+  }
+  /* NebulaBackground.tsx:66-69 */
+  @keyframes nebulaDriftMedium {
+    0%, 100% { transform: scale(1) translate(0, 0) rotate(0deg); }
+    50% { transform: scale(1.2) translate(25px, -10px) rotate(-2deg); }
+  }
+  /* AuroraBackground.tsx:55-72 */
+  @keyframes aurMoteFloat {
+    0%, 100% { transform: translateY(0) translateX(0) scale(1); opacity: 0.25; }
+    25%      { transform: translateY(-12px) translateX(6px) scale(1.04); opacity: 0.55; }
+    50%      { transform: translateY(-20px) translateX(-4px) scale(0.96); opacity: 0.4; }
+    75%      { transform: translateY(-10px) translateX(10px) scale(1.02); opacity: 0.6; }
+  }
+  /* AuroraBackground.tsx:74-87 */
+  @keyframes aurCloudDriftA {
+    0%, 100% { transform: scale(1) translate(0, 0) rotate(0deg); }
+    50%      { transform: scale(1.12) translate(-25px, 12px) rotate(1.5deg); }
+  }
+  @keyframes aurCloudDriftB {
+    0%, 100% { transform: scale(1) translate(0, 0) rotate(0deg); }
+    50%      { transform: scale(1.18) translate(20px, -8px) rotate(-1.5deg); }
+  }
+  @keyframes aurCloudDriftC {
+    0%, 100% { transform: scale(1) translate(0, 0) rotate(0deg); }
+    50%      { transform: scale(1.1) translate(-15px, -10px) rotate(1deg); }
+  }
+
+  /* ── Composite stage ─────────────────────────────────────────────────── */
+  .bgl-stage { position:relative; height:280px; border-radius:12px; overflow:hidden; border:1px solid var(--border); }
+  .bgl-layer { position:absolute; inset:0; pointer-events:none; }
+
+  /* Layer 1 — base wash. NebulaBackground.tsx:99-104 */
+  .neb-base {
+    background:
+      radial-gradient(ellipse at 20% 30%, rgba(100, 50, 255, 0.15) 0%, transparent 50%),
+      radial-gradient(ellipse at 80% 70%, rgba(0, 217, 255, 0.12) 0%, transparent 50%),
+      radial-gradient(ellipse at 50% 50%, rgba(50, 0, 100, 0.1) 0%, transparent 60%),
+      linear-gradient(135deg, #050810 0%, #0a0f1e 50%, #050810 100%);
+  }
+  /* AuroraBackground.tsx:118-123 */
+  .aur-base {
+    background:
+      radial-gradient(ellipse at 25% 20%, rgba(165, 180, 252, 0.10) 0%, transparent 55%),
+      radial-gradient(ellipse at 75% 75%, rgba(56, 189, 248, 0.08) 0%, transparent 55%),
+      radial-gradient(ellipse at 50% 50%, rgba(236, 172, 190, 0.05) 0%, transparent 60%),
+      linear-gradient(160deg, #f0f4ff 0%, #f8fafc 35%, #fdf2f8 65%, #f0fdfa 100%);
+  }
+
+  /* Layer 2 — clouds: pre-diffused radial gradients, NO filter:blur (iOS Safari GPU). */
+  .cloud { position:absolute; }
+  /* NebulaBackground.tsx:116-126 */
+  .neb-c1 { width:90%; height:90%; top:5%; left:-5%;
+    background:radial-gradient(ellipse, rgba(120, 60, 230, 0.12) 0%, transparent 55%);
+    animation:nebulaDriftSlow 40s ease-in-out infinite; }
+  /* NebulaBackground.tsx:127-137 */
+  .neb-c2 { width:75%; height:75%; bottom:5%; right:-5%;
+    background:radial-gradient(ellipse, rgba(0, 217, 255, 0.09) 0%, transparent 55%);
+    animation:nebulaDriftMedium 30s ease-in-out infinite reverse; }
+  /* NebulaBackground.tsx:138-148 */
+  .neb-c3 { width:65%; height:65%; top:25%; right:15%;
+    background:radial-gradient(ellipse, rgba(180, 60, 200, 0.07) 0%, transparent 55%);
+    animation:nebulaDriftSlow 50s ease-in-out infinite; }
+  /* AuroraBackground.tsx:135-145 */
+  .aur-c1 { width:85%; height:85%; top:0%; left:-5%;
+    background:radial-gradient(ellipse, rgba(165, 180, 252, 0.08) 0%, transparent 50%);
+    animation:aurCloudDriftA 42s ease-in-out infinite; }
+  /* AuroraBackground.tsx:146-156 */
+  .aur-c2 { width:75%; height:75%; bottom:0%; right:-5%;
+    background:radial-gradient(ellipse, rgba(56, 189, 248, 0.06) 0%, transparent 50%);
+    animation:aurCloudDriftB 34s ease-in-out infinite reverse; }
+  /* AuroraBackground.tsx:157-167 */
+  .aur-c3 { width:65%; height:65%; top:20%; right:10%;
+    background:radial-gradient(ellipse, rgba(236, 172, 190, 0.06) 0%, transparent 50%);
+    animation:aurCloudDriftC 48s ease-in-out infinite; }
+  /* AuroraBackground.tsx:168-178 */
+  .aur-c4 { width:60%; height:60%; bottom:10%; left:5%;
+    background:radial-gradient(ellipse, rgba(94, 234, 212, 0.05) 0%, transparent 50%);
+    animation:aurCloudDriftA 52s ease-in-out infinite reverse; }
+
+  /* Layer 3 — particles. Randomized in JS at mount (NebulaBackground.tsx:25-36,
+     AuroraBackground.tsx:35-47); the set below is a representative HAND-PLACED
+     sample within the real ranges. Star: size 1-5px, opacity .15-.75, duration
+     8-23s, delay 0-8s; ~30% get glow `0 0 size*3px rgba(255,255,255,op*0.6)`.
+     Mote: size 1-4.5px, opacity .25-.75, duration 10-28s, delay 0-10s, colors
+     cycle MOTE_COLORS (AuroraBackground.tsx:17-23); ~25% glow `0 0 size*4px color`. */
+  .star { position:absolute; border-radius:50%; background:rgba(255,255,255,var(--o));
+    width:var(--s); height:var(--s); left:var(--x); top:var(--y);
+    animation:nebulaFloat var(--d) ease-in-out infinite; animation-delay:var(--dl); }
+  .mote { position:absolute; border-radius:50%; background:var(--c);
+    width:var(--s); height:var(--s); left:var(--x); top:var(--y);
+    animation:aurMoteFloat var(--d) ease-in-out infinite; animation-delay:var(--dl); }
+
+  /* Layer 4 — grid overlay. NebulaBackground.tsx:183-195 */
+  .neb-grid {
+    background-image:
+      linear-gradient(transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px),
+      linear-gradient(90deg, transparent 24px, rgba(0, 217, 255, 0.025) 24px, rgba(0, 217, 255, 0.025) 25px, transparent 25px);
+    background-size:50px 50px; opacity:0.4;
+  }
+  /* AuroraBackground.tsx:210-223 */
+  .aur-grid {
+    background-image:
+      linear-gradient(transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px),
+      linear-gradient(90deg, transparent 24px, rgba(165, 180, 252, 0.03) 24px, rgba(165, 180, 252, 0.03) 25px, transparent 25px);
+    background-size:50px 50px; opacity:0.35;
+  }
+  /* Amplified twins (10x line alpha) — for legibility only, NOT a real value */
+  .neb-grid-amp { background-image:
+      linear-gradient(transparent 24px, rgba(0,217,255,0.25) 24px, rgba(0,217,255,0.25) 25px, transparent 25px),
+      linear-gradient(90deg, transparent 24px, rgba(0,217,255,0.25) 24px, rgba(0,217,255,0.25) 25px, transparent 25px);
+    background-size:50px 50px; opacity:0.4; }
+  .aur-grid-amp { background-image:
+      linear-gradient(transparent 24px, rgba(165,180,252,0.3) 24px, rgba(165,180,252,0.3) 25px, transparent 25px),
+      linear-gradient(90deg, transparent 24px, rgba(165,180,252,0.3) 24px, rgba(165,180,252,0.3) 25px, transparent 25px);
+    background-size:50px 50px; opacity:0.35; }
+
+  /* Exploded strips */
+  .strip { position:relative; height:64px; border-radius:8px; overflow:hidden; border:1px solid var(--border); margin-top:10px; }
+  .strip .bgl-layer { position:absolute; inset:0; }
+  .strip-label { position:absolute; top:6px; left:8px; z-index:5; font-size:.6rem; text-transform:uppercase;
+    letter-spacing:.1em; font-weight:600; color:var(--muted); background:color-mix(in srgb, var(--bg) 70%, transparent);
+    padding:1px 6px; border-radius:6px; }
+  .half { position:absolute; inset:0; }
+  .half.r { left:50%; }
+  .half-tag { position:absolute; top:6px; right:8px; z-index:5; font-size:.58rem; color:var(--muted); }
+
+  table.tiers { width:100%; border-collapse:collapse; font-size:.72rem; margin-top:8px; }
+  table.tiers th, table.tiers td { text-align:left; padding:6px 10px; border-bottom:1px solid #1f2937; color:#e5e7eb; }
+  table.tiers th { color:#94a3b8; font-weight:600; text-transform:uppercase; font-size:.62rem; letter-spacing:.08em; }
+  .gate { border-radius:16px; padding:18px; background:#0f172a; border:1px solid #1f2937; margin-top:16px; }
+  .gate h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#94a3b8; margin-bottom:10px; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Background Layers — Nebula (dark) / Aurora (light)</h1>
+  <p class="ds-sub">The site-wide 4-layer atmospheric background: base gradient wash &rarr; drifting clouds &rarr; floating particles &rarr; grid overlay. One fixed, pointer-events:none stack at zIndex:-1. Sources: nebula-background-technique.md, src/features/loadout-manager/components/NebulaBackground.tsx, AuroraBackground.tsx, src/components/shared/SiteBackground.tsx</p>
+
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark — NebulaBackground</h2>
+
+      <h3 class="sect">Full composite (all 4 layers)</h3>
+      <div class="bgl-stage">
+        <div class="bgl-layer neb-base"></div>
+        <div class="bgl-layer">
+          <div class="cloud neb-c1"></div>
+          <div class="cloud neb-c2"></div>
+          <div class="cloud neb-c3"></div>
+        </div>
+        <div class="bgl-layer">
+          <span class="star" style="--s:2px; --o:.55; --x:8%;  --y:22%; --d:12s; --dl:0s;"></span>
+          <span class="star" style="--s:4px; --o:.7;  --x:21%; --y:64%; --d:16s; --dl:2s; box-shadow:0 0 12px rgba(255,255,255,0.42);"></span>
+          <span class="star" style="--s:1px; --o:.25; --x:33%; --y:12%; --d:9s;  --dl:5s;"></span>
+          <span class="star" style="--s:3px; --o:.6;  --x:45%; --y:44%; --d:20s; --dl:1s;"></span>
+          <span class="star" style="--s:5px; --o:.75; --x:56%; --y:75%; --d:14s; --dl:3s; box-shadow:0 0 15px rgba(255,255,255,0.45);"></span>
+          <span class="star" style="--s:2px; --o:.4;  --x:63%; --y:18%; --d:22s; --dl:6s;"></span>
+          <span class="star" style="--s:1px; --o:.2;  --x:71%; --y:52%; --d:10s; --dl:4s;"></span>
+          <span class="star" style="--s:3px; --o:.65; --x:79%; --y:30%; --d:18s; --dl:7s; box-shadow:0 0 9px rgba(255,255,255,0.39);"></span>
+          <span class="star" style="--s:2px; --o:.5;  --x:88%; --y:68%; --d:13s; --dl:2.5s;"></span>
+          <span class="star" style="--s:4px; --o:.35; --x:93%; --y:14%; --d:23s; --dl:1.5s;"></span>
+          <span class="star" style="--s:1px; --o:.3;  --x:15%; --y:85%; --d:8s;  --dl:6.5s;"></span>
+          <span class="star" style="--s:2px; --o:.45; --x:39%; --y:88%; --d:15s; --dl:0.5s;"></span>
+          <span class="star" style="--s:3px; --o:.55; --x:68%; --y:90%; --d:11s; --dl:3.5s;"></span>
+          <span class="star" style="--s:1px; --o:.15; --x:50%; --y:8%;  --d:19s; --dl:7.5s;"></span>
+        </div>
+        <div class="bgl-layer neb-grid"></div>
+      </div>
+      <div class="ds-src">Layers: base :99-104 &middot; clouds :116-148 &middot; particles :160-178 &middot; grid :183-195 — NebulaBackground.tsx</div>
+      <p class="note">Particles are randomized in JS at mount (useMemo, NebulaBackground.tsx:25-36) — this card shows a representative hand-placed set within the real ranges (size 1&ndash;5px, opacity 0.15&ndash;0.75, duration 8&ndash;23s, delay 0&ndash;8s, ~30% with glow halo <code>0 0 size&times;3px rgba(255,255,255,opacity&times;0.6)</code>).</p>
+
+      <h3 class="sect">Exploded — one layer per strip</h3>
+      <div class="strip"><div class="bgl-layer neb-base"></div><span class="strip-label">L1 base wash &middot; z0</span></div>
+      <div class="ds-src">3 radial ellipses (alpha .10&ndash;.15) over linear-gradient(135deg, #050810 0%, #0a0f1e 50%, #050810 100%) — :99-104</div>
+      <div class="strip" style="background:#050810;">
+        <div class="bgl-layer">
+          <div class="cloud neb-c1"></div><div class="cloud neb-c2"></div><div class="cloud neb-c3"></div>
+        </div><span class="strip-label">L2 clouds &middot; z1</span>
+      </div>
+      <div class="ds-src">3 clouds, pre-diffused radial gradients (NO filter:blur), nebulaDriftSlow 40s / nebulaDriftMedium 30s reverse / nebulaDriftSlow 50s — :116-148 (shown over the L1 base color)</div>
+      <div class="strip" style="background:#050810;">
+        <div class="bgl-layer">
+          <span class="star" style="--s:3px; --o:.6;  --x:10%; --y:40%; --d:14s; --dl:0s;"></span>
+          <span class="star" style="--s:5px; --o:.75; --x:30%; --y:60%; --d:18s; --dl:2s; box-shadow:0 0 15px rgba(255,255,255,0.45);"></span>
+          <span class="star" style="--s:2px; --o:.4;  --x:52%; --y:30%; --d:10s; --dl:4s;"></span>
+          <span class="star" style="--s:4px; --o:.65; --x:70%; --y:55%; --d:21s; --dl:1s; box-shadow:0 0 12px rgba(255,255,255,0.39);"></span>
+          <span class="star" style="--s:1px; --o:.3;  --x:86%; --y:35%; --d:9s;  --dl:6s;"></span>
+        </div><span class="strip-label">L3 particles &middot; z2</span>
+      </div>
+      <div class="ds-src">white dots rgba(255,255,255,op), nebulaFloat 4-step firefly path — :160-178 (hand-placed sample, shown over base color)</div>
+      <div class="strip" style="background:#050810;">
+        <div class="half"><div class="bgl-layer neb-grid"></div></div>
+        <div class="half r"><div class="bgl-layer neb-grid-amp"></div></div>
+        <span class="strip-label">L4 grid &middot; z3</span><span class="half-tag">left: exact &middot; right: line alpha &times;10 for legibility</span>
+      </div>
+      <div class="ds-src">1px cyan lines every 50px, rgba(0,217,255,0.025) at opacity 0.4 (effective alpha &asymp;.01 — felt, not seen) — :183-195</div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light — AuroraBackground</h2>
+
+      <h3 class="sect">Full composite (all 4 layers)</h3>
+      <div class="bgl-stage">
+        <div class="bgl-layer aur-base"></div>
+        <div class="bgl-layer">
+          <div class="cloud aur-c1"></div>
+          <div class="cloud aur-c2"></div>
+          <div class="cloud aur-c3"></div>
+          <div class="cloud aur-c4"></div>
+        </div>
+        <div class="bgl-layer">
+          <span class="mote" style="--s:2.5px; --c:rgba(147, 130, 220, 0.45); --x:12%; --y:26%; --d:14s; --dl:0s;"></span>
+          <span class="mote" style="--s:4px;   --c:rgba(56, 189, 248, 0.40);  --x:26%; --y:62%; --d:20s; --dl:3s; box-shadow:0 0 16px rgba(56, 189, 248, 0.40);"></span>
+          <span class="mote" style="--s:1.5px; --c:rgba(94, 234, 212, 0.35);  --x:41%; --y:18%; --d:11s; --dl:6s;"></span>
+          <span class="mote" style="--s:3px;   --c:rgba(236, 172, 190, 0.35); --x:55%; --y:48%; --d:24s; --dl:1s;"></span>
+          <span class="mote" style="--s:4.5px; --c:rgba(165, 180, 252, 0.40); --x:67%; --y:74%; --d:16s; --dl:4s; box-shadow:0 0 18px rgba(165, 180, 252, 0.40);"></span>
+          <span class="mote" style="--s:2px;   --c:rgba(147, 130, 220, 0.45); --x:76%; --y:22%; --d:27s; --dl:8s;"></span>
+          <span class="mote" style="--s:1px;   --c:rgba(56, 189, 248, 0.40);  --x:85%; --y:56%; --d:12s; --dl:5s;"></span>
+          <span class="mote" style="--s:3.5px; --c:rgba(94, 234, 212, 0.35);  --x:92%; --y:34%; --d:22s; --dl:2s; box-shadow:0 0 14px rgba(94, 234, 212, 0.35);"></span>
+          <span class="mote" style="--s:2px;   --c:rgba(236, 172, 190, 0.35); --x:20%; --y:86%; --d:18s; --dl:9s;"></span>
+          <span class="mote" style="--s:1.5px; --c:rgba(165, 180, 252, 0.40); --x:48%; --y:90%; --d:13s; --dl:7s;"></span>
+        </div>
+        <div class="bgl-layer aur-grid"></div>
+      </div>
+      <div class="ds-src">Layers: base :118-123 &middot; clouds :135-178 &middot; motes :190-207 &middot; grid :210-223 — AuroraBackground.tsx</div>
+      <p class="note">Motes are randomized in JS at mount (AuroraBackground.tsx:35-47) — hand-placed sample within the real ranges (size 1&ndash;4.5px, opacity 0.25&ndash;0.75, duration 10&ndash;28s, delay 0&ndash;10s, colors cycle MOTE_COLORS :17-23, ~25% glow <code>0 0 size&times;4px color</code>).</p>
+
+      <h3 class="sect">Exploded — one layer per strip</h3>
+      <div class="strip"><div class="bgl-layer aur-base"></div><span class="strip-label">L1 base wash &middot; z0</span></div>
+      <div class="ds-src">3 pastel radial ellipses (alpha .05&ndash;.10) over linear-gradient(160deg, #f0f4ff 0%, #f8fafc 35%, #fdf2f8 65%, #f0fdfa 100%) — :118-123</div>
+      <div class="strip" style="background:#f8fafc;">
+        <div class="bgl-layer">
+          <div class="cloud aur-c1"></div><div class="cloud aur-c2"></div><div class="cloud aur-c3"></div><div class="cloud aur-c4"></div>
+        </div><span class="strip-label">L2 clouds &middot; z1</span>
+      </div>
+      <div class="ds-src">4 pastel clouds (NO filter:blur), aurCloudDriftA 42s / B 34s reverse / C 48s / A 52s reverse — :135-178</div>
+      <div class="strip" style="background:#f8fafc;">
+        <div class="bgl-layer">
+          <span class="mote" style="--s:3px;   --c:rgba(147, 130, 220, 0.45); --x:12%; --y:40%; --d:15s; --dl:0s;"></span>
+          <span class="mote" style="--s:4.5px; --c:rgba(56, 189, 248, 0.40);  --x:32%; --y:60%; --d:22s; --dl:2s; box-shadow:0 0 18px rgba(56, 189, 248, 0.40);"></span>
+          <span class="mote" style="--s:2px;   --c:rgba(94, 234, 212, 0.35);  --x:54%; --y:32%; --d:12s; --dl:5s;"></span>
+          <span class="mote" style="--s:3.5px; --c:rgba(236, 172, 190, 0.35); --x:72%; --y:55%; --d:26s; --dl:1s; box-shadow:0 0 14px rgba(236, 172, 190, 0.35);"></span>
+          <span class="mote" style="--s:1.5px; --c:rgba(165, 180, 252, 0.40); --x:88%; --y:38%; --d:11s; --dl:7s;"></span>
+        </div><span class="strip-label">L3 motes &middot; z2</span>
+      </div>
+      <div class="ds-src">tinted dots from MOTE_COLORS, aurMoteFloat path — :190-207 (hand-placed sample)</div>
+      <div class="strip" style="background:#f8fafc;">
+        <div class="half"><div class="bgl-layer aur-grid"></div></div>
+        <div class="half r"><div class="bgl-layer aur-grid-amp"></div></div>
+        <span class="strip-label">L4 grid &middot; z3</span><span class="half-tag">left: exact &middot; right: line alpha &times;10 for legibility</span>
+      </div>
+      <div class="ds-src">1px periwinkle lines every 50px, rgba(165,180,252,0.03) at opacity 0.35 — :210-223</div>
+    </section>
+  </div>
+
+  <div class="gate">
+    <h2>Performance gating</h2>
+    <table class="tiers">
+      <tr><th>data-perf tier</th><th>Nebula stars</th><th>Aurora motes</th><th>Cloud drift</th><th>Whole background</th></tr>
+      <tr><td>high</td><td>25</td><td>20</td><td>animated</td><td>rendered</td></tr>
+      <tr><td>medium</td><td>20</td><td>15</td><td>animated</td><td>rendered</td></tr>
+      <tr><td>low</td><td>0</td><td>0</td><td>animation: none</td><td><b>SiteBackground returns null</b> — CssBaseline flat body background is the fallback</td></tr>
+    </table>
+    <pre class="code"><b>// src/components/shared/SiteBackground.tsx:24-33</b>
+// Low tier: skip the whole layer stack (4 fixed composited gradient planes
+// even with animation off).
+if (perfTier === 'low') { return null; }
+if (theme.palette.mode === 'light') { return &lt;AuroraBackground /&gt;; }
+return &lt;NebulaBackground /&gt;;
+
+<b>// NebulaBackground.tsx:15-19</b>            <b>// AuroraBackground.tsx:25-29</b>
+PARTICLE_COUNTS = { low: 0,               PARTICLE_COUNTS = { low: 0,
+  medium: 20, high: 25 };                   medium: 15, high: 20 };
+<b>// Both: :38 / :49</b>  const animate = perfTier !== 'low';</pre>
+    <p class="note"><b>Doc vs implementation:</b> the root technique doc (nebula-background-technique.md) describes 45&ndash;60 particles and clouds with <code>filter: blur(60&ndash;80px)</code>. The production components deliberately ship <b>pre-diffused radial gradients with no filter:blur</b> and 20&ndash;25 particles max, "tuned to avoid iOS Safari GPU crashes" (NebulaBackground.tsx:6-7). The values in this card are the as-built component values. Both components also zero all animation under <code>prefers-reduced-motion: reduce</code> (NebulaBackground.tsx:70-75).</p>
+  </div>
+</div>

--- a/design-sync/preview/pattern-perf-tiers.html
+++ b/design-sync/preview/pattern-perf-tiers.html
@@ -1,0 +1,236 @@
+<!-- @dsCard group="Patterns" -->
+<meta charset="utf-8">
+<title>Performance Tiers — data-perf Axis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* Mini-backdrop (simplified Nebula/Aurora) so backdrop-filter is visible */
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+
+  /* ── Glass dialog paper — PickerDialog.tsx:286-303 (the ".glass-dialog" reduced-blur
+     variant the low-tier fallback in index.css:179-186 exists for) ── */
+  .pd { border-radius:20px; padding:14px; min-height:150px; }
+  [data-color-scheme="dark"] .pd-high {
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%);
+    border:1px solid #1f2937;
+    box-shadow:0 8px 30px rgba(0,0,0,0.25);
+  }
+  /* Low tier, dark: backdrop-filter stripped + opaque fallback (index.css:183-186) */
+  [data-color-scheme="dark"] .pd-low {
+    background:#0f172a; background-image:none;
+    border:1px solid #1f2937;
+    box-shadow:0 8px 30px rgba(0,0,0,0.25);
+  }
+  [data-color-scheme="light"] .pd-high {
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+    background:linear-gradient(135deg, rgba(255,255,255,0.98), rgba(248,250,252,0.98));
+    border:1px solid rgba(0, 0, 0, 0.08);
+    box-shadow:0 4px 12px rgba(15,23,42,0.06);
+  }
+  /* Low tier, light: SAME paper minus blur — >=98%-alpha, so no fallback rule exists */
+  [data-color-scheme="light"] .pd-low {
+    background:linear-gradient(135deg, rgba(255,255,255,0.98), rgba(248,250,252,0.98));
+    border:1px solid rgba(0, 0, 0, 0.08);
+    box-shadow:0 4px 12px rgba(15,23,42,0.06);
+  }
+  .pd h3 { font-size:.8rem; margin-bottom:8px; color:var(--text); }
+  .pd .line { height:6px; border-radius:3px; background:var(--muted); opacity:.3; margin-bottom:6px; }
+
+  /* Decorative infinite animation: runs at high tier, frozen at base styles on low
+     (frozen state emulated here with animation:none — in the app the freeze comes
+     from the index.css:155-162 rule, not from component code) */
+  @keyframes perfShimmer { 0%{background-position:0% 50%} 100%{background-position:200% 50%} }
+  .shimmer { height:8px; border-radius:4px; margin:10px 0 6px;
+    background:linear-gradient(90deg, rgba(56,189,248,.1), rgba(56,189,248,.55), rgba(56,189,248,.1));
+    background-size:200% 100%; animation:perfShimmer 3s linear infinite; }
+  .pd-low .shimmer { animation:none; }
+
+  /* Feedback animation: KEEPS moving on low tier via the custom-property escape
+     hatch (index.css:164-169) — durations match MUI's own timing */
+  @keyframes perfSpin { to { transform:rotate(360deg); } }
+  .spinner { width:18px; height:18px; border-radius:50%; display:inline-block; vertical-align:middle;
+    border:2px solid transparent; border-top-color:var(--accent); border-right-color:var(--accent);
+    animation:perfSpin 1.4s linear infinite; }
+  .spin-row { display:flex; align-items:center; gap:8px; font-size:.68rem; color:var(--muted); margin-top:8px; }
+
+  .pair { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  .pair-label { font-size:.66rem; font-family:'JetBrains Mono',Consolas,monospace; color:var(--muted); margin-bottom:6px; }
+
+  pre.code { background:#0d1430; border:1px solid #1f2937; border-radius:10px; padding:12px;
+    font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; line-height:1.55;
+    color:#94a3b8; overflow-x:auto; margin-top:8px; white-space:pre; }
+  pre.code b { color:#e5e7eb; font-weight:500; }
+  .doc-panel { border-radius:16px; padding:18px; background:#0f172a; border:1px solid #1f2937; margin-top:16px; }
+  .doc-panel h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#94a3b8; margin-bottom:10px; }
+  .note { font-size:.72rem; color:#94a3b8; line-height:1.5; margin-top:8px; }
+  .note b { color:#e5e7eb; font-weight:600; }
+  table.fx { width:100%; border-collapse:collapse; font-size:.72rem; margin-top:8px; }
+  table.fx th, table.fx td { text-align:left; padding:6px 10px; border-bottom:1px solid #1f2937; color:#e5e7eb; vertical-align:top; }
+  table.fx th { color:#94a3b8; font-weight:600; text-transform:uppercase; font-size:.62rem; letter-spacing:.08em; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Performance Tiers — the data-perf Axis</h1>
+  <p class="ds-sub">A third global styling axis beside color scheme: <code>&lt;html data-perf="low|medium|high"&gt;</code>, mirrored from the Redux store (src/index.tsx:29). Static CSS in src/index.css:129-186 strips expensive effects wholesale at low tier. Sources: src/index.css:100-190, src/utils/detectPerfTier.ts</p>
+
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2 class="demo-z">Dark</h2>
+      <div class="demo-z">
+        <div class="pair">
+          <div>
+            <div class="pair-label">data-perf="high"</div>
+            <div class="pd pd-high">
+              <h3>Glass dialog</h3>
+              <div class="line"></div><div class="line" style="width:70%"></div>
+              <div class="shimmer"></div>
+              <div class="spin-row"><span class="spinner"></span> loading&hellip;</div>
+            </div>
+          </div>
+          <div>
+            <div class="pair-label">data-perf="low"</div>
+            <div class="pd pd-low">
+              <h3>Glass dialog</h3>
+              <div class="line"></div><div class="line" style="width:70%"></div>
+              <div class="shimmer"></div>
+              <div class="spin-row"><span class="spinner"></span> loading&hellip;</div>
+            </div>
+          </div>
+        </div>
+        <div class="ds-src">high: blur(10) + rgba(56,189,248,.12)&rarr;rgba(0,225,255,.12) gradient — PickerDialog.tsx:286-303<br>low: opaque #0f172a, background-image none — index.css:183-186; shimmer frozen (:155-162); spinner keeps 1.4s via escape hatch (:166-169)</div>
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2 class="demo-z">Light</h2>
+      <div class="demo-z">
+        <div class="pair">
+          <div>
+            <div class="pair-label">data-perf="high"</div>
+            <div class="pd pd-high">
+              <h3>Glass dialog</h3>
+              <div class="line"></div><div class="line" style="width:70%"></div>
+              <div class="shimmer"></div>
+              <div class="spin-row"><span class="spinner"></span> loading&hellip;</div>
+            </div>
+          </div>
+          <div>
+            <div class="pair-label">data-perf="low"</div>
+            <div class="pd pd-low">
+              <h3>Glass dialog</h3>
+              <div class="line"></div><div class="line" style="width:70%"></div>
+              <div class="shimmer"></div>
+              <div class="spin-row"><span class="spinner"></span> loading&hellip;</div>
+            </div>
+          </div>
+        </div>
+        <div class="ds-src">high: blur(10) + rgba(255,255,255,.98)&rarr;rgba(248,250,252,.98) gradient — PickerDialog.tsx:286-303<br>low: same paper minus blur — light papers are &ge;98%-alpha even without blur, so NO fallback rule exists (index.css:179-182)</div>
+      </div>
+    </section>
+  </div>
+
+  <div class="doc-panel">
+    <h2>What low tier strips — src/index.css (verbatim)</h2>
+    <pre class="code"><b>/* 1. Every backdrop-filter — index.css:136-140. "this one rule drops the measured
+      27 active layers on landing to 0". `filter` is intentionally left alone. */</b>
+html[data-perf='low'],
+html[data-perf='low'] * {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+<b>/* 2. Animation kill — index.css:155-162. Entrance animations (fill forwards/both)
+      complete instantly at final state; infinite loops (landing orbs, marquee,
+      shimmers, electric borders, legendary chips) freeze at base styles. */</b>
+html[data-perf='low'] *,
+html[data-perf='low'] *::before,
+html[data-perf='low'] *::after {
+  animation-duration: var(--perf-anim-duration, 0.01ms) !important;
+  animation-iteration-count: var(--perf-anim-iteration, 1) !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+<b>/* 3. The escape hatch — index.css:166-177. Custom properties inherit, so
+      re-declaring them on an indicator root keeps FEEDBACK animations moving
+      (a frozen spinner reads as a hang). New functional animations must opt
+      out the same way or they will freeze on low tier. */</b>
+html[data-perf='low'] .MuiCircularProgress-root {
+  --perf-anim-duration: 1.4s;
+  --perf-anim-iteration: infinite;
+}
+html[data-perf='low'] .MuiLinearProgress-root {
+  --perf-anim-duration: 2.1s;
+  --perf-anim-iteration: infinite;
+}
+html[data-perf='low'] .MuiSkeleton-root {
+  --perf-anim-duration: 2s;
+  --perf-anim-iteration: infinite;
+}
+
+<b>/* 4. Opaque dialog fallback — index.css:183-186. Without blur the 12%-alpha
+      gradient becomes effectively transparent. Dark mode only. */</b>
+html[data-perf='low'][data-color-scheme='dark'] .glass-dialog .MuiDialog-paper {
+  background: #0f172a !important;
+  background-image: none !important;
+}</pre>
+
+    <h2 style="margin-top:16px;">Tier effects summary</h2>
+    <table class="fx">
+      <tr><th>Effect</th><th>high / medium</th><th>low</th></tr>
+      <tr><td>backdrop-filter (all glass)</td><td>as authored (blur 6&ndash;24)</td><td>stripped globally (:136-140)</td></tr>
+      <tr><td>CSS animations / transitions</td><td>as authored</td><td>0.01ms &times;1 — frozen/instant, unless escape hatch (:155-177)</td></tr>
+      <tr><td>.glass-dialog paper (dark)</td><td>12%-alpha cyan gradient + blur</td><td>opaque #0f172a (:183-186)</td></tr>
+      <tr><td>SiteBackground (nebula/aurora)</td><td>rendered; stars 25/20 (dark), motes 20/15 (light)</td><td>returns null — SiteBackground.tsx:27-29</td></tr>
+      <tr><td>scroll-behavior</td><td>as authored</td><td>auto (no smooth scroll)</td></tr>
+    </table>
+
+    <h2 style="margin-top:16px;">How the tier is decided — src/utils/detectPerfTier.ts</h2>
+    <p class="note"><b>Heuristic (sync, :20-33):</b> returns only 'low' | 'medium'. deviceMemory &le; 2 &rarr; low; cores &le; 2 &rarr; low; memory &le; 4 AND cores &le; 4 &rarr; low; otherwise medium ("don't know" neutral default). Runs before React mounts so low-end devices get low-tier CSS on first paint.</p>
+    <p class="note"><b>GPU benchmark (async, :35-78):</b> 'high' is reserved for a successful @pmndrs/detect-gpu BENCHMARK result. Result type gates trust: BLOCKLISTED &rarr; low; FALLBACK or WEBGL_UNSUPPORTED &rarr; defer to heuristic (FALLBACK's tier is a screen-size guess that misclassifies capable desktops). Benchmark tier &le; 1 &rarr; low; tier 2 &rarr; low on mobile, medium on desktop; tier 3 &rarr; high. The heuristic is downgrade-only: heuristic 'low' forces low, but never caps a benchmarked 'high' at medium. Catch path returns the heuristic — never 'high' unproven.</p>
+    <p class="note"><b>Reduced motion is NOT a tier input</b> (:5-12): OS reduced-motion is a separate signal handled by the motion layer — a reduced-motion user on a powerful desktop keeps every hardware-driven feature.</p>
+  </div>
+</div>

--- a/design-sync/preview/pattern-view-transitions.html
+++ b/design-sync/preview/pattern-view-transitions.html
@@ -1,0 +1,301 @@
+<!-- @dsCard group="Patterns" -->
+<meta charset="utf-8">
+<title>View Transitions — 8 Types + Easing Tokens</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  /* ── Easing tokens (view-transitions.css:17-21) ─────────────────────── */
+  :root {
+    --vt-decel: cubic-bezier(0.16, 1, 0.3, 1);
+    --vt-ease-out: cubic-bezier(0.32, 0.72, 0, 1);
+    --vt-snap: cubic-bezier(0.2, 0.9, 0.3, 1);
+  }
+  .ease-panel { border-radius:16px; padding:18px; background:#0f172a; border:1px solid #1f2937; margin-bottom:16px; }
+  .ease-panel h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#94a3b8; margin-bottom:12px; }
+  .ease-row { display:grid; grid-template-columns:150px 1fr 240px; gap:12px; align-items:center; margin-bottom:10px; }
+  .ease-name { font-family:'JetBrains Mono',Consolas,monospace; font-size:.7rem; color:#38bdf8; }
+  .ease-track { position:relative; height:14px; border-radius:7px; background:#0b1220; border:1px solid #1f2937; }
+  .ease-dot { position:absolute; top:2px; left:2px; width:8px; height:8px; border-radius:50%; background:#38bdf8;
+    animation:runner 2.4s infinite; }
+  .ease-val { font-family:'JetBrains Mono',Consolas,monospace; font-size:.64rem; color:#94a3b8; }
+  @keyframes runner { 0%{transform:translateX(0)} 50%,80%{transform:translateX(min(48vw,560px))} 92%,100%{transform:translateX(0)} }
+  .e-decel { animation-timing-function:var(--vt-decel); }
+  .e-out { animation-timing-function:var(--vt-ease-out); }
+  .e-snap { animation-timing-function:var(--vt-snap); }
+  @media (max-width:760px){ .ease-row { grid-template-columns:110px 1fr; } .ease-val { display:none; } }
+
+  /* ── Demo tiles ─────────────────────────────────────────────────────── */
+  /* Real view transitions snapshot the page; a static card can't run them.
+     Each tile REPLAYS the type's exact keyframe geometry as a looping CSS
+     animation: the transition plays in the first ~350ms of a 2.8s cycle
+     (same ms proportions as the real durations), holds, then resets. */
+  .vt-grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; position:relative; z-index:1; }
+  .vt-stage { position:relative; height:104px; border-radius:10px; overflow:hidden; background:var(--bg); border:1px solid var(--border); }
+  .vtp { position:absolute; inset:8px; border-radius:8px; background:var(--panel); border:1px solid var(--border); padding:8px; }
+  .vtp .hd { height:7px; border-radius:3px; margin-bottom:6px; background:var(--accent); opacity:.8; width:45%; }
+  .vtp .bar { height:5px; border-radius:2px; background:var(--muted); opacity:.3; margin-bottom:5px; }
+  .vtp.new { background:var(--panel-2); }
+  .vtp.new .hd { background:var(--accent-2); }
+  .vt-name { font-size:.72rem; font-weight:600; margin-top:6px; color:var(--text); font-family:'JetBrains Mono',Consolas,monospace; }
+
+  /* default crossfade — :267-273 (old 150ms ease-out / new 150ms ease-out) */
+  @keyframes dvt-fade-old { 0%{opacity:1} 5%,78%{opacity:0} 88%,100%{opacity:1} }
+  @keyframes dvt-fade-new { 0%{opacity:0} 5%,78%{opacity:1} 88%,100%{opacity:0} }
+  .t-fade .old { animation:dvt-fade-old 2.8s infinite ease-out; }
+  .t-fade .new { animation:dvt-fade-new 2.8s infinite ease-out; }
+
+  /* forward — :277-285 (old vt-recede 200ms ease-in z1 / new vt-card-expand 280ms --vt-decel z2) */
+  @keyframes dvt-recede { 0%{opacity:1;transform:scale(1)} 7%,78%{opacity:0;transform:scale(0.95)} 88%,100%{opacity:1;transform:scale(1)} }
+  @keyframes dvt-card-expand { 0%{clip-path:inset(4% round 16px);opacity:0} 10%,78%{clip-path:inset(0% round 0px);opacity:1} 88%,100%{clip-path:inset(4% round 16px);opacity:0} }
+  .t-fwd .old { animation:dvt-recede 2.8s infinite ease-in; z-index:1; }
+  .t-fwd .new { animation:dvt-card-expand 2.8s infinite var(--vt-decel); z-index:2; }
+
+  /* back — :289-297 (old vt-card-collapse 220ms ease-in z2 / new vt-surface 250ms --vt-decel z1) */
+  @keyframes dvt-card-collapse { 0%{clip-path:inset(0% round 0px);opacity:1} 8%,78%{clip-path:inset(4% round 16px);opacity:0} 88%,100%{clip-path:inset(0% round 0px);opacity:1} }
+  @keyframes dvt-surface { 0%{opacity:0;transform:scale(0.95)} 9%,78%{opacity:1;transform:scale(1)} 88%,100%{opacity:0;transform:scale(0.95)} }
+  .t-back .old { animation:dvt-card-collapse 2.8s infinite ease-in; z-index:2; }
+  .t-back .new { animation:dvt-surface 2.8s infinite var(--vt-decel); z-index:1; }
+
+  /* up — :321-329 (old vt-shrink-out 340ms ease-in z1 / new vt-circle-reveal 350ms --vt-ease-out z2) */
+  @keyframes dvt-shrink-out { 0%{opacity:1;transform:scale(1)} 12%,78%{opacity:0;transform:scale(0.92)} 88%,100%{opacity:1;transform:scale(1)} }
+  @keyframes dvt-circle-reveal { 0%{clip-path:circle(0% at 50% 45%)} 12.5%,78%{clip-path:circle(100% at 50% 45%)} 88%,100%{clip-path:circle(0% at 50% 45%)} }
+  .t-up .old { animation:dvt-shrink-out 2.8s infinite ease-in; z-index:1; }
+  .t-up .new { animation:dvt-circle-reveal 2.8s infinite var(--vt-ease-out); z-index:2; }
+
+  /* down — :333-341 (old vt-circle-close 280ms ease-in z2 / new vt-grow-in 280ms --vt-decel 30ms z1) */
+  @keyframes dvt-circle-close { 0%{clip-path:circle(100% at 50% 45%);opacity:1} 10%,78%{clip-path:circle(0% at 50% 45%);opacity:0} 88%,100%{clip-path:circle(100% at 50% 45%);opacity:1} }
+  @keyframes dvt-grow-in { 0%,1%{opacity:0;transform:scale(0.92)} 11%,78%{opacity:1;transform:scale(1)} 88%,100%{opacity:0;transform:scale(0.92)} }
+  .t-down .old { animation:dvt-circle-close 2.8s infinite ease-in; z-index:2; }
+  .t-down .new { animation:dvt-grow-in 2.8s infinite var(--vt-decel); z-index:1; }
+
+  /* hero — root :304-312 + group morph :239-261 (group 400ms --vt-snap; old fade 160ms; new fade 200ms +80ms) */
+  @keyframes dvt-hero-card {
+    0%   { top:54%; left:8%; width:38%; height:36%; border-radius:8px; }
+    14%,78% { top:8%; left:5%; width:90%; height:84%; border-radius:8px; }
+    92%,100% { top:54%; left:8%; width:38%; height:36%; border-radius:8px; }
+  }
+  .t-hero .old { animation:dvt-fade-old 2.8s infinite ease-out; z-index:1; }
+  .t-hero .hero-el { position:absolute; background:var(--panel-2); border:1px solid var(--accent);
+    padding:6px; overflow:hidden; z-index:2; animation:dvt-hero-card 2.8s infinite var(--vt-snap); }
+  .t-hero .hero-el .hd { height:6px; border-radius:3px; background:var(--accent-2); opacity:.8; width:55%; margin-bottom:5px; }
+  .t-hero .hero-el .bar { height:4px; border-radius:2px; background:var(--muted); opacity:.3; margin-bottom:4px; }
+
+  /* slide-left — :345-353 (old vt-slide-to-left 220ms ease-in z1 / new vt-slide-from-right 260ms --vt-decel z2) */
+  @keyframes dvt-slide-to-left { 0%{transform:translateX(0);opacity:1} 8%,78%{transform:translateX(-6%);opacity:0} 88%,100%{transform:translateX(0);opacity:1} }
+  @keyframes dvt-slide-from-right { 0%{transform:translateX(6%);opacity:0} 9%,78%{transform:translateX(0);opacity:1} 88%,100%{transform:translateX(6%);opacity:0} }
+  .t-sl .old { animation:dvt-slide-to-left 2.8s infinite ease-in; z-index:1; }
+  .t-sl .new { animation:dvt-slide-from-right 2.8s infinite var(--vt-decel); z-index:2; }
+
+  /* slide-right — :357-365 (old vt-slide-to-right 220ms ease-in z1 / new vt-slide-from-left 260ms --vt-decel z2) */
+  @keyframes dvt-slide-to-right { 0%{transform:translateX(0);opacity:1} 8%,78%{transform:translateX(6%);opacity:0} 88%,100%{transform:translateX(0);opacity:1} }
+  @keyframes dvt-slide-from-left { 0%{transform:translateX(-6%);opacity:0} 9%,78%{transform:translateX(0);opacity:1} 88%,100%{transform:translateX(-6%);opacity:0} }
+  .t-sr .old { animation:dvt-slide-to-right 2.8s infinite ease-in; z-index:1; }
+  .t-sr .new { animation:dvt-slide-from-left 2.8s infinite var(--vt-decel); z-index:2; }
+
+  pre.code { background:#0d1430; border:1px solid #1f2937; border-radius:10px; padding:12px;
+    font-family:'JetBrains Mono',Consolas,monospace; font-size:.64rem; line-height:1.5;
+    color:#94a3b8; overflow:auto; max-height:360px; margin-top:8px; white-space:pre; }
+  .doc-panel { border-radius:16px; padding:18px; background:#0f172a; border:1px solid #1f2937; margin-top:16px; }
+  .doc-panel h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:#94a3b8; margin-bottom:10px; }
+  .note { font-size:.72rem; color:#94a3b8; line-height:1.5; margin-top:8px; }
+  .note b { color:#e5e7eb; font-weight:600; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">View Transitions — 8 Types + Easing Tokens</h1>
+  <p class="ds-sub">View Transitions API Level 2 with <code>html:active-view-transition-type(...)</code> per-type animations. Source: src/styles/view-transitions.css (driver: src/hooks/useViewTransitionNavigate.ts). Tiles below are looping CSS re-creations of the real keyframes — actual view transitions cannot run inside a static card; exact CSS is transcribed at the bottom.</p>
+
+  <div class="ease-panel">
+    <h2>Easing tokens — view-transitions.css:17-21</h2>
+    <div class="ease-row"><span class="ease-name">--vt-decel</span><div class="ease-track"><div class="ease-dot e-decel"></div></div><span class="ease-val">cubic-bezier(0.16, 1, 0.3, 1)</span></div>
+    <div class="ease-row"><span class="ease-name">--vt-ease-out</span><div class="ease-track"><div class="ease-dot e-out"></div></div><span class="ease-val">cubic-bezier(0.32, 0.72, 0, 1)</span></div>
+    <div class="ease-row"><span class="ease-name">--vt-snap</span><div class="ease-track"><div class="ease-dot e-snap"></div></div><span class="ease-val">cubic-bezier(0.2, 0.9, 0.3, 1)</span></div>
+    <p class="note">No <code>filter: blur()</code> anywhere in the transition keyframes — it forces software rasterization on the full-page snapshot. Only opacity, transform, and clip-path (all GPU-composited) — view-transitions.css:24-26.</p>
+  </div>
+
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <h2>Dark</h2>
+      <div class="vt-grid">
+        <div><div class="vt-stage t-fade"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">(none) — crossfade</div><div class="ds-src">old/new vt-fade 150ms ease-out — :267-273</div></div>
+        <div><div class="vt-stage t-fwd"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">forward — container expand</div><div class="ds-src">vt-recede 200ms ease-in / vt-card-expand 280ms --vt-decel — :277-285</div></div>
+        <div><div class="vt-stage t-back"><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div></div><div class="vt-name">back — container collapse</div><div class="ds-src">vt-card-collapse 220ms ease-in / vt-surface 250ms --vt-decel — :289-297</div></div>
+        <div><div class="vt-stage t-up"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">up — circle reveal</div><div class="ds-src">vt-shrink-out 340ms ease-in / vt-circle-reveal 350ms --vt-ease-out — :321-329</div></div>
+        <div><div class="vt-stage t-down"><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div></div><div class="vt-name">down — circle close</div><div class="ds-src">vt-circle-close 280ms ease-in / vt-grow-in 280ms --vt-decel 30ms — :333-341</div></div>
+        <div><div class="vt-stage t-hero"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="hero-el"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:55%"></div></div></div><div class="vt-name">hero — shared element morph</div><div class="ds-src">group 400ms --vt-snap; root fades — :239-261, :304-312</div></div>
+        <div><div class="vt-stage t-sl"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">slide-left — lateral peer</div><div class="ds-src">vt-slide-to-left 220ms / vt-slide-from-right 260ms --vt-decel — :345-353</div></div>
+        <div><div class="vt-stage t-sr"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">slide-right — lateral peer</div><div class="ds-src">vt-slide-to-right 220ms / vt-slide-from-left 260ms --vt-decel — :357-365</div></div>
+      </div>
+    </section>
+
+    <section class="ds-mode" data-color-scheme="light">
+      <h2>Light</h2>
+      <div class="vt-grid">
+        <div><div class="vt-stage t-fade"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">(none) — crossfade</div><div class="ds-src">old/new vt-fade 150ms ease-out — :267-273</div></div>
+        <div><div class="vt-stage t-fwd"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">forward — container expand</div><div class="ds-src">vt-recede 200ms ease-in / vt-card-expand 280ms --vt-decel — :277-285</div></div>
+        <div><div class="vt-stage t-back"><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div></div><div class="vt-name">back — container collapse</div><div class="ds-src">vt-card-collapse 220ms ease-in / vt-surface 250ms --vt-decel — :289-297</div></div>
+        <div><div class="vt-stage t-up"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">up — circle reveal</div><div class="ds-src">vt-shrink-out 340ms ease-in / vt-circle-reveal 350ms --vt-ease-out — :321-329</div></div>
+        <div><div class="vt-stage t-down"><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div></div><div class="vt-name">down — circle close</div><div class="ds-src">vt-circle-close 280ms ease-in / vt-grow-in 280ms --vt-decel 30ms — :333-341</div></div>
+        <div><div class="vt-stage t-hero"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="hero-el"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:55%"></div></div></div><div class="vt-name">hero — shared element morph</div><div class="ds-src">group 400ms --vt-snap; root fades — :239-261, :304-312</div></div>
+        <div><div class="vt-stage t-sl"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">slide-left — lateral peer</div><div class="ds-src">vt-slide-to-left 220ms / vt-slide-from-right 260ms --vt-decel — :345-353</div></div>
+        <div><div class="vt-stage t-sr"><div class="vtp old"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:70%"></div></div><div class="vtp new"><div class="hd"></div><div class="bar"></div><div class="bar" style="width:60%"></div></div></div><div class="vt-name">slide-right — lateral peer</div><div class="ds-src">vt-slide-to-right 220ms / vt-slide-from-left 260ms --vt-decel — :357-365</div></div>
+      </div>
+    </section>
+  </div>
+
+  <div class="doc-panel">
+    <h2>Actual keyframes + type selectors — src/styles/view-transitions.css (verbatim)</h2>
+    <pre class="code">/* ── Easing tokens ── :17-21 */
+:root {
+  --vt-decel: cubic-bezier(0.16, 1, 0.3, 1);
+  --vt-ease-out: cubic-bezier(0.32, 0.72, 0, 1);
+  --vt-snap: cubic-bezier(0.2, 0.9, 0.3, 1);
+}
+
+/* ── Keyframes ── :28-198 (no filter:blur — GPU-composited props only) */
+@keyframes vt-fade-out { from { opacity: 1; } to { opacity: 0; } }
+@keyframes vt-fade-in  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes vt-recede {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.95); }
+}
+@keyframes vt-card-expand {
+  from { clip-path: inset(4% round 16px); opacity: 0; }
+  to   { clip-path: inset(0% round 0px); opacity: 1; }
+}
+@keyframes vt-card-collapse {
+  from { clip-path: inset(0% round 0px); opacity: 1; }
+  to   { clip-path: inset(4% round 16px); opacity: 0; }
+}
+@keyframes vt-surface {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes vt-circle-reveal {
+  from { clip-path: circle(0% at 50% 45%); }
+  to   { clip-path: circle(100% at 50% 45%); }
+}
+@keyframes vt-shrink-out {
+  from { opacity: 1; transform: scale(1); }
+  to   { opacity: 0; transform: scale(0.92); }
+}
+@keyframes vt-circle-close {
+  from { clip-path: circle(100% at 50% 45%); opacity: 1; }
+  to   { clip-path: circle(0% at 50% 45%); opacity: 0; }
+}
+@keyframes vt-grow-in {
+  from { opacity: 0; transform: scale(0.92); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@keyframes vt-slide-to-left    { from { transform: translateX(0);    opacity: 1; } to { transform: translateX(-6%); opacity: 0; } }
+@keyframes vt-slide-from-right { from { transform: translateX(6%);   opacity: 0; } to { transform: translateX(0);   opacity: 1; } }
+@keyframes vt-slide-to-right   { from { transform: translateX(0);    opacity: 1; } to { transform: translateX(6%);  opacity: 0; } }
+@keyframes vt-slide-from-left  { from { transform: translateX(-6%);  opacity: 0; } to { transform: translateX(0);   opacity: 1; } }
+@keyframes vt-tab-exit {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateY(-6px) scale(0.99); }
+}
+@keyframes vt-tab-enter {
+  from { opacity: 0; transform: translateY(8px) scale(0.99); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ── Global resets ── :206-217 (kill UA 250ms group anim, plus-lighter blend, isolate) */
+::view-transition-group(root) { animation: none; }
+::view-transition-image-pair(root) { isolation: auto; }
+::view-transition-old(root),
+::view-transition-new(root) { mix-blend-mode: normal; }
+
+/* ── Header isolation ── :221-232 */
+::view-transition-group(site-header) { animation: none; z-index: 100; }
+::view-transition-old(site-header) { display: none; }
+::view-transition-new(site-header) { animation: none; }
+
+/* ── Hero morph (shared element) ── :239-261 */
+::view-transition-group(build-hero),
+::view-transition-group(roster-hero) {
+  animation-duration: 400ms;
+  animation-timing-function: var(--vt-snap);
+  z-index: 10;
+}
+::view-transition-image-pair(build-hero),
+::view-transition-image-pair(roster-hero) { isolation: auto; }
+::view-transition-old(build-hero),
+::view-transition-old(roster-hero) { animation: vt-fade-out 160ms ease-out both; mix-blend-mode: normal; }
+::view-transition-new(build-hero),
+::view-transition-new(roster-hero) { animation: vt-fade-in 200ms ease-in 80ms both; mix-blend-mode: normal; }
+
+/* ── Default (crossfade) ── :267-273 */
+::view-transition-old(root) { animation: vt-fade-out 150ms ease-out both; }
+::view-transition-new(root) { animation: vt-fade-in 150ms ease-out both; }
+
+/* ── Forward ── :277-285 */
+html:active-view-transition-type(forward)::view-transition-old(root) { animation: vt-recede 200ms ease-in both; z-index: 1; }
+html:active-view-transition-type(forward)::view-transition-new(root) { animation: vt-card-expand 280ms var(--vt-decel) both; z-index: 2; }
+
+/* ── Back ── :289-297 */
+html:active-view-transition-type(back)::view-transition-old(root) { animation: vt-card-collapse 220ms ease-in both; z-index: 2; }
+html:active-view-transition-type(back)::view-transition-new(root) { animation: vt-surface 250ms var(--vt-decel) both; z-index: 1; }
+
+/* ── Hero override (softens root; placed after "forward" so source order wins) ── :304-312 */
+html:active-view-transition-type(hero)::view-transition-old(root) { animation: vt-fade-out 200ms ease-out both; z-index: 1; }
+html:active-view-transition-type(hero)::view-transition-new(root) { animation: vt-fade-in 280ms var(--vt-decel) 40ms both; z-index: 2; }
+
+/* ── Up ── :321-329 (old fade spans almost all of the 350ms reveal so the
+   receding page under-paints outside the expanding circle) */
+html:active-view-transition-type(up)::view-transition-old(root) { animation: vt-shrink-out 340ms ease-in both; z-index: 1; }
+html:active-view-transition-type(up)::view-transition-new(root) { animation: vt-circle-reveal 350ms var(--vt-ease-out) both; z-index: 2; }
+
+/* ── Down ── :333-341 */
+html:active-view-transition-type(down)::view-transition-old(root) { animation: vt-circle-close 280ms ease-in both; z-index: 2; }
+html:active-view-transition-type(down)::view-transition-new(root) { animation: vt-grow-in 280ms var(--vt-decel) 30ms both; z-index: 1; }
+
+/* ── Slide Left ── :345-353 */
+html:active-view-transition-type(slide-left)::view-transition-old(root) { animation: vt-slide-to-left 220ms ease-in both; z-index: 1; }
+html:active-view-transition-type(slide-left)::view-transition-new(root) { animation: vt-slide-from-right 260ms var(--vt-decel) both; z-index: 2; }
+
+/* ── Slide Right ── :357-365 */
+html:active-view-transition-type(slide-right)::view-transition-old(root) { animation: vt-slide-to-right 220ms ease-in both; z-index: 1; }
+html:active-view-transition-type(slide-right)::view-transition-new(root) { animation: vt-slide-from-left 260ms var(--vt-decel) both; z-index: 2; }
+
+/* ── Tab content ── :371-388 (styles remain, but see AnimatedTabContent note below) */
+::view-transition-group(tab-content) { animation-duration: 200ms; animation-timing-function: var(--vt-decel); }
+::view-transition-image-pair(tab-content) { isolation: auto; }
+::view-transition-old(tab-content) { animation: vt-tab-exit 120ms ease-out both; mix-blend-mode: normal; }
+::view-transition-new(tab-content) { animation: vt-tab-enter 180ms var(--vt-decel) both; mix-blend-mode: normal; }
+
+/* ── Accessibility ── :392-399 */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) { animation-duration: 0s !important; animation-delay: 0s !important; }
+}</pre>
+    <p class="note"><b>Driver:</b> src/hooks/useViewTransitionNavigate.ts wraps react-router navigate in <code>document.startViewTransition({ update, types })</code> (Level 2, :195-208; Level 1 fallback :210-218). Types are <code>['forward'|'back'|'up'|'down'|'slide-left'|'slide-right', 'hero'?]</code> (:181). For a hero morph it stamps <code>element.style.viewTransitionName</code> on the source before snapshot (:171-174) and waits (via MutationObserver, capped 300ms) for the destination element marked <code>data-vt-hero="&lt;name&gt;"</code> to mount — every route is React.lazy, so resolving on the first commit would capture the Suspense skeleton (:57-119). A module-level <code>vtActive</code> guard skips VT on rapid-fire navigations (:163-166), and reduced-motion users get a plain instant navigate (:156-159).</p>
+    <p class="note"><b>Deliberate non-use:</b> AnimatedTabContent does NOT use view transitions — it previously did, and the opaque VT snapshot overlay froze the page for 2-3+ seconds while React synchronously rendered heavy panel trees (Players, Insights). It now uses a lightweight CSS fade-in instead (src/components/AnimatedTabContent.tsx:12-15). The <code>tab-content</code> pseudo styles above (:371-388) remain in the stylesheet but are orphaned by that change.</p>
+  </div>
+</div>

--- a/design-sync/preview/spacing-radii.html
+++ b/design-sync/preview/spacing-radii.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Spacing" -->
+<meta charset="utf-8"><title>Radii Scale</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.row{display:flex;gap:14px;align-items:center;flex-wrap:wrap}
+.b{width:70px;height:52px;background:linear-gradient(135deg,rgba(56,189,248,.25),rgba(56,189,248,.05));border:1px solid rgba(56,189,248,.3);display:flex;align-items:center;justify-content:center;font-family:Consolas,Menlo,monospace;font-size:11px;color:#38bdf8}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:12px;line-height:1.6}
+</style>
+<div class="row">
+<div class="b" style="border-radius:8px">8</div>
+<div class="b" style="border-radius:10px">10</div>
+<div class="b" style="border-radius:12px">12</div>
+<div class="b" style="border-radius:14px">14</div>
+<div class="b" style="border-radius:24px">24</div>
+<div class="b" style="border-radius:28px">28</div>
+<div class="b" style="border-radius:9999px;width:90px">pill</div>
+</div>
+<div class="src">8 controls (buttons/inputs :278,:333) · 10 base shape (:88) · 12 alerts/accordions (:457,:504) · 14 Paper/Card (:165,:230) ·
+24 dialogs (:396) · 28 glossy chips (playerCardStyleUtils.ts:35) · pill 9999. Source: src/ReduxThemeProvider.tsx.</div>

--- a/design-sync/preview/spacing-scale.html
+++ b/design-sync/preview/spacing-scale.html
@@ -1,0 +1,18 @@
+<!-- @dsCard group="Spacing" -->
+<meta charset="utf-8"><title>Spacing Scale</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.row{display:flex;align-items:flex-end;gap:8px;margin-bottom:12px}
+.b{background:#38bdf8;opacity:.9;border-radius:2px;width:24px}
+.l{font-family:Consolas,Menlo,monospace;font-size:10px;color:var(--muted);width:48px;text-align:center}
+.cap{font-family:Consolas,Menlo,monospace;font-size:11px;color:var(--muted);margin-top:8px}
+</style>
+<div class="row">
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:4px"></div><div class="l">4 · 0.5</div></div>
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:8px"></div><div class="l">8 · 1</div></div>
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:12px"></div><div class="l">12 · 1.5</div></div>
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:16px"></div><div class="l">16 · 2</div></div>
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:24px"></div><div class="l">24 · 3</div></div>
+<div style="display:flex;flex-direction:column;align-items:center;gap:4px"><div class="b" style="height:32px"></div><div class="l">32 · 4</div></div>
+</div>
+<div class="cap">MUI 8px unit — sx value × 8px (0.5 → 4px). Tokens --space-1…--space-6 in colors_and_type.css §7.</div>

--- a/design-sync/preview/spacing-shadows.html
+++ b/design-sync/preview/spacing-shadows.html
@@ -1,0 +1,23 @@
+<!-- @dsCard group="Spacing" -->
+<meta charset="utf-8"><title>Shadow Recipes</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:24px;box-sizing:border-box}
+.row{display:flex;gap:24px;flex-wrap:wrap;align-items:flex-start}
+.b{width:110px;height:80px;border-radius:14px;background:linear-gradient(180deg,rgba(15,23,42,.66),rgba(3,7,18,.66));border:1px solid var(--border);display:flex;align-items:flex-end;padding:8px;font-family:Consolas,Menlo,monospace;font-size:10px;color:var(--muted)}
+.s1{box-shadow:0 8px 30px rgba(0,0,0,.25)}
+.s2{box-shadow:0 10px 40px rgba(0,0,0,.3),0 0 60px rgba(56,189,248,.08);border-color:rgba(56,189,248,.3)}
+.s3{box-shadow:0 4px 15px rgba(56,189,248,.25)}
+.s4{box-shadow:0 24px 64px rgba(0,0,0,.55),0 0 0 1px rgba(255,255,255,.03) inset;border-radius:24px}
+.s5{box-shadow:0 20px 60px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.1);border-color:rgba(56,189,248,.2);border-radius:16px}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:14px;line-height:1.6}
+</style>
+<div class="row">
+<div class="b s1">paper</div>
+<div class="b s2">card hover</div>
+<div class="b s3">button glow</div>
+<div class="b s4">dialog</div>
+<div class="b s5">hero field</div>
+</div>
+<div class="src">paper 0 8px 30px rgba(0,0,0,.25) (ReduxThemeProvider.tsx:166-167) · card hover 0 10px 40px rgba(0,0,0,.3), 0 0 60px rgba(56,189,248,.08) (:266-267) ·
+button glow 0 4px 15px rgba(56,189,248,.25) (:286-287) · dialog 0 24px 64px rgba(0,0,0,.55) + inset ring (:397-398) ·
+hero field 0 20px 60px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.1) (LandingPage.tsx:579-582)</div>

--- a/design-sync/preview/surface-be-glass.html
+++ b/design-sync/preview/surface-be-glass.html
@@ -1,0 +1,233 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Build-Editor Panel Glass (G3) + Class-Accent CSS Vars</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .sect { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin:16px 0 8px; position:relative; z-index:1; }
+  .sect:first-of-type { margin-top:0; }
+
+  /* ── G3 GlassPanel — buildEditorTokens.ts:9-17 + GlassPanel.tsx:31-124 ──
+     NOTE (faithful): BE_TOKENS.glass.blur = 16 exists as a token, but
+     GlassPanel never applies backdropFilter — panels are transcribed WITHOUT
+     blur, exactly as rendered in the app. borderRadius: 3 = 30px (base 10). */
+  .g3 {
+    position:relative; border-radius:30px; padding:14px 16px; font-size:.74rem;
+    transition:box-shadow 0.3s ease, border-color 0.25s ease;
+  }
+  .g3 .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.84rem; margin-bottom:2px; }
+  .g3 .b { color:var(--muted); font-size:.68rem; }
+  [data-color-scheme="dark"] .g3 { background:rgba(15, 23, 42, 0.84); }
+  [data-color-scheme="light"] .g3 { background:rgba(255, 255, 255, 0.84); }
+  /* default variant */
+  [data-color-scheme="dark"] .g3-default {
+    border:1px solid rgba(255, 255, 255, 0.09);
+    box-shadow:0 8px 32px rgba(0, 0, 0, 0.32), 0 1px 0 rgba(255, 255, 255, 0.05) inset;
+  }
+  [data-color-scheme="light"] .g3-default {
+    border:1px solid rgba(15, 23, 42, 0.13);
+    box-shadow:0 4px 24px rgba(15, 23, 42, 0.10), 0 1px 0 rgba(255, 255, 255, 0.80) inset;
+  }
+  [data-color-scheme="dark"] .g3-default.has-glow:hover {
+    box-shadow:0 8px 32px rgba(0, 0, 0, 0.26), 0 0 18px rgba(var(--be-accent-rgb, 56, 189, 248), 0.07);
+  }
+  /* primary variant — inner top glow slit ::after */
+  [data-color-scheme="dark"] .g3-primary {
+    border:1px solid rgba(255, 255, 255, 0.09);
+    box-shadow:0 8px 40px rgba(0, 0, 0, 0.42), 0 1px 0 rgba(255, 255, 255, 0.06) inset;
+  }
+  [data-color-scheme="light"] .g3-primary {
+    border:1px solid rgba(15, 23, 42, 0.13);
+    box-shadow:0 4px 28px rgba(15, 23, 42, 0.14), 0 1px 0 rgba(255, 255, 255, 0.90) inset;
+  }
+  .g3-primary::after {
+    content:""; position:absolute; top:1px; left:12%; right:12%; height:1px;
+    background:linear-gradient(90deg, transparent 0%, rgba(var(--be-accent-rgb, 56, 189, 248), 0.70) 50%, transparent 100%);
+    pointer-events:none; z-index:2;
+  }
+  [data-color-scheme="dark"] .g3-primary.has-glow:hover {
+    box-shadow:0 12px 48px rgba(0, 0, 0, 0.38), 0 0 32px rgba(var(--be-accent-rgb, 56, 189, 248), 0.12);
+  }
+  [data-color-scheme="light"] .g3-primary.has-glow:hover {
+    box-shadow:0 6px 32px rgba(15, 23, 42, 0.16);
+  }
+  /* subtle variant */
+  [data-color-scheme="dark"] .g3-subtle {
+    border:1px solid rgba(255, 255, 255, 0.05);
+    box-shadow:0 4px 16px rgba(0, 0, 0, 0.18);
+  }
+  [data-color-scheme="light"] .g3-subtle {
+    border:1px solid rgba(15, 23, 42, 0.06);
+    box-shadow:0 2px 8px rgba(15, 23, 42, 0.05);
+  }
+
+  /* ── Class-accent CSS-var mechanism (B8) — classColorMap.ts +
+       BuildEditorThemeProvider.tsx:26-29. Vars set inline per panel below. */
+  .class-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+  .class-panel { border-radius:16px; padding:10px 12px; }
+  .class-panel .cn { font-weight:600; font-size:.72rem; }
+  .class-panel .cv { font-family:'JetBrains Mono',Consolas,monospace; font-size:.58rem; color:var(--muted); margin-top:2px; }
+  .class-panel .swatchline { display:flex; align-items:center; gap:6px; margin-top:6px; }
+  .class-panel .dot { width:14px; height:14px; border-radius:50%; background:var(--be-accent); box-shadow:0 0 10px var(--be-glow); }
+  .class-panel .grad { flex:1; height:8px; border-radius:4px; background:var(--be-gradient); }
+  .class-panel.g3-primary:hover {
+    border-color:rgba(var(--be-accent-rgb), 0.35);
+    box-shadow:0 12px 48px rgba(0, 0, 0, 0.38), 0 0 32px rgba(var(--be-accent-rgb), 0.12);
+  }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Build-Editor Panel Glass (G3) + Class-Accent CSS Vars</h1>
+  <p class="ds-sub">GlassPanel's three variants over BE_TOKENS, the primary tier's ::after inset top slit (top:1px, left/right:12%), and the --be-accent / --be-accent-rgb / --be-glow / --be-gradient class-theming mechanism. Sources: src/features/build-editor/theme/buildEditorTokens.ts:9-17, components/primitives/GlassPanel.tsx:31-124, theme/classColorMap.ts:16-65, theme/BuildEditorThemeProvider.tsx:26-29.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="sect">Three variants (hover the primary/default for glow)</div>
+        <div class="g3 g3-primary has-glow" style="margin-bottom:8px;">
+          <div class="h">variant='primary'</div>
+          <div class="b">Inner top glow slit ::after — rgba(var(--be-accent-rgb), 0.70), left/right 12%. Used for Identity, Equipment, Skills, Champion.</div>
+          <div class="ds-src">GlassPanel.tsx:95-108; shadow :59-62</div>
+        </div>
+        <div class="g3 g3-default has-glow" style="margin-bottom:8px;">
+          <div class="h">variant='default'</div>
+          <div class="b">bg rgba(15, 23, 42, 0.84), border rgba(255, 255, 255, 0.09), shadow BE_TOKENS.glass.shadow</div>
+          <div class="ds-src">buildEditorTokens.ts:9-17</div>
+        </div>
+        <div class="g3 g3-subtle">
+          <div class="h">variant='subtle'</div>
+          <div class="b">Quieter border rgba(255, 255, 255, 0.05) + minimal shadow (Settings, Screenshots)</div>
+          <div class="ds-src">GlassPanel.tsx:49-57,63-66</div>
+        </div>
+
+        <div class="sect">One primary panel per ESO class (hover for class-keyed glow)</div>
+        <div class="class-grid">
+          <div class="g3 g3-primary class-panel" style="--be-accent:#94a3b8; --be-accent-rgb:148, 163, 184; --be-glow:rgba(148, 163, 184, 0.30); --be-gradient:linear-gradient(135deg, #64748b 0%, #94a3b8 100%);">
+            <div class="cn">any-class</div><div class="cv">#94a3b8 · glow 0.30</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#e05c00; --be-accent-rgb:224, 92, 0; --be-glow:rgba(224, 92, 0, 0.35); --be-gradient:linear-gradient(135deg, #e05c00 0%, #ff8a3d 100%);">
+            <div class="cn">dragonknight</div><div class="cv">#e05c00 → #ff8a3d</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#00acc1; --be-accent-rgb:0, 172, 193; --be-glow:rgba(0, 172, 193, 0.35); --be-gradient:linear-gradient(135deg, #00acc1 0%, #4dd0e1 100%);">
+            <div class="cn">sorcerer</div><div class="cv">#00acc1 → #4dd0e1</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#e53935; --be-accent-rgb:229, 57, 53; --be-glow:rgba(229, 57, 53, 0.35); --be-gradient:linear-gradient(135deg, #e53935 0%, #ef9a9a 100%);">
+            <div class="cn">nightblade</div><div class="cv">#e53935 → #ef9a9a</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#ffb300; --be-accent-rgb:255, 179, 0; --be-glow:rgba(255, 179, 0, 0.35); --be-gradient:linear-gradient(135deg, #ffb300 0%, #ffe082 100%);">
+            <div class="cn">templar</div><div class="cv">#ffb300 → #ffe082</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#26a69a; --be-accent-rgb:38, 166, 154; --be-glow:rgba(38, 166, 154, 0.35); --be-gradient:linear-gradient(135deg, #26a69a 0%, #4dd0c8 100%);">
+            <div class="cn">warden</div><div class="cv">#26a69a → #4dd0c8</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#7c4dff; --be-accent-rgb:124, 77, 255; --be-glow:rgba(124, 77, 255, 0.35); --be-gradient:linear-gradient(135deg, #7c4dff 0%, #b388ff 100%);">
+            <div class="cn">necromancer</div><div class="cv">#7c4dff → #b388ff</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#43a047; --be-accent-rgb:67, 160, 71; --be-glow:rgba(67, 160, 71, 0.35); --be-gradient:linear-gradient(135deg, #43a047 0%, #81c784 100%);">
+            <div class="cn">arcanist</div><div class="cv">#43a047 → #81c784</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+        </div>
+        <div class="ds-src">classColorMap.ts:16-65 — vars injected by BuildEditorThemeProvider.tsx:26-29</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="sect">Three variants</div>
+        <div class="g3 g3-primary has-glow" style="margin-bottom:8px;">
+          <div class="h">variant='primary'</div>
+          <div class="b">Same slit alphas in light mode (0.70) — only bg/border/shadow swap; inset highlight rises to white 0.90</div>
+          <div class="ds-src">GlassPanel.tsx:59-62,95-108</div>
+        </div>
+        <div class="g3 g3-default has-glow" style="margin-bottom:8px;">
+          <div class="h">variant='default'</div>
+          <div class="b">bg rgba(255, 255, 255, 0.84), border rgba(15, 23, 42, 0.13), inset white 0.80</div>
+          <div class="ds-src">buildEditorTokens.ts:10-16</div>
+        </div>
+        <div class="g3 g3-subtle">
+          <div class="h">variant='subtle'</div>
+          <div class="b">border rgba(15, 23, 42, 0.06), shadow 0 2px 8px rgba(15, 23, 42, 0.05)</div>
+          <div class="ds-src">GlassPanel.tsx:49-57,63-66</div>
+        </div>
+
+        <div class="sect">Class accents (same map in both modes)</div>
+        <div class="class-grid">
+          <div class="g3 g3-primary class-panel" style="--be-accent:#e05c00; --be-accent-rgb:224, 92, 0; --be-glow:rgba(224, 92, 0, 0.35); --be-gradient:linear-gradient(135deg, #e05c00 0%, #ff8a3d 100%);">
+            <div class="cn">dragonknight</div><div class="cv">#e05c00 → #ff8a3d</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#00acc1; --be-accent-rgb:0, 172, 193; --be-glow:rgba(0, 172, 193, 0.35); --be-gradient:linear-gradient(135deg, #00acc1 0%, #4dd0e1 100%);">
+            <div class="cn">sorcerer</div><div class="cv">#00acc1 → #4dd0e1</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#ffb300; --be-accent-rgb:255, 179, 0; --be-glow:rgba(255, 179, 0, 0.35); --be-gradient:linear-gradient(135deg, #ffb300 0%, #ffe082 100%);">
+            <div class="cn">templar</div><div class="cv">#ffb300 → #ffe082</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+          <div class="g3 g3-primary class-panel" style="--be-accent:#7c4dff; --be-accent-rgb:124, 77, 255; --be-glow:rgba(124, 77, 255, 0.35); --be-gradient:linear-gradient(135deg, #7c4dff 0%, #b388ff 100%);">
+            <div class="cn">necromancer</div><div class="cv">#7c4dff → #b388ff</div>
+            <div class="swatchline"><span class="dot"></span><span class="grad"></span></div>
+          </div>
+        </div>
+        <div class="ds-src">classColorMap.ts — CLASS_COLOR_MAP is mode-independent</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Faithful quirks:</strong> <code>BE_TOKENS.glass.blur: 16</code> is declared but GlassPanel never applies <code>backdropFilter</code> — these panels render <em>without</em> blur in the real app, and are shown without blur here. Primary panels previously used a gradient <code>borderImage</code>; it was removed because the shorthand let <code>border-color</code> fall back to <code>currentColor</code>, reading as a debug outline (GlassPanel.tsx:6-9,45-48). The provider also scopes a focus ring: <code>outline: 2px solid var(--be-accent, #38bdf8); outline-offset: 2px</code> (BuildEditorThemeProvider.tsx:35-43).
+  </div>
+</div>

--- a/design-sync/preview/surface-card-grid.html
+++ b/design-sync/preview/surface-card-grid.html
@@ -1,0 +1,208 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Card-Grid Glass (G13) + Scribing Glass (G10)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; display:flex; flex-direction:column; gap:12px; }
+
+  /* ── G13 profile build card — PublicProfilePage.tsx:94-120 (useCardSx),
+       accent shown: sorcerer #00acc1 (accent flows from CLASS_COLOR_MAP) ── */
+  .g13 {
+    display:flex; flex-direction:column; position:relative; border-radius:16px; overflow:hidden;
+    backdrop-filter:blur(12px); -webkit-backdrop-filter:blur(12px);
+    transition:transform 0.22s ease, box-shadow 0.22s ease;
+    padding:16px 14px 12px; font-size:.74rem;
+  }
+  .g13 .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.86rem; }
+  .g13 .b { color:var(--muted); font-size:.66rem; margin-top:2px; }
+  [data-color-scheme="dark"] .g13 {
+    border:1px solid rgba(255,255,255,0.09);
+    background:linear-gradient(135deg, #00acc114 0%, rgba(56, 189, 248, 0.10) 50%, rgba(0, 225, 255, 0.10) 100%);
+    box-shadow:0 2px 12px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.06);
+  }
+  [data-color-scheme="light"] .g13 {
+    border:1px solid rgba(0,0,0,0.09);
+    background:linear-gradient(135deg, #00acc112 0%, rgba(219, 234, 254, 0.45) 50%, rgba(224, 242, 254, 0.45) 100%);
+    box-shadow:0 2px 12px rgba(0,0,0,0.07), inset 0 1px 0 rgba(255,255,255,0.9);
+  }
+  .g13:hover, .g13.is-hover { transform:translateY(-5px); }
+  [data-color-scheme="dark"] .g13:hover, [data-color-scheme="dark"] .g13.is-hover {
+    box-shadow:0 0 0 1px #00acc135, 0 16px 40px -8px #00acc150, 0 6px 20px -4px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.08);
+  }
+  [data-color-scheme="light"] .g13:hover, [data-color-scheme="light"] .g13.is-hover {
+    box-shadow:0 0 0 1px #00acc125, 0 16px 40px -8px #00acc135, 0 6px 20px -4px rgba(0,0,0,0.1), inset 0 1px 0 rgba(255,255,255,0.9);
+  }
+  /* Glowing feathered accent bar — PublicProfilePage.tsx:122-138 */
+  .g13 .accentbar {
+    position:absolute; top:0; left:0; right:0; height:4px;
+    background:linear-gradient(90deg, transparent 0%, #00acc180 20%, #00acc1 50%, #00acc180 80%, transparent 100%);
+    box-shadow:0 0 12px #00acc180, 0 0 28px #00acc140;
+    border-radius:16px 16px 0 0; z-index:2;
+  }
+  /* Sub-tier: tag chips blur 8 — PublicProfilePage.tsx:328-347 */
+  .g13 .tags { display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
+  .g13 .tag {
+    display:inline-flex; align-items:center; padding:3px 8px; border-radius:6px;
+    font-size:.72rem; font-weight:700; letter-spacing:.02em; line-height:1.4; white-space:nowrap;
+    backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px);
+  }
+  [data-color-scheme="dark"] .g13 .tag { background:rgba(255,255,255,0.07); border:1px solid rgba(255,255,255,0.12); color:rgba(255,255,255,0.55); }
+  [data-color-scheme="light"] .g13 .tag { background:rgba(0,0,0,0.05); border:1px solid rgba(0,0,0,0.10); color:rgba(0,0,0,0.55); }
+  /* Sub-tier: footer bar blur 6 — PublicProfilePage.tsx:379-392 */
+  .g13 .cfoot {
+    display:flex; align-items:stretch; margin-top:10px; border-radius:8px; overflow:hidden;
+    backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); font-size:.66rem; color:var(--muted);
+  }
+  [data-color-scheme="dark"] .g13 .cfoot { background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.06); }
+  [data-color-scheme="light"] .g13 .cfoot { background:rgba(0,0,0,0.025); border:1px solid rgba(0,0,0,0.05); }
+  .g13 .cfoot .stripe { width:3px; background:#00acc1; }
+  .g13 .cfoot .fx { padding:6px 10px; }
+
+  /* ── RosterCard amber variant — RosterCard.tsx:215,227-244 (radius 3 = 30px) ── */
+  .roster { border-radius:30px; }
+  [data-color-scheme="dark"] .roster {
+    background:linear-gradient(135deg, #eab30818 0%, rgba(250, 204, 21, 0.10) 50%, rgba(245, 158, 11, 0.10) 100%);
+  }
+  [data-color-scheme="light"] .roster {
+    background:linear-gradient(135deg, #eab30814 0%, rgba(254, 243, 199, 0.55) 50%, rgba(253, 230, 138, 0.45) 100%);
+  }
+  [data-color-scheme="dark"] .roster:hover, [data-color-scheme="dark"] .roster.is-hover {
+    box-shadow:0 0 0 1px #eab30835, 0 16px 40px -8px #eab30850, 0 6px 20px -4px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.08);
+  }
+  [data-color-scheme="light"] .roster:hover, [data-color-scheme="light"] .roster.is-hover {
+    box-shadow:0 0 0 1px #eab30825, 0 16px 40px -8px #eab30835, 0 6px 20px -4px rgba(0,0,0,0.1), inset 0 1px 0 rgba(255,255,255,0.9);
+  }
+  .roster .accentbar {
+    background:linear-gradient(90deg, transparent 0%, #eab30880 20%, #eab308 50%, #eab30880 80%, transparent 100%);
+    box-shadow:0 0 12px #eab30880, 0 0 28px #eab30840;
+    border-radius:30px 30px 0 0;
+  }
+  .roster .cfoot .stripe { background:#eab308; }
+
+  /* ── G10 scribing glass — scribingStyles.ts:93-118 (glassPanelSx, radius 20) ── */
+  .g10 {
+    position:relative; border-radius:20px; padding:16px 14px; font-size:.74rem;
+    backdrop-filter:blur(16px) saturate(1.4); -webkit-backdrop-filter:blur(16px) saturate(1.4);
+  }
+  .g10 .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.86rem; }
+  .g10 .b { color:var(--muted); font-size:.66rem; margin-top:2px; }
+  [data-color-scheme="dark"] .g10 {
+    border:1px solid rgba(255, 255, 255, 0.08);
+    background:linear-gradient(180deg, rgba(16, 26, 46, 0.74) 0%, rgba(5, 8, 15, 0.74) 100%);
+    box-shadow:0 18px 50px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
+  [data-color-scheme="light"] .g10 {
+    border:1px solid rgba(15, 23, 42, 0.08);
+    background:linear-gradient(180deg, rgba(238, 244, 251, 0.85) 0%, rgba(255, 255, 255, 0.96) 100%);
+    box-shadow:0 12px 36px rgba(15, 23, 42, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+  /* accent-tinted border option: alpha(accent, dark ? 0.3 : 0.28) */
+  [data-color-scheme="dark"] .g10.has-accent { border-color:rgba(56, 189, 248, 0.3); }
+  [data-color-scheme="light"] .g10.has-accent { border-color:rgba(56, 189, 248, 0.28); }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Card-Grid Glass (G13) + Scribing Glass (G10)</h1>
+  <p class="ds-sub">G13: accent-tinted 135° gradient cards at blur 12 with glowing feathered accent bars and glass sub-tiers (tag chips blur 8, footer bar blur 6); the RosterCard amber sibling; G10: the scribing frosted panel at blur(16) saturate(1.4). Sources: src/pages/PublicProfilePage.tsx:94-138,328-392; src/features/roster-hub/components/RosterCard.tsx:215-244; src/features/scribing/presentation/components/scribingStyles.ts:93-118.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="g13">
+          <div class="accentbar"></div>
+          <div class="h">Sorcerer — Storm DPS</div>
+          <div class="b">useCardSx('#00acc1', true) — 135° accent14 → cyan 0.10 → aqua 0.10, blur 12</div>
+          <div class="tags"><span class="tag">PvE</span><span class="tag">Trial</span><span class="tag">U46</span></div>
+          <div class="cfoot"><span class="stripe"></span><span class="fx">▲ 128 · 2w ago</span></div>
+        </div>
+        <div class="ds-src">PublicProfilePage.tsx:94-120 card · :122-138 AccentBar · :328-347 tag chips (blur 8) · :379-392 footer (blur 6)</div>
+        <div class="g13 roster is-hover">
+          <div class="accentbar"></div>
+          <div class="h">Roster — vSE Prog (.is-hover)</div>
+          <div class="b">Amber #eab308: accent18 → rgba(250,204,21,0.10) → rgba(245,158,11,0.10); hover ring 0 0 0 1px #eab30835 + 0 16px 40px -8px #eab30850 + translateY(-5px)</div>
+          <div class="cfoot"><span class="stripe"></span><span class="fx">12 players · vSE HM</span></div>
+        </div>
+        <div class="ds-src">RosterCard.tsx:215,227-244 — same recipe, borderRadius 3 (30px) vs 16px</div>
+        <div class="g10 has-accent">
+          <div class="h">Scribing — Grimoire panel</div>
+          <div class="b">180° rgba(16,26,46,0.74) → rgba(5,8,15,0.74), blur(16px) saturate(1.4), accent border rgba(56,189,248,0.3)</div>
+        </div>
+        <div class="ds-src">scribingStyles.ts:93-118 — glassPanelSx(theme, { accent })</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="g13">
+          <div class="accentbar"></div>
+          <div class="h">Sorcerer — Storm DPS</div>
+          <div class="b">useCardSx('#00acc1', false) — accent12 → rgba(219,234,254,0.45) → rgba(224,242,254,0.45)</div>
+          <div class="tags"><span class="tag">PvE</span><span class="tag">Trial</span><span class="tag">U46</span></div>
+          <div class="cfoot"><span class="stripe"></span><span class="fx">▲ 128 · 2w ago</span></div>
+        </div>
+        <div class="ds-src">PublicProfilePage.tsx:94-120 — light blue-tinted whites; inset white 0.9 highlight</div>
+        <div class="g13 roster is-hover">
+          <div class="accentbar"></div>
+          <div class="h">Roster — vSE Prog (.is-hover)</div>
+          <div class="b">Light amber: accent14 → rgba(254,243,199,0.55) → rgba(253,230,138,0.45); hover ring #eab30825 / #eab30835</div>
+          <div class="cfoot"><span class="stripe"></span><span class="fx">12 players · vSE HM</span></div>
+        </div>
+        <div class="ds-src">RosterCard.tsx:227-244</div>
+        <div class="g10 has-accent">
+          <div class="h">Scribing — Grimoire panel</div>
+          <div class="b">180° rgba(238,244,251,0.85) → rgba(255,255,255,0.96), accent border rgba(56,189,248,0.28)</div>
+        </div>
+        <div class="ds-src">scribingStyles.ts:93-118</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Notes:</strong> G13's accent flows in from <code>CLASS_COLOR_MAP</code> / <code>ROLE_ACCENT</code> (sorcerer <code>#00acc1</code> shown) and uses 2-digit hex-alpha suffixes (<code>#00acc114</code>, hover <code>#00acc150</code>). Hover is a lift+ring signature: <code>translateY(-5px)</code> + <code>0 0 0 1px accent35</code> + <code>0 16px 40px -8px accent50</code>. The AccentBar is a feathered 4px gradient (<code>transparent → accent80 20% → accent 50% → accent80 80% → transparent</code>) with a double glow — the top-strip family's "solo bar" member. G10 is the alpha()-based dialect of the card recipe: same anatomy, <code>saturate(1.4)</code> added, radius 20.
+  </div>
+</div>

--- a/design-sync/preview/surface-corner-glow.html
+++ b/design-sync/preview/surface-corner-glow.html
@@ -1,0 +1,224 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Corner-Glow Surfaces — Replay Control Deck (G11) + Footer Radial Blooms</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .sect { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin:16px 0 8px; position:relative; z-index:1; }
+  .sect:first-of-type { margin-top:0; }
+
+  /* ── G11 replay transport deck — replayDesign.ts:92-154 (transportSurface)
+     Theme values resolved: dark primary #38bdf8, secondary #00e1ff, paper
+     #0f172a, default #0b1220; light primary #0f172a, secondary #1e293b,
+     paper #ffffff, default #f8fafc, divider #bcd9ff. Overlay variant shown
+     (blur applies only when overlay=true). */
+  .deck { position:relative; border:1px solid; padding:14px 16px; font-size:.72rem; color:var(--text); }
+  .deck .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.84rem; }
+  .deck .b { color:var(--muted); font-size:.66rem; margin-top:3px; }
+  /* Top-edge light seam ::before — left/right 6% */
+  .deck::before {
+    content:""; position:absolute; top:0; left:6%; right:6%; height:1px; pointer-events:none;
+  }
+  [data-color-scheme="dark"] .deck::before { background:linear-gradient(90deg, transparent, #00e1ff, transparent); opacity:0.7; }
+  [data-color-scheme="light"] .deck::before { background:linear-gradient(90deg, transparent, #1e293b, transparent); opacity:0.4; }
+  /* full overlay deck — blur 10, corner glows + vertical gradient */
+  .deck-full {
+    border-radius:12px 12px 0 0; border-bottom:none; overflow:hidden;
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+  }
+  [data-color-scheme="dark"] .deck-full {
+    border-color:rgba(148,210,255,0.18);
+    background-image:
+      radial-gradient(120% 140% at 12% 0%, #38bdf824, transparent 42%),
+      radial-gradient(90% 120% at 92% 8%, #00e1ff14, transparent 50%),
+      linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(11, 18, 32, 0.82) 100%);
+    box-shadow:0 14px 40px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05);
+  }
+  [data-color-scheme="light"] .deck-full {
+    border-color:#bcd9ff;
+    background-image:
+      radial-gradient(120% 140% at 12% 0%, #0f172a10, transparent 45%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(248, 250, 252, 0.88) 120%);
+    box-shadow:0 10px 28px rgba(15,23,42,0.12), inset 0 1px 0 rgba(255,255,255,0.7);
+  }
+  /* compact overlay deck — blur 6, bottom-up scrim, overflow visible */
+  .deck-compact {
+    border-radius:12px 12px 0 0; border-bottom:none; overflow:visible;
+    backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px);
+  }
+  [data-color-scheme="dark"] .deck-compact {
+    border-color:rgba(148,210,255,0.18);
+    background-image:linear-gradient(0deg, rgba(11, 18, 32, 0.88) 0%, rgba(15, 23, 42, 0.5) 60%, transparent 100%);
+    box-shadow:0 14px 40px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05);
+  }
+  [data-color-scheme="light"] .deck-compact {
+    border-color:#bcd9ff;
+    background-image:linear-gradient(0deg, rgba(248, 250, 252, 0.88) 0%, rgba(255, 255, 255, 0.5) 60%, transparent 100%);
+    box-shadow:0 10px 28px rgba(15,23,42,0.12), inset 0 1px 0 rgba(255,255,255,0.7);
+  }
+  .transport { display:flex; gap:10px; align-items:center; margin-top:8px; }
+  .transport .btn { width:26px; height:26px; border-radius:50%; border:1px solid var(--border); background:var(--panel); display:inline-flex; align-items:center; justify-content:center; font-size:.6rem; color:var(--accent); }
+  .transport .rail { flex:1; height:4px; border-radius:2px; background:var(--border); position:relative; }
+  .transport .rail i { position:absolute; inset:0 60% 0 0; border-radius:2px; background:linear-gradient(90deg, var(--accent), var(--accent-2)); }
+
+  /* ── Footer radial-bloom panels — src/components/Footer.tsx:99-193
+     accent: dark #38bdf8 / light #2563eb; secondary: dark #a855f7 / light #7c3aed */
+  .fp {
+    position:relative; isolation:isolate; overflow:hidden; border-radius:30px;
+    padding:18px; font-size:.72rem; color:var(--text);
+    backdrop-filter:blur(14px); -webkit-backdrop-filter:blur(14px);
+  }
+  .fp .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.84rem; }
+  .fp .b { color:var(--muted); font-size:.66rem; margin-top:3px; }
+  .fp > * { position:relative; z-index:1; }
+  .fp::before, .fp::after { content:""; position:absolute; pointer-events:none; z-index:0; }
+  .fp::before { inset:0; }
+  /* overview panel — Footer.tsx:99-145 */
+  [data-color-scheme="dark"] .fp-overview {
+    background:linear-gradient(150deg, rgba(15, 23, 42, 0.96) 0%, rgba(21, 34, 56, 0.88) 48%, rgba(12, 21, 36, 0.92) 100%);
+    border:1px solid rgba(56, 189, 248, 0.3);
+    box-shadow:0 32px 64px rgba(2, 6, 23, 0.58);
+  }
+  [data-color-scheme="light"] .fp-overview {
+    background:linear-gradient(150deg, rgba(226, 232, 240, 0.92) 0%, rgba(241, 245, 249, 0.95) 48%, rgba(248, 250, 252, 0.98) 100%);
+    border:1px solid rgba(37, 99, 235, 0.22);
+    box-shadow:0 28px 56px rgba(148, 163, 184, 0.3);
+  }
+  [data-color-scheme="dark"] .fp-overview::before { background:radial-gradient(circle at top left, rgba(56, 189, 248, 0.35) 0%, transparent 55%); }
+  [data-color-scheme="light"] .fp-overview::before { background:radial-gradient(circle at top left, rgba(37, 99, 235, 0.2) 0%, transparent 55%); }
+  .fp-overview::after { bottom:-80px; right:-80px; width:220px; height:220px; }
+  [data-color-scheme="dark"] .fp-overview::after { background:radial-gradient(circle, rgba(168, 85, 247, 0.28) 0%, transparent 65%); }
+  [data-color-scheme="light"] .fp-overview::after { background:radial-gradient(circle, rgba(124, 58, 237, 0.18) 0%, transparent 65%); }
+  /* links panel — Footer.tsx:147-193 */
+  [data-color-scheme="dark"] .fp-links {
+    background:linear-gradient(150deg, rgba(10, 15, 28, 0.96) 0%, rgba(17, 24, 39, 0.9) 52%, rgba(10, 15, 28, 0.94) 100%);
+    border:1px solid rgba(56, 189, 248, 0.32);
+    box-shadow:0 34px 66px rgba(2, 6, 23, 0.6);
+  }
+  [data-color-scheme="light"] .fp-links {
+    background:linear-gradient(150deg, rgba(226, 232, 240, 0.9) 0%, rgba(234, 239, 247, 0.95) 52%, rgba(248, 250, 252, 0.98) 100%);
+    border:1px solid rgba(37, 99, 235, 0.24);
+    box-shadow:0 30px 60px rgba(148, 163, 184, 0.32);
+  }
+  [data-color-scheme="dark"] .fp-links::before { background:radial-gradient(circle at top right, rgba(56, 189, 248, 0.32) 0%, transparent 55%); }
+  [data-color-scheme="light"] .fp-links::before { background:radial-gradient(circle at top right, rgba(37, 99, 235, 0.18) 0%, transparent 55%); }
+  .fp-links::after { bottom:-90px; left:-60px; width:200px; height:200px; }
+  [data-color-scheme="dark"] .fp-links::after { background:radial-gradient(circle, rgba(168, 85, 247, 0.25) 0%, transparent 60%); }
+  [data-color-scheme="light"] .fp-links::after { background:radial-gradient(circle, rgba(124, 58, 237, 0.16) 0%, transparent 60%); }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Corner-Glow Surfaces — Replay Deck (G11) + Footer Blooms</h1>
+  <p class="ds-sub">G11: the "lit control deck" — two radial corner glows over a vertical gradient, a 1px inset top seam at 6%, variable blur (compact 6 / full 10). Footer pattern: 150° panel gradient + opposing radial corner blooms under isolation:isolate. Sources: src/features/fight_replay/constants/replayDesign.ts:92-154; src/components/Footer.tsx:99-193.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="sect">G11 — transportSurface(overlay, full) · blur 10</div>
+        <div class="deck deck-full">
+          <div class="h">Fight Replay — control deck</div>
+          <div class="b">Corner glows #38bdf824 (12% 0%) + #00e1ff14 (92% 8%) over 180° paper→default at 0.82 alpha; seam #00e1ff @ 0.7</div>
+          <div class="transport"><span class="btn">▶</span><span class="rail"><i></i></span><span>0:42 / 5:10</span></div>
+        </div>
+        <div class="ds-src">replayDesign.ts:92-154 — transportSurface(theme, overlay=true, compact=false)</div>
+
+        <div class="sect">G11 — compact overlay · blur 6, bottom-up scrim, overflow:visible</div>
+        <div class="deck deck-compact">
+          <div class="transport" style="margin-top:0;"><span class="btn">▶</span><span class="rail"><i></i></span><span>0:42</span></div>
+          <div class="b">Scrim: 0° rgba(11,18,32,0.88) → rgba(15,23,42,0.5) 60% → transparent (scene reads through the top)</div>
+        </div>
+        <div class="ds-src">replayDesign.ts:107-131,139 — compact swaps the panel stops for a bottom-anchored scrim</div>
+
+        <div class="sect">Footer radial blooms (isolation:isolate)</div>
+        <div class="fp fp-overview" style="margin-bottom:10px;">
+          <div class="h">Overview panel</div>
+          <div class="b">::before top-left cyan rgba(56,189,248,0.35) → 55% · ::after 220px violet circle rgba(168,85,247,0.28) at bottom -80 / right -80</div>
+        </div>
+        <div class="fp fp-links">
+          <div class="h">Links panel</div>
+          <div class="b">::before top-right cyan 0.32 · ::after 200px violet 0.25 at bottom -90 / left -60</div>
+        </div>
+        <div class="ds-src">Footer.tsx:99-145 (overviewPanelSx), :147-193 (linksPanelSx) — accents #38bdf8 / #a855f7</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="sect">G11 — transportSurface(overlay, full) · blur 10</div>
+        <div class="deck deck-full">
+          <div class="h">Fight Replay — control deck</div>
+          <div class="b">Single whisper glow #0f172a10 (light primary is slate); seam #1e293b @ 0.4; border 'divider' #bcd9ff</div>
+          <div class="transport"><span class="btn">▶</span><span class="rail"><i></i></span><span>0:42 / 5:10</span></div>
+        </div>
+        <div class="ds-src">replayDesign.ts:130-131 — light drops the second corner glow</div>
+
+        <div class="sect">G11 — compact overlay · blur 6</div>
+        <div class="deck deck-compact">
+          <div class="transport" style="margin-top:0;"><span class="btn">▶</span><span class="rail"><i></i></span><span>0:42</span></div>
+          <div class="b">Scrim: rgba(248,250,252,0.88) → rgba(255,255,255,0.5) 60% → transparent</div>
+        </div>
+        <div class="ds-src">replayDesign.ts:123-125</div>
+
+        <div class="sect">Footer radial blooms</div>
+        <div class="fp fp-overview" style="margin-bottom:10px;">
+          <div class="h">Overview panel</div>
+          <div class="b">Light accents shift: #2563eb blooms at 0.2, #7c3aed at 0.18 over a 150° slate-white gradient</div>
+        </div>
+        <div class="fp fp-links">
+          <div class="h">Links panel</div>
+          <div class="b">::before top-right rgba(37,99,235,0.18) · ::after rgba(124,58,237,0.16)</div>
+        </div>
+        <div class="ds-src">Footer.tsx:25-27 — accentColor #2563eb, secondaryAccent #7c3aed in light</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Notes:</strong> transportSurface only gains <code>backdrop-filter</code> in the overlay variant (docked over the 3D canvas); the in-flow deck uses solid paper/default stops and no blur. The expanded deck keeps <code>overflow:hidden</code> so corner glows stay in the rounded corners; compact must be <code>overflow:visible</code> for the scrub-preview bubble. A quieter sibling, <code>markerDeckSurface</code> (replayDesign.ts:164-198), uses alpha() corner washes with the seam at 5%. The Footer's <code>isolation:isolate</code> + <code>&amp; &gt; * { z-index:1 }</code> keeps the blooms behind content. Corner-glow hexes use 2-digit hex alpha (<code>#38bdf824</code> ≈ 0.14) — a third alpha dialect beside rgba() and alpha().
+  </div>
+</div>

--- a/design-sync/preview/surface-filter-fields.html
+++ b/design-sync/preview/surface-filter-fields.html
@@ -1,0 +1,239 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Filter-Bar Glass (G9) + Recessed Input Wells (G12)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .sect { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin:16px 0 8px; position:relative; z-index:1; }
+  .sect:first-of-type { margin-top:0; }
+
+  /* ── G9 filter-bar panel — latestReportsStyles.ts:43-50 (blur 16) ──────
+     borderRadius: 3 = 30px (theme shape base 10; the in-source comment says
+     "24px glass panel" — a stale comment, see callout). */
+  .g9-panel {
+    border-radius:30px; padding:16px;
+    backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px);
+    display:flex; flex-wrap:wrap; gap:10px; align-items:center;
+  }
+  [data-color-scheme="dark"] .g9-panel { background:rgba(11,16,26,0.88); border:1px solid rgba(255,255,255,0.06); }
+  [data-color-scheme="light"] .g9-panel { background:rgba(248,250,252,0.92); border:1px solid rgba(0,0,0,0.06); }
+
+  /* field — glassFieldBg (blur 12) + glassOutlinedFieldSx, :34-72 */
+  .g9-field {
+    flex:1; min-width:150px; border-radius:14px; padding:9px 12px; font-size:.78rem; color:var(--text);
+    backdrop-filter:blur(12px); -webkit-backdrop-filter:blur(12px);
+    transition:border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  [data-color-scheme="dark"] .g9-field { background:rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.10); }
+  [data-color-scheme="light"] .g9-field { background:rgba(0,0,0,0.04); border:1px solid rgba(0,0,0,0.08); }
+  [data-color-scheme="dark"] .g9-field:hover { border-color:rgba(255,255,255,0.20); }
+  [data-color-scheme="light"] .g9-field:hover { border-color:rgba(0,0,0,0.14); }
+  .g9-field.is-focus {
+    border-color:rgba(96,165,250,0.55);
+    box-shadow:0 0 0 3px rgba(96,165,250,0.12);
+  }
+  .g9-field .ph { color:var(--muted); }
+
+  /* segmented control — segmentedTrackSx :89-98 (blur 8) + segmentedButtonSx :159-195 */
+  .g9-track {
+    display:inline-flex; padding:3px; border-radius:999px; flex-shrink:0;
+    backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px);
+  }
+  [data-color-scheme="dark"] .g9-track { background:rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.08); }
+  [data-color-scheme="light"] .g9-track { background:rgba(0,0,0,0.05); border:1px solid rgba(0,0,0,0.07); }
+  .g9-seg {
+    display:inline-flex; align-items:center; justify-content:center; gap:4px;
+    padding:5px 12px; border-radius:999px; border:none; cursor:pointer;
+    font-family:inherit; font-size:.78rem; font-weight:600; letter-spacing:.01em; line-height:1;
+    transition:all 0.2s ease; white-space:nowrap; background:transparent;
+  }
+  [data-color-scheme="dark"] .g9-seg { color:rgba(255,255,255,0.45); }
+  [data-color-scheme="light"] .g9-seg { color:rgba(0,0,0,0.45); }
+  [data-color-scheme="dark"] .g9-seg.is-active {
+    background:linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(139,92,246,0.9) 100%);
+    color:#fff;
+    box-shadow:0 0 10px rgba(96,165,250,0.35), 0 2px 8px rgba(0,0,0,0.35);
+  }
+  [data-color-scheme="light"] .g9-seg.is-active {
+    background:linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%);
+    color:#fff;
+    box-shadow:0 2px 8px rgba(59,130,246,0.35);
+  }
+
+  /* menu paper — glassMenuPaperSx :78-86 (blur 20) */
+  .g9-menu {
+    margin-top:8px; border-radius:20px; padding:8px; font-size:.74rem; color:var(--text);
+    backdrop-filter:blur(20px); -webkit-backdrop-filter:blur(20px); max-width:240px;
+  }
+  [data-color-scheme="dark"] .g9-menu {
+    background:rgba(18,24,38,0.96); border:1px solid rgba(255,255,255,0.08);
+    box-shadow:0 8px 32px rgba(0,0,0,0.6);
+  }
+  [data-color-scheme="light"] .g9-menu {
+    background:rgba(255,255,255,0.96); border:1px solid rgba(0,0,0,0.06);
+    box-shadow:0 8px 32px rgba(0,0,0,0.12);
+  }
+  .g9-menu .mi { padding:6px 10px; border-radius:8px; }
+  [data-color-scheme="dark"] .g9-menu .mi.sel { background:rgba(96,165,250,0.14); }
+  [data-color-scheme="light"] .g9-menu .mi.sel { background:rgba(59,130,246,0.1); }
+
+  /* ── G12a build-editor recessed well — glassInputSx.ts:9-39 + BE_TOKENS.input ── */
+  .g12-be {
+    font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-size:13px; color:var(--text);
+    border-radius:10px; padding:9px 12px; width:100%;
+    transition:background 0.2s ease;
+  }
+  [data-color-scheme="dark"] .g12-be { background:rgba(0, 0, 0, 0.22); border:1px solid rgba(255, 255, 255, 0.08); }
+  [data-color-scheme="light"] .g12-be { background:rgba(0, 0, 0, 0.04); border:1px solid rgba(0, 0, 0, 0.10); }
+  [data-color-scheme="dark"] .g12-be:hover { background:rgba(0, 0, 0, 0.28); border-color:rgba(255, 255, 255, 0.18); }
+  [data-color-scheme="light"] .g12-be:hover { background:rgba(0, 0, 0, 0.06); border-color:rgba(0, 0, 0, 0.18); }
+  .g12-be.is-focus { border-color:var(--be-accent, #38bdf8); }
+  [data-color-scheme="dark"] .g12-be .ph { color:rgba(255, 255, 255, 0.28); }
+  [data-color-scheme="light"] .g12-be .ph { color:rgba(0, 0, 0, 0.36); }
+
+  /* ── G12b TextEditor sunken input — src/components/TextEditor.tsx:265-301
+       (saturate in the % dialect: blur(6px) saturate(140%)) ── */
+  .g12-ed {
+    padding:14px 16px; border-radius:12px 12px 0 0; font-size:15px; line-height:1.6; color:var(--text);
+    backdrop-filter:blur(6px) saturate(140%); -webkit-backdrop-filter:blur(6px) saturate(140%);
+    transition:border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  [data-color-scheme="dark"] .g12-ed {
+    background:rgba(10, 16, 30, 0.95);
+    border:2px solid rgba(255,255,255,0.15);
+    box-shadow:inset 0 2px 4px rgba(0,0,0,0.4);
+  }
+  [data-color-scheme="light"] .g12-ed {
+    background:rgba(255, 255, 255, 0.97);
+    border:2px solid rgba(0,0,0,0.18);
+    box-shadow:inset 0 2px 4px rgba(0,0,0,0.06);
+  }
+  [data-color-scheme="dark"] .g12-ed:hover { border-color:rgba(255,255,255,0.3); }
+  [data-color-scheme="light"] .g12-ed:hover { border-color:rgba(0,0,0,0.35); }
+  .g12-ed.is-focus { border-color:var(--accent); }
+  [data-color-scheme="dark"] .g12-ed.is-focus { box-shadow:inset 0 2px 4px rgba(0,0,0,0.06), 0 0 0 3px rgba(56, 189, 248, 0.2); }
+  [data-color-scheme="light"] .g12-ed.is-focus { box-shadow:inset 0 2px 4px rgba(0,0,0,0.06), 0 0 0 3px rgba(15, 23, 42, 0.2); }
+  .g12-ed .ph { font-style:italic; }
+  [data-color-scheme="dark"] .g12-ed .ph { color:rgba(255,255,255,0.35); }
+  [data-color-scheme="light"] .g12-ed .ph { color:rgba(0,0,0,0.35); }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Filter-Bar Glass (G9) + Recessed Input Wells (G12)</h1>
+  <p class="ds-sub">G9 canonical values: panel blur 16 / field blur 12 / segmented track blur 8 / menu paper blur 20, focus ring rgba(96,165,250,…). G12: sunken input wells with inverted (inset) shadows and the saturate-% dialect. Sources: src/features/latest_reports/latestReportsStyles.ts; src/features/build-editor/components/primitives/glassInputSx.ts; src/components/TextEditor.tsx:265-301.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="sect">G9 — mock filter bar (glassPanelSx, blur 16)</div>
+        <div class="g9-panel">
+          <div class="g9-field"><span class="ph">Search reports…</span></div>
+          <div class="g9-field is-focus">vAS+2 (.is-focus — border rgba(96,165,250,0.55) + ring 0 0 0 3px rgba(96,165,250,0.12))</div>
+          <div class="g9-track">
+            <button class="g9-seg is-active">7d</button>
+            <button class="g9-seg">30d</button>
+            <button class="g9-seg">All</button>
+          </div>
+        </div>
+        <div class="ds-src">panel latestReportsStyles.ts:43-50 · field :34-40,56-72 · segmented :89-98,159-195 · focus :29-30</div>
+        <div class="g9-menu">
+          <div class="mi sel">Most recent</div>
+          <div class="mi">Highest score</div>
+          <div class="mi">Longest fight</div>
+        </div>
+        <div class="ds-src">menu paper glassMenuPaperSx — latestReportsStyles.ts:78-86 (blur 20, rgba(18,24,38,0.96))</div>
+
+        <div class="sect">G12a — build-editor recessed well (glassInputSx)</div>
+        <div class="g12-be" style="margin-bottom:8px;"><span class="ph">Build name…</span></div>
+        <div class="g12-be is-focus">Oakensoul DK (.is-focus — border var(--be-accent, #38bdf8))</div>
+        <div class="ds-src">glassInputSx.ts:9-39 · BE_TOKENS.input.dark — buildEditorTokens.ts:56-62 (bg rgba(0,0,0,0.22))</div>
+
+        <div class="sect">G12b — TextEditor sunken input (saturate-% dialect)</div>
+        <div class="g12-ed" style="margin-bottom:8px;"><span class="ph">Write your guide…</span></div>
+        <div class="g12-ed is-focus">Focused (.is-focus) — inset 0 2px 4px rgba(0,0,0,0.06) + 0 0 0 3px rgba(56,189,248,0.2)</div>
+        <div class="ds-src">src/components/TextEditor.tsx:265-301 — inset 0 2px 4px rgba(0,0,0,0.4), blur(6px) saturate(140%)</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="sect">G9 — mock filter bar (glassPanelSx, blur 16)</div>
+        <div class="g9-panel">
+          <div class="g9-field"><span class="ph">Search reports…</span></div>
+          <div class="g9-field is-focus">vAS+2 (.is-focus — same rgba(96,165,250,…) ring in light)</div>
+          <div class="g9-track">
+            <button class="g9-seg is-active">7d</button>
+            <button class="g9-seg">30d</button>
+            <button class="g9-seg">All</button>
+          </div>
+        </div>
+        <div class="ds-src">light: panel rgba(248,250,252,0.92) · field rgba(0,0,0,0.04) · active seg linear-gradient(135deg, #3b82f6, #8b5cf6)</div>
+        <div class="g9-menu">
+          <div class="mi sel">Most recent</div>
+          <div class="mi">Highest score</div>
+          <div class="mi">Longest fight</div>
+        </div>
+        <div class="ds-src">menu paper — rgba(255,255,255,0.96), shadow 0 8px 32px rgba(0,0,0,0.12)</div>
+
+        <div class="sect">G12a — build-editor recessed well (glassInputSx)</div>
+        <div class="g12-be" style="margin-bottom:8px;"><span class="ph">Build name…</span></div>
+        <div class="g12-be is-focus">Oakensoul DK (.is-focus)</div>
+        <div class="ds-src">BE_TOKENS.input.light — buildEditorTokens.ts:63-68 (bg rgba(0,0,0,0.04))</div>
+
+        <div class="sect">G12b — TextEditor sunken input</div>
+        <div class="g12-ed" style="margin-bottom:8px;"><span class="ph">Write your guide…</span></div>
+        <div class="g12-ed is-focus">Focused (.is-focus) — ring rgba(15,23,42,0.2) (light primary is slate #0f172a)</div>
+        <div class="ds-src">src/components/TextEditor.tsx:265-301 — light inset rgba(0,0,0,0.06)</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Notes:</strong> G9 is the canonical copy; near-duplicates live in the roster-hub / build-hub / pack-hub FilterBars. The recessed-well rule (B11 inversion): inputs shade <em>inward</em> (<code>inset 0 2px 4px</code> or a dark fill like <code>rgba(0,0,0,0.22)</code>) while panels highlight their top edge. Saturate appears in two dialects — unitless <code>saturate(1.4)</code> (tooltips, scribing) vs percentage <code>saturate(140%)</code> (TextEditor) — document, don't unify. The panel's <code>borderRadius: 3</code> resolves to 30px under the theme's shape base 10; the in-source comment calling it a "24px glass panel" (latestReportsStyles.ts:59) is stale. The prompt-cited path for the editor is actually <code>src/components/TextEditor.tsx</code>, not a build-editor primitive.
+  </div>
+</div>

--- a/design-sync/preview/surface-glass-cards.html
+++ b/design-sync/preview/surface-glass-cards.html
@@ -1,0 +1,190 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Accent Card Glass (G1) — glassCardSurfaceSx × SUMMARY_ACCENTS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; display:flex; flex-direction:column; gap:14px; }
+
+  /* ── G1 glassCardSurfaceSx — src/theme/glassCardSurface.ts:29-70 ────────
+     Per-accent RGB triplet A (SUMMARY_ACCENTS): info 56,189,248 / damage
+     251,191,36 / death 248,113,113. borderRadius: 2.5 (MUI spacing ×10 = 25px).
+     Values transcribed exactly; hover states duplicated under .is-hover. */
+  .g1 {
+    position:relative; overflow:hidden; border-radius:25px;
+    backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px);
+    transition:box-shadow 0.28s ease, border-color 0.28s ease;
+    padding:16px; min-height:88px;
+  }
+  .g1 .h { font-family:'Space Grotesk',Inter,sans-serif; font-weight:600; font-size:.9rem; }
+  .g1 .b { font-size:.72rem; color:var(--muted); margin-top:4px; }
+  /* Color-coded top accent bar */
+  .g1::before {
+    content:""; position:absolute; top:0; left:0; right:0; height:3px;
+    pointer-events:none; z-index:1;
+  }
+  [data-color-scheme="dark"] .g1 {
+    box-shadow:0 10px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+  [data-color-scheme="light"] .g1 {
+    box-shadow:0 6px 28px rgba(15, 23, 42, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+  /* info — 56, 189, 248 */
+  [data-color-scheme="dark"] .g1-info {
+    border:1px solid rgba(56, 189, 248, 0.20);
+    background:linear-gradient(180deg, rgba(56, 189, 248, 0.1) 0%, rgba(56, 189, 248, 0) 150px),
+               linear-gradient(160deg, rgba(20, 32, 54, 0.82) 0%, rgba(7, 12, 26, 0.8) 100%);
+  }
+  [data-color-scheme="dark"] .g1-info::before { background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.95) 50%, transparent 100%); }
+  [data-color-scheme="dark"] .g1-info:hover, [data-color-scheme="dark"] .g1-info.is-hover {
+    border-color:rgba(56, 189, 248, 0.42);
+    box-shadow:0 14px 48px rgba(0, 0, 0, 0.5), 0 0 28px rgba(56, 189, 248, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+  [data-color-scheme="light"] .g1-info {
+    border:1px solid rgba(56, 189, 248, 0.18);
+    background:linear-gradient(180deg, rgba(56, 189, 248, 0.08) 0%, rgba(56, 189, 248, 0) 150px),
+               linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 248, 255, 0.85) 100%);
+  }
+  [data-color-scheme="light"] .g1-info::before { background:linear-gradient(90deg, transparent 0%, rgba(56, 189, 248, 0.85) 50%, transparent 100%); }
+  [data-color-scheme="light"] .g1-info:hover, [data-color-scheme="light"] .g1-info.is-hover {
+    border-color:rgba(56, 189, 248, 0.34);
+    box-shadow:0 10px 36px rgba(15, 23, 42, 0.16), 0 0 24px rgba(56, 189, 248, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+  /* damage — 251, 191, 36 */
+  [data-color-scheme="dark"] .g1-damage {
+    border:1px solid rgba(251, 191, 36, 0.20);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.1) 0%, rgba(251, 191, 36, 0) 150px),
+               linear-gradient(160deg, rgba(20, 32, 54, 0.82) 0%, rgba(7, 12, 26, 0.8) 100%);
+  }
+  [data-color-scheme="dark"] .g1-damage::before { background:linear-gradient(90deg, transparent 0%, rgba(251, 191, 36, 0.95) 50%, transparent 100%); }
+  [data-color-scheme="dark"] .g1-damage:hover, [data-color-scheme="dark"] .g1-damage.is-hover {
+    border-color:rgba(251, 191, 36, 0.42);
+    box-shadow:0 14px 48px rgba(0, 0, 0, 0.5), 0 0 28px rgba(251, 191, 36, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+  [data-color-scheme="light"] .g1-damage {
+    border:1px solid rgba(251, 191, 36, 0.18);
+    background:linear-gradient(180deg, rgba(251, 191, 36, 0.08) 0%, rgba(251, 191, 36, 0) 150px),
+               linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 248, 255, 0.85) 100%);
+  }
+  [data-color-scheme="light"] .g1-damage::before { background:linear-gradient(90deg, transparent 0%, rgba(251, 191, 36, 0.85) 50%, transparent 100%); }
+  [data-color-scheme="light"] .g1-damage:hover, [data-color-scheme="light"] .g1-damage.is-hover {
+    border-color:rgba(251, 191, 36, 0.34);
+    box-shadow:0 10px 36px rgba(15, 23, 42, 0.16), 0 0 24px rgba(251, 191, 36, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+  /* death — 248, 113, 113 */
+  [data-color-scheme="dark"] .g1-death {
+    border:1px solid rgba(248, 113, 113, 0.20);
+    background:linear-gradient(180deg, rgba(248, 113, 113, 0.1) 0%, rgba(248, 113, 113, 0) 150px),
+               linear-gradient(160deg, rgba(20, 32, 54, 0.82) 0%, rgba(7, 12, 26, 0.8) 100%);
+  }
+  [data-color-scheme="dark"] .g1-death::before { background:linear-gradient(90deg, transparent 0%, rgba(248, 113, 113, 0.95) 50%, transparent 100%); }
+  [data-color-scheme="dark"] .g1-death:hover, [data-color-scheme="dark"] .g1-death.is-hover {
+    border-color:rgba(248, 113, 113, 0.42);
+    box-shadow:0 14px 48px rgba(0, 0, 0, 0.5), 0 0 28px rgba(248, 113, 113, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+  [data-color-scheme="light"] .g1-death {
+    border:1px solid rgba(248, 113, 113, 0.18);
+    background:linear-gradient(180deg, rgba(248, 113, 113, 0.08) 0%, rgba(248, 113, 113, 0) 150px),
+               linear-gradient(160deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 248, 255, 0.85) 100%);
+  }
+  [data-color-scheme="light"] .g1-death::before { background:linear-gradient(90deg, transparent 0%, rgba(248, 113, 113, 0.85) 50%, transparent 100%); }
+  [data-color-scheme="light"] .g1-death:hover, [data-color-scheme="light"] .g1-death.is-hover {
+    border-color:rgba(248, 113, 113, 0.34);
+    box-shadow:0 10px 36px rgba(15, 23, 42, 0.16), 0 0 24px rgba(248, 113, 113, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Accent Card Glass (G1) — glassCardSurfaceSx</h1>
+  <p class="ds-sub">Premium glass for the report-summary section cards: dual stacked gradients (accent bloom over translucent base), blur(16px), a 3px full-bleed fading top strip, inset top highlight, and a hover accent glow. Source: src/theme/glassCardSurface.ts:29-70; accents src/theme/glassCardSurface.ts:5-12.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="g1 g1-info">
+          <div class="h">Report Overview</div>
+          <div class="b">SUMMARY_ACCENTS.info — '56, 189, 248' (brand cyan)</div>
+          <div class="ds-src">glassCardSurfaceSx(true, '56, 189, 248') — glassCardSurface.ts:29</div>
+        </div>
+        <div class="g1 g1-damage is-hover">
+          <div class="h">Damage Breakdown — hover state (.is-hover)</div>
+          <div class="b">SUMMARY_ACCENTS.damage — '251, 191, 36' (amber). Hover: border 0.42, glow 0 0 28px rgba(A, 0.14)</div>
+          <div class="ds-src">hover — glassCardSurface.ts:63-68</div>
+        </div>
+        <div class="g1 g1-death">
+          <div class="h">Death Analysis</div>
+          <div class="b">SUMMARY_ACCENTS.death — '248, 113, 113' (coral)</div>
+          <div class="ds-src">glassCardSurfaceSx(true, '248, 113, 113')</div>
+        </div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="g1 g1-info">
+          <div class="h">Report Overview</div>
+          <div class="b">Bloom drops to 0.08; base is 160° white 0.9 → 0.85 gradient; strip alpha 0.85</div>
+          <div class="ds-src">glassCardSurfaceSx(false, '56, 189, 248')</div>
+        </div>
+        <div class="g1 g1-damage is-hover">
+          <div class="h">Damage Breakdown — hover state (.is-hover)</div>
+          <div class="b">Hover: border 0.34, glow 0 0 24px rgba(A, 0.12), inset white 0.9 kept</div>
+          <div class="ds-src">hover — glassCardSurface.ts:63-68</div>
+        </div>
+        <div class="g1 g1-death">
+          <div class="h">Death Analysis</div>
+          <div class="b">Coral accent over the white glass base</div>
+          <div class="ds-src">glassCardSurfaceSx(false, '248, 113, 113')</div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Anatomy:</strong> layer 1 <code>linear-gradient(180deg, rgba(A, 0.1) 0%, rgba(A, 0) 150px)</code> (accent bloom, dark; 0.08 light) over layer 2 <code>linear-gradient(160deg, rgba(20,32,54,0.82), rgba(7,12,26,0.8))</code> (dark base). <code>::before</code> strip: 3px, <code>linear-gradient(90deg, transparent, rgba(A, 0.95|0.85) 50%, transparent)</code>. Radius <code>borderRadius: 2.5</code> = 25px (theme shape base 10). Pair with <code>elevation={0}</code> — the recipe supplies its own shadow.
+  </div>
+</div>

--- a/design-sync/preview/surface-glass-menus.html
+++ b/design-sync/preview/surface-glass-menus.html
@@ -1,0 +1,255 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Menu Glass — Cyan Dropdown (G2) + HeaderBar Rich Dropdown (G8)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .sect { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin:16px 0 8px; position:relative; z-index:1; }
+  .sect:first-of-type { margin-top:0; }
+
+  /* ── G2 cyan dropdown glass — src/theme/dropdownMenu.ts:126-210 ────────
+     Opaque slate fill (wins over global .MuiMenu-paper !important via && +
+     !important), brightest border in the system, 2px top sheen, items with
+     cyan gradient fill + inset 3px left rail. */
+  .g2 {
+    position:relative; border-radius:14px; overflow:hidden; padding:7px 0;
+    backdrop-filter:blur(20px) saturate(1.5); -webkit-backdrop-filter:blur(20px) saturate(1.5);
+  }
+  [data-color-scheme="dark"] .g2 {
+    background-color:rgb(45,64,99);
+    border:1px solid rgba(56,189,248,0.6);
+    box-shadow:0 24px 60px rgba(0,0,0,0.65), 0 0 36px rgba(56,189,248,0.3), inset 0 1px 0 rgba(255,255,255,0.12);
+  }
+  [data-color-scheme="light"] .g2 {
+    background-color:rgb(250,253,255);
+    border:1px solid rgba(40,145,200,0.4);
+    box-shadow:0 20px 48px rgba(15,23,42,0.22), 0 0 24px rgba(40,145,200,0.18), inset 0 1px 0 rgba(255,255,255,0.9);
+  }
+  .g2::before {
+    content:""; position:absolute; top:0; left:0; right:0; height:2px; pointer-events:none; z-index:1;
+  }
+  [data-color-scheme="dark"] .g2::before { background:linear-gradient(90deg, transparent, rgba(0,225,255,0.7), transparent); }
+  [data-color-scheme="light"] .g2::before { background:linear-gradient(90deg, transparent, rgba(40,145,200,0.6), transparent); }
+  .g2 .mi {
+    border-radius:10px; margin:0 7px; padding:9px 12px; font-size:.78rem;
+    transition:background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    color:var(--text);
+  }
+  [data-color-scheme="dark"] .g2 .mi:hover, [data-color-scheme="dark"] .g2 .mi.is-hover {
+    background:linear-gradient(90deg, rgba(56,189,248,0.20), rgba(56,189,248,0.06));
+    box-shadow:inset 3px 0 0 rgb(56,189,248);
+  }
+  [data-color-scheme="light"] .g2 .mi:hover, [data-color-scheme="light"] .g2 .mi.is-hover {
+    background:linear-gradient(90deg, rgba(40,145,200,0.16), rgba(40,145,200,0.04));
+    box-shadow:inset 3px 0 0 rgb(40,145,200);
+  }
+  [data-color-scheme="dark"] .g2 .mi.is-selected {
+    color:rgb(186,236,255); font-weight:600;
+    background:linear-gradient(90deg, rgba(56,189,248,0.32), rgba(0,225,255,0.10));
+    box-shadow:inset 3px 0 0 rgb(56,189,248), 0 0 16px rgba(56,189,248,0.18);
+  }
+  [data-color-scheme="light"] .g2 .mi.is-selected {
+    color:rgb(20,110,160); font-weight:600;
+    background:linear-gradient(90deg, rgba(40,145,200,0.22), rgba(40,145,200,0.06));
+    box-shadow:inset 3px 0 0 rgb(40,145,200);
+  }
+
+  /* ── G8 HeaderBar rich dropdown — src/components/HeaderBar.tsx:307-372 ──
+     accent: dark #38bdf8 / light #3b82f6; accentAlt: dark #0ea5e9 / light #2563eb */
+  @keyframes dropdownShimmer {
+    0% { background-position:-200% center; }
+    100% { background-position:200% center; }
+  }
+  .g8 {
+    position:relative; overflow:hidden; min-width:280px; border-radius:16px; padding:6px 0 8px;
+    backdrop-filter:blur(24px); -webkit-backdrop-filter:blur(24px);
+  }
+  [data-color-scheme="dark"] .g8 {
+    background:linear-gradient(180deg, rgba(15, 23, 42, 0.78) 0%, rgba(3, 7, 18, 0.88) 100%);
+    border:1px solid rgba(56,189,248,0.12);
+    box-shadow:0 20px 60px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(56,189,248,0.08), inset 0 1px 0 rgba(255,255,255,0.05);
+  }
+  [data-color-scheme="light"] .g8 {
+    background:linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(248, 250, 252, 0.94) 100%);
+    border:1px solid rgba(59,130,246,0.1);
+    box-shadow:0 20px 60px rgba(15, 23, 42, 0.15), 0 0 0 1px rgba(59,130,246,0.06);
+  }
+  /* Animated shimmer accent line */
+  .g8::before {
+    content:""; display:block; position:absolute; top:0; left:0; right:0; height:2px;
+    background-size:200% 100%;
+    animation:dropdownShimmer 3s linear infinite;
+    z-index:2;
+  }
+  [data-color-scheme="dark"] .g8::before {
+    background-image:linear-gradient(90deg, transparent 0%, #38bdf8 15%, #0ea5e9 50%, #38bdf8 85%, transparent 100%);
+    background-size:200% 100%;
+  }
+  [data-color-scheme="light"] .g8::before {
+    background-image:linear-gradient(90deg, transparent 0%, #3b82f6 15%, #2563eb 50%, #3b82f6 85%, transparent 100%);
+    background-size:200% 100%;
+  }
+  /* Noise texture — inline SVG feTurbulence, HeaderBar.tsx:303 */
+  .g8::after {
+    content:""; position:absolute; inset:0;
+    background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+    background-size:128px 128px;
+    pointer-events:none; z-index:0; border-radius:inherit;
+  }
+  [data-color-scheme="dark"] .g8::after { opacity:0.4; }
+  [data-color-scheme="light"] .g8::after { opacity:0.2; }
+  /* Mouse-tracked spotlight — HeaderBar.tsx:362-371 */
+  .g8 .dropdown-spotlight {
+    position:absolute; inset:0; pointer-events:none; z-index:0; border-radius:inherit;
+    transition:background 0.15s ease;
+  }
+  [data-color-scheme="dark"] .g8 .dropdown-spotlight {
+    background:radial-gradient(320px circle at var(--mouse-x, 50%) var(--mouse-y, 0%), rgba(56,189,248,0.07), transparent 60%);
+  }
+  [data-color-scheme="light"] .g8 .dropdown-spotlight {
+    background:radial-gradient(320px circle at var(--mouse-x, 50%) var(--mouse-y, 0%), rgba(59,130,246,0.05), transparent 60%);
+  }
+  /* Section header — HeaderBar.tsx:377-411 */
+  .g8 .hd { display:flex; align-items:center; gap:8px; padding:16px 16px 8px; position:relative; z-index:1; }
+  .g8 .hd .lbl {
+    font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:700; font-size:.7rem;
+    letter-spacing:.08em; text-transform:uppercase;
+    -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent;
+  }
+  [data-color-scheme="dark"] .g8 .hd .lbl { background-image:linear-gradient(135deg, #38bdf8 0%, #0ea5e9 100%); }
+  [data-color-scheme="light"] .g8 .hd .lbl { background-image:linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); }
+  .g8 .hd::after { content:""; flex:1; height:1px; }
+  [data-color-scheme="dark"] .g8 .hd::after { background:linear-gradient(90deg, rgba(56,189,248,0.25), transparent); }
+  [data-color-scheme="light"] .g8 .hd::after { background:linear-gradient(90deg, rgba(59,130,246,0.25), transparent); }
+  /* Menu item + hover rail — HeaderBar.tsx:415-469 (rail at :454-456) */
+  .g8 .mi {
+    padding:8px 12px; border-radius:10px; margin:2px 6px; font-size:.875rem; font-weight:550;
+    position:relative; z-index:1; color:var(--text);
+    transition:background 0.25s ease, transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s ease;
+  }
+  .g8 .mi .sub { font-size:.7rem; opacity:.45; transition:opacity 0.25s ease; }
+  [data-color-scheme="dark"] .g8 .mi:hover, [data-color-scheme="dark"] .g8 .mi.is-hover {
+    background:linear-gradient(135deg, rgba(56,189,248,0.12) 0%, rgba(56,189,248,0.03) 100%);
+    transform:translateX(4px);
+    box-shadow:inset 2px 0 0 #38bdf8, 0 2px 12px rgba(56,189,248,0.1);
+  }
+  [data-color-scheme="light"] .g8 .mi:hover, [data-color-scheme="light"] .g8 .mi.is-hover {
+    background:linear-gradient(135deg, rgba(59,130,246,0.1) 0%, rgba(59,130,246,0.02) 100%);
+    transform:translateX(4px);
+    box-shadow:inset 2px 0 0 #3b82f6, 0 2px 8px rgba(59,130,246,0.06);
+  }
+  .g8 .mi:hover .sub, .g8 .mi.is-hover .sub { opacity:.75; }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Menu Glass — Cyan Dropdown (G2) + HeaderBar Rich Dropdown (G8)</h1>
+  <p class="ds-sub">G2: the shared Select-menu paper — opaque slate fill, the system's brightest border rgba(56,189,248,0.6), 2px cyan sheen, items with a 3px inset left rail. G8: the richest glass — blur(24px), animated shimmer strip, SVG noise, JS mouse-tracked spotlight, and 2px-rail items. Sources: src/theme/dropdownMenu.ts:126-210; src/components/HeaderBar.tsx:307-372,455-456.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="sect">G2 — dropdownMenuPaperSx(true)</div>
+        <div class="g2">
+          <div class="mi">All encounters</div>
+          <div class="mi is-hover">Trial bosses only (.is-hover — inset 3px 0 0 rgb(56,189,248))</div>
+          <div class="mi is-selected">Last boss pull (.Mui-selected)</div>
+          <div class="mi">Trash fights</div>
+        </div>
+        <div class="ds-src">src/theme/dropdownMenu.ts:126-210 — fill rgb(45,64,99), border rgba(56,189,248,0.6), blur(20px) saturate(1.5)</div>
+
+        <div class="sect">G8 — HeaderBar dropdownPaperSx (move mouse over it)</div>
+        <div class="g8">
+          <div class="dropdown-spotlight"></div>
+          <div class="hd"><span class="lbl">Tools</span></div>
+          <div class="mi">Build Editor<div class="sub">Craft and share loadouts</div></div>
+          <div class="mi is-hover">Fight Replay (.is-hover — inset 2px 0 0 #38bdf8 + translateX(4px))<div class="sub">3D encounter playback</div></div>
+          <div class="mi">Roster Hub<div class="sub">Community rosters</div></div>
+        </div>
+        <div class="ds-src">src/components/HeaderBar.tsx:307-372 paper; :415-469 items; rail :454-456</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="sect">G2 — dropdownMenuPaperSx(false)</div>
+        <div class="g2">
+          <div class="mi">All encounters</div>
+          <div class="mi is-hover">Trial bosses only (.is-hover — inset 3px 0 0 rgb(40,145,200))</div>
+          <div class="mi is-selected">Last boss pull (.Mui-selected — no glow in light)</div>
+          <div class="mi">Trash fights</div>
+        </div>
+        <div class="ds-src">src/theme/dropdownMenu.ts:126-210 — fill rgb(250,253,255), border rgba(40,145,200,0.4), cyan rgb(40,145,200)</div>
+
+        <div class="sect">G8 — HeaderBar dropdownPaperSx (move mouse over it)</div>
+        <div class="g8">
+          <div class="dropdown-spotlight"></div>
+          <div class="hd"><span class="lbl">Tools</span></div>
+          <div class="mi">Build Editor<div class="sub">Craft and share loadouts</div></div>
+          <div class="mi is-hover">Fight Replay (.is-hover — inset 2px 0 0 #3b82f6 + translateX(4px))<div class="sub">3D encounter playback</div></div>
+          <div class="mi">Roster Hub<div class="sub">Community rosters</div></div>
+        </div>
+        <div class="ds-src">src/components/HeaderBar.tsx:307-372 — accent #3b82f6, accentAlt #2563eb</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Notes:</strong> G2's fill is deliberately <em>opaque</em> — it must win over the global <code>.MuiMenu-paper</code> background <code>!important</code> rule via <code>&amp;&amp;</code> + <code>!important</code> — so its <code>blur(20px) saturate(1.5)</code> only shows at the anti-aliased edge. A verbatim duplicate lives at <code>UltimateCalculator.tsx:536-620</code>. G2 rails are <code>inset 3px 0 0</code>; G8's are <code>inset 2px 0 0</code> plus <code>translateX(4px)</code> — two rail dialects, both layout-safe (shadow, not border). G8 items also stagger in with <code>menuItemIn 0.3s ease-out</code> delayed <code>index * 0.04s</code>.
+  </div>
+</div>
+<script>
+  // Mouse-tracked spotlight (G8) — mirrors the useCallback handler in HeaderBar.tsx
+  document.querySelectorAll('.g8').forEach(function (paper) {
+    paper.addEventListener('mousemove', function (e) {
+      var r = paper.getBoundingClientRect();
+      var spot = paper.querySelector('.dropdown-spotlight');
+      spot.style.setProperty('--mouse-x', ((e.clientX - r.left) / r.width * 100).toFixed(1) + '%');
+      spot.style.setProperty('--mouse-y', ((e.clientY - r.top) / r.height * 100).toFixed(1) + '%');
+    });
+  });
+</script>

--- a/design-sync/preview/surface-glass-tiers.html
+++ b/design-sync/preview/surface-glass-tiers.html
@@ -1,0 +1,237 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Glass Tiers — Blur Ladder + Tooltip / Dialog / AppBar / Alert Glass</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .sect { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--muted); margin:16px 0 8px; position:relative; z-index:1; }
+  .sect:first-of-type { margin-top:0; }
+
+  /* ── Blur ladder tiles (emergent rule, not a single source file) ─────── */
+  .ladder { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
+  .tier { border-radius:12px; padding:10px 8px; border:1px solid rgba(148,210,255,0.18); min-height:74px; }
+  [data-color-scheme="dark"] .tier { background:rgba(15,23,42,0.35); }
+  [data-color-scheme="light"] .tier { background:rgba(255,255,255,0.35); border-color:rgba(15,23,42,0.14); }
+  .tier .t-name { font-size:.66rem; font-weight:600; }
+  .tier .t-blur { font-size:.6rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:2px; }
+  .b6{backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);}
+  .b8{backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);}
+  .b10{backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);}
+  .b16{backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);}
+  .b20{backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);}
+  .b24{backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);}
+
+  /* ── G5 tooltip glass — src/ReduxThemeProvider.tsx:233-263 ───────────── */
+  .tt { border-radius:12px; padding:10px 12px; font-size:.72rem;
+        backdrop-filter:blur(16px) saturate(1.4); -webkit-backdrop-filter:blur(16px) saturate(1.4); }
+  [data-color-scheme="dark"] .tt {
+    border:1px solid rgba(148, 210, 255, 0.12);
+    box-shadow:0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+  [data-color-scheme="light"] .tt {
+    border:1px solid rgba(0, 0, 0, 0.12);
+    box-shadow:0 8px 32px rgba(15, 23, 42, 0.1), 0 2px 8px rgba(15, 23, 42, 0.06), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  }
+  [data-color-scheme="dark"] .tt-gear  { background:rgba(10, 16, 32, 0.78); }
+  [data-color-scheme="dark"] .tt-skill { background:rgba(10, 16, 32, 0.92); }
+  [data-color-scheme="light"] .tt-gear  { background:rgba(255, 255, 255, 0.82); }
+  [data-color-scheme="light"] .tt-skill { background:rgba(255, 255, 255, 0.92); }
+
+  /* ── G6 dialog glass — src/ReduxThemeProvider.tsx:385-402 ────────────── */
+  .dlg { border-radius:24px; padding:14px; font-size:.72rem;
+         backdrop-filter:blur(20px); -webkit-backdrop-filter:blur(20px); }
+  [data-color-scheme="dark"] .dlg {
+    background:linear-gradient(135deg, rgba(15,23,42,0.97) 0%, rgba(13,20,48,0.97) 100%);
+    border:1px solid rgba(255,255,255,0.08);
+    box-shadow:0 24px 64px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03) inset;
+  }
+  [data-color-scheme="light"] .dlg {
+    background:linear-gradient(135deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.98) 100%);
+    border:1px solid rgba(0,0,0,0.08);
+    box-shadow:0 12px 40px rgba(15,23,42,0.12), 0 4px 12px rgba(15,23,42,0.06);
+  }
+  /* Reduced-blur PickerDialog variant — PickerDialog.tsx:282-320 */
+  .picker { position:relative; border-radius:20px; padding:14px; font-size:.72rem;
+            backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); }
+  [data-color-scheme="dark"] .picker {
+    background:linear-gradient(135deg, rgba(56, 189, 248, 0.12) 0%, rgba(0, 225, 255, 0.12) 100%);
+    border:1px solid #1f2937;
+    box-shadow:0 8px 30px rgba(0,0,0,0.25);
+  }
+  [data-color-scheme="light"] .picker {
+    background:linear-gradient(135deg, rgba(255,255,255,0.98), rgba(248,250,252,0.98));
+    border:1px solid rgba(0, 0, 0, 0.08);
+    box-shadow:0 4px 12px rgba(15,23,42,0.06);
+  }
+  .picker::after { content:""; position:absolute; top:0; left:10%; right:10%; height:1px; pointer-events:none; z-index:1; }
+  [data-color-scheme="dark"] .picker::after {
+    background:linear-gradient(90deg, transparent, rgba(var(--be-accent-rgb, 56, 189, 248), 0.35), transparent);
+  }
+  [data-color-scheme="light"] .picker::after {
+    background:linear-gradient(90deg, transparent, rgba(var(--be-accent-rgb, 56, 189, 248), 0.18), transparent);
+  }
+  /* Low-perf opaque fallback — src/index.css:183-186 (dark only) */
+  .dlg-lowperf { border-radius:24px; padding:14px; font-size:.72rem;
+                 background:#0f172a; background-image:none; border:1px solid rgba(255,255,255,0.08); }
+
+  /* ── G7 appbar glass — src/ReduxThemeProvider.tsx:147-156 ────────────── */
+  .appbar { padding:10px 14px; font-size:.72rem; font-weight:600;
+            backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px); }
+  [data-color-scheme="dark"] .appbar {
+    background-color:rgba(11, 18, 32, 0.95);
+    border-bottom:1px solid rgba(56, 189, 248, 0.15);
+  }
+  [data-color-scheme="light"] .appbar {
+    background-color:rgba(255, 255, 255, 0.98);
+    border-bottom:1px solid rgba(15, 23, 42, 0.08);
+  }
+
+  /* ── G15 alert glass — src/ReduxThemeProvider.tsx:454-482 ────────────── */
+  .alert { border-radius:12px; border:1px solid var(--border); padding:8px 12px; font-size:.72rem; color:var(--text);
+           backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); margin-bottom:6px; }
+  [data-color-scheme="dark"] .al-info    { background-color:rgba(56, 189, 248, 0.08); }
+  [data-color-scheme="light"] .al-info    { background-color:rgba(56, 189, 248, 0.06); }
+  [data-color-scheme="dark"] .al-warning { background-color:rgba(255, 152, 0, 0.08); }
+  [data-color-scheme="light"] .al-warning { background-color:rgba(249, 115, 22, 0.06); }
+  [data-color-scheme="dark"] .al-error   { background-color:rgba(239, 68, 68, 0.08); }
+  [data-color-scheme="light"] .al-error   { background-color:rgba(220, 38, 38, 0.06); }
+  [data-color-scheme="dark"] .al-success { background-color:rgba(34, 197, 94, 0.08); }
+  [data-color-scheme="light"] .al-success { background-color:rgba(5, 150, 105, 0.06); }
+
+  .row2 { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid var(--border); background:var(--panel); font-size:.7rem; line-height:1.5; color:var(--text); position:relative; z-index:1; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Glass Tiers — the Blur Ladder</h1>
+  <p class="ds-sub">The emergent blur-tier rule (chrome 8–10 → chips 6–10 → cards 12–16 → dialogs 10–20 → menus 20–24 → hero/tooltip 22–24), with live swatches of tooltip (G5), dialog (G6), appbar (G7) and alert (G15) glass. All values exact from source.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="sect">Blur ladder (emergent rule)</div>
+        <div class="ladder">
+          <div class="tier b8"><div class="t-name">Chips / pills</div><div class="t-blur">blur 6–10 (shown: 8)</div></div>
+          <div class="tier b10"><div class="t-name">Chrome / appbar</div><div class="t-blur">blur 8–10 (shown: 10)</div></div>
+          <div class="tier b16"><div class="t-name">Cards</div><div class="t-blur">blur 12–16 (shown: 16)</div></div>
+          <div class="tier b20"><div class="t-name">Dialogs</div><div class="t-blur">blur 10–20 (shown: 20)</div></div>
+          <div class="tier b24"><div class="t-name">Menus</div><div class="t-blur">blur 20–24 (shown: 24)</div></div>
+          <div class="tier b24"><div class="t-name">Hero / tooltip</div><div class="t-blur">blur 22–24 (shown: 24)</div></div>
+        </div>
+        <div class="ds-src">emergent ladder rule — see catalog; per-surface sources below</div>
+
+        <div class="sect">G5 tooltip glass — blur(16px) saturate(1.4)</div>
+        <div class="row2">
+          <div class="tt tt-gear">.gear-set-tooltip<br>rgba(10, 16, 32, 0.78)</div>
+          <div class="tt tt-skill">.skill-tooltip<br>rgba(10, 16, 32, 0.92)</div>
+        </div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:233-263</div>
+
+        <div class="sect">G6 dialog glass</div>
+        <div class="dlg">Global .MuiDialog paper — blur(20px), radius 24, 135° 0.97-alpha slate gradient</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:385-402</div>
+        <div class="picker" style="margin-top:8px;">PickerDialog variant — blur reduced 20px → 10px (Phase 3 M9), cyan 12%-alpha 135° gradient, ::after top-edge glow at left/right 10%</div>
+        <div class="ds-src">src/features/build-editor/components/primitives/PickerDialog.tsx:282-320</div>
+        <div class="dlg-lowperf" style="margin-top:8px;">Low-perf fallback — data-perf='low' strips all backdrop-filter; dark glass dialogs snap to solid #0f172a</div>
+        <div class="ds-src">src/index.css:136-140,183-186</div>
+
+        <div class="sect">G7 appbar glass</div>
+        <div class="appbar">MuiAppBar — rgba(11, 18, 32, 0.95) + blur(10px), borderBottom rgba(56, 189, 248, 0.15)</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:147-156</div>
+
+        <div class="sect">G15 alert glass — blur(8px), radius 12, border var(--border)</div>
+        <div class="alert al-info">standardInfo — rgba(56, 189, 248, 0.08)</div>
+        <div class="alert al-warning">standardWarning — rgba(255, 152, 0, 0.08)</div>
+        <div class="alert al-error">standardError — rgba(239, 68, 68, 0.08)</div>
+        <div class="alert al-success">standardSuccess — rgba(34, 197, 94, 0.08)</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:454-482</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="sect">Blur ladder (emergent rule)</div>
+        <div class="ladder">
+          <div class="tier b8"><div class="t-name">Chips / pills</div><div class="t-blur">blur 6–10 (shown: 8)</div></div>
+          <div class="tier b10"><div class="t-name">Chrome / appbar</div><div class="t-blur">blur 8–10 (shown: 10)</div></div>
+          <div class="tier b16"><div class="t-name">Cards</div><div class="t-blur">blur 12–16 (shown: 16)</div></div>
+          <div class="tier b20"><div class="t-name">Dialogs</div><div class="t-blur">blur 10–20 (shown: 20)</div></div>
+          <div class="tier b24"><div class="t-name">Menus</div><div class="t-blur">blur 20–24 (shown: 24)</div></div>
+          <div class="tier b24"><div class="t-name">Hero / tooltip</div><div class="t-blur">blur 22–24 (shown: 24)</div></div>
+        </div>
+        <div class="ds-src">emergent ladder rule — see catalog; per-surface sources below</div>
+
+        <div class="sect">G5 tooltip glass — blur(16px) saturate(1.4)</div>
+        <div class="row2">
+          <div class="tt tt-gear">.gear-set-tooltip<br>rgba(255, 255, 255, 0.82)</div>
+          <div class="tt tt-skill">.skill-tooltip<br>rgba(255, 255, 255, 0.92)</div>
+        </div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:233-263</div>
+
+        <div class="sect">G6 dialog glass</div>
+        <div class="dlg">Global .MuiDialog paper — blur(20px), radius 24, 135° 0.98-alpha white gradient</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:385-402</div>
+        <div class="picker" style="margin-top:8px;">PickerDialog variant — blur(10px), 0.98-alpha white gradient, ::after glow at 0.18 alpha</div>
+        <div class="ds-src">src/features/build-editor/components/primitives/PickerDialog.tsx:282-320</div>
+
+        <div class="sect">G7 appbar glass</div>
+        <div class="appbar">MuiAppBar — rgba(255, 255, 255, 0.98) + blur(10px), borderBottom rgba(15, 23, 42, 0.08)</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:147-156</div>
+
+        <div class="sect">G15 alert glass — blur(8px), radius 12, border var(--border)</div>
+        <div class="alert al-info">standardInfo — rgba(56, 189, 248, 0.06)</div>
+        <div class="alert al-warning">standardWarning — rgba(249, 115, 22, 0.06)</div>
+        <div class="alert al-error">standardError — rgba(220, 38, 38, 0.06)</div>
+        <div class="alert al-success">standardSuccess — rgba(5, 150, 105, 0.06)</div>
+        <div class="ds-src">src/ReduxThemeProvider.tsx:454-482</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout" data-color-scheme="dark" style="background:#0f172a; border-color:#1f2937; color:#e5e7eb;">
+    <strong>Ladder vs. source:</strong> the catalog's "hero/tooltip 22–24" tier refers to hero surfaces like the HeaderBar dropdown (<code>blur(24px)</code>); the tooltips themselves measure <code>blur(16px) saturate(1.4)</code> in source. The dialog tier spans 10 (PickerDialog, perf-reduced) to 20 (global). The low-perf axis (<code>html[data-perf='low']</code>) strips <em>every</em> backdrop-filter app-wide — src/index.css:136-140. Light-mode alerts use different rgb bases than dark (e.g. warning 249,115,22 vs 255,152,0).
+  </div>
+</div>

--- a/design-sync/preview/surface-glossy-chips.html
+++ b/design-sync/preview/surface-glossy-chips.html
@@ -1,0 +1,188 @@
+<!-- @dsCard group="Surfaces" -->
+<meta charset="utf-8">
+<title>Glossy Chip Glass (G4) — Shine Sweep, Gloss Dome, 11 Variants</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin:0; box-sizing:border-box; }
+  body { font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif; background:#0b1220; padding:20px; }
+  h1,h2,h3 { font-family:'Space Grotesk',Inter,system-ui,sans-serif; font-weight:600; }
+
+  [data-color-scheme="dark"] {
+    --bg:#0b1220; --panel:#0f172a; --panel-2:#0d1430; --text:#e5e7eb; --muted:#94a3b8;
+    --accent:#38bdf8; --accent-2:#00e1ff; --ok:#22c55e; --warn:#ff9800; --danger:#ef4444;
+    --border:#1f2937;
+  }
+  [data-color-scheme="light"] {
+    --bg:#f8fafc; --panel:#ffffff; --panel-2:#f8fafc; --text:#1e293b; --muted:#64748b;
+    --accent:#0f172a; --accent-2:#1e293b; --ok:#059669; --warn:#f97316; --danger:#dc2626;
+    --border:#bcd9ff;
+  }
+  /* NOTE: light --accent is deliberately dark slate #0f172a, NOT a light blue.
+     Cyan #38bdf8 accents remain hard-coded in many dark-leaning recipes even in light mode. */
+
+  .ds-card { max-width:1100px; margin:0 auto; color:#e5e7eb; }
+  .ds-title { font-size:1.4rem; color:#e5e7eb; margin-bottom:4px; }
+  .ds-sub { font-size:.8rem; color:#94a3b8; margin-bottom:16px; }
+  .ds-modes { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:760px){ .ds-modes { grid-template-columns:1fr; } }
+  .ds-mode { border-radius:16px; padding:18px; background:var(--bg); color:var(--text); border:1px solid var(--border); position:relative; overflow:hidden; }
+  .ds-mode > h2 { font-size:.72rem; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); margin-bottom:14px; position:relative; z-index:1; }
+  .ds-src { font-size:.68rem; color:var(--muted); font-family:'JetBrains Mono',Consolas,monospace; margin-top:6px; }
+
+  .ds-backdrop { position:absolute; inset:0; pointer-events:none; }
+  [data-color-scheme="dark"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(56,189,248,.28), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(129,140,248,.24), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(192,132,252,.18), transparent 65%),
+      #0b1220;
+  }
+  [data-color-scheme="light"] .ds-backdrop {
+    background:
+      radial-gradient(ellipse 60% 40% at 20% 25%, rgba(125,211,252,.5), transparent 65%),
+      radial-gradient(ellipse 50% 45% at 80% 30%, rgba(196,181,253,.42), transparent 65%),
+      radial-gradient(ellipse 55% 50% at 55% 80%, rgba(167,243,208,.38), transparent 65%),
+      #f8fafc;
+  }
+  .demo-z { position:relative; z-index:1; }
+  .chips { display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
+
+  /* ── G4 glossy chip — src/utils/playerCardStyleUtils.ts:30-84 ──────────
+     getGlossyBaseSx: the only recipe with BOTH a top-highlight AND a
+     bottom-shading inset; ::before skewed shine sweep; ::after gloss dome
+     with elliptical radius. Radius 28 here; re-typed at 25px in 10
+     report_details files. */
+  .chip {
+    position:relative; overflow:hidden; cursor:pointer; display:inline-flex; align-items:center;
+    padding:6px 14px; font-size:.74rem; line-height:1.4;
+    transition:all 0.3s ease;
+    border-radius:28px;
+    backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+    border:1px solid rgba(255, 255, 255, 0.15); /* DEFECT: hard-coded white in BOTH modes */
+  }
+  [data-color-scheme="dark"] .chip {
+    box-shadow:0 8px 32px 0 rgba(0, 0, 0, 0.37), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+    color:#ffffff; text-shadow:0 1px 3px rgba(0,0,0,0.5); font-weight:500;
+  }
+  [data-color-scheme="light"] .chip {
+    box-shadow:0 4px 16px 0 rgba(59, 130, 246, 0.15), 0 2px 8px 0 rgba(0, 0, 0, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+    color:#1f2937; text-shadow:0 1px 2px rgba(255,255,255,0.8); font-weight:600;
+  }
+  /* ::before — skewed shine sweep (hover slides left -100% → 100%) */
+  .chip::before {
+    content:""; position:absolute; top:0; left:-100%; width:100%; height:100%;
+    background:linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent);
+    transform:skewX(-15deg); transform-origin:center center;
+    transition:left 0.5s ease;
+  }
+  /* ::after — gloss dome, elliptical radius */
+  .chip::after {
+    content:""; position:absolute; top:0; left:0; right:0; height:50%;
+    background:linear-gradient(180deg, rgba(255,255,255,0.15) 0%, transparent 100%);
+    border-radius:28px 28px 100px 100px / 28px 28px 50px 50px;
+    pointer-events:none;
+  }
+  .chip:hover, .chip.is-hover { transform:translateY(-2px); }
+  [data-color-scheme="dark"] .chip:hover, [data-color-scheme="dark"] .chip.is-hover {
+    box-shadow:0 12px 40px 0 rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.3), inset 0 -1px 0 rgba(0,0,0,0.3);
+  }
+  [data-color-scheme="light"] .chip:hover, [data-color-scheme="light"] .chip.is-hover {
+    box-shadow:0 8px 24px 0 rgba(59, 130, 246, 0.25), 0 4px 12px 0 rgba(0,0,0,0.15), inset 0 1px 0 rgba(255,255,255,0.3), inset 0 -1px 0 rgba(0,0,0,0.15);
+  }
+  .chip:hover::before { left:100%; }
+  /* .is-hover demo loops the sweep so it stays visible (in-app it is a one-shot 0.5s hover transition) */
+  @keyframes shineSweepDemo { 0% { left:-100%; } 20% { left:100%; } 100% { left:100%; } }
+  .chip.is-hover::before { animation:shineSweepDemo 2.5s ease infinite; }
+
+  /* ── Dark variants — playerCardStyleUtils.ts:95-165 ── */
+  [data-color-scheme="dark"] .v-green { background:linear-gradient(135deg, rgba(76, 217, 100, 0.25) 0%, rgba(76, 217, 100, 0.15) 50%, rgba(76, 217, 100, 0.08) 100%); border-color:rgba(76, 217, 100, 0.3); color:#5ce572; }
+  [data-color-scheme="dark"] .v-blue { background:linear-gradient(135deg, rgba(0, 122, 255, 0.25) 0%, rgba(0, 122, 255, 0.15) 50%, rgba(0, 122, 255, 0.08) 100%); border-color:rgba(0, 122, 255, 0.3); color:#4da3ff; }
+  [data-color-scheme="dark"] .v-lightBlue { background:linear-gradient(135deg, rgba(94, 234, 255, 0.25) 0%, rgba(94, 234, 255, 0.15) 50%, rgba(94, 234, 255, 0.08) 100%); border-color:rgba(94, 234, 255, 0.35); color:#7ee8ff; }
+  [data-color-scheme="dark"] .v-purple { background:linear-gradient(135deg, rgba(175, 82, 222, 0.25) 0%, rgba(175, 82, 222, 0.15) 50%, rgba(175, 82, 222, 0.08) 100%); border-color:rgba(175, 82, 222, 0.3); color:#c57fff; }
+  [data-color-scheme="dark"] .v-indigo { background:linear-gradient(135deg, rgba(88, 86, 214, 0.25) 0%, rgba(88, 86, 214, 0.15) 50%, rgba(88, 86, 214, 0.08) 100%); border-color:rgba(88, 86, 214, 0.3); color:#8583ff; }
+  [data-color-scheme="dark"] .v-gold { background:linear-gradient(135deg, rgba(255, 193, 7, 0.25) 0%, rgba(255, 193, 7, 0.15) 50%, rgba(255, 193, 7, 0.08) 100%); border-color:rgba(255, 193, 7, 0.35); color:#ffd54f; }
+  [data-color-scheme="dark"] .v-silver { background:linear-gradient(135deg, rgba(236, 240, 241, 0.25) 0%, rgba(236, 240, 241, 0.15) 50%, rgba(236, 240, 241, 0.08) 100%); border-color:rgba(236, 240, 241, 0.35); color:#ecf0f1; }
+  [data-color-scheme="dark"] .v-championRed { background:linear-gradient(135deg, rgba(255, 68, 68, 0.25) 0%, rgba(255, 68, 68, 0.15) 50%, rgba(255, 68, 68, 0.08) 100%); border-color:rgba(255, 68, 68, 0.3); color:#ff6666; }
+  [data-color-scheme="dark"] .v-championBlue { background:linear-gradient(135deg, rgba(68, 136, 255, 0.25) 0%, rgba(68, 136, 255, 0.15) 50%, rgba(68, 136, 255, 0.08) 100%); border-color:rgba(68, 136, 255, 0.3); color:#66aaff; }
+  [data-color-scheme="dark"] .v-championGreen { background:linear-gradient(135deg, rgba(68, 255, 136, 0.25) 0%, rgba(68, 255, 136, 0.15) 50%, rgba(68, 255, 136, 0.08) 100%); border-color:rgba(68, 255, 136, 0.3); color:#66ffaa; }
+
+  /* ── Light variants — playerCardStyleUtils.ts:167-237 ── */
+  [data-color-scheme="light"] .v-green { background:linear-gradient(135deg, rgba(5, 150, 105, 0.12) 0%, rgba(16, 185, 129, 0.08) 50%, rgba(34, 197, 94, 0.04) 100%); border-color:rgba(5, 150, 105, 0.3); color:#065f46; }
+  [data-color-scheme="light"] .v-blue { background:linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(59, 130, 246, 0.08) 50%, rgba(96, 165, 250, 0.04) 100%); border-color:rgba(37, 99, 235, 0.3); color:#1e3a8a; }
+  [data-color-scheme="light"] .v-lightBlue { background:linear-gradient(135deg, rgba(2, 132, 199, 0.12) 0%, rgba(14, 165, 233, 0.08) 50%, rgba(56, 189, 248, 0.04) 100%); border-color:rgba(2, 132, 199, 0.3); color:#0c4a6e; }
+  [data-color-scheme="light"] .v-purple { background:linear-gradient(135deg, rgba(126, 34, 206, 0.12) 0%, rgba(147, 51, 234, 0.08) 50%, rgba(168, 85, 247, 0.04) 100%); border-color:rgba(126, 34, 206, 0.3); color:#581c87; }
+  [data-color-scheme="light"] .v-indigo { background:linear-gradient(135deg, rgba(67, 56, 202, 0.12) 0%, rgba(99, 102, 241, 0.08) 50%, rgba(129, 140, 248, 0.04) 100%); border-color:rgba(67, 56, 202, 0.3); color:#3730a3; }
+  [data-color-scheme="light"] .v-gold { background:linear-gradient(135deg, rgba(217, 119, 6, 0.12) 0%, rgba(245, 158, 11, 0.08) 50%, rgba(251, 191, 36, 0.04) 100%); border-color:rgba(217, 119, 6, 0.3); color:#92400e; }
+  [data-color-scheme="light"] .v-silver { background:linear-gradient(135deg, rgba(100, 116, 139, 0.12) 0%, rgba(148, 163, 184, 0.08) 50%, rgba(203, 213, 225, 0.04) 100%); border-color:rgba(100, 116, 139, 0.3); color:#334155; }
+  [data-color-scheme="light"] .v-championRed { background:linear-gradient(135deg, rgba(220, 38, 38, 0.12) 0%, rgba(239, 68, 68, 0.08) 50%, rgba(248, 113, 113, 0.04) 100%); border-color:rgba(220, 38, 38, 0.3); color:#991b1b; }
+  [data-color-scheme="light"] .v-championBlue { background:linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(59, 130, 246, 0.08) 50%, rgba(96, 165, 250, 0.04) 100%); border-color:rgba(37, 99, 235, 0.3); color:#1e3a8a; }
+  [data-color-scheme="light"] .v-championGreen { background:linear-gradient(135deg, rgba(5, 150, 105, 0.12) 0%, rgba(16, 185, 129, 0.08) 50%, rgba(34, 197, 94, 0.04) 100%); border-color:rgba(5, 150, 105, 0.3); color:#065f46; }
+
+  /* ── Rainbow legendary (B6) — playerCardStyleUtils.ts:156-164,228-236 + legendaryGlow :17-28 ── */
+  @keyframes legendaryGlow {
+    0%, 100% { box-shadow:0 8px 32px 0 rgba(255, 0, 150, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.3); }
+    50% { box-shadow:0 8px 32px 0 rgba(0, 150, 255, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.3); }
+  }
+  .v-legendary {
+    background:linear-gradient(135deg, rgba(255,0,150,0.2) 0%, rgba(255,150,0,0.2) 20%, rgba(255,255,0,0.2) 40%, rgba(0,255,0,0.2) 60%, rgba(0,150,255,0.2) 80%, rgba(150,0,255,0.2) 100%);
+    border-image:linear-gradient(135deg, #ff0096, #ff9600, #ffff00, #00ff00, #0096ff, #9600ff) 1;
+    border:1px solid transparent;
+    animation:legendaryGlow 3s ease-in-out infinite;
+  }
+  [data-color-scheme="dark"] .v-legendary { color:#ffffff; }
+  [data-color-scheme="light"] .v-legendary { color:#1f2937; font-weight:bold; }
+
+  .callout { margin-top:14px; padding:10px 12px; border-radius:10px; border:1px solid #1f2937; background:#0f172a; font-size:.7rem; line-height:1.5; color:#e5e7eb; }
+  .callout strong { color:#ef4444; }
+  .callout code { font-family:'JetBrains Mono',Consolas,monospace; font-size:.66rem; }
+</style>
+<div class="ds-card">
+  <h1 class="ds-title">Glossy Chip Glass (G4) — Shine Sweep + Gloss Dome</h1>
+  <p class="ds-sub">The gear-set chip recipe: blur(10px), radius 28, top-highlight AND bottom-shading insets, a ::before skewed shine sweep on hover, and a ::after elliptical gloss dome. 11 color variants per mode incl. the animated rainbow legendary. Source: src/utils/playerCardStyleUtils.ts:17-243.</p>
+  <div class="ds-modes">
+    <section class="ds-mode" data-color-scheme="dark">
+      <div class="ds-backdrop"></div>
+      <h2>Dark</h2>
+      <div class="demo-z">
+        <div class="chips">
+          <span class="chip v-green">5pc Set — green</span>
+          <span class="chip v-blue is-hover">Arena — blue (.is-hover: shine sweep)</span>
+          <span class="chip v-lightBlue">1pc Monster — lightBlue</span>
+          <span class="chip v-purple">2pc Monster — purple</span>
+          <span class="chip v-indigo">indigo</span>
+          <span class="chip v-gold">Mythic — gold</span>
+          <span class="chip v-silver">Default — silver</span>
+          <span class="chip v-championRed">championRed</span>
+          <span class="chip v-championBlue">championBlue</span>
+          <span class="chip v-championGreen">championGreen</span>
+          <span class="chip v-legendary">legendary — rainbow borderImage + legendaryGlow</span>
+        </div>
+        <div class="ds-src">darkVariants — playerCardStyleUtils.ts:95-165; base :30-84; mapping getGearChipProps :252-296</div>
+      </div>
+    </section>
+    <section class="ds-mode" data-color-scheme="light">
+      <div class="ds-backdrop"></div>
+      <h2>Light</h2>
+      <div class="demo-z">
+        <div class="chips">
+          <span class="chip v-green">5pc Set — green</span>
+          <span class="chip v-blue is-hover">Arena — blue (.is-hover: shine sweep)</span>
+          <span class="chip v-lightBlue">1pc Monster — lightBlue</span>
+          <span class="chip v-purple">2pc Monster — purple</span>
+          <span class="chip v-indigo">indigo</span>
+          <span class="chip v-gold">Mythic — gold</span>
+          <span class="chip v-silver">Default — silver</span>
+          <span class="chip v-championRed">championRed</span>
+          <span class="chip v-championBlue">championBlue</span>
+          <span class="chip v-championGreen">championGreen</span>
+          <span class="chip v-legendary">legendary — same rainbow both modes</span>
+        </div>
+        <div class="ds-src">lightVariants — playerCardStyleUtils.ts:167-237 (championBlue ≡ blue, championGreen ≡ green in light)</div>
+      </div>
+    </section>
+  </div>
+  <div class="callout">
+    <strong>Known defect (document, don't replicate):</strong> the base border is hard-coded <code>1px solid rgba(255, 255, 255, 0.15)</code> — a white border even in light mode (playerCardStyleUtils.ts:38); variants that set <code>borderColor</code> mask it, but silver/default light chips keep the near-invisible white edge. Also: the legendary <code>borderImage</code> shorthand suppresses <code>border-radius</code> on the border paint (square rainbow ring on a 28px-radius chip) — same caveat that got borderImage removed from GlassPanel (GlassPanel.tsx:6-9). The <code>.is-hover</code> sweep here loops for demo purposes; in-app it's a one-shot <code>transition: left 0.5s ease</code> from <code>left:-100%</code> to <code>100%</code> on hover.
+  </div>
+</div>

--- a/design-sync/preview/type-body.html
+++ b/design-sync/preview/type-body.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" -->
+<meta charset="utf-8"><title>Body & Support Text</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.eb{font-size:.72rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin-bottom:4px}
+.sub{font-weight:300;font-size:clamp(1.1rem,2vw,1.4rem);color:rgba(255,255,255,.9);line-height:1.7;margin:0 0 14px 0;max-width:52ch}
+.body{font-weight:400;font-size:1rem;line-height:1.6;color:#e5e7eb;margin:0 0 14px 0;max-width:60ch}
+.cap{font-family:Consolas,Menlo,monospace;font-size:11px;color:var(--muted);margin-top:10px;line-height:1.6}
+</style>
+<div class="eb">Eyebrow · uppercase · muted</div>
+<p class="sub">Combat analysis for players who don't settle for good enough.</p>
+<p class="body">Know exactly how you performed. After every parse, go deeper than the scoreboard — measure CPM, weave accuracy, buff uptimes, and more.</p>
+<div class="cap">hero subtitle: Inter 300 · clamp(1.1rem, 2vw, 1.4rem) / 1.7 · rgba(255,255,255,.9) dark — HeroSubtitle, LandingPage.tsx:540-548.<br>
+body: Inter 400 · 1rem / 1.6 · --text #e5e7eb — theme fontFamily ReduxThemeProvider.tsx:91-92 + type scale §9.<br>
+eyebrow: 600 · 0.72rem · uppercase · ls .12em · --muted — colors_and_type.css §9.</div>

--- a/design-sync/preview/type-display.html
+++ b/design-sync/preview/type-display.html
@@ -1,0 +1,12 @@
+<!-- @dsCard group="Type" -->
+<meta charset="utf-8"><title>Display / Hero Title</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:24px;box-sizing:border-box}
+.display{font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-weight:900;font-size:clamp(2rem,6vw,4.5rem);line-height:1.5;letter-spacing:-.02em;background:linear-gradient(135deg,#fff 0%,#38bdf8 50%,#00e1ff 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;margin:0}
+.display .light-text{display:block;font-family:Inter,sans-serif;font-weight:100;background:#fff;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.meta{font-family:Consolas,Menlo,monospace;font-size:11px;color:var(--muted);margin-top:10px;line-height:1.6}
+</style>
+<p class="display"><span class="light-text">Essential Tools</span>For Your ESO Journey</p>
+<div class="meta">HeroTitle — LandingPage.tsx:399-487. Family: theme h1 = Space Grotesk (declared weight 900; Space Grotesk loads 300–700, so heavy weights synthesize).<br>
+size clamp(2rem, 6vw, 4.5rem) · line-height 1.5 · letter-spacing −0.02em · dark gradient 135° #fff → #38bdf8 50% → #00e1ff.<br>
+".light-text" lead-in line: Inter 100, solid white. Light mode gradient: #1e293b → #0f172a 50% → #334155.</div>

--- a/design-sync/preview/type-headings.html
+++ b/design-sync/preview/type-headings.html
@@ -1,0 +1,17 @@
+<!-- @dsCard group="Type" -->
+<meta charset="utf-8"><title>Headings</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.row{display:flex;align-items:baseline;gap:16px;margin-bottom:10px;border-bottom:1px dashed var(--border);padding-bottom:8px}
+.tag{font-family:Consolas,Menlo,monospace;font-size:10px;color:var(--muted);width:130px;flex-shrink:0}
+h1,h2,h3{font-family:'Space Grotesk',Inter,system-ui,sans-serif;font-weight:600;margin:0}
+h1{font-size:2rem;line-height:1.2}
+h2{font-size:1.5rem;line-height:1.25}
+h3{font-size:1.17rem;line-height:1.3}
+.src{font-size:10px;color:var(--muted);font-family:Consolas,Menlo,monospace;margin-top:10px;line-height:1.6}
+</style>
+<div class="row"><div class="tag">h1 · SG 600 · 2rem/1.2</div><h1>Report Details</h1></div>
+<div class="row"><div class="tag">h2 · SG 600 · 1.5rem/1.25</div><h2>Players in this fight</h2></div>
+<div class="row"><div class="tag">h3 · SG 600 · 1.17rem/1.3</div><h3>Build Issues Detected</h3></div>
+<div class="src">All headings h1–h6: Space Grotesk, weight 600 — theme typography, ReduxThemeProvider.tsx:93-98.
+Ramp per design-system type scale (colors_and_type.css §9). Not Inter, not 700.</div>

--- a/design-sync/preview/type-mono.html
+++ b/design-sync/preview/type-mono.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" -->
+<meta charset="utf-8"><title>Mono / Numeric</title>
+<link rel="stylesheet" href="../colors_and_type.css">
+<style>html,body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif;padding:20px;box-sizing:border-box}
+.mono{font-family:source-code-pro,Menlo,Monaco,Consolas,'Courier New',monospace;font-size:14px;color:var(--muted);background:rgba(255,255,255,.04);padding:6px 10px;border-radius:6px;border:1px solid var(--border);font-variant-numeric:tabular-nums}
+.time{font-family:'JetBrains Mono','Fira Code','SF Mono',monospace;font-size:13px;color:#38bdf8}
+.row{display:flex;gap:24px;align-items:center;flex-wrap:wrap;margin-bottom:14px}
+.meta{font-family:Consolas,Menlo,monospace;font-size:10px;color:var(--muted);line-height:1.6}
+</style>
+<div class="row"><span class="mono">Ability ID: 191078</span><span class="time">03:42 · 01:07 duration</span></div>
+<div class="row"><span class="mono">@bigknifeboi · EU / PC</span><span class="mono">/report/a1b2c3d4e5</span></div>
+<div class="meta">No bundled mono webfont — index.html loads only Inter + Space Grotesk. Mono always resolves to system fallbacks.<br>
+code stack: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace — src/index.css:79.<br>
+stat tickers declare "JetBrains Mono", "Fira Code", "SF Mono", monospace — LandingPage.tsx:1652 (falls back to system).<br>
+Stat columns pair mono with font-variant-numeric: tabular-nums (.u-tabular, ReduxThemeProvider.tsx:910-912).</div>


### PR DESCRIPTION
## Why

Claude Design (claude.ai/design) couldn't reproduce our UI/UX patterns, colors, or advanced CSS. Investigation found the root cause: **almost nothing visual in this app is declared in CSS.** The real design system is ~950 lines of `createTheme` in `ReduxThemeProvider.tsx` plus a dozen TypeScript `sx` recipe modules — invisible to any tool reading stylesheets. The synced "ESO Helper Design System" claude.ai project was hand-copied months ago, dark-mode only, and missing the glassmorphism recipes and boundary/border treatments entirely; **all 19 of its legacy preview cards had drifted** (some were outright fiction — invented class colors, a tab style that doesn't exist, badges from the dead `landingpage.css`).

## What

### `design-sync/` (new) — local source for the claude.ai design project
46 self-contained preview cards + `colors_and_type.css` + project `SKILL.md`/`README.md`, every value transcribed exactly from source with `file:line` captions, dark+light side-by-side:

- **Colors**: dark+light tokens (incl. the deliberate slate light accent `#0f172a`), role solids/gradients/washes, both rarity palettes (gear-UI ESO vs build-editor Material — documented per-surface, not merged), class colors from `CLASS_COLOR_MAP`, ECharts 12-color palettes + glow/gradient styles
- **Surfaces**: all 15 glass recipe families (accent cards, dropdown, build-editor panels, glossy chips, tooltips, dialogs, appbar, HeaderBar shimmer/noise/spotlight dropdown, filter fields, scribing, replay corner-glow decks, card grids, pills, alerts) + the blur-tier ladder
- **Boundaries**: all 16 boundary techniques (accent rails, inset rails, 4 top-strip sub-patterns, mask-XOR gradient rings, animated `@property` conic electric border, rarity/class/role borders, glow signatures, inset-highlight alpha scale, table seams, dividers, edge masks, focus rings)
- **Patterns**: nebula/aurora 4-layer backgrounds (as-built values, incl. the doc-vs-implementation divergence), view transitions (8 types + easings), perf-tier axis
- 19 legacy cards corrected against current source; junk removed from the remote project (`localhost.har`, stale pasted `PlayerCard.tsx`, old screenshots)

Already synced to the claude.ai project via DesignSync (2026-07-26). The bundle is committed so future refreshes are reviewable diffs.

### `.agents/skills/ui-updates/SKILL.md` — drift fixes
- MUI **v9** (was v7), **ECharts 6** (was Chart.js/react-chartjs-2)
- New: shared recipe-module registry, blur-tier ladder, boundary idioms (mask-XOR ring, inset rails, glow signature, inset-highlight scale), view transitions, perf tiers
- Warnings: legacy `landingpage.css`/`--site-*` block/Storybook theme are not the design system; `u-hover-lift`/`u-fade-in-up` are referenced but never defined

## Verification
- All 46 cards: `@dsCard` marker on line 1, <27 KB each, render-checked in Chrome (dark/light differ, blur visible over backdrops, mask-XOR rings render, electric border + shimmer dividers animate, no console errors beyond the expected quirks-mode notice)
- Values spot-checked back against source (tokens, dropdown border `rgba(56,189,248,0.6)`, glossy shadow, rarity hexes, conic stops)
- Remote structure confirmed via `list_files` after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)