### PR TITLE
refactor(types): widen PlayerGear trait/type to raw numeric codes

### DIFF
--- a/src/features/build-leaderboard/hooks/useArchetypeBuildActions.ts
+++ b/src/features/build-leaderboard/hooks/useArchetypeBuildActions.ts
@@ -17,7 +17,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { saveBuild } from '../../../store/saved_builds/savedBuildsSlice';
-import type { GearTrait, GearType, PlayerGear, PlayerTalent } from '../../../types/playerDetails';
+import type { PlayerGear, PlayerTalent } from '../../../types/playerDetails';
 import { ItemQuality } from '../../../utils/gearUtilities';
 import { playerToBuild } from '../../../utils/playerToBuild';
 import type { Build } from '../../build-editor/types/build.types';
@@ -35,8 +35,9 @@ const ASSUMED_ITEM_QUALITY = ItemQuality.LEGENDARY;
  * Map the stored combatant payload onto the shape `playerToBuild` consumes.
  *
  * Two fields are absent upstream and defaulted here:
- *  - `type` (GearType): not returned. convertGear is called with
- *    `resolveWeaponType`, so it infers weapon types from the item itself.
+ *  - `type`: not returned, so it is left at 0 ("not reported"). convertGear is
+ *    called with `resolveWeaponType`, so it infers weapon types from the item
+ *    itself.
  *  - `quality`: the API's `quality` field is a bar designation
  *    ("primary"/"backup"), NOT an item tier — deliberately not forwarded.
  */
@@ -48,11 +49,11 @@ function toExtractionData(response: DpsParseBuildResponse): Parameters<typeof pl
     icon: piece.icon ?? '',
     name: piece.name,
     championPoints: piece.cp ?? 160,
-    trait: (piece.trait ?? 0) as GearTrait,
+    trait: piece.trait ?? 0,
     enchantType: piece.enchantType ?? 0,
     enchantQuality: piece.enchantQuality ?? 0,
     setID: piece.setId,
-    type: 0 as GearType,
+    type: 0,
     setName: response.combatant.sets.find((set) => set.setId === piece.setId)?.name,
   }));
 

--- a/src/features/role_detection/__tests__/extractSignals.test.ts
+++ b/src/features/role_detection/__tests__/extractSignals.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { CombatantInfoEvent, DamageEvent, HealEvent } from '@/types/combatlogEvents';
-import { ArmorType, GearSlot, GearTrait, WeaponType } from '@/types/playerDetails';
+import { ArmorType, GearSlot, WeaponType } from '@/types/playerDetails';
 
 import { extractSignals, FightContext, RoleDetectionEvents } from '../extractSignals';
 
@@ -125,13 +125,12 @@ function makeCombatantInfo(
       quality: 5,
       icon: '',
       championPoints: 160,
-      // GearTrait only models the traits the app reasons about; the log payload
-      // reports 0 for "no trait".
-      trait: 0 as GearTrait,
+      // Raw log codes: the payload reports 0 for "no trait".
+      trait: 0,
       enchantType: 0,
       enchantQuality: 0,
       setID: 0,
-      type: 1 as ArmorType,
+      type: ArmorType.LIGHT,
       ...g,
     })),
     auras: [],

--- a/src/types/playerDetails.ts
+++ b/src/types/playerDetails.ts
@@ -30,6 +30,10 @@ export enum GearSlot {
   BACKUP_OFF_HAND = 13,
 }
 
+/**
+ * Armor weight codes as reported by ESO Logs. Named constants for comparison
+ * only — see the note on {@link GearType}; not an exhaustive domain.
+ */
 export enum ArmorType {
   LIGHT = 1,
   MEDIUM = 2,
@@ -37,6 +41,14 @@ export enum ArmorType {
   JEWELRY = 4,
 }
 
+/**
+ * Weapon type codes as reported by ESO Logs. Named constants for comparison
+ * only — see the note on {@link GearType}; not an exhaustive domain.
+ *
+ * NOTE: these values overlap ArmorType numerically (AXE=1=LIGHT,
+ * TWO_HANDED_SWORD=4=JEWELRY), so callers must gate on the gear slot before
+ * interpreting a type code — see `isBodyArmorSlot` / `isWeaponSlot`.
+ */
 export enum WeaponType {
   AXE = 1,
   MACE = 2,
@@ -52,8 +64,22 @@ export enum WeaponType {
   LIGHTNING_STAFF = 15,
 }
 
+/**
+ * The gear type codes this app has names for. Deliberately NOT the type of
+ * `PlayerGear.type`: real log payloads (and the ESO Logs characterRankings API,
+ * which omits item type entirely and yields 0) carry codes outside this union.
+ * Use it when you genuinely hold a known constant; read raw values as `number`.
+ */
 export type GearType = WeaponType | ArmorType;
 
+/**
+ * The gear trait codes this app reasons about. ESO has ~30 traits and logs
+ * report all of them (plus 0 for "no trait / not reported"), so this enum is a
+ * named-constant lookup for specific comparisons — NOT the domain of
+ * `PlayerGear.trait`. Full code→name decoding lives in `TRAIT_NAMES`
+ * (`src/utils/gearMappings.ts`); add a member here only when code needs to
+ * compare against that trait by name.
+ */
 export enum GearTrait {
   SHARPENED = 32,
   REINFORCED = 8,
@@ -66,11 +92,17 @@ export interface PlayerGear {
   icon: string;
   name?: string;
   championPoints: number;
-  trait: GearTrait;
+  /** Raw ESO trait code; 0 = no trait / not reported. Compare via {@link GearTrait}. */
+  trait: number;
   enchantType: number;
   enchantQuality: number;
   setID: number;
-  type: GearType;
+  /**
+   * Raw ESO gear type code; 0 = not reported (the characterRankings API never
+   * reports it). Compare via {@link WeaponType} / {@link ArmorType}, gating on
+   * the slot first because the two enums share numeric values.
+   */
+  type: number;
   setName?: string;
   flags?: number;
 }

--- a/src/utils/__tests__/playerToBuild.test.ts
+++ b/src/utils/__tests__/playerToBuild.test.ts
@@ -33,7 +33,7 @@ function gearPiece(overrides: Partial<PlayerGear>): PlayerGear {
     icon: '',
     name: '',
     championPoints: 160,
-    trait: 0 as PlayerGear['trait'],
+    trait: 0,
     enchantType: 0,
     enchantQuality: 0,
     setID: 1,
@@ -69,21 +69,21 @@ describe('convertGear — traits & enchants', () => {
       gearPiece({
         slot: 0,
         type: ArmorType.LIGHT,
-        trait: 40 as PlayerGear['trait'],
+        trait: 40,
         enchantType: 22,
       }),
       // Ring 1 (jewelry, slot 8): Bloodthirsty (53) + Spell Damage (47)
       gearPiece({
         slot: 8,
         type: ArmorType.JEWELRY,
-        trait: 53 as PlayerGear['trait'],
+        trait: 53,
         enchantType: 47,
       }),
       // Main hand (weapon, slot 10): Sharpened (32) + Weapon Damage (27)
       gearPiece({
         slot: 10,
         type: WeaponType.INFERNO_STAFF,
-        trait: 32 as PlayerGear['trait'],
+        trait: 32,
         enchantType: 27,
       }),
     ];
@@ -102,8 +102,8 @@ describe('convertGear — traits & enchants', () => {
   it('keys off item.slot, not array order', () => {
     // Deliberately out-of-order array: weapon first, head second.
     const gear: PlayerGear[] = [
-      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 as PlayerGear['trait'] }),
-      gearPiece({ slot: 0, type: ArmorType.HEAVY, trait: 40 as PlayerGear['trait'] }),
+      gearPiece({ slot: 10, type: WeaponType.INFERNO_STAFF, trait: 32 }),
+      gearPiece({ slot: 0, type: ArmorType.HEAVY, trait: 40 }),
     ];
     const config = convertGear(gear);
     expect(config[4]).toMatchObject({ trait: 'sharpened' }); // main hand
@@ -116,7 +116,7 @@ describe('convertGear — traits & enchants', () => {
       gearPiece({
         slot: 0,
         type: ArmorType.LIGHT,
-        trait: 43 as PlayerGear['trait'],
+        trait: 43,
         enchantType: 0,
       }),
     ];
@@ -231,19 +231,19 @@ describe('extract → encode → decode round-trip', () => {
       gearPiece({
         slot: 0,
         type: ArmorType.LIGHT,
-        trait: 40 as PlayerGear['trait'],
+        trait: 40,
         enchantType: 22,
       }), // Divines + Increase Magicka
       gearPiece({
         slot: 8,
         type: ArmorType.JEWELRY,
-        trait: 53 as PlayerGear['trait'],
+        trait: 53,
         enchantType: 47,
       }), // Bloodthirsty + Spell Damage
       gearPiece({
         slot: 10,
         type: WeaponType.INFERNO_STAFF,
-        trait: 32 as PlayerGear['trait'],
+        trait: 32,
         enchantType: 27,
       }), // Sharpened + Weapon Damage
     ];

--- a/src/utils/armorUtils.ts
+++ b/src/utils/armorUtils.ts
@@ -2,7 +2,7 @@
  * Utilities for analyzing player gear and armor
  */
 
-import { ArmorType, GearSlot, GearType, PlayerGear } from '../types/playerDetails';
+import { ArmorType, GearSlot, PlayerGear } from '../types/playerDetails';
 
 /**
  * Item IDs for mythic armor pieces that ESOLogs misreports as Light.
@@ -48,8 +48,12 @@ const ARMOR_TYPE_CORRECTIONS: Record<MythicArmorId, ArmorType> = {
 /**
  * Returns the correct armor type for a gear item, applying any known corrections
  * for items where ESOLogs source data has an incorrect armor weight.
+ *
+ * Returns a raw type code, not `GearType`: `item.type` passes through unchanged
+ * for non-mythics, and logs report codes this app does not model (including 0
+ * for "not reported"). Compare the result against `ArmorType` members.
  */
-export function resolveArmorType(item: PlayerGear): GearType {
+export function resolveArmorType(item: PlayerGear): number {
   return ARMOR_TYPE_CORRECTIONS[item.id as MythicArmorId] ?? item.type;
 }
 

--- a/src/utils/damageReductionUtils.test.ts
+++ b/src/utils/damageReductionUtils.test.ts
@@ -645,7 +645,9 @@ describe('damageReductionUtils', () => {
       const gear = new Array(14).fill(null);
       const invalidGear = {
         ...createMockGearPiece(ArmorType.HEAVY),
-        type: 'INVALID' as unknown as ArmorType,
+        // Deliberately non-numeric: `type` is a raw code, so this exercises the
+        // runtime guard rather than a value the type system could have caught.
+        type: 'INVALID' as unknown as number,
       };
       gear[GearSlot.CHEST] = invalidGear;
 

--- a/src/utils/gearUtilities.ts
+++ b/src/utils/gearUtilities.ts
@@ -40,7 +40,7 @@ export function isPerfectedGear(gear: PlayerGear): boolean {
 
 export function isDoubleSetCount(gear: PlayerGear, slot: number, allGear: PlayerGear[]): boolean {
   return (
-    DOUBLE_SET_TYPES.has(gear.type as WeaponType) &&
+    DOUBLE_SET_TYPES.has(gear.type) &&
     ((slot === GearSlot.MAIN_HAND && allGear[GearSlot.OFF_HAND].id === 0) ||
       (slot === GearSlot.BACKUP_MAIN_HAND && allGear[GearSlot.BACKUP_OFF_HAND].id === 0))
   );
@@ -267,7 +267,7 @@ export function countOneHandedSharpenedWeapons(combatantInfo: CombatantInfoEvent
       if (
         weapon &&
         weapon.id !== 0 &&
-        isOneHandedWeapon(weapon.type as WeaponType) &&
+        isOneHandedWeapon(weapon.type) &&
         weapon.trait === GearTrait.SHARPENED
       ) {
         count++;
@@ -292,7 +292,7 @@ export function hasTwoHandedSharpenedWeapon(combatantInfo: CombatantInfoEvent): 
       if (
         weapon &&
         weapon.id !== 0 &&
-        isTwoHandedWeapon(weapon.type as WeaponType) &&
+        isTwoHandedWeapon(weapon.type) &&
         weapon.trait === GearTrait.SHARPENED
       ) {
         return true;
@@ -402,10 +402,10 @@ export function countDualWieldWeapons(combatantInfo: CombatantInfoEvent | null):
       if (
         mainHandWeapon &&
         mainHandWeapon.id !== 0 &&
-        isOneHandedWeapon(mainHandWeapon.type as WeaponType) &&
+        isOneHandedWeapon(mainHandWeapon.type) &&
         offHandWeapon &&
         offHandWeapon.id !== 0 &&
-        isOneHandedWeapon(offHandWeapon.type as WeaponType)
+        isOneHandedWeapon(offHandWeapon.type)
       ) {
         // Count both weapons in the dual wield setup
         count += 2;

--- a/src/utils/logToRoster.ts
+++ b/src/utils/logToRoster.ts
@@ -20,7 +20,6 @@ import {
   GREEN_CHAMPION_POINTS,
 } from '../types/abilities';
 import type { CombatantAura } from '../types/combatlogEvents';
-import { WeaponType } from '../types/playerDetails';
 import type { PlayerGear, PlayerTalent } from '../types/playerDetails';
 import {
   ALL_5PIECE_SETS,
@@ -155,7 +154,7 @@ function categorizeSets(gear: LogGearItem[]): {
       typeof item.slot === 'number' &&
       isWeaponSlot(item.slot) &&
       item.type !== undefined &&
-      isAnyTwoHandedWeapon(item.type as WeaponType);
+      isAnyTwoHandedWeapon(item.type);
     const pieceCount = isTwoHanded ? 2 : 1;
     rawCountMap.set(item.setName, (rawCountMap.get(item.setName) ?? 0) + pieceCount);
     if (isPerfected(item.setName)) {

--- a/src/utils/playerToBuild.ts
+++ b/src/utils/playerToBuild.ts
@@ -39,7 +39,6 @@ import {
   BLUE_CHAMPION_POINTS,
   GREEN_CHAMPION_POINTS,
 } from '../types/abilities';
-import { WeaponType } from '../types/playerDetails';
 import type { PlayerGear, PlayerTalent } from '../types/playerDetails';
 
 import { isWeaponSlot } from './armorUtils';
@@ -424,8 +423,7 @@ function buildGearDescription(gear: PlayerGear[]): string {
     // A two-handed weapon occupies one slot but grants two set pieces (matches
     // P2-M3 in logToRoster and setPieceCounting.buildSetPieceCounts). Gate on a
     // weapon slot: JEWELRY (type 4) collides with TWO_HANDED_SWORD (4).
-    const pieceCount =
-      isWeaponSlot(item.slot) && isAnyTwoHandedWeapon(item.type as WeaponType) ? 2 : 1;
+    const pieceCount = isWeaponSlot(item.slot) && isAnyTwoHandedWeapon(item.type) ? 2 : 1;
     setCounts.set(name, (setCounts.get(name) ?? 0) + pieceCount);
   }
 

--- a/src/utils/weaponClassificationUtils.ts
+++ b/src/utils/weaponClassificationUtils.ts
@@ -5,17 +5,23 @@
 
 import { WeaponType } from '../types/playerDetails';
 
-// Weapon type sets for efficient lookups
-const ONE_HANDED_WEAPONS = Object.freeze(
-  new Set([WeaponType.AXE, WeaponType.SWORD, WeaponType.DAGGER, WeaponType.MACE]),
+// Weapon type sets for efficient lookups.
+//
+// Typed as ReadonlySet<number> — not Set<WeaponType> — because callers pass raw
+// `PlayerGear.type` codes straight from the log payload, which include values
+// WeaponType does not model (0 = not reported, armor codes on non-weapon slots).
+// Membership testing is well-defined for those; narrowing the sets would only
+// force every call site back into an `as WeaponType` cast.
+const ONE_HANDED_WEAPONS: ReadonlySet<number> = Object.freeze(
+  new Set<number>([WeaponType.AXE, WeaponType.SWORD, WeaponType.DAGGER, WeaponType.MACE]),
 );
 
-const TWO_HANDED_WEAPONS = Object.freeze(
-  new Set([WeaponType.TWO_HANDED_SWORD, WeaponType.TWO_HANDED_AXE, WeaponType.MAUL]),
+const TWO_HANDED_WEAPONS: ReadonlySet<number> = Object.freeze(
+  new Set<number>([WeaponType.TWO_HANDED_SWORD, WeaponType.TWO_HANDED_AXE, WeaponType.MAUL]),
 );
 
-const STAFF_WEAPONS = Object.freeze(
-  new Set([
+const STAFF_WEAPONS: ReadonlySet<number> = Object.freeze(
+  new Set<number>([
     WeaponType.FROST_STAFF,
     WeaponType.INFERNO_STAFF,
     WeaponType.LIGHTNING_STAFF,
@@ -23,8 +29,8 @@ const STAFF_WEAPONS = Object.freeze(
   ]),
 );
 
-const DOUBLE_SET_TYPES = Object.freeze(
-  new Set([
+const DOUBLE_SET_TYPES: ReadonlySet<number> = Object.freeze(
+  new Set<number>([
     WeaponType.FROST_STAFF,
     WeaponType.INFERNO_STAFF,
     WeaponType.LIGHTNING_STAFF,
@@ -38,51 +44,56 @@ const DOUBLE_SET_TYPES = Object.freeze(
 // ========================================
 
 /**
- * Determines if a weapon type is 1-handed
+ * Determines if a weapon type is 1-handed.
+ *
+ * Takes a raw type code (`PlayerGear.type`) rather than `WeaponType`: log
+ * payloads report codes this app does not model, and an unknown code is simply
+ * not a 1H weapon. Callers must already have gated on a weapon slot, since
+ * armor codes collide numerically with weapon codes.
  */
-export function isOneHandedWeapon(weaponType: WeaponType): boolean {
+export function isOneHandedWeapon(weaponType: number): boolean {
   return ONE_HANDED_WEAPONS.has(weaponType);
 }
 
 /**
  * Determines if a weapon type is 2-handed (excluding staves)
  */
-export function isTwoHandedWeapon(weaponType: WeaponType): boolean {
+export function isTwoHandedWeapon(weaponType: number): boolean {
   return TWO_HANDED_WEAPONS.has(weaponType);
 }
 
 /**
  * Determines if a weapon type is a staff (2-handed magical weapon)
  */
-export function isStaff(weaponType: WeaponType): boolean {
+export function isStaff(weaponType: number): boolean {
   return STAFF_WEAPONS.has(weaponType);
 }
 
 /**
  * Determines if a weapon type is any 2-handed weapon (including staves)
  */
-export function isAnyTwoHandedWeapon(weaponType: WeaponType): boolean {
+export function isAnyTwoHandedWeapon(weaponType: number): boolean {
   return isTwoHandedWeapon(weaponType) || isStaff(weaponType);
 }
 
 /**
  * Determines if a weapon counts as double set pieces
  */
-export function isDoubleSetWeapon(weaponType: WeaponType): boolean {
+export function isDoubleSetWeapon(weaponType: number): boolean {
   return DOUBLE_SET_TYPES.has(weaponType);
 }
 
 /**
  * Determines if a weapon is a mace (for Twin Blade and Blunt passive)
  */
-export function isMace(weaponType: WeaponType): boolean {
+export function isMace(weaponType: number): boolean {
   return weaponType === WeaponType.MACE;
 }
 
 /**
  * Determines if a weapon can be dual wielded
  */
-export function canDualWield(weaponType: WeaponType): boolean {
+export function canDualWield(weaponType: number): boolean {
   return isOneHandedWeapon(weaponType);
 }
 


### PR DESCRIPTION
## Summary

`PlayerGear.trait` and `PlayerGear.type` now hold plain `number` — the raw ESO Logs codes they always carried — instead of enum types that could not express most real values. The enums stay as named-constant lookups for the handful of comparisons that need them. This removes 16 `as` casts and the class of cast that Copilot flagged in #1413.

## Problem

`GearTrait` declared only `SHARPENED = 32` and `REINFORCED = 8`, but ESO has ~30 traits and real combat-log payloads contain the rest. `GearType = WeaponType | ArmorType` had the same gap for the "unknown / not reported" case (`0`).

Because the declared types were narrower than the data, callers had to launder out-of-domain values through the enums with `as`, which defeats the safety the enums were supposed to provide:

- `src/utils/__tests__/playerToBuild.test.ts` cast traits 40, 53 and 43 as `PlayerGear['trait']`
- `src/features/role_detection/__tests__/extractSignals.test.ts` had `trait: 0 as GearTrait`
- `src/features/build-leaderboard/hooks/useArchetypeBuildActions.ts` cast `(piece.trait ?? 0) as GearTrait` and `0 as GearType`, because the ESO Logs `characterRankings` API does not report item type at all

Copilot flagged the build-leaderboard casts in #1413. They were left alone there because this was a pre-existing shared-type gap (87 `GearTrait` references across 22 files), not something that PR introduced.

## Root Cause

The enums were modelling a *closed domain* that the data source does not actually have. ESO Logs reports opaque numeric codes; this app only has names for a few of them.

Notably the codebase already said as much — `src/utils/combatLogGearMapping.ts` documents these fields as "opaque numeric codes", and the decode table `TRAIT_NAMES` is already typed `Record<number, string>`. The field declarations were the outlier.

## Approach

Two options were considered:

- **(a)** declare the full ~30-member trait enum plus an explicit `UNKNOWN = 0`
- **(b)** widen the fields to `number` and keep the enums as named-constant lookups

**(b) was chosen.** A survey of all 87 `GearTrait` references found that production code touches the enums in exactly four places, all simple equality checks:

- `src/features/parse_analysis/utils/parseAnalysisUtils.ts:2086`
- `src/utils/damageReductionUtils.ts:310`
- `src/utils/gearUtilities.ts:271` and `:296`

Everything else is test fixtures. There are no exhaustive switches and no `Record<GearTrait, …>` maps, so nothing depended on the enum being a complete domain. Option (a) would have meant maintaining a 30-member enum in lockstep with the game purely to satisfy casts, while option (b) makes the type say what the data actually is.

## Changes Made

- **`src/types/playerDetails.ts`** — `PlayerGear.trait` and `PlayerGear.type` are now `number`, documented as raw codes with `0` = "not reported". `GearTrait` / `ArmorType` / `WeaponType` are documented as named-constant lookups, not exhaustive domains. `GearType` is retained and re-documented as "the codes this app has names for", explicitly *not* the type of the field.
- **`src/utils/weaponClassificationUtils.ts`** — the seven predicates accept a raw `number`; the lookup sets are typed `ReadonlySet<number>`. Without this the widening would have relocated the casts to the call sites rather than removing them.
- **`src/utils/armorUtils.ts`** — `resolveArmorType` returns `number`, since `item.type` passes through unchanged for non-mythics.
- **Casts removed (16 total):** 6 `as WeaponType` across `gearUtilities.ts`, `logToRoster.ts` and `playerToBuild.ts`; 8 in `playerToBuild.test.ts`; 2 in `extractSignals.test.ts`. Plus the 2 in `useArchetypeBuildActions.ts` that motivated this work, and 3 now-orphaned imports.

One cast was deliberately kept: `'INVALID' as unknown as number` in `damageReductionUtils.test.ts` injects a non-numeric value to exercise a runtime guard, so it needs a double cast either way. It was retargeted to `number` and annotated.

No behaviour changes — every touched site was an equality check or a `Set.has` membership test, both of which are well-defined on the wider type.

## Testing Done

- [x] TypeScript compiles (`npm run typecheck`)
- [x] Test sources typecheck (`npm run typecheck:test`)
- [x] ESLint passes (`npm run lint`)
- [x] Formatting passes (`npm run format:check`)
- [x] Pre-commit validation passes (`npm run validate`)
- [x] Full unit suite passes — 362 suites, 4738 tests, 0 failures
- [ ] Screenshots — not applicable, no UI/`.tsx` changes

### Note for reviewers running validation locally

Two pre-existing environment traps, unrelated to this change, will bite anyone validating from a `.claude/worktrees/` path:

- `npm run typecheck` can fail with `TS5103: Invalid value for '--ignoreDeprecations'` when `node_modules` is stale — `package.json` and the lockfile pin TypeScript 6.0.3, but an older tree may still have 5.9.3 installed.
- Jest discovers **0 tests** inside a `.claude/...` path, because `testMatch` is anchored to `<rootDir>` and the `.claude` dot gets escaped into the glob. Also note `npm test` bakes in `--onlyChanged`, so it is not the full suite.
