### PR TITLE
fix(lint): restore green lint on main

### DIFF
--- a/src/utils/perFightRunSheet.test.ts
+++ b/src/utils/perFightRunSheet.test.ts
@@ -1,5 +1,6 @@
 import { createDefaultRoster } from '../types/roster';
 import type { EncounterOverrides } from '../types/trial-encounters';
+
 import { buildSlotRows, summarizeFight } from './perFightRunSheet';
 
 // Real resolving set IDs (verified in SET_DISPLAY_NAMES):


### PR DESCRIPTION
`main` is currently red on the required `lint` check.

#1253 (`feat(roster): collapsible per-fight cards on the /rv run sheet`, merged earlier today) added a test file whose imports trip `import/order`:

```
src/utils/perFightRunSheet.test.ts
  2:1  error  There should be at least one empty line between import groups  import/order
```

Because `lint` is a required context, every open PR inherits the failure on rebase. #1369 (`@axe-core/playwright`) and #1366 (`@swc/core`) both went red for this reason alone, with nothing wrong in either bump — which is exactly the kind of false signal that makes a dependency queue look unsafe when it isn't.

Fix is `eslint --fix` output: one blank line separating the parent-group imports from the sibling import. No behaviour change.

Verified locally: `npx eslint ./src ./tests --max-warnings 0` exits clean.