### PR TITLE
fix(test): target the real replay transport, not a chapter-rail stop

### DIFF
--- a/playwright/nightly.config.ts
+++ b/playwright/nightly.config.ts
@@ -91,6 +91,17 @@ export default defineConfig({
     navigationTimeout: 60000,
     actionTimeout: 30000,
 
+    /* Emulate prefers-reduced-motion. SiteBackground is mounted on every route and runs
+       three infinite transform animations plus floating particles (NebulaBackground);
+       stacked on the GPU-less WebGL replay scene in CI that starves WebKit's main thread,
+       which is what inflated a scrollIntoViewIfNeeded to 13s and an actionability wait past
+       the 30s actionTimeout. The app already ships a prefers-reduced-motion kill switch, so
+       this exercises a supported code path and also makes screenshots deterministic.
+       Lives under contextOptions because Playwright 1.61 has no top-level `reducedMotion`
+       use-option; projects only override the keys they set, so this survives the
+       `...devices[...]` spreads below. */
+    contextOptions: { reducedMotion: 'reduce' },
+
     /* Always record traces for nightly runs */
     trace: 'retain-on-failure',
     video: 'retain-on-failure',

--- a/tests/nightly-regression-interactive.spec.ts
+++ b/tests/nightly-regression-interactive.spec.ts
@@ -326,17 +326,9 @@ test.describe('Nightly Regression - Interactive Features', () => {
         return;
       }
 
-      // Check if accordion is collapsed and expand it if needed
-      const accordion = page.locator('[data-testid*="trial-accordion"]').first();
-      if (await accordion.isVisible()) {
-        const isExpanded = await accordion.getAttribute('aria-expanded');
-        if (isExpanded === 'false' || isExpanded === null) {
-          const accordionSummary = accordion.locator('.MuiAccordionSummary-root');
-          await accordionSummary.click();
-          // Wait a moment for the accordion to expand
-          await page.waitForTimeout(2000);
-        }
-      }
+      // (No accordion expansion step: `[data-testid*="trial-accordion"]` matches nothing —
+      // the trial container in ReportFightsView is always expanded and imports no MUI
+      // Accordion, so the old block was dead code around an unguarded .click().)
 
       // Take screenshot of report page
       await page.screenshot({
@@ -419,60 +411,93 @@ test.describe('Nightly Regression - Interactive Features', () => {
         timeout: TEST_TIMEOUTS.navigation,
       });
 
-      // Wait for replay to load - this might take longer
-      await page.waitForTimeout(5000);
+      // The transport orb is the ONLY control in src/ whose accessible name is exactly
+      // "Play"/"Pause" (PlaybackButtons.tsx). An anchored RegExp name is matched
+      // case-sensitively against the FULL accessible name, so it can never re-match
+      // ", currently playing" (chapterAriaLabel in ChapterList.tsx, reused by
+      // ChapterRail.tsx), "Show playback controls", "Choose playback speed" or
+      // "Replay quality: …".
+      //
+      // Do NOT go back to `button[aria-label*="play"]`: CSS attribute matching is
+      // case-sensitive, so it never matched "Play" at all — it matched the lowercase
+      // "play" inside ", currently playing" and clicked the active chapter-rail stop
+      // instead, which is what hung this test for the full 30s actionTimeout on WebKit
+      // and let it pass vacuously everywhere else.
+      const playPause = page.getByRole('button', { name: /^(Play|Pause)$/ });
 
-      // Look for replay controls
-      const replayControls = page.locator(
-        'button[aria-label*="play"], button[aria-label*="pause"], .replay-controls, .play-button, .pause-button',
-      );
+      // When the fight has no actor-position data the arena renders a ReplayStatePanel
+      // instead of the transport (see FightReplay.tsx renderArena) — a legitimate skip,
+      // not a failure. Race the two terminal states rather than sleeping blindly.
+      const replayUnavailable = page
+        .getByText(/No position data for this fight|Couldn't load the replay|No fight selected/)
+        .first();
 
-      const hasReplayInterface = await replayControls
-        .first()
-        .isVisible({ timeout: TEST_TIMEOUTS.interaction });
+      const replayOutcome = await Promise.race([
+        playPause
+          .waitFor({ state: 'visible', timeout: TEST_TIMEOUTS.dataLoad })
+          .then(() => 'transport' as const),
+        replayUnavailable
+          .waitFor({ state: 'visible', timeout: TEST_TIMEOUTS.dataLoad })
+          .then(() => 'unavailable' as const),
+      ]).catch(() => 'missing' as const);
 
-      // Take screenshot whether replay loaded or not (for debugging)
+      // Viewport-only: a fullPage capture forces a full-document repaint of the WebGL
+      // arena, which starved WebKit's main thread for ~10s immediately before the click.
       await page.screenshot({
         path: `test-results/nightly-regression-replay-${reportId}-${fightId}.png`,
-        fullPage: true,
         timeout: TEST_TIMEOUTS.screenshot,
       });
 
-      if (hasReplayInterface) {
-        // Test play/pause functionality
-        const playButton = replayControls.first();
-        await playButton.click();
+      test.skip(
+        replayOutcome === 'unavailable',
+        `Fight ${fightId} has no 3D replay data to exercise`,
+      );
 
-        // Wait for replay to start
-        await page.waitForTimeout(3000);
+      // Hard assertion. This used to be an `if (hasReplayInterface)` gate, so when the
+      // locator matched nothing the entire interaction below was silently skipped.
+      await expect(playPause).toBeVisible({ timeout: TEST_TIMEOUTS.interaction });
+
+      // Read the starting label rather than hardcoding "Play" — keeps the assertion
+      // correct if a future autoplay path ever lands the page already playing.
+      const initialLabel = await playPause.getAttribute('aria-label');
+      expect(['Play', 'Pause']).toContain(initialLabel);
+      const toggledLabel = initialLabel === 'Play' ? 'Pause' : 'Play';
+
+      await playPause.click();
+      await expect(playPause).toHaveAttribute('aria-label', toggledLabel);
+
+      await page.waitForTimeout(3000);
+
+      await page.screenshot({
+        path: `test-results/nightly-regression-replay-playing-${reportId}.png`,
+        timeout: TEST_TIMEOUTS.screenshot,
+      });
+
+      // Toggle back — guarded because a short trash pull can run out during the wait
+      // above and self-pause, which would flip the label without a second click.
+      if ((await playPause.getAttribute('aria-label')) === toggledLabel) {
+        await playPause.click();
+        await expect(playPause).toHaveAttribute('aria-label', initialLabel!);
+      }
+
+      // Timeline scrubbing. MUI puts role="slider" on a visually hidden input inside the
+      // thumb, so the previous `click({ force: true })` landed on the playhead itself and
+      // could not seek — and its `.timeline-slider` / `.scrubber` fallbacks match nothing.
+      // Drive it by keyboard, and name the slider explicitly: a multi-fight trial run also
+      // renders TrialTimeline's "Trial timeline" slider.
+      const timeline = page.getByRole('slider', { name: 'Replay timeline' });
+      if (await timeline.count()) {
+        const timeBefore = await timeline.inputValue();
+        await timeline.press('ArrowRight');
+        await timeline.press('ArrowRight');
+        await expect
+          .poll(() => timeline.inputValue(), { timeout: TEST_TIMEOUTS.interaction })
+          .not.toBe(timeBefore);
 
         await page.screenshot({
-          path: `test-results/nightly-regression-replay-playing-${reportId}.png`,
-          fullPage: true,
+          path: `test-results/nightly-regression-replay-scrubbed-${reportId}.png`,
           timeout: TEST_TIMEOUTS.screenshot,
         });
-
-        // Test pause
-        const pauseButton = page.locator('button[aria-label*="pause"], .pause-button').first();
-
-        if (await pauseButton.isVisible({ timeout: 3000 })) {
-          await pauseButton.click();
-          await page.waitForTimeout(1000);
-        }
-
-        // Test timeline scrubbing if available
-        const timeline = page.locator('input[type="range"], .timeline-slider, .scrubber');
-        if (await timeline.first().isVisible({ timeout: 3000 })) {
-          // For sliders, force click is often needed due to overlay elements
-          await timeline.first().click({ force: true });
-          await page.waitForTimeout(2000);
-
-          await page.screenshot({
-            path: `test-results/nightly-regression-replay-scrubbed-${reportId}.png`,
-            fullPage: true,
-            timeout: TEST_TIMEOUTS.screenshot,
-          });
-        }
       }
 
       // Verify no critical errors occurred

--- a/tests/selectors.ts
+++ b/tests/selectors.ts
@@ -49,8 +49,16 @@ export const SELECTORS = {
   // Report structure
   REPORT_TITLE: 'h1, h2, h3, h4, h5, h6',
   
-  // Replay controls
-  REPLAY_CONTROLS: 'button[aria-label*="play"], button[aria-label*="pause"], .replay-controls, .play-button, .pause-button',
+  // Replay controls.
+  //
+  // Prefer `page.getByRole('button', { name: /^(Play|Pause)$/ })` — an anchored RegExp
+  // matches the full accessible name case-sensitively.
+  //
+  // NEVER `aria-label*="play"`: CSS attribute matching is case-sensitive, so it misses the
+  // real orb (aria-label="Play"/"Pause") entirely and instead matches the lowercase "play"
+  // inside ", currently playing" on the active chapter-rail stop — plus "Replay quality: …",
+  // "Share current replay time", "Show playback controls" and "Choose playback speed".
+  REPLAY_PLAY_PAUSE: 'button[aria-label="Play"], button[aria-label="Pause"]',
 } as const;
 
 /**


### PR DESCRIPTION
Nightly run [363](https://eso-toolkit.github.io/eso-log-aggregator-reports/nightly-tests/363/) failed one test of 231 — `Fight Replay Functionality > should load and interact with fight replay`, `webkit-desktop`, `TimeoutError: locator.click: Timeout 30000ms exceeded`, on both the run and the retry.

The replay-controls selector could never match the transport:

```
button[aria-label*="play"], button[aria-label*="pause"], .replay-controls, .play-button, .pause-button
```

CSS attribute-substring matching is case-sensitive, and the play orb's label is `"Play"`/`"Pause"` (`PlaybackButtons.tsx:129`), so `*="play"` missed it entirely. The three class fallbacks match nothing in `src/`. What it matched instead was the lowercase `play` inside `", currently playing"` — appended by `chapterAriaLabel()` (`ChapterList.tsx:106`) and rendered by `ChapterRail`, which sits above the arena in the page shell, so `.first()` deterministically resolved to the active chapter stop. Playwright's log confirms it: `aria-label="Trash: Tormented Skullmancer, Cleared, 0:08, currently playing"`.

So this test has never exercised play/pause on any browser. On chromium/firefox the click lands on the current fight's own stop, whose handler early-returns, and the follow-up pause locator matched nothing (`src/` contains no lowercase `"pause"` label), so the whole interaction was a silent no-op that reported green. WebKit only surfaced it because the click starved past `actionTimeout` on the GPU-less WebGL route — the same run shows an unrelated `scrollIntoViewIfNeeded` taking 13.4s on a snap-free page.

## Changes

- Target the orb with `getByRole('button', { name: /^(Play|Pause)$/ })`. The anchored regex matches the full accessible name case-sensitively. A bare `name: 'Play'` would **not** work — Playwright's string name is substring + case-insensitive and re-matches the very chapter stop we're avoiding.
- Replace the `if (hasReplayInterface)` gate with hard assertions that the label actually flips `Play -> Pause -> Play`. A fight with no position data now skips explicitly instead of passing vacuously.
- Scrub the timeline by keyboard. MUI puts `role="slider"` on a visually hidden input inside the thumb, so the previous `click({ force: true })` landed on the playhead itself and could not seek; its `.timeline-slider` / `.scrubber` fallbacks match nothing.
- Drop the dead `[data-testid*="trial-accordion"]` block — that container has no collapsed state and imports no MUI Accordion, so it was dead code wrapped around an unguarded `.click()`.
- `tests/selectors.ts` carried the identical broken string as `REPLAY_CONTROLS` (unused). Replaced with `REPLAY_PLAY_PAUSE` plus a note on the case-sensitivity trap, so the next test doesn't copy it.
- Emulate `prefers-reduced-motion` for the nightly suite. `SiteBackground` is mounted on every route and runs three infinite transform animations plus particles (`NebulaBackground`); the app already ships the kill switch, so this exercises a supported path and makes screenshots deterministic.

## Alternatives considered

Adding a `data-testid` to the play orb was the tempting fix, and it is the more rename-proof hook. Rejected for now: the nightly suite runs against **production** (`baseURL` defaults to `https://esotk.com/`), so a test written against a brand-new testid would fail every night until an app deploy landed — turning a test fix into a release dependency. The role-based locator is already unique (`aria-label="Play"/"Pause"` occurs exactly once in `src/`). If we want the testid, it should ship first and the locator switch second.

## Review notes

- `contextOptions: { reducedMotion: 'reduce' }` rather than a top-level `reducedMotion` — Playwright 1.61 has no top-level use-option for it. Projects only override the keys they set, so it survives the `...devices[...]` spreads.
- This test self-skips without `tests/auth-metadata.json`, so it can't be validated locally without OAuth credentials. I verified the locator semantics instead: a fixture reproducing the real DOM shapes, run through actual chromium/firefox/webkit — the old selector matches 8 buttons with `.first()` always the chapter stop; the new one matches only the orb and survives the label flip; the named slider responds to ArrowRight; and the `reducedMotion` emulation genuinely applies. 24/24 across the three engines.
- The initial label is read rather than hardcoded, and the toggle-back is guarded, because a short trash pull can run out during the 3s wait and self-pause.