### PR TITLE
feat(roster-hub-api): apply the dps_parses schema via the D1 binding

### DIFF
--- a/roster-hub-api/src/db/dps-parse-schema.test.ts
+++ b/roster-hub-api/src/db/dps-parse-schema.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  DPS_PARSE_SCHEMA_STATEMENTS,
+  ensureDpsParsesSchema,
+  resetDpsParsesSchemaCache,
+} from './dps-parse-schema';
+
+/**
+ * Reduce SQL to something comparable across two hand-maintained copies:
+ * strip line comments, split on statement boundaries, collapse whitespace.
+ *
+ * Formatting is explicitly NOT part of the comparison — the .sql file is
+ * annotated for humans and the TS copy is not, and requiring them to match
+ * character for character would make the test fail for reasons nobody cares
+ * about. What must match is the statements themselves.
+ */
+function normalize(sql: string): string[] {
+  return sql
+    .replace(/--[^\n]*/g, '')
+    .split(';')
+    .map((statement) => statement.replace(/\s+/g, ' ').trim())
+    .filter((statement) => statement.length > 0);
+}
+
+const MIGRATION_SQL = readFileSync(join(__dirname, 'migration-dps-parses.sql'), 'utf8');
+
+beforeEach(() => {
+  resetDpsParsesSchemaCache();
+});
+
+describe('DPS_PARSE_SCHEMA_STATEMENTS', () => {
+  /**
+   * The bootstrap exists because the deploy token cannot reach D1's management
+   * API, so this constant is what actually creates production's tables. If it
+   * drifts from the migration file, the two paths silently build different
+   * schemas — this test is the only thing standing between us and that.
+   */
+  it('matches migration-dps-parses.sql statement for statement', () => {
+    expect(normalize(DPS_PARSE_SCHEMA_STATEMENTS.join(';\n'))).toEqual(normalize(MIGRATION_SQL));
+  });
+
+  /** Re-running against a migrated database must be a no-op, not an error. */
+  it('is entirely idempotent', () => {
+    DPS_PARSE_SCHEMA_STATEMENTS.forEach((statement) => {
+      expect(statement).toMatch(/CREATE (TABLE|INDEX) IF NOT EXISTS/i);
+    });
+  });
+});
+
+/** Minimal D1 stand-in that records the SQL it was handed. */
+function fakeDb(onRun?: () => void) {
+  const statements: string[] = [];
+  const db = {
+    prepare: (sql: string) => ({
+      run: async () => {
+        statements.push(sql);
+        onRun?.();
+        return { success: true };
+      },
+    }),
+  };
+  return { db: db as never, statements };
+}
+
+describe('ensureDpsParsesSchema', () => {
+  it('applies every statement', async () => {
+    const { db, statements } = fakeDb();
+    await ensureDpsParsesSchema(db);
+    expect(statements).toEqual([...DPS_PARSE_SCHEMA_STATEMENTS]);
+  });
+
+  /**
+   * An isolate serves many requests. Paying for the DDL on each one would put
+   * this on the hot path of a read route, which is the objection to bootstrapping
+   * from a request handler in the first place.
+   */
+  it('runs once per isolate, and shares one attempt between concurrent callers', async () => {
+    const { db, statements } = fakeDb();
+
+    await Promise.all([ensureDpsParsesSchema(db), ensureDpsParsesSchema(db)]);
+    await ensureDpsParsesSchema(db);
+
+    expect(statements).toHaveLength(DPS_PARSE_SCHEMA_STATEMENTS.length);
+  });
+
+  /**
+   * Caching the rejection would turn one transient D1 blip into a permanently
+   * broken isolate — every later request reusing a promise that can only ever
+   * reject, with no path back short of eviction.
+   */
+  it('retries after a failure instead of caching it', async () => {
+    let attempt = 0;
+    const failing = {
+      prepare: () => ({
+        run: async () => {
+          attempt++;
+          if (attempt === 1) throw new Error('D1 unavailable');
+          return { success: true };
+        },
+      }),
+    };
+
+    await expect(ensureDpsParsesSchema(failing as never)).rejects.toThrow('D1 unavailable');
+    await expect(ensureDpsParsesSchema(failing as never)).resolves.toBeUndefined();
+  });
+});

--- a/roster-hub-api/src/db/dps-parse-schema.test.ts
+++ b/roster-hub-api/src/db/dps-parse-schema.test.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+// Imported explicitly rather than relying on the global from
+// @cloudflare/workers-types, the way dps-parse-queries.test.ts does: that global
+// comes from tsconfig.json's `types`, which the test config does not set.
+import type { D1Database } from '@cloudflare/workers-types';
+
 import {
   DPS_PARSE_SCHEMA_STATEMENTS,
   ensureDpsParsesSchema,
@@ -61,7 +66,7 @@ function fakeDb(onRun?: () => void) {
       },
     }),
   };
-  return { db: db as never, statements };
+  return { db: db as unknown as D1Database, statements };
 }
 
 describe('ensureDpsParsesSchema', () => {
@@ -102,7 +107,8 @@ describe('ensureDpsParsesSchema', () => {
       }),
     };
 
-    await expect(ensureDpsParsesSchema(failing as never)).rejects.toThrow('D1 unavailable');
-    await expect(ensureDpsParsesSchema(failing as never)).resolves.toBeUndefined();
+    const db = failing as unknown as D1Database;
+    await expect(ensureDpsParsesSchema(db)).rejects.toThrow('D1 unavailable');
+    await expect(ensureDpsParsesSchema(db)).resolves.toBeUndefined();
   });
 });

--- a/roster-hub-api/src/db/dps-parse-schema.ts
+++ b/roster-hub-api/src/db/dps-parse-schema.ts
@@ -1,0 +1,142 @@
+/**
+ * Applies the `dps_parses` schema through the Worker's own D1 binding.
+ *
+ * WHY THIS EXISTS, given `migration-dps-parses.sql` and the d1-migrate workflow:
+ * the deploy token (`CLOUDFLARE_API_TOKEN`) has no D1 permission at all. Probed
+ * against production on 2026-08-05, all three D1 API surfaces reject it —
+ * `d1 list` and `--file` (import endpoint) with `Authentication error [10000]`,
+ * `--command` (query endpoint) with `code 7403`. Adding the permission needs the
+ * token's owner, who is not always available.
+ *
+ * A D1 *binding* is a separate grant from an API token's scopes: the deployed
+ * Worker can read and write this database regardless of what the management API
+ * allows. So the schema can be applied by the Worker itself, on a deploy CI can
+ * already perform.
+ *
+ * This does NOT replace the migration file or the workflow — those remain the
+ * documented path, and the test in this directory fails if the two drift. It is
+ * a bootstrap for the case where the out-of-band path is unavailable.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types';
+
+/**
+ * Mirrors `migration-dps-parses.sql`, statement for statement.
+ *
+ * Duplicated rather than imported as a text module on purpose. A wrangler `Text`
+ * rule would make the SQL unreadable to jest without a bundler shim, and the
+ * point of this file is that it is unit-testable. `dps-parse-schema.test.ts`
+ * reads the .sql off disk and asserts these match, so drift is a failing test
+ * rather than a production surprise.
+ *
+ * Every statement is IF NOT EXISTS: this runs against a database that may
+ * already be fully migrated, and must be a no-op when it is.
+ */
+export const DPS_PARSE_SCHEMA_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS dps_parses (
+  encounter_id     INTEGER NOT NULL,
+  difficulty       INTEGER NOT NULL DEFAULT -1,
+  zone_id          INTEGER NOT NULL DEFAULT 0,
+  trial_id         TEXT    NOT NULL DEFAULT '',
+  encounter_name   TEXT    NOT NULL DEFAULT '',
+  hard_mode_level  INTEGER,
+  partition        INTEGER NOT NULL DEFAULT -1,
+
+  character_key    TEXT    NOT NULL,
+  character_name   TEXT,
+  eso_class        TEXT    NOT NULL DEFAULT '',
+  spec_name        TEXT    NOT NULL DEFAULT '',
+  race             TEXT,
+  server_region    TEXT,
+  server_name      TEXT,
+  guild_name       TEXT,
+
+  report_code      TEXT    NOT NULL,
+  fight_id         INTEGER NOT NULL,
+  rank             INTEGER,
+  amount           REAL    NOT NULL,
+  duration_ms      INTEGER,
+  log_start_ms     INTEGER,
+  log_date         TEXT,
+  bracket_data     INTEGER,
+
+  set1_id          INTEGER,
+  set2_id          INTEGER,
+  monster_id       INTEGER,
+  mythic_id        INTEGER,
+  arena_set_id     INTEGER,
+  mundus_id        INTEGER,
+  food_ability_id  INTEGER,
+  signature_hash   TEXT    NOT NULL,
+
+  build_json       TEXT    NOT NULL,
+  combatant_json   TEXT,
+
+  signature_version INTEGER NOT NULL DEFAULT 1,
+  evidence_enriched INTEGER NOT NULL DEFAULT 0,
+  ingested_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+
+  PRIMARY KEY (encounter_id, difficulty, character_key)
+)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_parses_encounter ON dps_parses (encounter_id, difficulty, amount DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_parses_class ON dps_parses (eso_class, amount DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_parses_class_enc ON dps_parses (eso_class, encounter_id, difficulty, amount DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_parses_signature ON dps_parses (signature_hash, encounter_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_parses_updated ON dps_parses (updated_at)`,
+  `CREATE TABLE IF NOT EXISTS dps_parse_blocklist (
+  character_key TEXT PRIMARY KEY,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+)`,
+  `CREATE TABLE IF NOT EXISTS dps_parse_sync_state (
+  encounter_id    INTEGER NOT NULL,
+  difficulty      INTEGER NOT NULL DEFAULT -1,
+  encounter_name  TEXT    NOT NULL DEFAULT '',
+  zone_id         INTEGER NOT NULL DEFAULT 0,
+  last_page       INTEGER NOT NULL DEFAULT 0,
+  last_partition  INTEGER,
+  last_synced_at  TEXT,
+  last_status     TEXT    NOT NULL DEFAULT '',
+  last_error      TEXT    NOT NULL DEFAULT '',
+  rows_ingested   INTEGER NOT NULL DEFAULT 0,
+  empty_streak    INTEGER NOT NULL DEFAULT 0,
+
+  PRIMARY KEY (encounter_id, difficulty)
+)`,
+  `CREATE INDEX IF NOT EXISTS idx_dps_sync_state_stale ON dps_parse_sync_state (last_synced_at)`,
+];
+
+/**
+ * Memoized per isolate, not per request.
+ *
+ * The work is a handful of no-op DDL statements, but an isolate serves many
+ * requests and there is no reason to pay for them more than once. The promise
+ * itself is cached so concurrent callers share one attempt rather than racing.
+ *
+ * A failure clears the cache so the next caller retries; caching a rejection
+ * would make one transient D1 error permanent for the isolate's lifetime.
+ */
+let schemaReady: Promise<void> | null = null;
+
+export function ensureDpsParsesSchema(db: D1Database): Promise<void> {
+  schemaReady ??= applySchema(db).catch((error: unknown) => {
+    schemaReady = null;
+    throw error;
+  });
+  return schemaReady;
+}
+
+async function applySchema(db: D1Database): Promise<void> {
+  // Sequential rather than `batch()`: D1 wraps a batch in a transaction, and
+  // SQLite cannot run DDL for a table inside the same transaction that indexes
+  // it. Each statement is independently idempotent, so a partial application is
+  // simply completed by the next call.
+  for (const statement of DPS_PARSE_SCHEMA_STATEMENTS) {
+    await db.prepare(statement).run();
+  }
+}
+
+/** Test seam — the isolate-level cache would otherwise leak between cases. */
+export function resetDpsParsesSchemaCache(): void {
+  schemaReady = null;
+}

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -69,6 +69,7 @@ import { handleGraphqlProxy } from './graphql-proxy';
 import { getReportBuildEvidence, putReportBuildEvidence } from './report-build-evidence';
 import type { Env, RecommendedAddonEntry, RecommendedAddons } from './types';
 import { getDpsParseCombatant, listDpsEncounters, listDpsParses } from './db/dps-parse-queries';
+import { ensureDpsParsesSchema } from './db/dps-parse-schema';
 import { syncDpsParses } from './leaderboard-sync/dps-parse-sync';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -2155,6 +2156,7 @@ async function notifyDiscordSync(env: Env, rosterId: string): Promise<void> {
 
 /** Which encounters have data — feeds the trial/boss picker. */
 app.get('/dps-leaderboard/encounters', async (c) => {
+  await ensureDpsParsesSchema(c.env.DB);
   const encounters = await listDpsEncounters(c.env.DB);
   return c.json({ encounters });
 });
@@ -2180,6 +2182,8 @@ app.get('/dps-leaderboard/parses', async (c) => {
     return c.json({ error: 'Provide at least one of: encounter, class' }, 400);
   }
 
+  await ensureDpsParsesSchema(c.env.DB);
+
   const sortParam = c.req.query('sort');
   const result = await listDpsParses(c.env.DB, {
     encounterId,
@@ -2202,6 +2206,7 @@ app.get('/dps-leaderboard/parses', async (c) => {
  * opens an archetype in the Build Editor.
  */
 app.get('/dps-leaderboard/parses/:parseId/build', async (c) => {
+  await ensureDpsParsesSchema(c.env.DB);
   const build = await getDpsParseCombatant(c.env.DB, c.req.param('parseId'));
   if (!build) return c.json({ error: 'Parse not found' }, 404);
   return c.json(build);

--- a/roster-hub-api/src/leaderboard-sync/dps-parse-sync.ts
+++ b/roster-hub-api/src/leaderboard-sync/dps-parse-sync.ts
@@ -17,6 +17,8 @@ import {
   fetchTrialZones,
   getClientToken,
 } from './esologs-client';
+import { ensureDpsParsesSchema } from '../db/dps-parse-schema';
+
 import { buildDpsEncounterTargets, type DpsEncounterTarget } from './dps-encounter-targets';
 import {
   hasRealCombatantInfo,
@@ -169,6 +171,10 @@ export async function syncDpsParses(
 ): Promise<DpsSyncResult[]> {
   const results: DpsSyncResult[] = [];
   let subrequests = 0;
+
+  // The cron must not depend on a read request having warmed the schema first —
+  // on a fresh database this sync is the very first thing to touch these tables.
+  await ensureDpsParsesSchema(env.DB);
 
   const token = await getClientToken(env);
   subrequests++;


### PR DESCRIPTION
## Why

The build leaderboard's tables were never created, so `/dps-leaderboard/*` cannot work — and we cannot create them.

`CLOUDFLARE_API_TOKEN` has **no D1 access at all**. Probed against production today ([run 30978577716](https://github.com/ESO-Toolkit/eso-toolkit/actions/runs/30978577716)), every D1 API surface rejects it:

| wrangler command | Cloudflare endpoint | result |
|---|---|---|
| `d1 list` | `/d1/database` | `Authentication error [code: 10000]` |
| `d1 execute --file` | `/d1/database/:id/import` | `Authentication error [code: 10000]` |
| `d1 execute --command` | `/d1/database/:id/query` | `code 7403` — not authorized for this service |

The token belongs to another developer, so `d1-migrate` cannot be run on demand.

Worth noting the migrate logs print `Membership roles in "WebPath Agency": Super Administrator - All Privileges`. That is the **account membership of the user the token belongs to**, not the token's own scopes — API tokens are independently scoped, so this is misleading when diagnosing.

## What

A D1 **binding** is a separate grant from an API token's scopes. The deployed Worker already reads and writes this database (that is how `/health` reports `db_size_bytes`), and CI can already deploy the Worker because `Workers Scripts · Edit` is unaffected. So the Worker applies its own schema, on a deploy we can perform today with no token change.

- `ensureDpsParsesSchema()` — memoized per isolate, so the DDL is not on the hot path of a read route. Concurrent callers share one attempt. A failure clears the cache rather than caching the rejection, which would otherwise leave an isolate permanently broken after one transient blip.
- Statements run sequentially rather than through `batch()`: D1 wraps a batch in a transaction, and SQLite will not create a table and index it in the same one.
- Called from the three read routes and from `syncDpsParses` — the cron must not depend on a request having warmed the schema. The parses route calls it *after* the 400 validation, so a malformed request never triggers DDL.

## What this is not

It does **not** replace `migration-dps-parses.sql` or the `d1-migrate` workflow. Both remain the documented path for future migrations. This is a bootstrap for when the out-of-band path is unavailable.

The statements are duplicated in TypeScript rather than imported as a wrangler `Text` module, because a Text rule would make the SQL unreadable to jest without a bundler shim, and this needs to be unit-testable. `dps-parse-schema.test.ts` reads the `.sql` off disk and compares statement by statement ignoring formatting, so drift is a failing test rather than two silently different schemas. Verified by injecting a changed column default and confirming the test caught it.

## After merging

`deploy-worker.yml` is `workflow_dispatch`-only, so merging does not deploy. Production is still running the 2026-07-08 build, which is why the routes 404 today. Once deployed, the first request creates the tables and the routes return empty results.

**First data still arrives at the 16:00 UTC cron.** Triggering ingest by hand needs `INTERNAL_API_KEY`, which is not in GitHub secrets — and that is true regardless of this PR or the D1 token.

## Testing

- 5 new tests; full worker suite 80 passed
- `roster-hub-api` typecheck clean
