### PR TITLE
fix(api): fit both scheduled passes into one cron trigger

### DIFF
--- a/roster-hub-api/src/cron-schedule.ts
+++ b/roster-hub-api/src/cron-schedule.ts
@@ -1,0 +1,30 @@
+/**
+ * Which work a scheduled invocation should do.
+ *
+ * The worker wants two passes a day — a full one in the morning and a
+ * DPS-ingest-only one in the afternoon — but the Cloudflare account is on the
+ * free plan, capped at FIVE cron triggers across ALL workers, and four of those
+ * belong to other projects. Declaring two separate crons here therefore fails
+ * to register at deploy time (`code: 10072`), silently leaving the second pass
+ * not running at all.
+ *
+ * One expression with a list — `0 4,16 * * *` — is a SINGLE trigger that fires
+ * at both hours, so it fits in the one slot this worker has. The cost is that
+ * `event.cron` is then the same string for both firings and can no longer tell
+ * them apart; the fire time can.
+ */
+
+/** UTC hour before which a firing is treated as the full daily pass. */
+const FULL_RUN_BEFORE_UTC_HOUR = 12;
+
+/**
+ * True when this firing should do the full daily work (temp-build cleanup and
+ * the roster sync) in addition to the DPS parse ingest that runs every time.
+ *
+ * Keyed off the scheduled time rather than the cron string so a combined
+ * `0 4,16 * * *` expression still distinguishes the morning pass from the
+ * afternoon one.
+ */
+export function isFullDailyRun(scheduledTimeMs: number): boolean {
+  return new Date(scheduledTimeMs).getUTCHours() < FULL_RUN_BEFORE_UTC_HOUR;
+}

--- a/roster-hub-api/src/index.ts
+++ b/roster-hub-api/src/index.ts
@@ -9,6 +9,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { clientIpFromHeaders, validateToken } from './auth';
+import { isFullDailyRun } from './cron-schedule';
 import {
   listRosters,
   getRosterById,
@@ -2397,15 +2398,20 @@ export default {
   fetch: app.fetch,
 
   /**
-   * Two triggers (see wrangler.toml):
+   * ONE trigger firing twice a day (see wrangler.toml, `0 4,16 * * *`):
    *   04:00 UTC — temp-build cleanup + roster sync + DPS parse ingest
    *   16:00 UTC — DPS parse ingest only
+   *
+   * It is a single combined expression because the account is at the free-plan
+   * cap of five cron triggers; two separate crons fail to register and the
+   * second pass then never runs. `event.cron` is identical for both firings, so
+   * the pass is derived from the fire time — see cron-schedule.ts.
    *
    * Each job is isolated in its own try/catch. Previously a throw in
    * `cleanupExpiredTempBuilds` would silently skip the roster sync for that day.
    */
   async scheduled(event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
-    const isDailyRun = event.cron === '0 4 * * *';
+    const isDailyRun = isFullDailyRun(event.scheduledTime);
 
     if (isDailyRun) {
       try {

--- a/roster-hub-api/wrangler.toml
+++ b/roster-hub-api/wrangler.toml
@@ -28,7 +28,12 @@ binding = "AI"
 # Two DPS passes a day cover the full ~35-boss rotation (20 encounters per run).
 # The handler branches on `event.cron`; see the `scheduled` export in src/index.ts.
 [triggers]
-crons = ["0 4 * * *", "0 16 * * *"]
+# ONE trigger, two fire times. The account is on the Workers Free plan, capped
+# at 5 cron triggers across ALL workers, and 4 are used by other projects — so a
+# second entry here fails to register (code 10072) and that pass silently never
+# runs. A list expression costs one slot and fires at both hours; the handler
+# tells the passes apart by fire time (src/cron-schedule.ts).
+crons = ["0 4,16 * * *"]
 
 [vars]
 ALLOWED_ORIGINS = "https://esotk.com,https://www.esotk.com,https://esohelpers.com,https://www.esohelpers.com,https://eso-toolkit.github.io,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:5173"

--- a/src/graphql/rosterHubCronSchedule.test.ts
+++ b/src/graphql/rosterHubCronSchedule.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The roster-hub-api worker runs two scheduled passes a day from ONE cron
+ * trigger (`0 4,16 * * *`), because the Cloudflare account is at the free-plan
+ * cap of five triggers. `event.cron` is therefore identical for both firings
+ * and the pass has to be derived from the fire time.
+ *
+ * Getting this wrong is silent: the 04:00 pass owns the temp-build cleanup and
+ * the roster sync, so a bad predicate means those simply stop happening.
+ */
+import { isFullDailyRun } from '../../roster-hub-api/src/cron-schedule';
+
+/** Epoch ms for a given UTC hour on a fixed date. */
+const atUtcHour = (hour: number, minute = 0): number => Date.UTC(2026, 7, 5, hour, minute, 0, 0);
+
+describe('isFullDailyRun', () => {
+  it('treats the 04:00 UTC firing as the full daily pass', () => {
+    expect(isFullDailyRun(atUtcHour(4))).toBe(true);
+  });
+
+  it('treats the 16:00 UTC firing as the DPS-only pass', () => {
+    expect(isFullDailyRun(atUtcHour(16))).toBe(false);
+  });
+
+  it('splits the day at noon UTC', () => {
+    expect(isFullDailyRun(atUtcHour(11, 59))).toBe(true);
+    expect(isFullDailyRun(atUtcHour(12))).toBe(false);
+  });
+
+  it('is unaffected by the local timezone of whatever runs it', () => {
+    // getUTCHours, not getHours: a Worker isolate is UTC but a dev machine
+    // running these helpers is not, and the pass must not flip because of that.
+    const morning = new Date(atUtcHour(4));
+    expect(morning.getUTCHours()).toBe(4);
+    expect(isFullDailyRun(morning.getTime())).toBe(true);
+  });
+
+  it('classifies every hour of the day exactly once', () => {
+    const full: number[] = [];
+    const dpsOnly: number[] = [];
+    for (let h = 0; h < 24; h += 1) (isFullDailyRun(atUtcHour(h)) ? full : dpsOnly).push(h);
+    expect(full).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(dpsOnly).toEqual([12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]);
+  });
+});


### PR DESCRIPTION
## The problem

#1413 added a second cron to `roster-hub-api`:

```toml
crons = ["0 4 * * *", "0 16 * * *"]
```

The Cloudflare account is on the **Workers Free plan — 5 cron triggers across ALL workers** — and four are already taken by unrelated projects:

| Worker | Crons |
|---|---|
| `hemp-discord-bot` | **2** (`0 11 * * *`, `0 14 * * 6`) |
| `kalpa-pack-hub` | 1 (`0 0 * * *`) |
| `tjamesontax` | 1 (`0 */6 * * *`) |
| **`roster-hub-api`** | 1 (`0 4 * * *`) |

So registering a second trigger here fails with `code: 10072`. Two consequences, both silent:

1. **The 16:00 pass has never run.** `syncDpsParses` fires once a day, not twice — the account only ever accepted the original `0 4 * * *`.
2. **Every deploy of this worker reports failure** *after* the script has already uploaded, so CI (`deploy-worker.yml`) goes red on a deploy that actually shipped.

## The fix

`0 4,16 * * *` is **one** trigger that fires at both hours — it fits the single slot this worker already holds. No plan upgrade, and no touching another project's triggers.

The catch: `event.cron` is then the same string for both firings, so the existing `event.cron === '0 4 * * *'` test would be false at *both* times and the 04:00 work (temp-build cleanup + roster sync) would stop entirely. The pass is now derived from `event.scheduledTime` instead, in `src/cron-schedule.ts`.

## Verification

- 5 unit tests on the split, incl. the noon boundary and a full 24-hour classification sweep
- worker typecheck, `typecheck:test`, lint (`--max-warnings 0`), format all clean
- `wrangler deploy --dry-run` builds clean; the real deploy is the proof the trigger registers

## Follow-up for the account owner

Only **1 of 5** cron slots belongs to ESO Toolkit. If more scheduled work is coming, Workers Paid raises the cap to 1,000 — or `hemp-discord-bot`/`tjamesontax` could give a slot back if they are dormant.
