### PR TITLE
chore(test): shrink the typecheck quarantine 34 → 24 files

### DIFF
--- a/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
+++ b/src/components/SkillTooltip.kalpa-ground-truth.test.tsx
@@ -35,6 +35,7 @@ const baseProps: SkillTooltipProps = {
   abilityId: 217784,
   iconSlug: 'ability_grimoire_soulmagic1',
   lineText: 'Scribing — Wield Soul',
+  description: '',
 };
 
 describe('SkillTooltip - Kalpa ground-truth scripts', () => {
@@ -96,7 +97,7 @@ describe('SkillTooltip - Kalpa ground-truth scripts', () => {
 
   it('renders ground-truth scripts even when the skill was never cast (no inference)', () => {
     mockUseSkillScribingData.mockReturnValue({
-      scribedSkillData: undefined,
+      scribedSkillData: null,
       loading: false,
       error: null,
     });

--- a/src/features/report_summary/__tests__/EnhancedDeathAnalysisSection.test.tsx
+++ b/src/features/report_summary/__tests__/EnhancedDeathAnalysisSection.test.tsx
@@ -17,6 +17,8 @@ const analysis: ReportDeathAnalysis = {
       playerName: 'Alice',
       totalDeaths: 1,
       averageTimeAlive: 45_000, // 45s — stored in ms, rendered as seconds
+      // Distinct from averageTimeAlive so the ms->s assertions stay unambiguous.
+      averageTimeAliveTotal: 90_000,
       fightDeaths: [],
       topCausesOfDeath: [],
     },
@@ -29,6 +31,7 @@ const analysis: ReportDeathAnalysis = {
       percentage: 100,
       playersAffected: ['Alice'],
       fightsWithDeaths: [1],
+      averageKillingBlowHitSize: 0,
       averageKillingBlowDamage: 1000,
       category: MechanicCategory.DIRECT_DAMAGE,
     },

--- a/src/hooks/useSelectedFight.test.tsx
+++ b/src/hooks/useSelectedFight.test.tsx
@@ -5,6 +5,7 @@ import { createStore, combineReducers, Store } from 'redux';
 
 import { FightFragment, ReportFragment } from '../graphql/gql/graphql';
 import { ReportFightContext } from '../ReportFightContext';
+import type { TabId } from '../utils/getSkeletonForTab';
 
 import { useReportData } from './useReportData';
 import { useSelectedFight } from './useSelectedFight';
@@ -16,6 +17,7 @@ jest.mock('./useReportData');
 // Mock fight data
 const mockFight1: FightFragment = {
   __typename: 'ReportFight',
+  encounterID: 0,
   id: 1,
   startTime: 1000,
   endTime: 2000,
@@ -32,6 +34,7 @@ const mockFight1: FightFragment = {
 
 const mockFight2: FightFragment = {
   __typename: 'ReportFight',
+  encounterID: 0,
   id: 2,
   startTime: 2000,
   endTime: 3000,
@@ -81,9 +84,16 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
 }) => {
   const store = createMockStore();
 
+  // The hook only reads reportId/fightId; the rest of the context is required by
+  // the type, so stub it rather than widening the context contract for a test.
   const contextValue = {
     reportId,
     fightId,
+    tabId: null,
+    selectedTabId: 'summary' as TabId,
+    showExperimentalTabs: false,
+    setSelectedTab: jest.fn(),
+    setShowExperimentalTabs: jest.fn(),
   };
 
   return (
@@ -102,6 +112,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -115,6 +127,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: true,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -128,6 +142,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: null,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -146,6 +162,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: emptyReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -159,6 +177,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -172,6 +192,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -185,6 +207,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -198,6 +222,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -211,6 +237,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result, rerender } = renderHook(() => useSelectedFight(), {
@@ -232,6 +260,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -250,6 +280,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: reportDataWithUndefinedFights,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result } = renderHook(() => useSelectedFight(), {
@@ -263,6 +295,8 @@ describe('useSelectedFight', () => {
     mockUseReportData.mockReturnValue({
       reportData: mockReportData,
       isReportLoading: false,
+      reportError: null,
+      refetchReport: jest.fn(),
     });
 
     const { result, rerender } = renderHook(() => useSelectedFight(), {

--- a/src/store/worker_results/workerTaskSliceFactory.test.ts
+++ b/src/store/worker_results/workerTaskSliceFactory.test.ts
@@ -25,11 +25,42 @@ jest.mock('@/workers', () => ({
 describe('workerTaskSliceFactory', () => {
   let mockWorkerManager: jest.Mocked<typeof workerManager>;
 
-  const mockTaskName = 'calculateActorPositions' as ReduxBackedWorkerTaskType;
-  const mockInput = { reportCode: 'test', fightId: 1 } as SharedWorkerInputType<
+  const mockTaskName = 'calculateActorPositions' satisfies ReduxBackedWorkerTaskType;
+  // This suite exercises the slice's STATE MACHINE — loading flags, result
+  // caching, request-id races, abort handling — not payload shape. The real
+  // task type wants a whole FightFragment plus FightEvents; an opaque stand-in
+  // keeps the tests about what they are actually asserting.
+  const mockInput = { reportCode: 'test', fightId: 1 } as unknown as SharedWorkerInputType<
     typeof mockTaskName
   >;
-  const mockResult = { positions: [{ x: 1, y: 2 }] } as SharedWorkerResultType<typeof mockTaskName>;
+  const mockResult = { positions: [{ x: 1, y: 2 }] } as unknown as SharedWorkerResultType<
+    typeof mockTaskName
+  >;
+
+  /**
+   * Store type derived from a REAL configureStore call. A bare
+   * `ReturnType<typeof configureStore>` resolves to the no-argument overload,
+   * whose Dispatch lacks the thunk signature, so `store.dispatch(someThunk)`
+   * would not typecheck even though it is exactly what the slice is for.
+   */
+  function makeTaskStore(taskName: ReduxBackedWorkerTaskType, reducer: TaskSlice['reducer']) {
+    const store = configureStore({
+      reducer: {
+        workerResults: combineReducers({ [taskName]: reducer }),
+      },
+    });
+    // The slice's thunks are typed against the app's FULL RootState, while this
+    // suite deliberately mounts only the worker slice — so the dispatch overload
+    // does not line up even though the runtime behaviour is identical. Widen the
+    // dispatch rather than dragging every app reducer into a unit test.
+    return store as Omit<typeof store, 'dispatch'> & {
+      dispatch: ((action: unknown) => Promise<unknown> & { abort: (reason?: string) => void }) &
+        typeof store.dispatch;
+    };
+  }
+  type TaskStore = ReturnType<typeof makeTaskStore>;
+  /** Slice instantiated for THIS suite's task, so input/result types stay concrete. */
+  type TaskSlice = ReturnType<typeof createWorkerTaskSlice<typeof mockTaskName>>;
 
   const createInputHash = (input: SharedWorkerInputType<typeof mockTaskName>): string => {
     return JSON.stringify(input);
@@ -87,18 +118,12 @@ describe('workerTaskSliceFactory', () => {
   });
 
   describe('reducer actions', () => {
-    let store: ReturnType<typeof configureStore>;
-    let workerSlice: ReturnType<typeof createWorkerTaskSlice>;
+    let store: TaskStore;
+    let workerSlice: TaskSlice;
 
     beforeEach(() => {
       workerSlice = createWorkerTaskSlice(mockTaskName, createInputHash);
-      store = configureStore({
-        reducer: {
-          workerResults: combineReducers({
-            [mockTaskName]: workerSlice.reducer,
-          }),
-        },
-      });
+      store = makeTaskStore(mockTaskName, workerSlice.reducer);
     });
 
     describe('startTask', () => {
@@ -278,18 +303,12 @@ describe('workerTaskSliceFactory', () => {
   });
 
   describe('executeTask async thunk', () => {
-    let store: ReturnType<typeof configureStore>;
-    let workerSlice: ReturnType<typeof createWorkerTaskSlice>;
+    let store: TaskStore;
+    let workerSlice: TaskSlice;
 
     beforeEach(() => {
       workerSlice = createWorkerTaskSlice(mockTaskName, createInputHash);
-      store = configureStore({
-        reducer: {
-          workerResults: combineReducers({
-            [mockTaskName]: workerSlice.reducer,
-          }),
-        },
-      });
+      store = makeTaskStore(mockTaskName, workerSlice.reducer);
     });
 
     describe('pending', () => {
@@ -412,9 +431,10 @@ describe('workerTaskSliceFactory', () => {
       });
 
       it('should execute if input is different', async () => {
-        const differentInput = { reportCode: 'different', fightId: 2 } as SharedWorkerInputType<
-          typeof mockTaskName
-        >;
+        const differentInput = {
+          reportCode: 'different',
+          fightId: 2,
+        } as unknown as SharedWorkerInputType<typeof mockTaskName>;
 
         mockWorkerManager.executeTask
           .mockResolvedValueOnce(mockResult)
@@ -452,9 +472,10 @@ describe('workerTaskSliceFactory', () => {
           .mockReturnValueOnce(aPromise as never) // input A stays pending
           .mockResolvedValueOnce(mockResult); // input B resolves
 
-        const differentInput = { reportCode: 'different', fightId: 2 } as SharedWorkerInputType<
-          typeof mockTaskName
-        >;
+        const differentInput = {
+          reportCode: 'different',
+          fightId: 2,
+        } as unknown as SharedWorkerInputType<typeof mockTaskName>;
 
         const firstExecution = store.dispatch(workerSlice.executeTask(mockInput));
         // Dispatch B while A is still loading (A has not resolved).
@@ -477,10 +498,10 @@ describe('workerTaskSliceFactory', () => {
       it('should handle concurrent requests with latest result winning', async () => {
         // Test that when multiple requests are dispatched rapidly,
         // the system handles them gracefully and the latest completion is preserved
-        const firstResult = { positions: [{ x: 1, y: 1 }] } as SharedWorkerResultType<
+        const firstResult = { positions: [{ x: 1, y: 1 }] } as unknown as SharedWorkerResultType<
           typeof mockTaskName
         >;
-        const secondResult = { positions: [{ x: 2, y: 2 }] } as SharedWorkerResultType<
+        const secondResult = { positions: [{ x: 2, y: 2 }] } as unknown as SharedWorkerResultType<
           typeof mockTaskName
         >;
 
@@ -493,9 +514,10 @@ describe('workerTaskSliceFactory', () => {
         const firstExecution = store.dispatch(workerSlice.executeTask(mockInput));
 
         // Dispatch second request with different input (bypasses cache condition)
-        const secondInput = { reportCode: 'second', fightId: 2 } as SharedWorkerInputType<
-          typeof mockTaskName
-        >;
+        const secondInput = {
+          reportCode: 'second',
+          fightId: 2,
+        } as unknown as SharedWorkerInputType<typeof mockTaskName>;
         const secondExecution = store.dispatch(workerSlice.executeTask(secondInput));
 
         // Wait for both to complete
@@ -533,16 +555,17 @@ describe('workerTaskSliceFactory', () => {
       });
 
       it('should return cached result without calling worker', async () => {
-        const firstInput = { reportCode: 'first', fightId: 1 } as SharedWorkerInputType<
+        const firstInput = { reportCode: 'first', fightId: 1 } as unknown as SharedWorkerInputType<
           typeof mockTaskName
         >;
-        const secondInput = { reportCode: 'second', fightId: 2 } as SharedWorkerInputType<
+        const secondInput = {
+          reportCode: 'second',
+          fightId: 2,
+        } as unknown as SharedWorkerInputType<typeof mockTaskName>;
+        const firstResult = { positions: [{ x: 1, y: 1 }] } as unknown as SharedWorkerResultType<
           typeof mockTaskName
         >;
-        const firstResult = { positions: [{ x: 1, y: 1 }] } as SharedWorkerResultType<
-          typeof mockTaskName
-        >;
-        const secondResult = { positions: [{ x: 2, y: 2 }] } as SharedWorkerResultType<
+        const secondResult = { positions: [{ x: 2, y: 2 }] } as unknown as SharedWorkerResultType<
           typeof mockTaskName
         >;
 
@@ -577,11 +600,13 @@ describe('workerTaskSliceFactory', () => {
         const inputs = Array.from({ length: 4 }, (_, i) => ({
           reportCode: `report-${i}`,
           fightId: i,
-        })) as SharedWorkerInputType<typeof mockTaskName>[];
+        })) as unknown as SharedWorkerInputType<typeof mockTaskName>[];
 
         const results = inputs.map(
           (_, i) =>
-            ({ positions: [{ x: i, y: i }] }) as SharedWorkerResultType<typeof mockTaskName>,
+            ({ positions: [{ x: i, y: i }] }) as unknown as SharedWorkerResultType<
+              typeof mockTaskName
+            >,
         );
 
         results.forEach((r) => mockWorkerManager.executeTask.mockResolvedValueOnce(r));
@@ -699,13 +724,7 @@ describe('workerTaskSliceFactory', () => {
         } as typeof AbortController;
 
         const abortSlice = createWorkerTaskSlice(mockTaskName, abortingHash);
-        const abortStore = configureStore({
-          reducer: {
-            workerResults: combineReducers({
-              [mockTaskName]: abortSlice.reducer,
-            }),
-          },
-        });
+        const abortStore = makeTaskStore(mockTaskName, abortSlice.reducer);
 
         try {
           const promise = abortStore.dispatch(abortSlice.executeTask(mockInput));

--- a/src/utils/BuffLookupUtils.test.ts
+++ b/src/utils/BuffLookupUtils.test.ts
@@ -37,6 +37,7 @@ describe('BuffLookupUtils', () => {
     targetID,
     targetIsFriendly: true,
     abilityGameID,
+    extraAbilityGameID: 0,
     fight: 1,
   });
 
@@ -53,6 +54,7 @@ describe('BuffLookupUtils', () => {
     targetID,
     targetIsFriendly: false,
     abilityGameID,
+    extraAbilityGameID: 0,
     fight: 1,
   });
 
@@ -68,6 +70,7 @@ describe('BuffLookupUtils', () => {
     targetID,
     targetIsFriendly: false,
     abilityGameID,
+    extraAbilityGameID: 0,
     fight: 1,
   });
 

--- a/src/workers/calculations/CalculateCriticalDamage.test.ts
+++ b/src/workers/calculations/CalculateCriticalDamage.test.ts
@@ -33,9 +33,22 @@ describe('CalculateCriticalDamage', () => {
   });
 
   const createMockBuffLookupData = (
-    intervals: Record<string, Array<{ start: number; end: number; targetID: number }>>,
+    intervals: Record<
+      string,
+      Array<{ start: number; end: number; targetID: number; sourceID?: number }>
+    >,
   ) => ({
-    buffIntervals: intervals,
+    // BuffTimeInterval requires sourceID; these fixtures never vary it,
+
+    // so default it rather than restating it at every call site.
+
+    buffIntervals: Object.fromEntries(
+      Object.entries(intervals).map(([ability, list]) => [
+        ability,
+
+        list.map((interval) => ({ sourceID: 0, ...interval })),
+      ]),
+    ),
   });
   // Helper to create mock damage events for testing
   const createMockDamageEvents = (): DamageEvent[] => {

--- a/src/workers/calculations/CalculateDamageReduction.test.ts
+++ b/src/workers/calculations/CalculateDamageReduction.test.ts
@@ -31,9 +31,22 @@ describe('CalculateDamageReduction', () => {
   });
 
   const createMockBuffLookupData = (
-    intervals: Record<string, Array<{ start: number; end: number; targetID: number }>>,
+    intervals: Record<
+      string,
+      Array<{ start: number; end: number; targetID: number; sourceID?: number }>
+    >,
   ) => ({
-    buffIntervals: intervals,
+    // BuffTimeInterval requires sourceID; these fixtures never vary it,
+
+    // so default it rather than restating it at every call site.
+
+    buffIntervals: Object.fromEntries(
+      Object.entries(intervals).map(([ability, list]) => [
+        ability,
+
+        list.map((interval) => ({ sourceID: 0, ...interval })),
+      ]),
+    ),
   });
 
   describe('calculateDamageReductionData', () => {

--- a/src/workers/calculations/CalculateElementalWeaknessStacks.test.ts
+++ b/src/workers/calculations/CalculateElementalWeaknessStacks.test.ts
@@ -13,9 +13,22 @@ describe('CalculateElementalWeaknessStacks', () => {
   const TARGET_ID = 123;
 
   const createMockBuffLookupData = (
-    intervals: Record<string, Array<{ start: number; end: number; targetID: number }>>,
+    intervals: Record<
+      string,
+      Array<{ start: number; end: number; targetID: number; sourceID?: number }>
+    >,
   ): BuffLookupData => ({
-    buffIntervals: intervals,
+    // BuffTimeInterval requires sourceID; these fixtures never vary it,
+
+    // so default it rather than restating it at every call site.
+
+    buffIntervals: Object.fromEntries(
+      Object.entries(intervals).map(([ability, list]) => [
+        ability,
+
+        list.map((interval) => ({ sourceID: 0, ...interval })),
+      ]),
+    ),
   });
 
   it('should return empty results when no elemental weakness debuffs are present', () => {

--- a/src/workers/calculations/CalculatePenetration.test.ts
+++ b/src/workers/calculations/CalculatePenetration.test.ts
@@ -33,9 +33,22 @@ describe('CalculatePenetration', () => {
   });
 
   const createMockBuffLookupData = (
-    intervals: Record<string, Array<{ start: number; end: number; targetID: number }>>,
+    intervals: Record<
+      string,
+      Array<{ start: number; end: number; targetID: number; sourceID?: number }>
+    >,
   ) => ({
-    buffIntervals: intervals,
+    // BuffTimeInterval requires sourceID; these fixtures never vary it,
+
+    // so default it rather than restating it at every call site.
+
+    buffIntervals: Object.fromEntries(
+      Object.entries(intervals).map(([ability, list]) => [
+        ability,
+
+        list.map((interval) => ({ sourceID: 0, ...interval })),
+      ]),
+    ),
   });
 
   // Helper to create mock damage events for testing

--- a/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
+++ b/src/workers/calculations/CalculateStatusEffectUptimes.test.ts
@@ -81,10 +81,10 @@ describe('CalculateStatusEffectUptimes', () => {
         expect(burningResult.icon).toBe('ability_mage_062');
 
         // Check target segmentation
-        expect(Object.keys(burningResult.targetData)).toHaveLength(1);
-        expect(burningResult.targetData[TARGET_ID_1]).toBeDefined();
+        expect(Object.keys(burningResult.targetData!)).toHaveLength(1);
+        expect(burningResult.targetData![TARGET_ID_1]).toBeDefined();
 
-        const targetData = burningResult.targetData[TARGET_ID_1];
+        const targetData = burningResult.targetData![TARGET_ID_1];
         expect(targetData.totalDuration).toBe(5000); // 5 seconds
         expect(targetData.uptime).toBe(5); // Converted to seconds
         expect(targetData.uptimePercentage).toBeCloseTo(25, 1); // 5/20 * 100 = 25%
@@ -110,19 +110,19 @@ describe('CalculateStatusEffectUptimes', () => {
         const burningResult = result[0];
 
         // Check that both targets are segmented correctly
-        expect(Object.keys(burningResult.targetData)).toHaveLength(2);
-        expect(burningResult.targetData[TARGET_ID_1]).toBeDefined();
-        expect(burningResult.targetData[TARGET_ID_2]).toBeDefined();
+        expect(Object.keys(burningResult.targetData!)).toHaveLength(2);
+        expect(burningResult.targetData![TARGET_ID_1]).toBeDefined();
+        expect(burningResult.targetData![TARGET_ID_2]).toBeDefined();
 
         // Target 1: 5 seconds (1000-6000ms)
-        const target1Data = burningResult.targetData[TARGET_ID_1];
+        const target1Data = burningResult.targetData![TARGET_ID_1];
         expect(target1Data.totalDuration).toBe(5000);
         expect(target1Data.uptime).toBe(5);
         expect(target1Data.uptimePercentage).toBeCloseTo(25, 1);
         expect(target1Data.applications).toBe(1);
 
         // Target 2: 7 seconds (3000-10000ms)
-        const target2Data = burningResult.targetData[TARGET_ID_2];
+        const target2Data = burningResult.targetData![TARGET_ID_2];
         expect(target2Data.totalDuration).toBe(7000);
         expect(target2Data.uptime).toBe(7);
         expect(target2Data.uptimePercentage).toBeCloseTo(35, 1);
@@ -148,8 +148,8 @@ describe('CalculateStatusEffectUptimes', () => {
         expect(result).toHaveLength(1);
         const poisonedResult = result[0];
 
-        expect(Object.keys(poisonedResult.targetData)).toHaveLength(1);
-        const targetData = poisonedResult.targetData[TARGET_ID_1];
+        expect(Object.keys(poisonedResult.targetData!)).toHaveLength(1);
+        const targetData = poisonedResult.targetData![TARGET_ID_1];
 
         // Total: 3s + 4s + 3s = 10 seconds
         expect(targetData.totalDuration).toBe(10000);
@@ -177,20 +177,20 @@ describe('CalculateStatusEffectUptimes', () => {
         const overchargedResult = result[0];
 
         expect(overchargedResult.isDebuff).toBe(false);
-        expect(Object.keys(overchargedResult.targetData)).toHaveLength(2);
+        expect(Object.keys(overchargedResult.targetData!)).toHaveLength(2);
 
         // Hostile-buff branch also resolves a canonical name + icon.
         expect(overchargedResult.abilityName).toBe('Overcharged');
         expect(overchargedResult.icon).toBe('death_recap_magic_dot_heavy');
 
         // Target 1: 6 seconds (2000-8000ms)
-        const target1Data = overchargedResult.targetData[TARGET_ID_1];
+        const target1Data = overchargedResult.targetData![TARGET_ID_1];
         expect(target1Data.totalDuration).toBe(6000);
         expect(target1Data.uptime).toBe(6);
         expect(target1Data.uptimePercentage).toBeCloseTo(30, 1);
 
         // Target 2: 7 seconds (5000-12000ms)
-        const target2Data = overchargedResult.targetData[TARGET_ID_2];
+        const target2Data = overchargedResult.targetData![TARGET_ID_2];
         expect(target2Data.totalDuration).toBe(7000);
         expect(target2Data.uptime).toBe(7);
         expect(target2Data.uptimePercentage).toBeCloseTo(35, 1);
@@ -235,19 +235,19 @@ describe('CalculateStatusEffectUptimes', () => {
         );
 
         // Burning affects both targets
-        expect(Object.keys(burningResult!.targetData)).toHaveLength(2);
-        expect(burningResult!.targetData[TARGET_ID_1]).toBeDefined();
-        expect(burningResult!.targetData[TARGET_ID_2]).toBeDefined();
+        expect(Object.keys(burningResult!.targetData!)).toHaveLength(2);
+        expect(burningResult!.targetData![TARGET_ID_1]).toBeDefined();
+        expect(burningResult!.targetData![TARGET_ID_2]).toBeDefined();
 
         // Poisoned affects only target 1
-        expect(Object.keys(poisonedResult!.targetData)).toHaveLength(1);
-        expect(poisonedResult!.targetData[TARGET_ID_1]).toBeDefined();
-        expect(poisonedResult!.targetData[TARGET_ID_2]).toBeUndefined();
+        expect(Object.keys(poisonedResult!.targetData!)).toHaveLength(1);
+        expect(poisonedResult!.targetData![TARGET_ID_1]).toBeDefined();
+        expect(poisonedResult!.targetData![TARGET_ID_2]).toBeUndefined();
 
         // Sundered affects only target 2
-        expect(Object.keys(sunderedResult!.targetData)).toHaveLength(1);
-        expect(sunderedResult!.targetData[TARGET_ID_1]).toBeUndefined();
-        expect(sunderedResult!.targetData[TARGET_ID_2]).toBeDefined();
+        expect(Object.keys(sunderedResult!.targetData!)).toHaveLength(1);
+        expect(sunderedResult!.targetData![TARGET_ID_1]).toBeUndefined();
+        expect(sunderedResult!.targetData![TARGET_ID_2]).toBeDefined();
       });
     });
 
@@ -276,17 +276,17 @@ describe('CalculateStatusEffectUptimes', () => {
         expect(result).toHaveLength(1);
         const burningResult = result[0];
 
-        expect(Object.keys(burningResult.targetData)).toHaveLength(2);
+        expect(Object.keys(burningResult.targetData!)).toHaveLength(2);
 
         // Target 1: Clipped to fight duration (20 seconds)
-        const target1Data = burningResult.targetData[TARGET_ID_1];
+        const target1Data = burningResult.targetData![TARGET_ID_1];
         expect(target1Data.totalDuration).toBe(FIGHT_DURATION);
         expect(target1Data.uptime).toBe(20);
         expect(target1Data.uptimePercentage).toBeCloseTo(100, 1);
         expect(target1Data.applications).toBe(1); // Only the valid interval counts
 
         // Target 2: Normal 5-second interval
-        const target2Data = burningResult.targetData[TARGET_ID_2];
+        const target2Data = burningResult.targetData![TARGET_ID_2];
         expect(target2Data.totalDuration).toBe(5000);
         expect(target2Data.uptime).toBe(5);
         expect(target2Data.uptimePercentage).toBeCloseTo(25, 1);
@@ -363,7 +363,7 @@ describe('CalculateStatusEffectUptimes', () => {
         expect(result).toHaveLength(1);
         const burningResult = result[0];
 
-        const targetData = burningResult.targetData[TARGET_ID_1];
+        const targetData = burningResult.targetData![TARGET_ID_1];
         expect(targetData.totalDuration).toBe(5000); // Only the valid interval
         expect(targetData.applications).toBe(1); // Zero-duration interval should be ignored
       });
@@ -400,13 +400,13 @@ describe('CalculateStatusEffectUptimes', () => {
 
         // Should be sorted by target count: Poisoned (3) > Hemorrhaging (2) > Burning (1)
         expect(result[0].abilityGameID).toBe(KnownAbilities.POISONED.toString());
-        expect(Object.keys(result[0].targetData)).toHaveLength(3);
+        expect(Object.keys(result[0].targetData!)).toHaveLength(3);
 
         expect(result[1].abilityGameID).toBe(KnownAbilities.HEMMORRHAGING.toString());
-        expect(Object.keys(result[1].targetData)).toHaveLength(2);
+        expect(Object.keys(result[1].targetData!)).toHaveLength(2);
 
         expect(result[2].abilityGameID).toBe(KnownAbilities.BURNING.toString());
-        expect(Object.keys(result[2].targetData)).toHaveLength(1);
+        expect(Object.keys(result[2].targetData!)).toHaveLength(1);
       });
 
       it('should set correct unique keys and metadata', () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -36,40 +36,32 @@
     "**/*.stories.ts",
     "**/*.stories.tsx",
 
-    // ── Quarantine (pre-existing test type errors; count at time of quarantine) ──
-    "src/features/report_details/synergy/synergyUtils.test.ts",
-    "src/features/report_summary/__tests__/ReportSummaryPage.test.tsx",
-    "src/features/report_summary/hooks/useOptimizedReportSummaryData.test.tsx",
-    "src/pages/ParseAnalysisPage.test.tsx",
-    "src/store/user_reports/userReportsSlice.test.ts",
-    "src/utils/BuffLookupUtils.test.ts",
-    "src/utils/classDetectionUtils.test.ts",
-    "src/workers/WorkerPool.test.ts",
+    // ── Quarantine: pre-existing test type errors, shrink-only ──
     "src/components/dashboard/DeathCausesWidget.test.tsx",
-    "src/components/SkillTooltip.kalpa-ground-truth.test.tsx",
     "src/features/build-editor/engine/stat-engine.baseClassPassives.test.ts",
     "src/features/fight_replay/components/MapMarkers.integration.test.tsx",
-    "src/features/loadout-manager/utils/__tests__/wizardsWardrobeSavedVariables.test.ts",
     "src/features/loadout-manager/utils/__tests__/wizardWardrobeImport.integration.test.ts",
+    "src/features/loadout-manager/utils/__tests__/wizardsWardrobeSavedVariables.test.ts",
     "src/features/parse_analysis/utils/parseAnalysisUtils.test.ts",
     "src/features/report_details/deaths/DeathEventPanel.test.tsx",
     "src/features/report_details/insights/StatusEffectUptimesPanel.integration.test.ts",
-    "src/features/report_summary/__tests__/EnhancedDeathAnalysisSection.test.tsx",
+    "src/features/report_details/synergy/synergyUtils.test.ts",
+    "src/features/report_summary/__tests__/ReportSummaryPage.test.tsx",
+    "src/features/report_summary/hooks/useOptimizedReportSummaryData.test.tsx",
     "src/features/scribing/analysis/__tests__/scribingDetectionAnalysis.affix-accuracy.test.ts",
-    "src/hooks/useSelectedFight.test.tsx",
     "src/hooks/useSelectedTargetIds.test.tsx",
+    "src/pages/ParseAnalysisPage.test.tsx",
     "src/pages/RaidDashboardPage.test.tsx",
     "src/player1-shattering-knife-new-architecture.test.ts",
     "src/store/report/reportSlice.test.ts",
     "src/store/storeWithHistory.test.ts",
     "src/store/user_reports/userReportsSelectors.test.ts",
-    "src/store/worker_results/workerTaskSliceFactory.test.ts",
+    "src/store/user_reports/userReportsSlice.test.ts",
+    "src/utils/classDetectionUtils.test.ts",
     "src/utils/errorTracking.test.ts",
     "src/utils/skillTooltipMapper.test.ts",
-    "src/workers/calculations/CalculateCriticalDamage.test.ts",
-    "src/workers/calculations/CalculateDamageReduction.test.ts",
-    "src/workers/calculations/CalculateElementalWeaknessStacks.test.ts",
-    "src/workers/calculations/CalculatePenetration.test.ts",
-    "src/workers/calculations/CalculateStatusEffectUptimes.test.ts"
+    "src/workers/WorkerPool.test.ts"
+
+    // ── Quarantine (pre-existing test type errors; count at time of quarantine) ──
   ]
 }


### PR DESCRIPTION
## What

Shrinks the `tsconfig.test.json` quarantine from **34 files to 24** (324 → 134 errors), by fixing the fixture drift underneath rather than the symptoms. The list has always been documented shrink-only; this is that.

## The four root causes

| Fix | Errors cleared |
|---|---|
| `createMockBuffLookupData`, copy-pasted across four calculation suites, omitted the required `BuffTimeInterval.sourceID`. Defaulted **inside the helper**, so no call site changed. | **103** |
| `workerTaskSliceFactory.test.ts` typed its store as `ReturnType<typeof configureStore>` — the *no-argument* overload, whose `Dispatch` has no thunk signature — and its slice as `ReturnType<typeof createWorkerTaskSlice>`, which drops the generic and collapses **every** task's input type into an impossible intersection. Pinning both took that file **35 → 0**. | **35** |
| `CalculateStatusEffectUptimes` asserts through `targetData`, which the result type marks optional (a deprecated back-compat field the calculator always populates — these assertions are what verify that). | **29** |
| `FightFragment` fixtures missing `encounterID`; context/hook mocks missing required members. | **15** |

Payload fixtures in suites that exercise a **state machine** rather than a payload shape (loading flags, cache eviction, request-id races, abort) are cast through `unknown` with the reason recorded inline — the real types want a whole `FightFragment` plus `FightEvents`, which would be noise, not coverage.

## Two things caught by running the tests, not the typechecker

- Adding the now-required `averageTimeAliveTotal: 45_000` made the component render a **second** `45s`, so an existing `getByText('45s')` became ambiguous and failed. Types were satisfied; the test was not. Given a distinct value — which is also a more honest fixture, since an average and a total should not be identical.
- One anchored replacement split a comment (`// 45s — stored in ms…`) across two lines and produced an invalid-character parse error. Caught and repaired.

## Verification

- `typecheck`, `typecheck:test`, `lint --max-warnings 0`, `format:check` all clean
- every touched suite re-run individually
- **full jest suite: 4729 passed, 0 failed**

The remaining 24 files stay quarantined so the gate is green, and the list still only shrinks.
