### PR TITLE
fix(api): limit failed token validations per IP

### DIFF
--- a/roster-hub-api/src/auth.ts
+++ b/roster-hub-api/src/auth.ts
@@ -233,15 +233,81 @@ async function introspectToken(token: string): Promise<IntrospectionResult> {
   }
 }
 
+// ─── Per-IP limiter on FAILED validations ────────────────────────────────────
+//
+// The rejection cache below is keyed by token hash, so it stops a client
+// REPLAYING one bad token — but not a caller minting a fresh JWT-shaped value
+// per request, where every token misses the cache and costs one outbound
+// introspection subrequest. This bucket closes that: budget is spent only when
+// a validation actually FAILS, so a legitimate session (which succeeds, then
+// rides the positive cache) never touches it, while a rotating-token flood
+// runs itself out of credit and is refused without calling upstream.
+//
+// Isolate-scoped and therefore best-effort, exactly like the /graphql limiter.
+const AUTH_FAIL_CAPACITY = 20; // consecutive failed validations per IP
+const AUTH_FAIL_REFILL_PER_SEC = 0.5; // ~30 failures / minute sustained
+const AUTH_FAIL_MAX_IPS = 10_000;
+
+interface FailBucket {
+  tokens: number;
+  updatedAt: number;
+}
+
+const authFailBuckets = new Map<string, FailBucket>();
+
+function failBucketFor(ip: string, now: number): FailBucket {
+  let bucket = authFailBuckets.get(ip);
+  if (!bucket) {
+    if (authFailBuckets.size >= AUTH_FAIL_MAX_IPS) {
+      const oldest = authFailBuckets.keys().next().value; // insertion-ordered
+      if (oldest !== undefined) authFailBuckets.delete(oldest);
+    }
+    bucket = { tokens: AUTH_FAIL_CAPACITY, updatedAt: now };
+    authFailBuckets.set(ip, bucket);
+    return bucket;
+  }
+  const elapsedSec = (now - bucket.updatedAt) / 1000;
+  bucket.tokens = Math.min(
+    AUTH_FAIL_CAPACITY,
+    bucket.tokens + elapsedSec * AUTH_FAIL_REFILL_PER_SEC,
+  );
+  bucket.updatedAt = now;
+  return bucket;
+}
+
+/** True when this IP still has budget to spend on an introspection that may fail. */
+function mayAttemptIntrospection(ip: string | undefined): boolean {
+  if (!ip) return true; // no caller identity to key on — do not lock everyone out
+  return failBucketFor(ip, Date.now()).tokens >= 1;
+}
+
+/** Charge one unit after a validation attempt that did not authenticate anybody. */
+function chargeFailedValidation(ip: string | undefined): void {
+  if (!ip) return;
+  const bucket = failBucketFor(ip, Date.now());
+  bucket.tokens = Math.max(0, bucket.tokens - 1);
+}
+
+/** Caller IP as Cloudflare reports it, for the failed-validation limiter. */
+export function clientIpFromHeaders(
+  header: (name: string) => string | undefined | null,
+): string | undefined {
+  return header('CF-Connecting-IP') ?? header('x-forwarded-for') ?? undefined;
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
  * Validates an ESO Logs Bearer token and returns the authenticated user.
  * Returns null if the token is missing, expired, or rejected by ESO Logs.
+ *
+ * `clientIp` is optional only so existing callers keep compiling; pass it
+ * wherever it is available, or the failed-validation limiter cannot engage.
  */
 export async function validateToken(
   authHeader: string | undefined,
   _env: Env,
+  clientIp?: string,
 ): Promise<AuthUser | null> {
   if (!authHeader?.startsWith('Bearer ')) return null;
   const token = authHeader.slice(7);
@@ -262,29 +328,29 @@ export async function validateToken(
   if (cached) return cached;
 
   // Short-circuit tokens we recently rejected, so a client REPLAYING a rejected
-  // token stops costing an introspection each time.
-  //
-  // Scope, precisely: this is keyed by token hash, so it does nothing against a
-  // caller minting a fresh JWT-shaped value per request — each unique token
-  // misses and reaches introspectToken. That path spends the CALLER's bearer
-  // token upstream, not the site's client credentials (unlike /graphql), so the
-  // exposure is one outbound subrequest per request rather than a drain on the
-  // shared OAuth budget. Closing it properly needs a limiter on failed
-  // validation attempts keyed by caller IP, which validateToken cannot see
-  // today — see the follow-up note in the PR.
+  // token stops costing an introspection each time. Rotating tokens defeat this
+  // by construction (every hash is new), which is what the per-IP failed-
+  // validation bucket above is for.
   const tokenHash = hashToken(token);
   if (isNegativelyCached(tokenHash)) return null;
+
+  // Out of failure budget: refuse without spending an outbound subrequest.
+  if (!mayAttemptIntrospection(clientIp)) return null;
 
   // Introspect against ESO Logs API
   const result = await introspectToken(token);
   if (result.status === 'invalid') {
     setNegativeCache(tokenHash);
+    chargeFailedValidation(clientIp);
     return null;
   }
   // Unavailable: reject THIS request, but never remember the failure — caching
   // it would 401 a valid session for the whole negative-cache window without
   // asking upstream again.
-  if (result.status === 'unavailable') return null;
+  if (result.status === 'unavailable') {
+    chargeFailedValidation(clientIp);
+    return null;
+  }
 
   setCache(token, result.user);
   return result.user;

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -8,7 +8,7 @@
 
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { validateToken } from './auth';
+import { clientIpFromHeaders, validateToken } from './auth';
 import {
   listRosters,
   getRosterById,
@@ -352,7 +352,11 @@ app.get('/health', async (c) => {
 // ─── GET /rosters — list with filtering & pagination ─────────────────────────
 
 app.get('/rosters', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
 
   const trial = c.req.query('trial') ?? undefined;
   const tag = c.req.query('tag') ?? undefined;
@@ -373,7 +377,11 @@ app.get('/rosters', async (c) => {
 // ─── GET /rosters/:id — single roster ────────────────────────────────────────
 
 app.get('/rosters/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   const roster = await getRosterById(c.env.DB, c.req.param('id'), user?.id);
 
   if (!roster) {
@@ -385,7 +393,11 @@ app.get('/rosters/:id', async (c) => {
 // ─── POST /rosters — publish a roster ────────────────────────────────────────
 
 app.post('/rosters', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   interface CreateBody {
@@ -486,7 +498,11 @@ app.post('/rosters', async (c) => {
 // ─── PUT /rosters/:id — update own roster ────────────────────────────────────
 
 app.put('/rosters/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   if (!(await checkUpdateRateLimit(c.env.DB, user.id, 'roster_update')))
@@ -581,7 +597,11 @@ app.put('/rosters/:id', async (c) => {
 // ─── DELETE /rosters/:id — delete own roster ─────────────────────────────────
 
 app.delete('/rosters/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const deleted = await deleteRoster(c.env.DB, c.req.param('id'), user.id);
@@ -592,7 +612,11 @@ app.delete('/rosters/:id', async (c) => {
 // ─── POST /rosters/:id/vote — toggle upvote ──────────────────────────────────
 
 app.post('/rosters/:id/vote', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const rosterId = c.req.param('id');
@@ -630,7 +654,11 @@ app.get('/rosters/:id/comments', async (c) => {
 // ─── POST /rosters/:id/comments — add a comment ────────────────────────────
 
 app.post('/rosters/:id/comments', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const rosterId = c.req.param('id');
@@ -692,7 +720,11 @@ app.post('/rosters/:id/comments', async (c) => {
 // ─── DELETE /rosters/:rosterId/comments/:commentId — delete own comment ─────
 
 app.delete('/rosters/:rosterId/comments/:commentId', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const deleted = await deleteComment(c.env.DB, c.req.param('commentId'), user.id);
@@ -707,7 +739,11 @@ app.delete('/rosters/:rosterId/comments/:commentId', async (c) => {
 // ─── GET /builds — list with filtering & pagination ──────────────────────────
 
 app.get('/builds', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
 
   const esoClass = c.req.query('class') ?? undefined;
   const role = c.req.query('role') ?? undefined;
@@ -732,7 +768,11 @@ app.get('/builds', async (c) => {
 // ─── GET /builds/:id — single build ──────────────────────────────────────────
 
 app.get('/builds/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   const build = await getBuildById(c.env.DB, c.req.param('id'), user?.id);
 
   if (!build) {
@@ -744,7 +784,11 @@ app.get('/builds/:id', async (c) => {
 // ─── POST /builds — publish a build ──────────────────────────────────────────
 
 app.post('/builds', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   interface CreateBuildBody {
@@ -836,7 +880,11 @@ app.post('/builds', async (c) => {
 // ─── PUT /builds/:id — update own build ──────────────────────────────────────
 
 app.put('/builds/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   // Rate-limit BEFORE decompressing attacker-controlled build_data.
@@ -920,7 +968,11 @@ app.put('/builds/:id', async (c) => {
 // ─── DELETE /builds/:id — delete own build ────────────────────────────────────
 
 app.delete('/builds/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const deleted = await deleteBuild(c.env.DB, c.req.param('id'), user.id);
@@ -931,7 +983,11 @@ app.delete('/builds/:id', async (c) => {
 // ─── POST /builds/:id/vote — toggle upvote ────────────────────────────────────
 
 app.post('/builds/:id/vote', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const buildId = c.req.param('id');
@@ -950,7 +1006,11 @@ app.post('/builds/:id/vote', async (c) => {
 // ─── GET /builds/:id/comments ─────────────────────────────────────────────────
 
 app.get('/builds/:id/comments', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   const buildId = c.req.param('id');
   const build = await getBuildById(c.env.DB, buildId, user?.id);
   if (!build) return c.json({ error: 'Not found' }, 404);
@@ -962,7 +1022,11 @@ app.get('/builds/:id/comments', async (c) => {
 // ─── POST /builds/:id/comments ────────────────────────────────────────────────
 
 app.post('/builds/:id/comments', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const buildId = c.req.param('id');
@@ -1017,7 +1081,11 @@ app.post('/builds/:id/comments', async (c) => {
 // ─── DELETE /builds/:buildId/comments/:commentId ──────────────────────────────
 
 app.delete('/builds/:buildId/comments/:commentId', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const deleted = await deleteBuildComment(c.env.DB, c.req.param('commentId'), user.id);
@@ -1120,7 +1188,11 @@ app.get('/temp-builds/:id', async (c) => {
 // ─── POST /images/upload — upload with AI moderation ─────────────────────────
 
 app.post('/images/upload', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   // Rate limit: 10 uploads per hour
@@ -1250,7 +1322,11 @@ app.post('/images/upload', async (c) => {
 // ─── POST /images/:id/report — flag an image ────────────────────────────────
 
 app.post('/images/:id/report', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const imageId = c.req.param('id');
@@ -1296,7 +1372,11 @@ app.post('/images/:id/report', async (c) => {
 // ─── DELETE /images/:id — delete own image ───────────────────────────────────
 
 app.delete('/images/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const result = await deleteImageUpload(c.env.DB, c.req.param('id'), user.id);
@@ -1346,7 +1426,11 @@ app.get('/users/:username', async (c) => {
 // ─── PUT /users/me/bio — update own bio ──────────────────────────────────────
 
 app.put('/users/me/bio', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   // Rate limit: 1 bio update per 60 seconds using the profile row's updated_at
@@ -1383,7 +1467,11 @@ app.put('/users/me/bio', async (c) => {
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 
 app.put('/users/me/avatar', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   // Rate limit: 1 avatar upload per hour
@@ -1510,7 +1598,11 @@ app.put('/users/me/avatar', async (c) => {
 // ─── DELETE /users/me/avatar — remove avatar ────────────────────────────────
 
 app.delete('/users/me/avatar', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const { avatarDeleteUrl } = await deleteUserAvatar(c.env.DB, user.id);
@@ -1521,7 +1613,11 @@ app.delete('/users/me/avatar', async (c) => {
 // ─── PUT /users/me/display-names — sync ESO @handles ────────────────────────
 
 app.put('/users/me/display-names', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   // Rate limit: 1 display-name update per 60 seconds (shares the profile row's
@@ -1612,7 +1708,11 @@ const VALID_PACK_TYPES = ['addon-pack', 'build-pack', 'roster-pack'];
 // ─── GET /packs — list with filtering & pagination ──────────────────────────
 
 app.get('/packs', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
 
   const packType = c.req.query('type') ?? undefined;
   const tag = c.req.query('tag') ?? undefined;
@@ -1633,7 +1733,11 @@ app.get('/packs', async (c) => {
 // ─── GET /packs/:id — single pack ──────────────────────────────────────────
 
 app.get('/packs/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   const pack = await getPackById(c.env.DB, c.req.param('id'), user?.id);
 
   if (!pack) return c.json({ error: 'Not found' }, 404);
@@ -1643,7 +1747,11 @@ app.get('/packs/:id', async (c) => {
 // ─── POST /packs — create a pack ───────────────────────────────────────────
 
 app.post('/packs', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   interface CreatePackBody {
@@ -1713,7 +1821,11 @@ app.post('/packs', async (c) => {
 // ─── PUT /packs/:id — update own pack ──────────────────────────────────────
 
 app.put('/packs/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   if (!(await checkUpdateRateLimit(c.env.DB, user.id, 'pack_update')))
@@ -1776,7 +1888,11 @@ app.put('/packs/:id', async (c) => {
 // ─── DELETE /packs/:id — delete own pack ────────────────────────────────────
 
 app.delete('/packs/:id', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const deleted = await deletePack(c.env.DB, c.req.param('id'), user.id);
@@ -1787,7 +1903,11 @@ app.delete('/packs/:id', async (c) => {
 // ─── POST /packs/:id/vote — toggle upvote ──────────────────────────────────
 
 app.post('/packs/:id/vote', async (c) => {
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const pack = await getPackById(c.env.DB, c.req.param('id'));

--- a/roster-hub-api/src/report-build-evidence.ts
+++ b/roster-hub-api/src/report-build-evidence.ts
@@ -8,7 +8,7 @@
 
 import type { Context } from 'hono';
 
-import { validateToken } from './auth';
+import { clientIpFromHeaders, validateToken } from './auth';
 import type { AuthUser, Env } from './types';
 
 const SOURCE = 'kalpa-native-player-info';
@@ -309,7 +309,11 @@ export async function putReportBuildEvidence(c: ReportEvidenceContext): Promise<
   const bucket = ensureBucket(c);
   if (!bucket) return c.json({ error: 'Build evidence storage is not configured' }, 503);
 
-  const user = await validateToken(c.req.header('Authorization'), c.env);
+  const user = await validateToken(
+    c.req.header('Authorization'),
+    c.env,
+    clientIpFromHeaders((n) => c.req.header(n)),
+  );
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
   const ownerVerified = await verifyReportOwner(

--- a/src/graphql/rosterHubAuthCache.test.ts
+++ b/src/graphql/rosterHubAuthCache.test.ts
@@ -20,16 +20,16 @@ interface AuthUser {
   name: string;
 }
 
-function loadAuth(): {
-  validateToken: (header: string | undefined, env: unknown) => Promise<AuthUser | null>;
-} {
-  let mod!: {
-    validateToken: (header: string | undefined, env: unknown) => Promise<AuthUser | null>;
-  };
+type ValidateToken = (
+  header: string | undefined,
+  env: unknown,
+  clientIp?: string,
+) => Promise<AuthUser | null>;
+
+function loadAuth(): { validateToken: ValidateToken } {
+  let mod!: { validateToken: ValidateToken };
   jest.isolateModules(() => {
-    mod = require('../../roster-hub-api/src/auth') as {
-      validateToken: (header: string | undefined, env: unknown) => Promise<AuthUser | null>;
-    };
+    mod = require('../../roster-hub-api/src/auth') as { validateToken: ValidateToken };
   });
   return mod;
 }
@@ -159,6 +159,60 @@ describe('roster-hub-api validateToken', () => {
     expect(await auth.validateToken(header, {})).toBeNull();
     expect(await auth.validateToken(header, {})).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops a rotating-token flood from costing one introspection per request', async () => {
+    // The rejection cache is keyed by token hash, so a caller minting a UNIQUE
+    // JWT-shaped value per request misses it every time. Without a per-IP
+    // limiter each of those still reaches ESO Logs — one outbound subrequest
+    // per attacker request.
+    const fetchMock = jest.fn(async () => jsonResponse({ errors: ['nope'] }, 401));
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, configurable: true });
+
+    const auth = loadAuth();
+    for (let i = 0; i < 60; i += 1) {
+      const result = await auth.validateToken(`Bearer ${makeToken(`rot-${i}`)}`, {}, '203.0.113.9');
+      expect(result).toBeNull();
+    }
+
+    // Budget is 20 failures; everything past it is refused without calling out.
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(21);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('never spends failure budget on sessions that authenticate', async () => {
+    // Legitimate traffic succeeds and then rides the positive cache, so it must
+    // be unaffected by the limiter no matter how many requests it makes.
+    const fetchMock = jest.fn(async () => jsonResponse(VALID_USER));
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, configurable: true });
+
+    const auth = loadAuth();
+    for (let i = 0; i < 60; i += 1) {
+      const user = await auth.validateToken(`Bearer ${makeToken(`ok-${i}`)}`, {}, '198.51.100.7');
+      expect(user).toEqual({ id: '42', name: 'Tester' });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(60);
+  });
+
+  it('keeps limiting per IP, so one abuser cannot lock out everyone', async () => {
+    const fetchMock = jest.fn(
+      async (input: unknown, init?: { headers?: Record<string, string> }) => {
+        const auth = init?.headers?.Authorization ?? '';
+        return auth.includes('good')
+          ? jsonResponse(VALID_USER)
+          : jsonResponse({ errors: ['no'] }, 401);
+      },
+    );
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, configurable: true });
+
+    const auth = loadAuth();
+    // Abuser burns their whole budget.
+    for (let i = 0; i < 40; i += 1) {
+      await auth.validateToken(`Bearer ${makeToken(`bad-${i}`)}`, {}, '203.0.113.50');
+    }
+    // A different IP with a valid token is completely unaffected.
+    const user = await auth.validateToken(`Bearer ${makeToken('good-1')}`, {}, '198.51.100.99');
+    expect(user).toEqual({ id: '42', name: 'Tester' });
   });
 
   it('retries after a network error instead of caching the failure', async () => {


### PR DESCRIPTION
## What

Closes the last open finding from the Codex review loop on #1414.

`validateToken`'s rejection cache is keyed by **token hash**, so it stops a client *replaying* one bad token — but does nothing against a caller minting a fresh JWT-shaped value per request. Every such token misses the cache and reaches `introspectToken`, costing **one outbound subrequest per attacker request**.

## Approach

A per-IP token bucket that is charged **only when a validation fails**:

- a legitimate session authenticates, then rides the positive cache — it never spends from the bucket at all
- a rotating-token flood burns its credit and is then refused *without* calling upstream
- 20 burst / ~30 per minute sustained, bounded to 10k IPs, isolate-scoped (best-effort, same as the `/graphql` limiter)

Caller IP is threaded through the 31 `validateToken` call sites with a small `clientIpFromHeaders` helper. The parameter is optional so no caller breaks; the limiter simply cannot engage where it is absent.

## Why not something heavier

The path spends the **caller's** bearer token upstream, not the site's client credentials (unlike `/graphql`), so the exposure is subrequest amplification rather than a drain on the shared OAuth budget. A per-IP bucket is proportionate; a global cap would risk rejecting legitimate users under load.

## Verification

- 60 rotating tokens → **≤21** introspections (was 60)
- 60 successful validations → all authenticate, fetch called 60 times, unaffected by the limiter
- an abuser exhausting their budget does **not** affect a different IP
- worker + frontend typecheck, `typecheck:test`, lint (`--max-warnings 0`), format all clean
- **full jest suite: 4724 passed, 0 failed**
