### PR TITLE
fix(api): surface silent DPS-sync failures

### DIFF
--- a/roster-hub-api/src/leaderboard-sync/dps-parse-sync.ts
+++ b/roster-hub-api/src/leaderboard-sync/dps-parse-sync.ts
@@ -198,9 +198,23 @@ export async function syncDpsParses(
     return [{ encounter: '(no targets)', encounterId: 0, status: 'error', rows: 0 }];
   }
 
-  const targets = await selectTargets(env, allTargets, opts);
   const pages = Math.max(1, opts.pages ?? PAGES_PER_ENCOUNTER);
-  const blocked = await getBlockedCharacterKeys(env.DB);
+
+  // Pre-flight database reads, guarded because they sit OUTSIDE the per-encounter
+  // try/catch below. A schema-level problem here throws past every encounter at
+  // once, and the cron handler's own catch only `console.error`s it — so the run
+  // wrote nothing, advanced no cursor, and left no trace. Returning it as a result
+  // instead means `/admin/sync-dps-parses` answers with the real reason.
+  let targets: DpsEncounterTarget[];
+  let blocked: Set<string>;
+  try {
+    targets = await selectTargets(env, allTargets, opts);
+    blocked = await getBlockedCharacterKeys(env.DB);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error('[dps-sync] preflight failed:', detail);
+    return [{ encounter: '(preflight failed)', encounterId: 0, status: 'error', rows: 0, detail }];
+  }
 
   for (const target of targets) {
     if (subrequests + pages > MAX_SUBREQUESTS_PER_RUN) {

--- a/roster-hub-api/wrangler.toml
+++ b/roster-hub-api/wrangler.toml
@@ -35,6 +35,14 @@ binding = "AI"
 # tells the passes apart by fire time (src/cron-schedule.ts).
 crons = ["0 4,16 * * *"]
 
+# Persistent logs. Every cron job runs inside its own try/catch that only
+# `console.error`s, so without this a failing scheduled pass is INVISIBLE — which
+# is exactly how `dps_parses` went unnoticed as missing from the database for two
+# days while the cron fired on schedule and aborted on the first query.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 ALLOWED_ORIGINS = "https://esotk.com,https://www.esotk.com,https://esohelpers.com,https://www.esohelpers.com,https://eso-toolkit.github.io,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:5173"
 DISCORD_BOT_URL = "https://eso-toolkit-discord-bot.eso-toolkit.workers.dev"


### PR DESCRIPTION
## Why

#1413's DPS parse sync has been producing **no output at all**, and nothing in the system said so.

Root cause: **`src/db/migration-dps-parses.sql` was never applied to the production D1 database.** Verified directly:

```
$ wrangler d1 execute roster-hub-db --remote --command "SELECT COUNT(*) FROM dps_parses"
no such table: dps_parses [code: 7500]
```

`sqlite_master` on `roster-hub-db` lists 20 tables; `dps_parses`, `dps_parse_blocklist` and `dps_parse_sync_state` are all absent. The worker itself is deployed and the cron is registered and firing — the schema simply is not there. `GET /dps-leaderboard/encounters` returns a 500 in production for the same reason.

Why it stayed invisible is the part worth fixing in code:

- `syncDpsParses` does its pre-flight reads (`listStaleSyncTargets`, `getBlockedCharacterKeys`) **outside** the per-encounter `try/catch`, so a schema-level error throws past every encounter at once — no rows, no cursor update, no `dps_parse_sync_state` row recording the failure.
- The `scheduled()` handler catches that run-level throw into a bare `console.error`.
- The worker had **no `[observability]` block**, so those logs were never retained. The error was written to a log nobody could read.

## What changed

- **`wrangler.toml`** — enable persistent logs (`[observability] enabled = true`, `head_sampling_rate = 1`). Without this any failing scheduled pass is undiagnosable after the fact.
- **`dps-parse-sync.ts`** — guard the pre-flight reads and return the failure as a `status: 'error'` result instead of letting it propagate. `/admin/sync-dps-parses` now answers with the real reason rather than an opaque 500.

No behavioural change on the success path.

## Still required (manual, not in this PR)

This PR makes the failure *visible*; it does not create the tables. That needs a production D1 write:

```
cd roster-hub-api
npx wrangler d1 execute roster-hub-db --remote --file=src/db/migration-dps-parses.sql
```

The migration is idempotent (`CREATE TABLE/INDEX IF NOT EXISTS` throughout) and purely additive — it creates three new tables and five indexes and touches no existing data. After it runs, `GET /dps-leaderboard/encounters` should return 200 with an empty list, and the next 16:00 UTC pass should populate it.

## Verification

- `npx tsc --noEmit -p roster-hub-api/tsconfig.json` — clean
- `npx wrangler deploy --dry-run` — config valid, `[observability]` accepted, bundle builds (272 KiB)
- `npx prettier --check` on the changed TS file — clean
- Root cause confirmed against the live database, not inferred
