### PR TITLE
ci: add manual D1 migration workflow

### DIFF
--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -1,0 +1,83 @@
+name: Run D1 Migration
+
+# Applies a SQL migration to a remote D1 database.
+#
+# Manual-only: schema changes should be a deliberate act, not a side effect of a
+# push. Until this existed, migrations under roster-hub-api/src/db/ had to be
+# applied by hand from a developer machine holding Cloudflare credentials.
+
+on:
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker whose wrangler.toml defines the database binding'
+        required: true
+        type: choice
+        options:
+          - roster-hub-api
+      database:
+        description: 'D1 database name (must match wrangler.toml)'
+        required: true
+        default: roster-hub-db
+        type: string
+      migration:
+        description: 'Migration file, relative to the worker dir (e.g. src/db/migration-dps-parses.sql)'
+        required: true
+        type: string
+      confirm:
+        description: 'Type the database name again to confirm you are writing to production'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # Guard rails: this job has production database write access, so validate
+      # the inputs before handing anything to wrangler.
+      - name: Validate inputs
+        working-directory: ${{ inputs.worker }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ inputs.confirm }}" != "${{ inputs.database }}" ]; then
+            echo "::error::Confirmation '${{ inputs.confirm }}' does not match database '${{ inputs.database }}'."
+            exit 1
+          fi
+
+          MIGRATION="${{ inputs.migration }}"
+
+          # Constrain to SQL files inside the worker's db directory. Blocks path
+          # traversal and stops this becoming a run-arbitrary-SQL button.
+          case "$MIGRATION" in
+            src/db/*.sql) ;;
+            *) echo "::error::Migration must match src/db/*.sql (got '$MIGRATION')."; exit 1 ;;
+          esac
+          case "$MIGRATION" in
+            *..*) echo "::error::Migration path must not contain '..'."; exit 1 ;;
+          esac
+
+          if [ ! -f "$MIGRATION" ]; then
+            echo "::error::Migration file '$MIGRATION' not found in ${{ inputs.worker }}."
+            exit 1
+          fi
+
+          # Surface the exact SQL in the run log, so the job output is a record of
+          # what was applied.
+          echo "### Applying \`$MIGRATION\` to \`${{ inputs.database }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo '```sql' >> "$GITHUB_STEP_SUMMARY"
+          cat "$MIGRATION" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply migration
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: ${{ inputs.worker }}
+          command: d1 execute ${{ inputs.database }} --remote --yes --file=${{ inputs.migration }}

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -16,10 +16,14 @@ on:
         options:
           - roster-hub-api
       database:
-        description: 'D1 database name (must match wrangler.toml)'
+        description: 'D1 database name'
         required: true
         default: roster-hub-db
-        type: string
+        # A choice rather than free text: there is exactly one database, and this
+        # value reaches a command line. No reason to accept arbitrary strings.
+        type: choice
+        options:
+          - roster-hub-db
       migration:
         description: 'Migration file, relative to the worker dir (e.g. src/db/migration-dps-parses.sql)'
         required: true
@@ -32,6 +36,14 @@ on:
 permissions:
   contents: read
 
+# One migration at a time per database. Concurrent dispatches could interleave
+# DDL in ways that are hard to reason about afterwards, and the run logs are the
+# audit trail. Never cancel in progress — a half-applied migration is worse than
+# a queued one.
+concurrency:
+  group: d1-migrate-${{ inputs.worker }}-${{ inputs.database }}
+  cancel-in-progress: false
+
 jobs:
   migrate:
     runs-on: ubuntu-latest
@@ -39,45 +51,64 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      # Guard rails: this job has production database write access, so validate
-      # the inputs before handing anything to wrangler.
+      # This job has production database write access, so inputs are validated
+      # before anything is handed to wrangler.
+      #
+      # Inputs are passed via `env:` and referenced as quoted shell variables,
+      # never interpolated into the script body. Direct `${{ }}` interpolation
+      # would let a crafted value break out of the surrounding quotes and run
+      # arbitrary commands — which would defeat the point of a validation step.
       - name: Validate inputs
         working-directory: ${{ inputs.worker }}
+        env:
+          DATABASE: ${{ inputs.database }}
+          MIGRATION: ${{ inputs.migration }}
+          CONFIRM: ${{ inputs.confirm }}
         run: |
           set -euo pipefail
 
-          if [ "${{ inputs.confirm }}" != "${{ inputs.database }}" ]; then
-            echo "::error::Confirmation '${{ inputs.confirm }}' does not match database '${{ inputs.database }}'."
+          if [ "$CONFIRM" != "$DATABASE" ]; then
+            echo "::error::Confirmation does not match the database name."
             exit 1
           fi
 
-          MIGRATION="${{ inputs.migration }}"
-
-          # Constrain to SQL files inside the worker's db directory. Blocks path
-          # traversal and stops this becoming a run-arbitrary-SQL button.
+          # Only migration files. src/db/ also holds schema.sql and seed.sql, and
+          # applying either to production would be destructive in a way this
+          # workflow should make impossible rather than merely discouraged.
           case "$MIGRATION" in
-            src/db/*.sql) ;;
-            *) echo "::error::Migration must match src/db/*.sql (got '$MIGRATION')."; exit 1 ;;
+            src/db/migration-*.sql) ;;
+            *) echo "::error::Migration must match src/db/migration-*.sql."; exit 1 ;;
           esac
+
+          # Belt and braces: reject path traversal and anything outside a
+          # conservative filename charset, so the value is safe as a CLI argument.
           case "$MIGRATION" in
             *..*) echo "::error::Migration path must not contain '..'."; exit 1 ;;
           esac
+          if ! printf '%s' "$MIGRATION" | grep -qE '^src/db/migration-[A-Za-z0-9._-]+\.sql$'; then
+            echo "::error::Migration path contains unexpected characters."
+            exit 1
+          fi
 
           if [ ! -f "$MIGRATION" ]; then
-            echo "::error::Migration file '$MIGRATION' not found in ${{ inputs.worker }}."
+            echo "::error::Migration file not found in this worker directory."
             exit 1
           fi
 
           # Surface the exact SQL in the run log, so the job output is a record of
           # what was applied.
-          echo "### Applying \`$MIGRATION\` to \`${{ inputs.database }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo '```sql' >> "$GITHUB_STEP_SUMMARY"
-          cat "$MIGRATION" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Applying \`$MIGRATION\` to \`$DATABASE\`"
+            echo '```sql'
+            cat "$MIGRATION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Apply migration
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           workingDirectory: ${{ inputs.worker }}
-          command: d1 execute ${{ inputs.database }} --remote --yes --file=${{ inputs.migration }}
+          # Quoted so the arguments survive intact. Both values are constrained
+          # above — `database` is a choice, `migration` passed the charset check.
+          command: d1 execute "${{ inputs.database }}" --remote --yes --file="${{ inputs.migration }}"


### PR DESCRIPTION
## Why

CI already holds `CLOUDFLARE_API_TOKEN`, but [`deploy-worker.yml`](.github/workflows/deploy-worker.yml) only ever uses it to run `wrangler deploy`. Nothing in CI can apply a D1 migration, so the ~19 migrations under `roster-hub-api/src/db/` have had to be run by hand from a machine holding Cloudflare credentials.

This adds the missing path.

## Split out of #1413 deliberately

A `workflow_dispatch` workflow **is not triggerable until it exists on the default branch** — dispatching it from a feature branch returns:

```
HTTP 404: workflow d1-migrate.yml not found on the default branch
```

So the workflow has to land on `main` before it can run, even though the migration it will apply lives on the feature branch. Once merged here, it can be dispatched with `--ref` pointing at any branch to pick up that branch's SQL.

## Guard rails

The job has **production database write access**, so inputs are validated before wrangler is invoked:

- Migration path constrained to `src/db/*.sql` — this is not a run-arbitrary-SQL button
- `..` rejected, and the file must actually exist
- Database name must be typed twice (`confirm` input) to make writing to production a deliberate act
- The full SQL is echoed into the run summary, so the job log is a record of exactly what was applied

Manual dispatch only — a schema change shouldn't be a side effect of a push.

## First use

Applying `migration-dps-parses.sql` for #1413. That migration is purely additive (`CREATE TABLE IF NOT EXISTS`) and touches no existing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
